### PR TITLE
simx86: fix INT xx (performance regression from a7e3612d4)

### DIFF
--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -723,6 +723,7 @@ erseg:
 void reset_emu_cpu(void)
 {
   TheCPU.cr[0] = 0x13;	/* valid bits: 0xe005003f */
+  TheCPU.cr[4] = CR4_VME;
   TheCPU.dr[4] = 0xffff1ff0;
   TheCPU.dr[5] = 0x400;
   TheCPU.dr[6] = 0xffff1ff0;


### PR DESCRIPTION
Changing IOPL to 3 the INT instruction was now always trapped into a GPF instead
of quickly going back into the emulator when possible.

I've now fixed this and made the logic more like the Intel docs, in that
it uses the bitmap only for CR4.VME, and so I set TheCPU.cr[4]=CR4_VME at
init time, and it handles IF and VIF correctly depending on IOPL.