### PR TITLE
simx86: allow longjmp in JIT mode

### DIFF
--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -437,7 +437,7 @@ static unsigned int _Interp86(unsigned int PC, int basemode)
 			}
 		}
 		P0 = PC;	// P0 changes on instruction boundaries
-		if (PC==0 || FetchL(PC)==0 || debug_level('e')) {
+		if (PC==0 || debug_level('e')>1) {
 			e_printf("\n%s\nFetch %08x at %08x mode %x\n",
 				e_print_regs(),FetchL(PC),PC,mode);
 		}

--- a/src/base/emu-i386/simx86/protmode.c
+++ b/src/base/emu-i386/simx86/protmode.c
@@ -390,6 +390,10 @@ int emu_ldt_write(unsigned char *paddr, uint32_t op, int len)
 	return 1;
 }
 
+#undef min
+#undef max
+#include "utilities.h"
+
 void emu_check_read_pagefault(dosaddr_t addr)
 {
 	if (addr >= LOWMEM_SIZE + HMASIZE && !dpmi_read_access(addr)) {
@@ -398,6 +402,7 @@ void emu_check_read_pagefault(dosaddr_t addr)
 		/* uncommitted page is never "present" */
 		TheCPU.scp_err = 4;
 		TheCPU.cr2 = addr;
+		dosemu_error("Simulated DPMI read page fault, addr=%x\n", addr);
 		longjmp(jmp_env, 0);
 	}
 }
@@ -412,6 +417,7 @@ int emu_check_write_pagefault(dosaddr_t addr, uint32_t op, int len)
 		TheCPU.err = EXCP0E_PAGE;
 		TheCPU.scp_err = 6 + dpmi_read_access(addr);
 		TheCPU.cr2 = addr;
+		dosemu_error("Simulated DPMI write page fault, addr=%x\n", addr);
 		longjmp(jmp_env, 0);
 	}
 	return 0;


### PR DESCRIPTION
Since the read_* and write_* functions are also called in JIT mode the setjmp
needs to be set there too.

Please don't merge yet!
This is for @jschwartzenberg to test as I added a `dosemu_error` call which should produce a backtrace before calling `longjmp()`, as I'd like to know what triggered it.