### PR TITLE
Dosdebug 47

### DIFF
--- a/src/include/mhpdbg.h
+++ b/src/include/mhpdbg.h
@@ -15,6 +15,7 @@
 #include <stdint.h>
 
 #include "dosemu_debug.h"
+#include "memory.h"
 
 // There is also an argument field shifted 8 bits left
 enum dosdebug_event {
@@ -45,7 +46,7 @@ void mhp_input(void);
 void mhp_close(void);
 void mhp_printf(const char *,...) FORMAT(printf, 1, 2);
 int mhp_getaxlist_value(int v, int mask);
-int mhp_getcsip_value(void);
+dosaddr_t mhp_getcsip_value(void);
 void mhp_modify_eip(int delta);
 void mhp_intercept_log(const char *flags, int temporary);
 void mhp_intercept(const char *msg, const char *logflags);
@@ -94,18 +95,17 @@ extern struct mhpdbg mhpdbg;
 void mhp_cmd(const char *);
 void mhp_bpset(void);
 void mhp_bpclr(void);
-int  mhp_bpchk(unsigned int);
-int mhp_setbp(unsigned int seekval);
-int mhp_clearbp(unsigned int seekval);
+int mhp_bpchk(dosaddr_t addr);
+int mhp_setbp(dosaddr_t seekval, int one_shot);
+int mhp_clearbp(dosaddr_t seekval);
 void mhp_regex(const char *fmt, va_list args);
 
-void mhpdbg_trace_init(void);
-
 struct brkentry {
-   unsigned int brkaddr;
+   dosaddr_t brkaddr;
    unsigned char opcode;
    char is_dpmi;
    char is_valid;
+   char is_one_shot;
 };
 
 struct segoff {
@@ -133,7 +133,6 @@ struct mhpdbgc
    int want_to_stop;
    enum dosdebug_event currcode;
    enum { TRACE_NONE, TRACE_INTO, TRACE_OVER } trapcmd;
-   int trapip; /* ip that we were on when we started the "tracei" command */
    int bpload;
    int bpload_bp;
    int int21_count;

--- a/src/include/mhpdbg.h
+++ b/src/include/mhpdbg.h
@@ -132,7 +132,7 @@ struct mhpdbgc
    int stopped;
    int want_to_stop;
    enum dosdebug_event currcode;
-   int trapcmd;
+   enum { TRACE_NONE, TRACE_INTO, TRACE_OVER } trapcmd;
    int trapip; /* ip that we were on when we started the "tracei" command */
    int bpload;
    int bpload_bp;

--- a/src/include/mhpdbg.h
+++ b/src/include/mhpdbg.h
@@ -97,7 +97,7 @@ void mhp_bpset(void);
 void mhp_bpclr(void);
 int mhp_bpchk(dosaddr_t addr);
 int mhp_setbp(dosaddr_t seekval, int one_shot);
-int mhp_clearbp(dosaddr_t seekval);
+int mhp_clearbp(int indx);
 void mhp_regex(const char *fmt, va_list args);
 
 struct brkentry {
@@ -135,6 +135,7 @@ struct mhpdbgc
    enum { TRACE_NONE, TRACE_INTO, TRACE_OVER } trapcmd;
    int bpload;
    int bpload_bp;
+   int bpload_indx;
    int int21_count;
    int int_handled;
    int saved_if;

--- a/src/plugin/debugger/mhpdbg.c
+++ b/src/plugin/debugger/mhpdbg.c
@@ -399,7 +399,8 @@ unsigned int mhp_debug(enum dosdebug_event code, unsigned int parm1, unsigned in
       if (test_bit(DBG_ARG(mhpdbgc.currcode), mhpdbg.intxxtab)) {
         if ((mhpdbgc.bpload == 1) && (DBG_ARG(mhpdbgc.currcode) == 0x21) && (LWORD(eax) == 0x4b00)) {
           mhpdbgc.bpload_bp = SEGOFF2LINEAR(SREG(cs), LWORD(eip));
-          if (mhp_setbp(mhpdbgc.bpload_bp, 0)) {
+          mhpdbgc.bpload_indx = mhp_setbp(mhpdbgc.bpload_bp, 0);
+          if (mhpdbgc.bpload_indx >= 0) {
             Bit16u int_op = READ_WORD(SEGOFF2LINEAR(SREG(cs), LWORD(eip) - 2));
             mhp_printf("bpload: intercepting EXEC\n");
             if (int_op == 0x21cd) {
@@ -496,7 +497,7 @@ unsigned int mhp_debug(enum dosdebug_event code, unsigned int parm1, unsigned in
               mhpdbgc.bpload++;
               break;
             case 3:
-              mhp_clearbp(mhpdbgc.bpload_bp);
+              mhp_clearbp(mhpdbgc.bpload_indx);
               mhp_modify_eip(-1);
               mhp_printf("bpload: program exited\n");
               mhpdbgc.bpload = 0;

--- a/src/plugin/debugger/mhpdbg.c
+++ b/src/plugin/debugger/mhpdbg.c
@@ -281,17 +281,19 @@ static void mhp_poll_loop(void)
 
 static void mhp_pre_vm86(void)
 {
-    if (!mhpdbg.active)
-	return;
-    if (isset_TF()) {
-	if (mhpdbgc.trapip != mhp_getcsip_value()) {
-	    mhpdbgc.trapcmd = 0;
-	    mhpdbgc.stopped = 1;
-	    mhp_poll();
-	}
+  if (!mhpdbg.active)
+    return;
+
+  if (isset_TF()) {
+    if (mhpdbgc.trapip != mhp_getcsip_value()) {
+      mhpdbgc.trapcmd = 0;
+      mhpdbgc.stopped = 1;
+      mhp_poll();
     }
-    if (mhpdbgc.stopped)
-	mhp_poll();
+  }
+
+  if (mhpdbgc.stopped)
+    mhp_poll();
 }
 
 static void mhp_poll(void)

--- a/src/plugin/debugger/mhpdbgc.c
+++ b/src/plugin/debugger/mhpdbgc.c
@@ -756,7 +756,7 @@ static void mhp_go(int argc, char * argv[])
       if (bpchk(csip)) {
         dpmi_mhp_setTF(1);
         set_TF();
-        mhpdbgc.trapcmd = 2;
+        mhpdbgc.trapcmd = TRACE_OVER;
         mhpdbgc.trapip = csip;
         trapped_bp = -1;
         return;
@@ -845,9 +845,9 @@ static void mhp_trace(int argc, char *argv[])
   set_TF();
 
   if (!strcmp(argv[0], "ti")) {
-    mhpdbgc.trapcmd = 1;
+    mhpdbgc.trapcmd = TRACE_INTO;
   } else {
-    mhpdbgc.trapcmd = 2;
+    mhpdbgc.trapcmd = TRACE_OVER;
   }
 
   mhpdbgc.trapip = mhp_getcsip_value();
@@ -856,7 +856,7 @@ static void mhp_trace(int argc, char *argv[])
     unsigned char *csp = SEG_ADR((unsigned char *), cs, ip);
     switch (csp[0]) {
       case 0xcc:
-        if (mhpdbgc.trapcmd != 1)
+        if (mhpdbgc.trapcmd != TRACE_INTO)
           break;
         // ti
         LWORD(eip)++;
@@ -867,7 +867,7 @@ static void mhp_trace(int argc, char *argv[])
         mhp_cmd("r0");
         break;
       case 0xcd:
-        if (mhpdbgc.trapcmd != 1) { // plain 't'
+        if (mhpdbgc.trapcmd != TRACE_INTO) { // plain 't'
           if (csp[1] == 0x21 || csp[1] == 0x2f || csp[1] == 0x28 || csp[1] == 0x33)
             break;
           LWORD(eip) += 2;

--- a/src/plugin/debugger/mhpdbgc.c
+++ b/src/plugin/debugger/mhpdbgc.c
@@ -2198,6 +2198,18 @@ static void mhp_bpload(int argc, char * argv[])
    return;
 }
 
+static char *flags_to_string(uint32_t flags)
+{
+  static char ret[17];
+  const char *names = ".N..ODITSZ.A.P.C";
+  int i;
+
+  for (i = 0; i <= 15; i++)
+    ret[15 - i] = (flags & (1 << i)) ? names[15 - i] : '_';
+  ret[16] = '\0';
+  return ret;
+}
+
 static void mhp_regs(int argc, char * argv[])
 {
   unsigned long newval;
@@ -2281,8 +2293,8 @@ static void mhp_regs(int argc, char * argv[])
                 LWORD(eax), LWORD(ebx), LWORD(ecx), LWORD(edx));
     mhp_printf("  SI=%04x  DI=%04x  SP=%04x  BP=%04x",
                 LWORD(esi), LWORD(edi), LWORD(esp), LWORD(ebp));
-    mhp_printf("\nDS=%04x  ES=%04x  FS=%04x  GS=%04x  FL=%08x",
-                SREG(ds), SREG(es), SREG(fs), SREG(gs), REG(eflags));
+    mhp_printf("\nDS=%04x  ES=%04x  FS=%04x  GS=%04x  FL=%08x(%s)",
+                SREG(ds), SREG(es), SREG(fs), SREG(gs), REG(eflags), flags_to_string(REG(eflags)));
     mhp_printf("\nCS:IP=%04x:%04x       SS:SP=%04x:%04x\n",
                 SREG(cs), LWORD(eip), SREG(ss), LWORD(esp));
   }


### PR DESCRIPTION
I'm experimenting with replacing the trace over ring buffer with a one shot breakpoint. For now I'm just testing with real mode. I have some of it working but:
- [x] Not quite sure where to clean up the one shot breakpoint after it's been hit.
- [x] I must have broken the normal trace code, because after I step over the interrupt using the breakpoint method tracing with just 't' / 'ti' the instruction pointer never moves on.
- [ ] Need to work out why 't' doesn't advance cs:ip in DPMI mode.
- [ ] Need to work out why I have a crash on tracing in DPMI.