### PR TITLE
Proof-of-concept faultless JIT

### DIFF
--- a/src/arch/linux/async/sigsegv.c
+++ b/src/arch/linux/async/sigsegv.c
@@ -59,8 +59,10 @@
  *
  * DANG_END_FUNCTION
  */
+int emupagefaults = 0;
 static void dosemu_fault1(int signal, sigcontext_t *scp)
 {
+  emupagefaults++;
   if (fault_cnt > 1) {
     error("Fault handler re-entered! signal=%i _trapno=0x%X\n",
       signal, _trapno);

--- a/src/base/core/emu.c
+++ b/src/base/core/emu.c
@@ -464,6 +464,8 @@ static void leavedos_thr(void *arg)
 /* "graceful" shutdown */
 void __leavedos(int code, int sig, const char *s, int num)
 {
+    extern int emupagefaults;
+    printf("%d pagefaults\n", emupagefaults);
     int tmp;
     dbug_printf("leavedos(%s:%i|%i) called - shutting down\n", s, num, sig);
     if (in_leavedos)

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -1135,8 +1135,8 @@ shrot0:
 			// 16-bit stack seg w/underflow (RM)
 			// andl StackMask(%%ebx),%%ecx
 			0x23,0x4b,Ofs_STACKM,
-			// movw %%ax,(%%esi,%%ecx,1)
-			0x66,0x89,0x04,0x0e,
+			// call stub_stk_16(%%ebx)
+			0xff,0x53,Ofs_stub_stk_16,
 			// do 16-bit PM apps exist which use a 32-bit stack seg?
 			// movl %%ecx,Ofs_ESP(%%ebx)
 			0x89,0x4b,Ofs_ESP
@@ -1150,8 +1150,8 @@ shrot0:
 			0x8d,0x49,0xfc,
 			// andl StackMask(%%ebx),%%ecx
 			0x23,0x4b,Ofs_STACKM,
-			// movl %%eax,(%%esi,%%ecx,1)
-			0x89,0x04,0x0e,
+			// call stub_stk_32(%%ebx)
+			0xff,0x53,Ofs_stub_stk_32,
 #if 0	/* keep high 16-bits of ESP in small-stack mode */
 			// movl StackMask(%%ebx),%%edx
 			0x8b,0x53,Ofs_STACKM,
@@ -1190,8 +1190,8 @@ shrot0:
 			0x8d,0x49,0xfe,
 			// andl StackMask(%%ebx),%%ecx
 			0x23,0x4b,Ofs_STACKM,
-			// movw %%ax,(%%esi,%%ecx,1)
-			0x66,0x89,0x04,0x0e,
+			// call stub_stk_16(%%ebx)
+			0xff,0x53,Ofs_stub_stk_16,
 		};
 		const unsigned char pseq32[] = {
 			// movl offs(%%ebx),%%eax
@@ -1200,8 +1200,8 @@ shrot0:
 			0x8d,0x49,0xfc,
 			// andl StackMask(%%ebx),%%ecx
 			0x23,0x4b,Ofs_STACKM,
-			// movl %%eax,(%%esi,%%ecx,1)
-			0x89,0x04,0x0e,
+			// call stub_stk_32(%%ebx)
+			0xff,0x53,Ofs_stub_stk_32,
 		};
 		const unsigned char *p;
 		unsigned char *q;
@@ -1265,11 +1265,11 @@ shrot0:
 			G4M(0x13,0xc1,0xd0,0x0a,Cp);
 //		}
 		if (mode&DATA16) {
-			// movw %%ax,(%%esi,%%ecx,1)
-			G4M(0x66,0x89,0x04,0x0e,Cp);
+			// call stub_stk_16(%%ebx)
+			G3M(0xff,0x53,Ofs_stub_stk_16,Cp);
 		} else {
-			// movl %%eax,(%%esi,%%ecx,1)
-			G3M(0x89,0x04,0x0e,Cp);
+			// call stub_stk_32(%%ebx)
+			G3M(0xff,0x53,Ofs_stub_stk_32,Cp);
 		}
 		// movl %%ecx,Ofs_ESP(%%ebx)
 		G3M(0x89,0x4b,Ofs_ESP,Cp);
@@ -1287,8 +1287,8 @@ shrot0:
 			0x8d,0x49,0xfe,
 			// andl StackMask(%%ebx),%%ecx
 			0x23,0x4b,Ofs_STACKM,
-			// movw %%ax,(%%esi,%%ecx,1)
-			0x66,0x89,0x04,0x0e,
+			// call stub_stk_16(%%ebx)
+			0xff,0x53,Ofs_stub_stk_16,
 			// movl %%ecx,Ofs_ESP(%%ebx)
 			0x89,0x4b,Ofs_ESP
 		};
@@ -1303,8 +1303,8 @@ shrot0:
 			0x8d,0x49,0xfc,
 			// andl StackMask(%%ebx),%%ecx
 			0x23,0x4b,Ofs_STACKM,
-			// movl %%eax,(%%esi,%%ecx,1)
-			0x89,0x04,0x0e,
+			// call stub_stk_32(%%ebx)
+			0xff,0x53,Ofs_stub_stk_32,
 			// movl %%ecx,Ofs_ESP(%%ebx)
 			0x89,0x4b,Ofs_ESP
 		};
@@ -1826,7 +1826,8 @@ shrot0:
 
 	case O_MOVS_MovD:
 		GetDF(Cp);
-		G3M(NOP,NOP,REP,Cp);
+		G2M(0xff,0x13,Cp); /* call (%ebx) */
+		G1(REP,Cp);
 		if (mode&MBYTE)	{ G1(MOVSb,Cp); }
 		else {
 			Gen66(mode,Cp);
@@ -1846,7 +1847,8 @@ shrot0:
 		break;
 	case O_MOVS_StoD:
 		GetDF(Cp);
-		G3M(NOP,NOP,REP,Cp);
+		G2M(0xff,0x13,Cp); /* call (%ebx) */
+		G1(REP,Cp);
 		if (mode&MBYTE)	{ G1(STOSb,Cp); }
 		else {
 			Gen66(mode,Cp);
@@ -2207,8 +2209,8 @@ shrot0:
 			0x8d,0x49,0xfe,
 			// andl StackMask(%%ebx),%%ecx
 			0x23,0x4b,Ofs_STACKM,
-			// movw %%ax,(%%esi,%%ecx,1)
-			0x66,0x89,0x04,0x0e,
+			// call stub_stk_16(%%ebx)
+			0xff,0x53,Ofs_stub_stk_16,
 			// movl %%ecx,Ofs_ESP(%%ebx)
 			0x89,0x4b,Ofs_ESP
 		};
@@ -2223,8 +2225,8 @@ shrot0:
 			0x8d,0x49,0xfc,
 			// andl StackMask(%%ebx),%%ecx
 			0x23,0x4b,Ofs_STACKM,
-			// movl %%eax,(%%esi,%%ecx,1)
-			0x89,0x04,0x0e,
+			// call stub_stk_32(%%ebx)
+			0xff,0x53,Ofs_stub_stk_32,
 			// movl %%ecx,Ofs_ESP(%%ebx)
 			0x89,0x4b,Ofs_ESP
 		};

--- a/src/base/emu-i386/simx86/codegen-x86.h
+++ b/src/base/emu-i386/simx86/codegen-x86.h
@@ -57,8 +57,8 @@ extern unsigned int Exec_x86(TNode *G, int ln);
 
 /////////////////////////////////////////////////////////////////////////////
 
-#define STD_WRITE_B	G3M(0x88,0x07,0x90,Cp);
-#define STD_WRITE_WL(m)	G3((m)&DATA16?0x078966:0x900789,Cp)
+#define STD_WRITE_B	G3M(0xff,0x53,Ofs_stub_wri_8,Cp);
+#define STD_WRITE_WL(m)	G3((((m)&DATA16?Ofs_stub_wri_16:Ofs_stub_wri_32)<<16)|0x53ff,Cp);
 
 #define GenAddECX(o)	if (((o) > -128) && ((o) < 128)) {\
 			G2(0xc183,Cp); G1((o),Cp); } else {\

--- a/src/base/emu-i386/simx86/cpatch.c
+++ b/src/base/emu-i386/simx86/cpatch.c
@@ -47,8 +47,8 @@ static int in_cpatch;
 void m_munprotect(unsigned int addr, unsigned int len, unsigned char *eip)
 {
 	if (debug_level('e')>3) e_printf("\tM_MUNPROT %08x:%p\n", addr,eip);
-	/* if only data in aliased low memory is hit, nothing to do */
-	if (LINEAR2UNIX(addr) != MEM_BASE32(addr) && !e_querymark(addr, len))
+	/* if only data is hit, nothing to do */
+	if (!e_querymark(addr, len))
 		return;
 	/* Always unprotect and clear all code in the pages
 	 * for either DPMI data or code.

--- a/src/base/emu-i386/simx86/memory.c
+++ b/src/base/emu-i386/simx86/memory.c
@@ -246,7 +246,9 @@ int e_mprotect(unsigned int addr, size_t len)
 		aend1 = a;
 	    }
 	    if ((a == aend || qp) && abeg1 != (unsigned)-1) {
-		e = mprotect(MEM_BASE32(abeg1), aend1-abeg1+PAGE_SIZE,
+		e = 0;
+	        if (abeg1 < LOWMEM_SIZE + HMASIZE)
+		    e = mprotect(MEM_BASE32(abeg1), aend1-abeg1+PAGE_SIZE,
 			    PROT_READ|PROT_EXEC);
 		if (e<0) {
 		    e_printf("MPMAP: %s\n",strerror(errno));
@@ -283,7 +285,9 @@ int e_munprotect(unsigned int addr, size_t len)
 		aend1 = a;
 	    }
 	    if ((a == aend || !qp) && abeg1 != (unsigned)-1) {
-		e = mprotect(MEM_BASE32(abeg1), aend1-abeg1+PAGE_SIZE,
+		e = 0;
+	        if (abeg1 < LOWMEM_SIZE + HMASIZE)
+		    e = mprotect(MEM_BASE32(abeg1), aend1-abeg1+PAGE_SIZE,
 			     PROT_READ|PROT_WRITE|PROT_EXEC);
 		if (e<0) {
 		    e_printf("MPUNMAP: %s\n",strerror(errno));


### PR DESCRIPTION
This basically does:
* apply Cpatch unconditionally for every write
* no longer mprotect DPMI memory
* still mprotect low memory for compatibility with JIT+native, but JIT
  writes via alias to low memory
* add a counter

this is for testing only, not to be merged. It will fail the Travis tests
but only because of unhandled DPMI page faults.

In my testing it still faults on PUSHA which causes a few faults when you
running Win31.

I'm just curious how this does in your vm86jit benchmark @stsp.