### PR TITLE
dpmi: check all clients' memory, not just current's

### DIFF
--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -382,10 +382,16 @@ static void dpmi_set_pm(int pm)
 
 static dpmi_pm_block *lookup_pm_blocks_by_addr(dosaddr_t addr)
 {
+  int i;
   dpmi_pm_block *blk = lookup_pm_block_by_addr(&host_pm_block_root, addr);
   if (blk)
     return blk;
-  return lookup_pm_block_by_addr(&DPMI_CLIENT.pm_block_root, addr);
+  for (i = 0; i < in_dpmi; i++) {
+    blk = lookup_pm_block_by_addr(&DPMIclient[i].pm_block_root, addr);
+    if (blk)
+      return blk;
+  }
+  return NULL;
 }
 
 int dpmi_is_valid_range(dosaddr_t addr, int len)


### PR DESCRIPTION
This fixes a simulated page fault when running Win31 on top of
comcom32.exe, so there are at least 2 DPMI clients active.
Fixes #1100.