### PR TITLE
Kvm log dirty

### DIFF
--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -484,18 +484,6 @@ int mprotect_mapping(int cap, dosaddr_t targ, size_t mapsize, int protect)
 {
   int i, ret = -1;
 
-  /* it is important to r/o protect the KVM guest page tables BEFORE
-     calling mprotect as this function is called by parallel threads
-     (vgaemu.c:_vga_emu_update).
-     Otherwise the page can be r/w in the guest but r/o on the host which
-     causes KVM to exit with EFAULT when the guest writes there.
-     We do not need to worry about caching/TLBs because the kernel will
-     walk the guest page tables (see kernel:
-     Documentation/virtual/kvm/mmu.txt:
-     - if needed, walk the guest page tables to determine the guest translation
-       (gva->gpa or ngpa->gpa)
-       - if permissions are insufficient, reflect the fault back to the guest)
-  */
   Q__printf("MAPPING: mprotect, cap=%s, targ=%x, size=%zx, protect=%x\n",
 	cap, targ, mapsize, protect);
   if (is_kvm_map(cap))

--- a/src/base/emu-i386/kvm.c
+++ b/src/base/emu-i386/kvm.c
@@ -27,6 +27,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <limits.h>
 #include <sys/mman.h>
 #include <sys/ioctl.h>
 #include <linux/kvm.h>
@@ -470,6 +471,21 @@ errcap:
   return 0;
 }
 
+static struct kvm_userspace_memory_region *
+kvm_get_memory_region(dosaddr_t dosaddr, dosaddr_t size)
+{
+  int slot;
+  struct kvm_userspace_memory_region *p = &maps[0];
+
+  for (slot = 0; slot < MAXSLOT; slot++, p++)
+    if (p->guest_phys_addr <= dosaddr &&
+	dosaddr + size <= p->guest_phys_addr + p->memory_size)
+      break;
+
+  assert(slot < MAXSLOT);
+  return p;
+}
+
 static void set_kvm_memory_region(struct kvm_userspace_memory_region *region)
 {
   int ret = ioctl(vmfd, KVM_SET_USER_MEMORY_REGION, region);
@@ -502,7 +518,7 @@ void set_kvm_memory_regions(void)
   }
 }
 
-static void mmap_kvm_no_overlap(unsigned targ, void *addr, size_t mapsize)
+static void mmap_kvm_no_overlap(unsigned targ, void *addr, size_t mapsize, int flags)
 {
   struct kvm_userspace_memory_region *region;
   int slot;
@@ -522,8 +538,9 @@ static void mmap_kvm_no_overlap(unsigned targ, void *addr, size_t mapsize)
   region->guest_phys_addr = targ;
   region->userspace_addr = (uintptr_t)addr;
   region->memory_size = mapsize;
-  Q_printf("KVM: mapped guest %#x to host addr %p, size=%zx\n",
-	   targ, addr, mapsize);
+  region->flags = flags;
+  Q_printf("KVM: mapped guest %#x to host addr %p, size=%zx, LOG_DIRTY=%d\n",
+	   targ, addr, mapsize, flags == KVM_MEM_LOG_DIRTY_PAGES ? 1 : 0);
   /* NOTE: the actual EPT update is delayed to set_kvm_memory_regions */
 }
 
@@ -547,7 +564,7 @@ static void do_munmap_kvm(dosaddr_t targ, size_t mapsize)
 	mmap_kvm_no_overlap(targ + mapsize,
 			    (void *)((uintptr_t)region->userspace_addr +
 				     targ + mapsize - gpa),
-			    gpa + sz - (targ + mapsize));
+			    gpa + sz - (targ + mapsize), region->flags);
       }
     }
   }
@@ -558,7 +575,7 @@ void mmap_kvm(int cap, void *addr, size_t mapsize, int protect, dosaddr_t targ)
   assert(cap & (MAPPING_INIT_LOWRAM|MAPPING_KVM));
   /* with KVM we need to manually remove/shrink existing mappings */
   do_munmap_kvm(targ, mapsize);
-  mmap_kvm_no_overlap(targ, addr, mapsize);
+  mmap_kvm_no_overlap(targ, addr, mapsize, 0);
   if (!(cap & MAPPING_KVM))
     mprotect_kvm(cap, targ, mapsize, protect);
 }
@@ -573,6 +590,11 @@ void mprotect_kvm(int cap, dosaddr_t targ, size_t mapsize, int protect)
   if (!(cap & (MAPPING_INIT_LOWRAM|MAPPING_LOWMEM|MAPPING_EMS|MAPPING_HMA|
 	       MAPPING_DPMI|MAPPING_VGAEMU|MAPPING_KVM|MAPPING_CPUEMU|
 	       MAPPING_EXTMEM))) return;
+
+  /* never apply write-protect to regions with dirty logging */
+  if ((protect & (PROT_READ|PROT_WRITE)) == PROT_READ &&
+      (kvm_get_memory_region(targ, mapsize)->flags == KVM_MEM_LOG_DIRTY_PAGES))
+    return;
 
   if (monitor == NULL) return;
 
@@ -592,6 +614,41 @@ void mprotect_kvm(int cap, dosaddr_t targ, size_t mapsize, int protect)
   }
 
   mprotected_kvm = 1;
+}
+
+/* Enable dirty logging from base to base+size.
+ * This will not change the KVM-phys->host user space mapping itself but due
+ * to the way KVM works the memory slot typically needs to be split in 3 parts:
+ * 1. part without dirty log 2. part with dirty log 3. part without dirty log.
+ */
+void kvm_set_dirty_log(dosaddr_t base, dosaddr_t size)
+{
+  struct kvm_userspace_memory_region *p = kvm_get_memory_region(base, size);
+  void *addr = (void *)((uintptr_t)(p->userspace_addr +
+				    (base - p->guest_phys_addr)));
+  do_munmap_kvm(base, size);
+  mmap_kvm_no_overlap(base, addr, size, KVM_MEM_LOG_DIRTY_PAGES);
+}
+
+/* get dirty bitmap for memory region containing base.
+ * If base is not at the start of that region, the bitmap is shifted.
+ */
+void kvm_get_dirty_map(dosaddr_t base, unsigned char *bitmap)
+{
+  size_t bitmap_size;
+  struct kvm_dirty_log dirty_log = {0};
+  struct kvm_userspace_memory_region *p =
+    kvm_get_memory_region(base, PAGE_SIZE);
+
+  assert(p->flags == KVM_MEM_LOG_DIRTY_PAGES);
+  dirty_log.slot = p->slot;
+  dirty_log.dirty_bitmap = bitmap;
+  ioctl(vmfd, KVM_GET_DIRTY_LOG, &dirty_log);
+  bitmap_size = ((p->memory_size >> PAGE_SHIFT)+CHAR_BIT-1) / CHAR_BIT;
+  if (p->guest_phys_addr < base) {
+    int offset = ((base - p->guest_phys_addr) >> PAGE_SHIFT) / CHAR_BIT;
+    memmove(bitmap, bitmap + offset, bitmap_size - offset);
+  }
 }
 
 /* This function works like handle_vm86_fault in the Linux kernel,

--- a/src/include/kvm.h
+++ b/src/include/kvm.h
@@ -28,6 +28,8 @@ int kvm_dpmi(cpuctx_t *scp);
 void mprotect_kvm(int cap, dosaddr_t targ, size_t mapsize, int protect);
 void mmap_kvm(int cap, void *addr, size_t mapsize, int protect, dosaddr_t targ);
 void set_kvm_memory_regions(void);
+void kvm_set_dirty_log(dosaddr_t base, dosaddr_t size);
+void kvm_get_dirty_map(dosaddr_t base, unsigned char *bitmap);
 
 void kvm_set_idt_default(int i);
 void kvm_set_idt(int i, uint16_t sel, uint32_t offs, int is_32, int tg);
@@ -47,6 +49,8 @@ static inline void mprotect_kvm(int cap, dosaddr_t targ, size_t mapsize, int pro
 static inline void mmap_kvm(int cap, void *addr, size_t mapsize, int protect, dosaddr_t targ) {}
 static inline void munmap_kvm(int cap, dosaddr_t targ, size_t mapsize) {}
 static inline void set_kvm_memory_regions(void) {}
+static inline void kvm_set_dirty_log(dosaddr_t base, dosaddr_t size) {}
+static inline void kvm_get_dirty_map(dosaddr_t base, unsigned char *bitmap) {}
 static inline void kvm_set_idt_default(int i) {}
 static inline void kvm_set_idt(int i, uint16_t sel, uint32_t offs, int is_32,
     int tg) {}

--- a/src/include/vgaemu.h
+++ b/src/include/vgaemu.h
@@ -270,6 +270,7 @@ typedef struct {
   unsigned bank_pages;			/* size of a bank in pages */
   unsigned bank;			/* selected bank */
   unsigned char *dirty_map;		/* 1 == dirty */
+  unsigned char *dirty_bitmap;		/* filled in by KVM */
   unsigned char *prot_map0, *prot_map1;	/* prot flags per page */
   int planes;				/* 4 for PL4 and ModeX, 1 otherwise */
   int plane_pages;			/* pages per plane  */


### PR DESCRIPTION
This is another attempt at avoiding the double page protection and TLBs being out of sync.
This uses the proper KVM api to track dirty pages. This way it is possible to do VGA dirty page tracking without needing to page fault into dosemu at all. I've also avoided needing an expensive syscall when back-switching VGA code tries to switch to the same bank it is already on.

I can confirm that micro machines and tristan pinball work fine with this patchset. I am not sure about Geos. @bolle732 could you test?

(Another working alternative I have is to completely use guest paging for everything -- in that case the assembly code in kvmmon.S will need to use invlpg or mov cr3 to invalidate the TLB.)
