### PR TITLE
simx86: add cache for FindTree

### DIFF
--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -1153,7 +1153,6 @@ int e_vm86(void)
     fesetenv(&dosemu_fenv);
   }
 
-  LastXNode = NULL;
   if (debug_level('e')>1)
     e_printf("EMU86: retval=%s\n", retdescs[retval&7]);
 
@@ -1254,7 +1253,6 @@ int e_dpmi(sigcontext_t *scp)
   while (retval == DPMI_RET_CLIENT);
   /* ------ OUTER LOOP -- exit to user level ---------------------- */
 
-  LastXNode = NULL;
   if (debug_level('e')) {
     dbug_printf("DPM86: retval=%#x\n", retval);
     TotalTime += (GETTSC() - tt0);

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -76,8 +76,6 @@ int NodesNotFound = 0;
 int TreeCleanups = 0;
 #endif
 
-TNode *LastXNode = NULL;
-
 #ifdef HOST_ARCH_X86
 
 #define FINDTREE_CACHE_HASH_MASK 0xfff
@@ -105,7 +103,6 @@ static inline TNode *Tmalloc(void)
   if (G1==TNodePool) leavedos_main(0x4c4c); // return NULL;
   TNodePool->link[0] = G1; G->link[0]=NULL;
   memset(G, 0, sizeof(TNode));	// "bug covering"
-  G->nxkey = -1;
   return G;
 }
 
@@ -558,7 +555,6 @@ static void avltr_init(void)
 #endif
   g_printf("avltr_init\n");
   CurrIMeta = -1;
-  LastXNode = NULL;
   NodesCleaned = 0;
   ninodes = 0;
 }
@@ -824,7 +820,6 @@ void DumpTree (FILE *fd)
 		G->bal,G->cache,G->pad,G->rtag);
     fprintf(fd,"     source:     instr=%d, len=%#x\n",G->seqnum,G->seqlen);
     fprintf(fd,"     translated: len=%#x\n",G->len);
-    fprintf(fd,"     HIST n=%p k=%08x\n",G->nxnode,G->nxkey);
     L = &G->clink;
     fprintf(fd,"     LINK type=%d refs=%d\n",L->t_type,L->nrefs);
     if (L->t_type >= JMP_LINK) {
@@ -1252,7 +1247,7 @@ void InvalidateNodeRange(int al, int len, unsigned char *eip)
 	    unsigned char *ahE = G->addr + G->len;
 	    if (debug_level('e')>1)
 		dbug_printf("Invalidated node %p at %08x\n",G,G->key);
-	    G->alive = 0; G->nxkey = -1;
+	    G->alive = 0;
 	    e_unmarkpage(G->seqbase, G->seqlen);
 	    NodeUnlinker(G);
 	    NodesCleaned++;
@@ -1274,7 +1269,6 @@ void InvalidateNodeRange(int al, int len, unsigned char *eip)
       G = NEXTNODE(G);
   }
 quit:
-  LastXNode = NULL;
   if (debug_level('e') && e_querymark(al, len))
     error("simx86: InvalidateNodeRange did not clear all code for %#08x, len=%x\n",
 	  al, len);

--- a/src/base/emu-i386/simx86/trees.h
+++ b/src/base/emu-i386/simx86/trees.h
@@ -128,13 +128,10 @@ typedef struct avltr_node
 	unsigned char *addr;
 	Addr2Pc *pmeta;
 	unsigned short len, flags, seqlen, seqnum __attribute__ ((packed));
-	int nxkey, seqbase;
-	struct avltr_node *nxnode;
+	int seqbase;
 	linkdesc clink;
 	unsigned cs;
 } TNode;
-
-extern TNode *LastXNode;
 
 /* Used for traversing a right-threaded AVL tree. */
 typedef struct avltr_traverser


### PR DESCRIPTION
By adding a hash-table like cache to FindTree, indexed by the low 12 bits
of the PC we can obtain a 99.99% hit rate and speed up searches so FindTree
is sped up by a factor 3, and goes from 12% to 4% of total execution time.

This obsoletes most uses of LastXNode.

See also the discussion at #86