### PR TITLE
simx86: Add cache of unprotected pages for read/write functions.

### DIFF
--- a/src/base/dev/vga/vgaemu.c
+++ b/src/base/dev/vga/vgaemu.c
@@ -275,6 +275,7 @@
 #include "utilities.h"
 #include "instremu.h"
 #include "cpi.h"
+#include "cpu-emu.h"
 
 /* table with video mode definitions */
 #include "vgaemu_modelist.h"
@@ -2525,6 +2526,7 @@ int vgaemu_map_bank()
 #endif
 
   i = vga_emu_map(VGAEMU_MAP_BANK_MODE, first);
+  e_invalidate_full(0xa0000, 0x20000);
 
   if(i) {
     vga_msg(

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -1306,6 +1306,7 @@ void e_invalidate_full(unsigned data, int cnt)
         	InvalidateNodePage(data, cnt, 0, NULL);
 #endif
 	e_resetpagemarks(data, cnt);
+	invalidate_unprotected_page_cache(data, cnt);
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/include/dos2linux.h
+++ b/src/include/dos2linux.h
@@ -315,6 +315,7 @@ extern int change_config(unsigned item, void *buf, int grab_active, int kbd_grab
 
 void show_welcome_screen(void);
 
+void invalidate_unprotected_page_cache(dosaddr_t addr, int len);
 uint8_t read_byte(dosaddr_t addr);
 uint16_t read_word(dosaddr_t addr);
 uint32_t read_dword(dosaddr_t addr);


### PR DESCRIPTION
This adds a cache with 4096 rounded down unprotected page addresses, indexed
by bits 12..23 of the address, see http://www.emulators.com/docs/nx08_stlb.htm
for how this works.

This speeds up the checks for unprotected pages, otherwise the faultless sim
will be too slow.