### PR TITLE
memory mapped i/o traceing

### DIFF
--- a/etc/dosemu.conf
+++ b/etc/dosemu.conf
@@ -293,6 +293,12 @@
 
 # $_trace_ports = ""
 
+# which memory mapped i/o addresses to trace (only displayed if you also use -D+F)
+# list of addresses such as "0xA0000 0xB0000 0xFFFFF" or
+# "0xA0000 range 0xB0000 0xB0FFF"
+
+# $_trace_mmio = ""
+
 ##############################################################################
 ## Dosemu-specific hacks
 

--- a/etc/global.conf
+++ b/etc/global.conf
@@ -142,7 +142,7 @@ else
     ## now we take over the allowed variables, only those which exist
     ## with 'dosemu_' prefixed will overwrite those without the prefix.
 
-    checkuservar $_debug, $_trace_ports,
+    checkuservar $_debug, $_trace_ports, $_trace_mmio,
       $_features, $_mapping, $_hogthreshold, $_cli_timeout,
       $_timemode,
       $_mathco, $_cpu, $_cpu_vm, $_cpu_vm_dpmi, $_cpu_emu, $_rdtsc, $_cpuspeed,
@@ -202,6 +202,7 @@ else
     debug { off }
   endif
   if (strlen($_trace_ports)) trace ports { $$_trace_ports } endif
+  if (strlen($_trace_mmio)) trace_mmio { $$_trace_mmio } endif
 
   cpuspeed $_cpuspeed
   rdtsc $_rdtsc

--- a/man/dosemu.bin.1.in
+++ b/man/dosemu.bin.1.in
@@ -456,7 +456,7 @@ parses this string from left to right.
  E  EMS			x  XMS			M  DPMI
  n  IPX network	P  Pkt-driver		S  SOUND
  r  PIC			T  IO-tracing		Z  PCI-BIOS
- A  ASPI driver	Q  mapping driver
+ A  ASPI driver	Q  mapping driver	F  MMIO
 
 Any debugging classes following a 
 .I \+ 

--- a/src/base/core/dyndeb.c
+++ b/src/base/core/dyndeb.c
@@ -259,6 +259,7 @@ CONSTRUCTOR(static void init(void))
   register_debug_class('C', 0, "CDROM");
   register_debug_class('D', int21_change_level, "dos int 21h");
   register_debug_class('E', 0, "EMS");
+  register_debug_class('F', 0, "MMIO trace");
   register_debug_class('I', 0, "IPC");
   register_debug_class('N', 0, "NE2000 emulation");
   register_debug_class('P', 0, "Packet driver");

--- a/src/base/core/ports.c
+++ b/src/base/core/ports.c
@@ -122,7 +122,7 @@ void init_port_traceing(void)
 }
 
 #define TT_printf(p,f,v,m) ({ \
-  if (debug_level('T')) { \
+  if (debug_level('T') && (test_bit(p, portlog_map) || debug_level('T') >= 5)) { \
     log_printf(1, "%hx %c %x\n", (unsigned short)p, f, v & m); \
   } \
 })

--- a/src/base/init/config.c
+++ b/src/base/init/config.c
@@ -312,6 +312,8 @@ void dump_config_status(void (*printfunc)(const char *, ...))
     (*print)("\nFS:\nset_int_hooks %i\nforce_int_revect %i\nforce_fs_redirect %i\n\n",
         config.int_hooks, config.force_revect, config.force_redir);
 
+    (*print)("\nMMIO:\nmmio_tracing %i\n\n", config.mmio_tracing);
+
     if (!printfunc) {
       (*print)("\n--------------end of runtime configuration dump -------------\n");
       (*print)(  "-------------------------------------------------------------\n\n");

--- a/src/base/init/lexer.l
+++ b/src/base/init/lexer.l
@@ -380,6 +380,7 @@ ext_mem			RETURN(EXT_MEM);
 ports			RETURN(PORTS);
 trace			RETURN(TRACE);
 clear			RETURN(CLEAR);
+trace_mmio		RETURN(TRACE_MMIO);
 sillyint		RETURN(SILLYINT);
 irqpassing		RETURN(SILLYINT);
 hardware_ram		RETURN(HARDWARE_RAM);

--- a/src/base/misc/Makefile
+++ b/src/base/misc/Makefile
@@ -2,7 +2,7 @@
 top_builddir=../../..
 include $(top_builddir)/Makefile.conf
 
-CFILES = hma.c ioctl.c disks.c utilities.c dos2linux.c fatfs.c
+CFILES = hma.c ioctl.c disks.c utilities.c dos2linux.c fatfs.c mmio_tracing.c
 
 include $(REALTOPDIR)/src/Makefile.common
 

--- a/src/base/misc/mmio_tracing.c
+++ b/src/base/misc/mmio_tracing.c
@@ -1,0 +1,125 @@
+#include "mmio_tracing.h"
+
+struct mmio_address_range {
+  dosaddr_t start, stop;
+};
+
+struct mmio_tracing_config {
+  struct mmio_address_range address_ranges[MMIO_TRACING_MAX_REGIONS];
+  unsigned valid_ranges;
+  dosaddr_t min_addr, max_addr;
+};
+
+static struct mmio_tracing_config mmio_tracing_config;
+
+
+static void mmio_tracing_scrub(void)
+{
+  if ((config.cpuemu != 4) ||
+      (config.cpu_vm != 2) || (config.cpu_vm_dpmi != 2))
+    error("MMIO: tracing is only only working for fully simulated cpu. "
+          "Config must be set to '$_cpu_vm=\"emulated\"', '$_cpu_vm_dpmi=\"emulated\"' and '$_cpu_emu=\"fullsim\"'\n");
+}
+
+void register_mmio_tracing(dosaddr_t startaddr, dosaddr_t stopaddr)
+{
+  if (stopaddr < startaddr) {
+    error("MMIO: address order wrong.");
+    return;
+  }
+
+  if (mmio_tracing_config.valid_ranges < MMIO_TRACING_MAX_REGIONS - 1) {
+    if (mmio_tracing_config.valid_ranges == 0) {
+      mmio_tracing_config.min_addr = startaddr;
+      mmio_tracing_config.max_addr = stopaddr;
+      register_config_scrub(mmio_tracing_scrub);
+    } else {
+      if (startaddr < mmio_tracing_config.min_addr)
+        mmio_tracing_config.min_addr = startaddr;
+      if (stopaddr > mmio_tracing_config.max_addr)
+        mmio_tracing_config.max_addr = stopaddr;
+    }
+    mmio_tracing_config.address_ranges[mmio_tracing_config.valid_ranges].
+        start = startaddr;
+    mmio_tracing_config.address_ranges[mmio_tracing_config.valid_ranges].
+        stop = stopaddr;
+    mmio_tracing_config.valid_ranges++;
+  } else
+    error
+        ("MMIO: Too many address regions to trace. Increase MMIO_TRACING_MAX_REGIONS to allow some more...");
+}
+
+bool mmio_check(dosaddr_t addr)
+{
+  /* to not slow down too much for any other memory access (not in tracing region,
+     MMIO is usually in some distance to RAM) */
+  if ((addr >= mmio_tracing_config.min_addr)
+      && (addr <= mmio_tracing_config.max_addr)) {
+    for (unsigned k = 0; k < mmio_tracing_config.valid_ranges; k++) {
+      if ((addr >= mmio_tracing_config.address_ranges[k].start) &&
+          (addr <= mmio_tracing_config.address_ranges[k].stop))
+        return true;
+    }
+  }
+  return false;
+}
+
+uint8_t mmio_trace_byte(dosaddr_t addr, uint8_t value, uint8_t type)
+{
+  switch (type) {
+    case MMIO_READ:
+      F_printf("MMIO: Reading byte at %X: %02X\n", addr, value);
+      break;
+    case MMIO_WRITE:
+      F_printf("MMIO: Writing byte at %X: %02X\n", addr, value);
+      break;
+    default:
+      F_printf("MMIO: Failed. Wrong arguments.");
+  }
+  return value;
+}
+
+uint16_t mmio_trace_word(dosaddr_t addr, uint16_t value, uint8_t type)
+{
+  switch (type) {
+    case MMIO_READ:
+      F_printf("MMIO: Reading word at %X: %04X\n", addr, value);
+      break;
+    case MMIO_WRITE:
+      F_printf("MMIO: Writing word at %X: %04X\n", addr, value);
+      break;
+    default:
+      F_printf("MMIO: Failed. Wrong arguments.");
+  }
+  return value;
+}
+
+uint32_t mmio_trace_dword(dosaddr_t addr, uint32_t value, uint8_t type)
+{
+  switch (type) {
+    case MMIO_READ:
+      F_printf("MMIO: Reading dword at %X: %08X\n", addr, value);
+      break;
+    case MMIO_WRITE:
+      F_printf("MMIO: Writing dword at %X: %08X\n", addr, value);
+      break;
+    default:
+      F_printf("MMIO: Failed. Wrong arguments.");
+  }
+  return value;
+}
+
+uint64_t mmio_trace_qword(dosaddr_t addr, uint64_t value, uint8_t type)
+{
+  switch (type) {
+    case MMIO_READ:
+      F_printf("MMIO: Reading qword at %X: %016lX\n", addr, value);
+      break;
+    case MMIO_WRITE:
+      F_printf("MMIO: Writing qword at %X: %016lX\n", addr, value);
+      break;
+    default:
+      F_printf("MMIO: Failed. Wrong arguments.");
+  }
+  return value;
+}

--- a/src/include/dosemu_debug.h
+++ b/src/include/dosemu_debug.h
@@ -35,8 +35,8 @@
  * Here is an overview of which flags are used and which not, please keep
  * this comment in sync with the reality:
  *
- *   used: aA  cCdDeE  g h iIj k   mMn   pP QrRsStTu v wW X   Z#
- *   free:   bB      fF G H   J KlL   NoO  q        U V  x yYz
+ *   used: aA  cCdDeE Fg h iIj k   mMn   pP QrRsStTu v wW X   Z#
+ *   free:   bB      f  G H   J KlL   NoO  q        U V  x yYz
  */
 
 #define DEBUG_CLASSES 128

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -334,6 +334,8 @@ typedef struct config_info {
        int joy_granularity;	/* the higher, the less sensitive - for wobbly joysticks */
        int joy_latency;		/* delay between nonblocking linux joystick reads */
 
+       int mmio_tracing;
+
        int cli_timeout;		/* cli timeout hack */
 
         char *dos_cmd;

--- a/src/include/mmio_tracing.h
+++ b/src/include/mmio_tracing.h
@@ -1,0 +1,24 @@
+#ifndef MMIO_TRACING_H
+#define MMIO_TRACING_H
+
+#include <stdbool.h>
+#include "emu.h"
+#include "dosemu_debug.h"
+
+#define MMIO_TRACING_MAX_REGIONS 16
+#define MMIO_READ 0x01
+#define MMIO_WRITE 0x02
+
+extern void register_mmio_tracing(dosaddr_t startaddr,
+                                  dosaddr_t stopaddr);
+extern bool mmio_check(dosaddr_t addr);
+extern uint8_t mmio_trace_byte(dosaddr_t addr, uint8_t value,
+                               uint8_t type);
+extern uint16_t mmio_trace_word(dosaddr_t addr, uint16_t value,
+                                uint8_t type);
+extern uint32_t mmio_trace_dword(dosaddr_t addr, uint32_t value,
+                                 uint8_t type);
+extern uint64_t mmio_trace_qword(dosaddr_t addr, uint64_t value,
+                                 uint8_t type);
+
+#endif                          /* MMIO_TRACING_H */


### PR DESCRIPTION
This PR is basically an implementation of the feature request #1161.

It adds the option to set `$_trace_mmio` in the configuration file. With enabled debug printing (`-D+F`), memory mapped i/o transactions are logged. It is only working for an fully emulated CPU (set by `$_cpu_vm="emulated"`, `$_cpu_vm_dpmi="emulated"` and `$_cpu_emu="fullsim"`).