### PR TITLE
Fix dpmi_is_valid_range

### DIFF
--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -397,14 +397,10 @@ int dpmi_is_valid_range(dosaddr_t addr, int len)
     return 0;
   if (blk->base + blk->size < addr + len)
     return 0;
-  for (i = 0; i < (PAGE_ALIGN(len) >> PAGE_SHIFT); i++) {
-    u_short attr;
-    if (!DPMI_GetPageAttributes(&DPMI_CLIENT.pm_block_root, blk->handle,
-        i << PAGE_SHIFT, &attr, 1))
+  for (i = (addr - blk->base) >> PAGE_SHIFT;
+       i < (PAGE_ALIGN(addr + len - 1) - blk->base) >> PAGE_SHIFT; i++)
+    if ((blk->attrs[i] & 7) != 1)
       return 0;
-    if ((attr & 7) != 1)
-      return 0;
-  }
   return 1;
 }
 


### PR DESCRIPTION
This fixes dpmi_is_valid_range so it can be used in a future PR to check for page faults, one bug fix and one extension to mapped (virtual) hardware RAM such as the VGAEMU LFB.