### PR TITLE
simx86: use "dosaddr_t" addresses throughout in sim mode

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -537,7 +537,7 @@ void Gen_sim(int op, int mode, ...)
 		break;
 	case S_DI_IMM: {
 		int v = va_arg(ap,int);
-		dosaddr_t addr = DOSADDR_REL(AR1.pu);
+		dosaddr_t addr = AR1.d;
 		if (mode&MBYTE) {
 			GTRACE3("S_DI_IMM_B",0xff,0xff,v);
 			write_byte(addr, v);
@@ -606,18 +606,18 @@ void Gen_sim(int op, int mode, ...)
 		signed char o = Offs_From_Arg();
 		GTRACE1("L_LXS1",o);
 		if (mode&DATA16) {
-		    CPUWORD(o) = DR1.w.l = read_word(DOSADDR_REL(AR1.pu));
+		    CPUWORD(o) = DR1.w.l = read_word(AR1.d);
 		    AR1.d += 2;
 		}
 		else {
-		    CPULONG(o) = DR1.d = read_dword(DOSADDR_REL(AR1.pu));
+		    CPULONG(o) = DR1.d = read_dword(AR1.d);
 		    AR1.d += 4;
 		} }
 		break;
 	case L_LXS2: {	/* real mode segment base from segment value */
 		signed char o = Offs_From_Arg();
 		GTRACE1("L_LXS2",o);
-		DR1.d = read_word(DOSADDR_REL(AR1.pu));
+		DR1.d = read_word(AR1.d);
 		SetSegReal(DR1.w.l, o);
 		}
 		break;
@@ -627,7 +627,7 @@ void Gen_sim(int op, int mode, ...)
 		break;
 
 	case L_DI_R1: {
-		dosaddr_t addr = DOSADDR_REL(AR1.pu);
+		dosaddr_t addr = AR1.d;
 		GTRACE0("L_DI");
 		if (mode & (MBYTE|MBYTX)) {
 		    DR1.b.bl = read_byte(addr);
@@ -642,7 +642,7 @@ void Gen_sim(int op, int mode, ...)
 		}
 		break;
 	case S_DI: {
-		dosaddr_t addr = DOSADDR_REL(AR1.pu);
+		dosaddr_t addr = AR1.d;
 		GTRACE0("S_DI");
 		if (mode&MBYTE) {
 		    write_byte(addr, DR1.b.bl);
@@ -2055,7 +2055,7 @@ void Gen_sim(int op, int mode, ...)
 			AR2.d = CPULONG(Ofs_XSS);
 			SR1.d = CPULONG(Ofs_ESP) - 2;
 			SR1.d &= CPULONG(Ofs_STACKM);
-			write_word(DOSADDR_REL(AR2.pu) + SR1.d, DR1.w.l);
+			write_word(AR2.d + SR1.d, DR1.w.l);
 			CPULONG(Ofs_ESP) = SR1.d;
 		}
 		else {
@@ -2064,7 +2064,7 @@ void Gen_sim(int op, int mode, ...)
 			AR2.d = CPULONG(Ofs_XSS);
 			SR1.d = (tesp = CPULONG(Ofs_ESP)) - 4;
 			SR1.d &= stackm;
-			write_dword(DOSADDR_REL(AR2.pu) + SR1.d, DR1.d);
+			write_dword(AR2.d + SR1.d, DR1.d);
 #if 0	/* keep high 16-bits of ESP in small-stack mode */
 			SR1.d |= (tesp & ~stackm);
 #endif
@@ -2087,13 +2087,13 @@ void Gen_sim(int op, int mode, ...)
 			DR1.w.l = CPUWORD(o);
 			SR1.d -= 2;
 			SR1.d &= CPULONG(Ofs_STACKM);
-			write_word(DOSADDR_REL(AR2.pu) + SR1.d, DR1.w.l);
+			write_word(AR2.d + SR1.d, DR1.w.l);
 		}
 		else {
 			DR1.d = CPULONG(o);
 			SR1.d -= 4;
 			SR1.d &= CPULONG(Ofs_STACKM);
-			write_dword(DOSADDR_REL(AR2.pu) + SR1.d, DR1.d);
+			write_dword(AR2.d + SR1.d, DR1.d);
 		}
 		if (debug_level('e')>3) dbug_printf("(V) %08x\n",DR1.d);
 		} break;
@@ -2113,11 +2113,11 @@ void Gen_sim(int op, int mode, ...)
 		SR1.d = CPULONG(Ofs_ESP);
 		if (mode & DATA16) {
 			SR1.d = (SR1.d - 2) & CPULONG(Ofs_STACKM);
-			write_word(DOSADDR_REL(AR2.pu) + SR1.d, ftmp & 0x7eff);
+			write_word(AR2.d + SR1.d, ftmp & 0x7eff);
 		}
 		else {
 			SR1.d = (SR1.d - 4) & CPULONG(Ofs_STACKM);
-			write_dword(DOSADDR_REL(AR2.pu) + SR1.d, ftmp & 0x3c7eff);
+			write_dword(AR2.d + SR1.d, ftmp & 0x3c7eff);
 		}
 		CPULONG(Ofs_ESP) = SR1.d;
 		if (debug_level('e')>3) dbug_printf("(V) %08x\n",ftmp&0x3c7eff);
@@ -2131,7 +2131,7 @@ void Gen_sim(int op, int mode, ...)
 			AR2.d = CPULONG(Ofs_XSS);
 			SR1.d = CPULONG(Ofs_ESP) - 2;
 			SR1.d &= CPULONG(Ofs_STACKM);
-			write_word(DOSADDR_REL(AR2.pu) + SR1.d, DR1.w.l);
+			write_word(AR2.d + SR1.d, DR1.w.l);
 			CPULONG(Ofs_ESP) = SR1.d;
 		}
 		else {
@@ -2139,7 +2139,7 @@ void Gen_sim(int op, int mode, ...)
 			AR2.d = CPULONG(Ofs_XSS);
 			SR1.d = CPULONG(Ofs_ESP) - 4;
 			SR1.d &= CPULONG(Ofs_STACKM);
-			write_dword(DOSADDR_REL(AR2.pu) + SR1.d, DR1.d);
+			write_dword(AR2.d + SR1.d, DR1.d);
 			CPULONG(Ofs_ESP) = SR1.d;
 		}
 		} break;
@@ -2152,7 +2152,7 @@ void Gen_sim(int op, int mode, ...)
 			AR2.d = CPULONG(Ofs_XSS);
 			SR1.d = CPULONG(Ofs_ESP) - 16;
 			SR1.d &= CPULONG(Ofs_STACKM);
-			pw = DOSADDR_REL(AR2.pu) + SR1.d;
+			pw = AR2.d + SR1.d;
 			write_word(pw, CPUWORD(Ofs_DI)); pw += 2;
 			write_word(pw, CPUWORD(Ofs_SI)); pw += 2;
 			write_word(pw, CPUWORD(Ofs_BP)); pw += 2;
@@ -2168,7 +2168,7 @@ void Gen_sim(int op, int mode, ...)
 			AR2.d = CPULONG(Ofs_XSS);
 			SR1.d = CPULONG(Ofs_ESP) - 32;
 			SR1.d &= CPULONG(Ofs_STACKM);
-			pd = DOSADDR_REL(AR2.pu) + SR1.d;
+			pd = AR2.d + SR1.d;
 			memcpy_2dos(pd, CPUOFFS(Ofs_EDI), 32);
 			CPULONG(Ofs_ESP) = SR1.d;
 		}
@@ -2182,7 +2182,7 @@ void Gen_sim(int op, int mode, ...)
 			AR2.d = CPULONG(Ofs_XSS);
 			SR1.d = CPULONG(Ofs_ESP);
 			SR1.d &= stackm;
-			DR1.w.l = read_word(DOSADDR_REL(AR2.pu) + SR1.d);
+			DR1.w.l = read_word(AR2.d + SR1.d);
 			SR1.d += 2;
 #ifdef STACK_WRAP_MP	/* mask after incrementing */
 			SR1.d &= stackm;
@@ -2194,7 +2194,7 @@ void Gen_sim(int op, int mode, ...)
 			AR2.d = CPULONG(Ofs_XSS);
 			SR1.d = tesp = CPULONG(Ofs_ESP);
 			SR1.d &= stackm;
-			DR1.d = read_dword(DOSADDR_REL(AR2.pu) + SR1.d);
+			DR1.d = read_dword(AR2.d + SR1.d);
 			SR1.d += 4;
 #ifdef STACK_WRAP_MP	/* mask after incrementing */
 			SR1.d &= stackm;
@@ -2220,14 +2220,14 @@ void Gen_sim(int op, int mode, ...)
 		GTRACE1("O_POP2",o);
 		if (mode & DATA16) {
 			SR1.d &= stackm;
-			DR1.w.l = read_word(DOSADDR_REL(AR2.pu) + SR1.d);
+			DR1.w.l = read_word(AR2.d + SR1.d);
 			if (!(mode & MPOPRM))
 				CPUWORD(o) = DR1.w.l;
 			SR1.d += 2;
 		}
 		else {
 			SR1.d &= stackm;
-			DR1.d = read_dword(DOSADDR_REL(AR2.pu) + SR1.d);
+			DR1.d = read_dword(AR2.d + SR1.d);
 			if (!(mode & MPOPRM))
 				CPULONG(o) = DR1.d;
 			SR1.d += 4;
@@ -2252,7 +2252,7 @@ void Gen_sim(int op, int mode, ...)
 			AR2.d = CPULONG(Ofs_XSS);
 			SR1.d = CPULONG(Ofs_ESP);
 			SR1.d &= stackm;
-			pw = DOSADDR_REL(AR2.pu) + SR1.d;
+			pw = AR2.d + SR1.d;
 			CPUWORD(Ofs_DI) = read_word(pw); pw += 2;
 			CPUWORD(Ofs_SI) = read_word(pw); pw += 2;
 			CPUWORD(Ofs_BP) = read_word(pw); pw += 2;
@@ -2273,7 +2273,7 @@ void Gen_sim(int op, int mode, ...)
 			AR2.d = CPULONG(Ofs_XSS);
 			SR1.d = tesp = CPULONG(Ofs_ESP);
 			SR1.d &= stackm;
-			pd = DOSADDR_REL(AR2.pu) + SR1.d;
+			pd = AR2.d + SR1.d;
 			memcpy_2unix(CPUOFFS(Ofs_EDI), pd, 32);
 			SR1.d += 32;
 #ifdef STACK_WRAP_MP	/* mask after incrementing */
@@ -2293,7 +2293,7 @@ void Gen_sim(int op, int mode, ...)
 			SR1.d = CPUWORD(Ofs_BP);
 			AR2.d = CPULONG(Ofs_XSS);
 			SR1.d &= stackm;
-			DR1.w.l = read_word(DOSADDR_REL(AR2.pu) + SR1.d);
+			DR1.w.l = read_word(AR2.d + SR1.d);
 			CPUWORD(Ofs_BP) = DR1.w.l;
 			SR1.d += 2;
 #ifdef STACK_WRAP_MP	/* mask after incrementing */
@@ -2305,7 +2305,7 @@ void Gen_sim(int op, int mode, ...)
 			SR1.d = CPULONG(Ofs_EBP);
 			AR2.d = CPULONG(Ofs_XSS);
 			SR1.d &= stackm;
-			DR1.d = read_dword(DOSADDR_REL(AR2.pu) + SR1.d);
+			DR1.d = read_dword(AR2.d + SR1.d);
 			CPULONG(Ofs_EBP) = DR1.d;
 			SR1.d += 4;
 #ifdef STACK_WRAP_MP	/* mask after incrementing */
@@ -2394,8 +2394,8 @@ void Gen_sim(int op, int mode, ...)
 			break;
 		    }
 		}
-		dest = DOSADDR_REL(AR1.pu);
-		src = DOSADDR_REL(AR2.pu);
+		dest = AR1.d;
+		src = AR2.d;
 		if (df<0) {
 		    if (mode&MBYTE) {
 			while (i--) write_byte(dest--, read_byte(src--));
@@ -2423,8 +2423,8 @@ void Gen_sim(int op, int mode, ...)
 		    }
 		}
 		TR1.d = 0;
-		AR1.pu = MEM_BASE32(dest);
-		AR2.pu = MEM_BASE32(src);
+		AR1.d = dest;
+		AR2.d = src;
 		}
 		break;
 	case O_MOVS_LodD: {
@@ -2436,7 +2436,7 @@ void Gen_sim(int op, int mode, ...)
 		if (mode&(MREP|MREPNE))	{
 		    dbug_printf("odd: REP LODS %d\n",i);
 		}
-		addr = DOSADDR_REL(AR2.pu);
+		addr = AR2.d;
 		if (mode&MBYTE) {
 		    while (i--) { DR1.b.bl = read_byte(addr); addr += df; }
 		}
@@ -2447,7 +2447,7 @@ void Gen_sim(int op, int mode, ...)
 		    while (i--) { DR1.d = read_dword(addr); addr += 4*df; }
 		}
 		if (mode&(MREP|MREPNE))	TR1.d = 0;
-		AR2.pu = MEM_BASE32(addr);
+		AR2.d = addr;
 		// ! Warning DI,SI wrap	in 16-bit mode
 		}
 		break;
@@ -2487,7 +2487,7 @@ void Gen_sim(int op, int mode, ...)
 			break;
 		    }
 		}
-		addr = DOSADDR_REL(AR1.pu);
+		addr = AR1.d;
 		if (mode&MBYTE) {
 		    while (i--) { write_byte(addr, DR1.b.bl); addr += df; }
 		}
@@ -2497,7 +2497,7 @@ void Gen_sim(int op, int mode, ...)
 		else {
 		    while (i--) { write_dword(addr, DR1.d); addr += 4*df; }
 		}
-		AR1.pu = MEM_BASE32(addr);
+		AR1.d = addr;
 		TR1.d = 0;
 		}
 		break;
@@ -2512,7 +2512,7 @@ void Gen_sim(int op, int mode, ...)
 		RFL.mode = mode;
 		RFL.valid = V_SUB;
 		z = k = (mode&MREP? 1:0);
-		addr = DOSADDR_REL(AR1.pu);
+		addr = AR1.d;
 		while (i && (z==k)) {
 		    if (mode&MBYTE) {
 			RFL.RES.d = (S1=DR1.b.bl) - (S2=read_byte(addr));
@@ -2534,7 +2534,7 @@ void Gen_sim(int op, int mode, ...)
 		    }
 		    i--;
 		}
-		AR1.pu = MEM_BASE32(addr);
+		AR1.d = addr;
 		TR1.d = i;
 		// ! Warning DI,SI wrap	in 16-bit mode
 		}
@@ -2549,7 +2549,7 @@ void Gen_sim(int op, int mode, ...)
 		if (i == 0) break; /* eCX = 0, no-op, no flags updated */
 		RFL.mode = mode;
 		RFL.valid = V_SUB;
-		addr1 = DOSADDR_REL(AR1.pu);
+		addr1 = AR1.d;
 		if(!(mode & (MREP|MREPNE))) {
 			// assumes DR1=*AR2
 			if (mode&MBYTE) {
@@ -2567,7 +2567,7 @@ void Gen_sim(int op, int mode, ...)
 		}
 		df = (CPUWORD(Ofs_FLAGS) & EFLAGS_DF? -1:1);
 		z = k = (mode&MREP? 1:0);
-		addr2 = DOSADDR_REL(AR2.pu);
+		addr2 = AR2.d;
 		while (i && (z==k)) {
 		    if (mode&MBYTE) {
 			RFL.RES.d = (S1=read_byte(addr2)) - (S2=read_byte(addr1));
@@ -2590,8 +2590,8 @@ void Gen_sim(int op, int mode, ...)
 		    i--;
 		}
 		TR1.d = i;
-		AR1.pu = MEM_BASE32(addr1);
-		AR2.pu = MEM_BASE32(addr2);
+		AR1.d = addr1;
+		AR2.d = addr2;
 		// ! Warning DI,SI wrap	in 16-bit mode
 		}
 		break;
@@ -2763,7 +2763,7 @@ void Gen_sim(int op, int mode, ...)
 		    }
 		} else {
 		    /* add bit offset to effective address */
-		    AR1.pu += (mode&DATA16) ? 2*(DR2.d>>4) : 4*(DR2.d>>5);
+		    AR1.d += (mode&DATA16) ? 2*(DR2.d>>4) : 4*(DR2.d>>5);
 		    break;
 		}
 		if (flg != 2)

--- a/src/base/emu-i386/simx86/codegen-sim.h
+++ b/src/base/emu-i386/simx86/codegen-sim.h
@@ -48,7 +48,6 @@
 typedef union {
 	unsigned int d;
 	signed int ds;
-	unsigned char *pu;
 	struct { unsigned short l,h; } w;
 	struct { signed short l,h; } ws;
 	struct { unsigned char bl,bh,b2,b3; } b;

--- a/src/base/emu-i386/simx86/cpatch.c
+++ b/src/base/emu-i386/simx86/cpatch.c
@@ -178,21 +178,21 @@ asmlinkage void rep_movs_stos(struct rep_stack *stack)
 	}
 	else if ((op & 0xf6) == 0xa6) { /* cmps/scas */
 		int repmod = (size == 1 ? MBYTE : size == 2 ? DATA16 : 0);
-		AR1.pu = stack->edi;
+		AR1.d = DOSADDR_REL(stack->edi);
 		TR1.d = stack->ecx;
 		repmod |= MOVSDST|MREPCOND|(eip[-1]==REPNE? MREPNE:MREP);
 		if ((op & 0xf6) == 0xa6) { /* cmps */
 			repmod |= MOVSSRC;
-			AR2.pu = stack->esi;
+			AR2.d = DOSADDR_REL(stack->esi);
 			Gen_sim(O_MOVS_CmpD, repmod);
-			stack->esi = AR2.pu;
+			stack->esi = MEM_BASE32(AR2.d);
 		}
 		else { /* scas */
 			DR1.d = stack->eax;
 			Gen_sim(O_MOVS_ScaD, repmod);
 		}
 		FlagSync_All();
-		stack->edi = AR1.pu;
+		stack->edi = MEM_BASE32(AR1.d);
 		stack->ecx = TR1.d;
 		stack->eflags = (stack->eflags & ~EFLAGS_CC) |
 			(EFLAGS & EFLAGS_CC);

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -1115,7 +1115,9 @@ int e_vm86(void)
 #endif
   e_sigpa_count = 0;
   mode = ADDR16|DATA16; TheCPU.StackMask = 0x0000ffff;
-  TheCPU.mem_base = (uintptr_t)mem_base;
+  /* The simulator uses dosaddr_t throughout, the JIT adds mem_base
+     to the segment bases */
+  TheCPU.mem_base = CONFIG_CPUSIM ? 0 : (uintptr_t)mem_base;
   /* FPU state is loaded later on demand for JIT, not used for simulator */
   TheCPU.fpstate = vm86_fpu_state;
   VgaAbsBankBase = TheCPU.mem_base + vga.mem.bank_base;

--- a/src/base/emu-i386/simx86/fp87-sim.c
+++ b/src/base/emu-i386/simx86/fp87-sim.c
@@ -195,12 +195,12 @@ static int Fp87_op_sim(int exop, int reg)
 //	2F	DF xx101nnn	FILD	qw
 		DECFSPP;
 		switch(exop) {		// Fop (edi)
-		case 0x01: WFR0 = read_float(DOSADDR_REL(AR1.pu)); break;
-		case 0x03: WFR0 = (int32_t)read_dword(DOSADDR_REL(AR1.pu)); break;
-		case 0x05: WFR0 = read_double(DOSADDR_REL(AR1.pu)); break;
-		case 0x07: WFR0 = (int16_t)read_word(DOSADDR_REL(AR1.pu)); break;
+		case 0x01: WFR0 = read_float(AR1.d); break;
+		case 0x03: WFR0 = (int32_t)read_dword(AR1.d); break;
+		case 0x05: WFR0 = read_double(AR1.d); break;
+		case 0x07: WFR0 = (int16_t)read_word(AR1.d); break;
 		case 0x27: {
-			dosaddr_t p = DOSADDR_REL(AR1.pu);
+			dosaddr_t p = AR1.d;
 			long long b = 0;
 			int i;
 			for (i = 8; i >= 0; i--) {
@@ -210,8 +210,8 @@ static int Fp87_op_sim(int exop, int reg)
 			WFR0 = ((read_byte(p+9) & 0x80) ? -1 : 1) * b;
 			break;
 		}
-		case 0x2b: WFR0 = read_long_double(DOSADDR_REL(AR1.pu)); break;
-		case 0x2f: WFR0 = (int64_t)read_qword(DOSADDR_REL(AR1.pu)); break;
+		case 0x2b: WFR0 = read_long_double(AR1.d); break;
+		case 0x2f: WFR0 = (int64_t)read_qword(AR1.d); break;
 		}
 		*ST0 = WFR0;
 		break;
@@ -266,30 +266,30 @@ static int Fp87_op_sim(int exop, int reg)
 //	3E	DE xx111nnn	FIDIVR	w
 		WFR0 = *ST0;
 		switch(exop) {		// Fop (edi)
-		case 0x00: WFR0 += read_float(DOSADDR_REL(AR1.pu)); break;
-		case 0x02: WFR0 += (int32_t)read_dword(DOSADDR_REL(AR1.pu)); break;
-		case 0x04: WFR0 += read_double(DOSADDR_REL(AR1.pu)); break;
-		case 0x06: WFR0 += (int16_t)read_word(DOSADDR_REL(AR1.pu)); break;
-		case 0x08: WFR0 *= read_float(DOSADDR_REL(AR1.pu)); break;
-		case 0x0a: WFR0 *= (int32_t)read_dword(DOSADDR_REL(AR1.pu)); break;
-		case 0x0c: WFR0 *= read_double(DOSADDR_REL(AR1.pu)); break;
-		case 0x0e: WFR0 *= (int16_t)read_word(DOSADDR_REL(AR1.pu)); break;
-		case 0x20: WFR0 -= read_float(DOSADDR_REL(AR1.pu)); break;
-		case 0x22: WFR0 -= (int32_t)read_dword(DOSADDR_REL(AR1.pu)); break;
-		case 0x24: WFR0 -= read_double(DOSADDR_REL(AR1.pu)); break;
-		case 0x26: WFR0 -= (int16_t)read_word(DOSADDR_REL(AR1.pu)); break;
-		case 0x28: WFR0 = (long double)read_float(DOSADDR_REL(AR1.pu)) - WFR0; break;
-		case 0x2a: WFR0 = (long double)(int32_t)read_dword(DOSADDR_REL(AR1.pu)) - WFR0; break;
-		case 0x2c: WFR0 = (long double)read_double(DOSADDR_REL(AR1.pu)) - WFR0; break;
-		case 0x2e: WFR0 = (long double)(int16_t)read_word(DOSADDR_REL(AR1.pu)) - WFR0; break;
-		case 0x30: WFR0 /= read_float(DOSADDR_REL(AR1.pu)); break;
-		case 0x32: WFR0 /= (int32_t)read_dword(DOSADDR_REL(AR1.pu)); break;
-		case 0x34: WFR0 /= read_double(DOSADDR_REL(AR1.pu)); break;
-		case 0x36: WFR0 /= (int16_t)read_word(DOSADDR_REL(AR1.pu)); break;
-		case 0x38: WFR0 = (long double)read_float(DOSADDR_REL(AR1.pu)) / WFR0; break;
-		case 0x3a: WFR0 = (long double)(int32_t)read_dword(DOSADDR_REL(AR1.pu)) / WFR0; break;
-		case 0x3c: WFR0 = (long double)read_double(DOSADDR_REL(AR1.pu)) / WFR0; break;
-		case 0x3e: WFR0 = (long double)(int16_t)read_word(DOSADDR_REL(AR1.pu)) / WFR0; break;
+		case 0x00: WFR0 += read_float(AR1.d); break;
+		case 0x02: WFR0 += (int32_t)read_dword(AR1.d); break;
+		case 0x04: WFR0 += read_double(AR1.d); break;
+		case 0x06: WFR0 += (int16_t)read_word(AR1.d); break;
+		case 0x08: WFR0 *= read_float(AR1.d); break;
+		case 0x0a: WFR0 *= (int32_t)read_dword(AR1.d); break;
+		case 0x0c: WFR0 *= read_double(AR1.d); break;
+		case 0x0e: WFR0 *= (int16_t)read_word(AR1.d); break;
+		case 0x20: WFR0 -= read_float(AR1.d); break;
+		case 0x22: WFR0 -= (int32_t)read_dword(AR1.d); break;
+		case 0x24: WFR0 -= read_double(AR1.d); break;
+		case 0x26: WFR0 -= (int16_t)read_word(AR1.d); break;
+		case 0x28: WFR0 = (long double)read_float(AR1.d) - WFR0; break;
+		case 0x2a: WFR0 = (long double)(int32_t)read_dword(AR1.d) - WFR0; break;
+		case 0x2c: WFR0 = (long double)read_double(AR1.d) - WFR0; break;
+		case 0x2e: WFR0 = (long double)(int16_t)read_word(AR1.d) - WFR0; break;
+		case 0x30: WFR0 /= read_float(AR1.d); break;
+		case 0x32: WFR0 /= (int32_t)read_dword(AR1.d); break;
+		case 0x34: WFR0 /= read_double(AR1.d); break;
+		case 0x36: WFR0 /= (int16_t)read_word(AR1.d); break;
+		case 0x38: WFR0 = (long double)read_float(AR1.d) / WFR0; break;
+		case 0x3a: WFR0 = (long double)(int32_t)read_dword(AR1.d) / WFR0; break;
+		case 0x3c: WFR0 = (long double)read_double(AR1.d) / WFR0; break;
+		case 0x3e: WFR0 = (long double)(int16_t)read_word(AR1.d) / WFR0; break;
 		}
 		ftest(WFR0);
 		*ST0 = WFR0;
@@ -330,13 +330,13 @@ static int Fp87_op_sim(int exop, int reg)
 		WFR0 = *ST0;
 		switch(exop) {		// Fop (edi), no pop
 		case 0x10:
-		case 0x18: WFR1 = (long double)read_float(DOSADDR_REL(AR1.pu)); goto fcom00;
+		case 0x18: WFR1 = (long double)read_float(AR1.d); goto fcom00;
 		case 0x12:
-		case 0x1a: WFR1 = (long double)(int32_t)read_dword(DOSADDR_REL(AR1.pu)); goto fcom00;
+		case 0x1a: WFR1 = (long double)(int32_t)read_dword(AR1.d); goto fcom00;
 		case 0x14:
-		case 0x1c: WFR1 = (long double)read_double(DOSADDR_REL(AR1.pu)); goto fcom00;
+		case 0x1c: WFR1 = (long double)read_double(AR1.d); goto fcom00;
 		case 0x16:
-		case 0x1e: WFR1 = (long double)(int16_t)read_word(DOSADDR_REL(AR1.pu));
+		case 0x1e: WFR1 = (long double)(int16_t)read_word(AR1.d);
 fcom00:			TheCPU.fpus &= (~0x4500);	/* (C3,C2,C0) <-- 000 */
 			if (WFR0 < WFR1)
 			    TheCPU.fpus |= 0x100;	/* (C3,C2,C0) <-- 001 */
@@ -346,9 +346,9 @@ fcom00:			TheCPU.fpus &= (~0x4500);	/* (C3,C2,C0) <-- 000 */
 			        else /* not comparable */ TheCPU.fpus |= 0x4500;
 			    break;
 		case 0x11:
-		case 0x19: write_float(DOSADDR_REL(AR1.pu), WFR0); break;
+		case 0x19: write_float(AR1.d, WFR0); break;
 		case 0x15:
-		case 0x1d: write_double(DOSADDR_REL(AR1.pu), WFR0); break;
+		case 0x1d: write_double(AR1.d, WFR0); break;
 		case 0x13:
 		case 0x1b:
 		case 0x17:
@@ -361,7 +361,7 @@ fcom00:			TheCPU.fpus &= (~0x4500);	/* (C3,C2,C0) <-- 000 */
 				TheCPU.fpus |= 1;
 				WFR0 = (long double)-0x8000;
 			    }
-			    write_word(DOSADDR_REL(AR1.pu), (int16_t)WFR0); break;
+			    write_word(AR1.d, (int16_t)WFR0); break;
 			}
 			if (isnan(WFR0) || isinf(WFR0) ||
 			    WFR0 < -(long double)0x80000000 ||
@@ -369,14 +369,14 @@ fcom00:			TheCPU.fpus &= (~0x4500);	/* (C3,C2,C0) <-- 000 */
 			    TheCPU.fpus |= 1;
 			    WFR0 = -(long double)0x80000000;
 			}
-			write_dword(DOSADDR_REL(AR1.pu), (int32_t)WFR0); break; }
+			write_dword(AR1.d, (int32_t)WFR0); break; }
 		}
 		if (exop&8) INCFSPP;
 		break;
 
 /*37*/	case 0x37: {
 //	37	DF xx110nnn	FBSTP
-		dosaddr_t p = DOSADDR_REL(AR1.pu);
+		dosaddr_t p = AR1.d;
 		long long b;
 		int i;
 		WFR0 = *ST0;
@@ -396,7 +396,7 @@ fcom00:			TheCPU.fpus &= (~0x4500);	/* (C3,C2,C0) <-- 000 */
 /*3b*/	case 0x3b:
 //	3B	DB xx111nnn	FSTP	ext
 		WFR0 = *ST0;
-		write_long_double(DOSADDR_REL(AR1.pu), WFR0);
+		write_long_double(AR1.d, WFR0);
 		INCFSPP;
 		break;
 /*3f*/	case 0x3f: {
@@ -409,17 +409,17 @@ fcom00:			TheCPU.fpus &= (~0x4500);	/* (C3,C2,C0) <-- 000 */
 		    TheCPU.fpus |= 1;
 		    WFR0 = (long double)(long long)0x8000000000000000ULL;
 		}
-		write_qword(DOSADDR_REL(AR1.pu), (int64_t)WFR0);
+		write_qword(AR1.d, (int64_t)WFR0);
 		INCFSPP;
 		}
 		break;
 /*29*/	case 0x29:
 //*	29	D9 xx101nnn	FLDCW	2b
-		TheCPU.fpuc = read_word(DOSADDR_REL(AR1.pu)) | 0x40;
+		TheCPU.fpuc = read_word(AR1.d) | 0x40;
 		break;
 /*39*/	case 0x39:
 //*	39	D9 xx111nnn	FSTCW	2b
-		write_word(DOSADDR_REL(AR1.pu), TheCPU.fpuc);
+		write_word(AR1.d, TheCPU.fpuc);
 		break;
 
 /*67*/	case 0x67: if (reg!=0) goto fp_notok;
@@ -435,7 +435,7 @@ fcom00:			TheCPU.fpus &= (~0x4500);	/* (C3,C2,C0) <-- 000 */
 		SYNCFSP;
 		if (exop==0x3d) {
 			// movw	ax,(edi)
-			write_word(DOSADDR_REL(AR1.pu), TheCPU.fpus);
+			write_word(AR1.d, TheCPU.fpus);
 		}
 		else {
 			CPUWORD(Ofs_AX) = TheCPU.fpus;


### PR DESCRIPTION
Now that all direct memory accesses are gone we don't need to add
and subtract mem_base to segment bases any more.