### PR TITLE
simx86: fix SIM regression from 507e05f in e.g. Windows

### DIFF
--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -253,6 +253,7 @@ static unsigned int _JumpGen(unsigned int P2, int mode, int cond,
 		}
 #if !defined(SINGLESTEP)
 		if (CONFIG_CPUSIM && !(EFLAGS & TF) &&
+		    pskip != 3 + BT24(BitDATA16,mode) && // not far jmp
 		    ((P2 ^ j_t) & PAGE_MASK)==0) {	// same page
 		    if (debug_level('e')>1) dbug_printf("** JMP: ignored\n");
 		    TheCPU.mode |= SKIPOP;


### PR DESCRIPTION
The skip jmp optimization is not valid for far jumps, so just skip it for
those. See also #1128.