### PR TITLE
simx86: simulate page faults in DPMI.

### DIFF
--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -399,15 +399,15 @@ unsigned int Interp86(unsigned int PC, int mod0)
 
 static unsigned int _Interp86(unsigned int PC, int basemode)
 {
-	volatile unsigned int P0 = PC; /* volatile because of sigsetjmp */
+	volatile unsigned int P0 = PC; /* volatile because of setjmp */
 	unsigned char opc;
 	unsigned short ocs = TheCPU.cs;
 	unsigned int temp;
 	register int mode;
 	int NewNode;
 
-	if (CONFIG_CPUSIM && PROTMODE() && sigsetjmp(jmp_env, 1)) {
-		/* long jump to here from page fault */
+	if (CONFIG_CPUSIM && PROTMODE() && setjmp(jmp_env)) {
+		/* long jump to here from simulated page fault */
 		return P0;
 	}
 

--- a/src/base/emu-i386/simx86/protmode.c
+++ b/src/base/emu-i386/simx86/protmode.c
@@ -390,3 +390,29 @@ int emu_ldt_write(unsigned char *paddr, uint32_t op, int len)
 	return 1;
 }
 
+void emu_check_read_pagefault(dosaddr_t addr)
+{
+	if (addr >= LOWMEM_SIZE + HMASIZE && !dpmi_read_access(addr)) {
+		/* trigger an exception in DPMI */
+		TheCPU.err = EXCP0E_PAGE;
+		/* uncommitted page is never "present" */
+		TheCPU.scp_err = 4;
+		TheCPU.cr2 = addr;
+		longjmp(jmp_env, 0);
+	}
+}
+
+/* callers must make sure that addr and addr+len-1 are on the same page */
+int emu_check_write_pagefault(dosaddr_t addr, uint32_t op, int len)
+{
+	if (addr >= LOWMEM_SIZE + HMASIZE && !dpmi_write_access(addr)) {
+		if (emu_ldt_write(MEM_BASE32(addr), op, len))
+			return 1;
+		/* trigger an exception in DPMI */
+		TheCPU.err = EXCP0E_PAGE;
+		TheCPU.scp_err = 6 + dpmi_read_access(addr);
+		TheCPU.cr2 = addr;
+		longjmp(jmp_env, 0);
+	}
+	return 0;
+}

--- a/src/base/emu-i386/simx86/protmode.h
+++ b/src/base/emu-i386/simx86/protmode.h
@@ -231,6 +231,7 @@ int SetSegReal(unsigned short sel, int ofs);
 int e_larlsl(int mode, unsigned short sel);
 int hsw_verr(unsigned short sel);
 int hsw_verw(unsigned short sel);
+int emu_ldt_write(unsigned char *paddr, uint32_t op, int len);
 //
 
 #endif

--- a/src/base/emu-i386/simx86/sigsegv.c
+++ b/src/base/emu-i386/simx86/sigsegv.c
@@ -239,20 +239,7 @@ int e_vgaemu_fault(sigcontext_t *scp, unsigned page_fault)
 /* this function is called from dosemu_fault */
 int e_emu_pagefault(sigcontext_t *scp, int pmode)
 {
-    if (CONFIG_CPUSIM) {
-	/* in cpusim mode we do not fault for vgaemu */
-	if (in_dpmi_emu) {
-	    /* reflect DPMI page fault back to a DOSEMU crash or
-	       DPMI exception;
-	       vm86 faults cannot happen in sim mode so then we die.
-	     */
-	    TheCPU.err = EXCP0E_PAGE;
-	    TheCPU.scp_err = _err;
-	    TheCPU.cr2 = _cr2;
-	    fault_cnt--;
-	    siglongjmp(jmp_env, 0);
-	}
-    } else if (InCompiledCode) {
+    if (InCompiledCode) {
 	/* in vga.inst_emu mode, vga_emu_fault() can handle
 	 * only faults from DOS code, and here we are with
 	 * the fault from jit-compiled code. But in !inst_emu

--- a/src/dosext/dpmi/dpmi.h
+++ b/src/dosext/dpmi/dpmi.h
@@ -210,6 +210,8 @@ unsigned int GetSegmentLimit(unsigned short sel);
 int CheckSelectors(sigcontext_t *scp, int in_dosemu);
 int ValidAndUsedSelector(unsigned short selector);
 int dpmi_is_valid_range(dosaddr_t addr, int len);
+int dpmi_read_access(dosaddr_t addr);
+int dpmi_write_access(dosaddr_t addr);
 
 extern char *DPMI_show_state(sigcontext_t *scp);
 extern void dpmi_sigio(sigcontext_t *scp);
@@ -268,6 +270,16 @@ static inline void dpmi_realmode_hlt(unsigned int lina)
 }
 
 static inline int dpmi_is_valid_range(dosaddr_t addr, int len)
+{
+    return 0;
+}
+
+static inline int dpmi_read_access(dosaddr_t addr)
+{
+    return 0;
+}
+
+static inline int dpmi_write_access(dosaddr_t addr)
 {
     return 0;
 }

--- a/src/include/cpu-emu.h
+++ b/src/include/cpu-emu.h
@@ -87,7 +87,8 @@ void e_invalidate_full(unsigned data, int cnt);
 #endif
 
 /* called from dos2linux.c */
-int emu_ldt_write(unsigned char *paddr, uint32_t op, int len);
+void emu_check_read_pagefault(dosaddr_t addr);
+int emu_check_write_pagefault(dosaddr_t addr, uint32_t op, int len);
 
 /* called from cpu.c */
 void init_emu_cpu (void);


### PR DESCRIPTION
Instead of using the host MMU, check memory accesses for valid memory, and
simulate a page fault when necessary.

Without optimizations this slows the simulator down, by a factor 2.5 or so
for test-i386.exe.