### PR TITLE
simx86: use read/write functions in interp.c

### DIFF
--- a/src/base/emu-i386/simx86/host.h
+++ b/src/base/emu-i386/simx86/host.h
@@ -151,16 +151,16 @@ static __inline__ void ppc_dswap8(long addr, unsigned long long val)
 	__asm__ ("boundl %0,%1" : : "r"(p),"m"(CS_DTR) : "memory" );\
 	(f&2? *((int *)(a)):*((short *)(a))); })
 #else
-#define Fetch(a)	*((unsigned char *)MEM_BASE32(a))
-#define FetchW(a)	*((unsigned short *)MEM_BASE32((a)))
-#define FetchL(a)	*((unsigned int *)MEM_BASE32((a)))
+#define Fetch(a)	read_byte(a)
+#define FetchW(a)	read_word(a)
+#define FetchL(a)	read_dword(a)
 #define DataFetchWL_U(m,a) ((m)&DATA16? FetchW(a):FetchL(a))
 #define DataFetchWL_S(m,a) ((m)&DATA16? (short)FetchW(a):(int)FetchL(a))
 #define AddrFetchWL_U(m,a) ((m)&ADDR16? FetchW(a):FetchL(a))
 #define AddrFetchWL_S(m,a) ((m)&ADDR16? (short)FetchW(a):(int)FetchL(a))
 #endif
-#define GetDWord(a)	*((unsigned short *)MEM_BASE32((a)))
-#define GetDLong(a)	*((unsigned int *)MEM_BASE32((a)))
+#define GetDWord(a)	read_word(a)
+#define GetDLong(a)	read_dword(a)
 #define DataGetWL_U(m,a) ((m)&DATA16? GetDWord(a):GetDLong(a))
 #define DataGetWL_S(m,a) ((m)&DATA16? (short)GetDWord(a):(int)GetDLong(a))
 #endif

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -1619,7 +1619,8 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			Gen(O_LEAVE, mode); PC++;
 			break;
 /*ca*/	case RETlisp: { /* restartable */
-			unsigned long dr, sv=0;
+			unsigned long dr;
+			uint16_t sv=0;
 			CODE_FLUSH();
 			NOS_WORD(mode, &sv);
 			dr = AddrFetchWL_U(mode,PC+1);
@@ -1676,7 +1677,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 
 /*cb*/	case RETl:
 /*cf*/	case IRET: {	/* restartable */
-			long sv=0;
+			uint16_t sv=0;
 			int m = mode;
 			CODE_FLUSH();
 			NOS_WORD(m, &sv);	/* get segment */
@@ -1687,11 +1688,11 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			PC = LONG_CS + TheCPU.eip;
 			if (opc==RETl) {
 			    if (debug_level('e')>1)
-				e_printf("RET_FAR: ret=%04lx:%08x\n",sv,TheCPU.eip);
+				e_printf("RET_FAR: ret=%04x:%08x\n",sv,TheCPU.eip);
 			    break;	/* un-fall */
 			}
 			if (debug_level('e')>1) {
-				e_printf("IRET: ret=%04lx:%08x\n",sv,TheCPU.eip);
+				e_printf("IRET: ret=%04x:%08x\n",sv,TheCPU.eip);
 			}
 			temp=0; POP(m, &temp);
 			if (CONFIG_CPUSIM) RFL.valid = V_INVALID;
@@ -3042,7 +3043,7 @@ repag0:
 					goto illegal_op;
 				PC++; PC += ModRMSim(PC, mode);
 				edxeax = ((uint64_t)rEDX << 32) | rEAX;
-				m = *(uint64_t*)MEM_BASE32(TheCPU.mem_ref);
+				m = read_qword(TheCPU.mem_ref);
 				if (edxeax == m)
 				{
 					EFLAGS |= EFLAGS_ZF;
@@ -3052,7 +3053,7 @@ repag0:
 					rEDX = m >> 32;
 					rEAX = m & 0xffffffff;
 				}
-				*(uint64_t*)LINEAR2UNIX(TheCPU.mem_ref) = m;
+				write_qword(TheCPU.mem_ref, m);
 				if (CONFIG_CPUSIM) RFL.valid = V_INVALID;
 				break;
 				}


### PR DESCRIPTION
Now all memory accesses in the simulator use the read/write functions, so after this PR I can eliminate the page fault handler for the simulator.