### PR TITLE
simx86: only longjmp for invalid access if Interp86 is active.

### DIFF
--- a/src/base/emu-i386/simx86/emu86.h
+++ b/src/base/emu-i386/simx86/emu86.h
@@ -642,7 +642,7 @@ extern int eTimeCorrect;
 //
 extern unsigned int return_addr;
 extern jmp_buf jmp_env;
-extern int in_dpmi_emu;
+extern int in_vm86_emu, in_dpmi_emu;
 extern unsigned long eTSSMASK;
 extern int Running;		/* into interpreter loop */
 extern unsigned int mMaxMem;

--- a/src/base/emu-i386/simx86/host.h
+++ b/src/base/emu-i386/simx86/host.h
@@ -35,6 +35,16 @@
 #ifndef _EMU86_HOST_H
 #define _EMU86_HOST_H
 
+#include "dos2linux.h"
+#define read_byte(x) do_read_byte((x), emu_pagefault_handler)
+#define read_word(x) do_read_word((x), emu_pagefault_handler)
+#define read_dword(x) do_read_dword((x), emu_pagefault_handler)
+#define read_qword(x) do_read_qword((x), emu_pagefault_handler)
+#define write_byte(x,y) do_write_byte((x), (y), emu_pagefault_handler)
+#define write_word(x,y) do_write_word((x), (y), emu_pagefault_handler)
+#define write_dword(x,y) do_write_dword((x), (y), emu_pagefault_handler)
+#define write_qword(x,y) do_write_qword((x), (y), emu_pagefault_handler)
+
 #if defined(ppc)||defined(__ppc)||defined(__ppc__)
 /* NO PAGING! */
 /*

--- a/src/base/emu-i386/simx86/protmode.h
+++ b/src/base/emu-i386/simx86/protmode.h
@@ -232,6 +232,7 @@ int e_larlsl(int mode, unsigned short sel);
 int hsw_verr(unsigned short sel);
 int hsw_verw(unsigned short sel);
 int emu_ldt_write(unsigned char *paddr, uint32_t op, int len);
+void emu_pagefault_handler(dosaddr_t addr, int err, uint32_t op, int len);
 //
 
 #endif

--- a/src/include/cpu-emu.h
+++ b/src/include/cpu-emu.h
@@ -83,10 +83,6 @@ void e_invalidate_full(unsigned data, int cnt);
 #define e_invalidate_full(x,y)
 #endif
 
-/* called from dos2linux.c */
-void emu_check_read_pagefault(dosaddr_t addr);
-int emu_check_write_pagefault(dosaddr_t addr, uint32_t op, int len);
-
 /* called from cpu.c */
 void init_emu_cpu (void);
 void reset_emu_cpu (void);

--- a/src/include/dos2linux.h
+++ b/src/include/dos2linux.h
@@ -315,6 +315,8 @@ extern int change_config(unsigned item, void *buf, int grab_active, int kbd_grab
 
 void show_welcome_screen(void);
 
+typedef void (*sim_pagefault_handler_t)(dosaddr_t, int, uint32_t op, int);
+void default_sim_pagefault_handler(dosaddr_t addr, int err, uint32_t op, int len);
 void invalidate_unprotected_page_cache(dosaddr_t addr, int len);
 uint8_t read_byte(dosaddr_t addr);
 uint16_t read_word(dosaddr_t addr);
@@ -324,6 +326,16 @@ void write_byte(dosaddr_t addr, uint8_t byte);
 void write_word(dosaddr_t addr, uint16_t word);
 void write_dword(dosaddr_t addr, uint32_t dword);
 void write_qword(dosaddr_t addr, uint64_t qword);
+
+uint8_t do_read_byte(dosaddr_t addr, sim_pagefault_handler_t handler);
+uint16_t do_read_word(dosaddr_t addr, sim_pagefault_handler_t handler);
+uint32_t do_read_dword(dosaddr_t addr, sim_pagefault_handler_t handler);
+uint64_t do_read_qword(dosaddr_t addr, sim_pagefault_handler_t handler);
+void do_write_byte(dosaddr_t addr, uint8_t byte, sim_pagefault_handler_t handler);
+void do_write_word(dosaddr_t addr, uint16_t word, sim_pagefault_handler_t handler);
+void do_write_dword(dosaddr_t addr, uint32_t dword, sim_pagefault_handler_t handler);
+void do_write_qword(dosaddr_t addr, uint64_t qword, sim_pagefault_handler_t handler);
+
 void memcpy_2unix(void *dest, unsigned src, size_t n);
 void memcpy_2dos(unsigned dest, const void *src, size_t n);
 void memmove_dos2dos(unsigned dest, unsigned src, size_t n);


### PR DESCRIPTION
Otherwise call dosemu_error and terminate.
This also moves some simx86-independent checks to dos2linux.c.