### PR TITLE
simx86: eliminate TheCPU.veflags for vm86

### DIFF
--- a/src/base/emu-i386/simx86/emu86.h
+++ b/src/base/emu-i386/simx86/emu86.h
@@ -538,6 +538,16 @@ extern hitimer_t GenTime, LinkTime;
 #define IS_OF_SET		((EFLAGS & EFLAGS_OF)!=0)
 #define IS_PF_SET		((EFLAGS & EFLAGS_PF)!=0)
 
+/*
+ *  ID VIP VIF AC VM RF 0 NT IOPL OF DF IF TF SF ZF 0 AF 0 PF 1 CF
+ *                                 1  1  0  1  1  1 0  1 0  1 0  1
+ */
+#define SAFE_MASK	(EFLAGS_OF|EFLAGS_DF|EFLAGS_TF|EFLAGS_SF| \
+			 EFLAGS_ZF|EFLAGS_AF|EFLAGS_PF|EFLAGS_CF| /* 0xDD5 */ \
+			 (eTSSMASK & ~IOPL_MASK))
+#define notSAFE_MASK	(~SAFE_MASK&0x3fffff)
+#define RETURN_MASK	((0xFFF&~EFLAGS_IF) | eTSSMASK)
+
 #define REALMODE()		((TheCPU.cr[0] & CR0_PE)==0)
 #define V86MODE()		((TheCPU.eflags&EFLAGS_VM)!=0)
 #define PROTMODE()		(!REALMODE() && !V86MODE())

--- a/src/base/emu-i386/simx86/syncpu.h
+++ b/src/base/emu-i386/simx86/syncpu.h
@@ -115,7 +115,6 @@ typedef struct {
 	unsigned int sreg1;
 	unsigned int dreg1;
 	unsigned int xreg1;
-	unsigned int veflags;
 
 /*
  * DR0-3 = linear address of breakpoint 0-3
@@ -280,7 +279,6 @@ extern union _SynCPU TheCPU_union;
 #define MEMREF		TheCPU.mem_ref
 #define EFLAGS		TheCPU.eflags
 #define FLAGS		CPUWORD(Ofs_EFLAGS)
-#define eVEFLAGS	TheCPU.veflags
 #define FPX		TheCPU.fpstt
 
 #define CS_DTR		TheCPU.cs_cache


### PR DESCRIPTION
Just keep those flags (ID,AC,NT, which in v86 mode just serve CPU detection
algorithms) in TheCPU.eflags, as there is no danger having them
there unlike in real flags. IOPL is a bit special but pushf will need to
set that to 3 on the stack image anyway so a program can't flip it visibly.

This makes pushf, popf, int and iret a little simpler so easier to compile.