### PR TITLE
mfs: Change temporary share error as Clipper expects

### DIFF
--- a/src/dosext/mfs/mfs.c
+++ b/src/dosext/mfs/mfs.c
@@ -3949,7 +3949,7 @@ do_open_existing:
         }
         if (!share(fd, unix_mode & O_ACCMODE, drive, sft)) {
           close(fd);
-          SETWORD(&(state->eax), FILE_LOCK_VIOLATION);
+          SETWORD(&(state->eax), SHARING_VIOLATION);
           return FALSE;
         }
         ftype = TYPE_DISK;


### PR DESCRIPTION
Clipper expects the DOS error to be SHARING_VIOLATION not
FILE_LOCK_VIOLATION as per the following code snippet.

```
// for network open error, set NETERR() and subsystem default
if ( e:genCode == EG_OPEN
    .and. (e:osCode == 32 .or. e:osCode == 5)
    .and. e:canDefault )
  NetErr(.t.)
  return (.f.)
end
```

Tested with TESTLOCK.ZIP and test #3 still passes.
~~~
Test #3:
Open of "d:\TESTLOCK.TMP" for REPLACE was successful, handle=5
Wrote 128 bytes at offset 0 to handle 5.
File length is now 128
Open of "d:\TESTLOCK.TMP" for REPLACE failed, _doserrno=32=SHARING_VIOLATION
This is a retriable/sharing error, which is normal here (but TLIB wouldn't
retry it)
Open of "d:\TESTLOCK.TMP" for APPEND failed, _doserrno=32=SHARING_VIOLATION
This is a retriable/sharing error, which is normal here (TLIB would display
"awaiting access...")
Open of "d:\TESTLOCK.TMP" for MODIFY failed, _doserrno=32=SHARING_VIOLATION
This is a retriable/sharing error, which is normal here (TLIB would display
"awaiting access...")
Open of "d:\TESTLOCK.TMP" for READ failed, _doserrno=32=SHARING_VIOLATION
This is a retriable/sharing error, which is normal here (TLIB would display
"awaiting access...")
Closed d:\TESTLOCK.TMP
Open of "d:\TESTLOCK.TMP" for READ was successful, handle=5
Closed d:\TESTLOCK.TMP
Test #3: Passed.
-----------------------------
~~~