### PR TITLE
Correct name for PDF printer

### DIFF
--- a/etc/dosemu.conf
+++ b/etc/dosemu.conf
@@ -90,7 +90,7 @@
 #   Group 0: user's main drives. This group consists of just one path that
 #     should normally be mapped to drive C. You can omit that group if you
 #     want to map your own directory to drive C.
-#   Group 1: boot & utility drives. This group includes multiple pathes
+#   Group 1: boot & utility drives. This group includes multiple paths
 #     that you can map to any drive letters. This group provides the boot
 #     files, dosemu-specific drivers and utilities, and the shell.
 # Warning: You need to map group 1 or the boot may fail.
@@ -107,7 +107,7 @@
 # letters (D, E), then map group 1.
 # Note that letter skipping only works correctly with fdpp.
 #
-# Default: "+0 +1" (map both groups of pathes to the consecutive drives)
+# Default: "+0 +1" (map both groups of paths to the consecutive drives)
 
 # $_hdimage = "+0 +1"
 
@@ -489,9 +489,10 @@
 # "-l" means raw printing mode (no preprocessing).
 # Use "direct /dev/lpX" to print directly to /dev/lpX.
 # Accessing /dev/lpX may also be tried with an LPT dongle.
+# "lpr -P PDF" requires installation of cups-pdf.   
 
 # $_lpt1 = "lpr -l"
-# $_lpt2 = "lpr -P cups-pdf"
+# $_lpt2 = "lpr -P PDF"
 # $_lpt3 = ""
 # $_lpt4 = ""
 # $_lpt5 = ""


### PR DESCRIPTION
Corrected name of PDF printer; brief explanation; two spellings corrected.