### PR TITLE
simx86: cleanup: eliminate some global variables

### DIFF
--- a/src/base/emu-i386/simx86/codegen-x86.h
+++ b/src/base/emu-i386/simx86/codegen-x86.h
@@ -117,11 +117,9 @@ extern unsigned int Exec_x86(TNode *G, int ln);
 
 /////////////////////////////////////////////////////////////////////////////
 //
+unsigned char *Fp87_op_x86(unsigned char *CodePtr, int exop, int reg);
 void InitGen_x86(void);
 void NodeUnlinker(TNode *G);
-
-extern CodeBuf *GenCodeBuf;
-extern unsigned char *CodePtr;
 
 extern unsigned char TailCode[];
 

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -1059,7 +1059,6 @@ int e_vm86(void)
   TheCPU.mem_base = CONFIG_CPUSIM ? 0 : (uintptr_t)mem_base;
   /* FPU state is loaded later on demand for JIT, not used for simulator */
   TheCPU.fpstate = vm86_fpu_state;
-  VgaAbsBankBase = TheCPU.mem_base + vga.mem.bank_base;
   if (eTimeCorrect >= 0) TheCPU.EMUtime = GETTSC();
 #ifdef SKIP_VM86_TRACE
   demusav=debug_level('e'); if (debug_level('e')) set_debug_level('e', 1);

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -936,10 +936,9 @@ static int TraverseAndClean(void)
  * code addresses. At the end, we reset both CodeBuf and InstrMeta to prepare
  * for a new sequence.
  */
-TNode *Move2Tree(void)
+TNode *Move2Tree(IMeta *I0, CodeBuf *GenCodeBuf)
 {
   TNode *nG = NULL;
-  IMeta *I0;
 #ifdef PROFILE
   hitimer_t t0 = 0;
   if (debug_level('e')) t0 = GETTSC();
@@ -958,7 +957,6 @@ TNode *Move2Tree(void)
 	for (i=0; i<CreationIndex; i++) TraverseAndClean();
   }
 
-  I0 = &InstrMeta[0];		// root of code buffer
   key = I0->npc;
 
   found = 0;
@@ -1012,7 +1010,6 @@ TNode *Move2Tree(void)
   nap = nG->seqnum+1;
   mallmb = GenCodeBuf;
   nG->mblock = GenCodeBuf;
-  GenCodeBuf = NULL;
   nG->mblock->bkptr = nG;
   cp = &nG->mblock->selfptr;
   *cp = cp;

--- a/src/base/emu-i386/simx86/trees.h
+++ b/src/base/emu-i386/simx86/trees.h
@@ -159,7 +159,7 @@ extern avltr_tree CollectTree;
 void avltr_delete (const int key);
 //
 TNode *FindTree(int key);
-TNode *Move2Tree(void);
+TNode *Move2Tree(IMeta *I0, CodeBuf *GenCodeBuf);
 //
 #endif
 


### PR DESCRIPTION
Replace global variables CodePtr, GenCodeBuf, and BaseGenBuf with locals.
Replace some use of InstrMeta global array with locals.

Also eliminate the no longer used VgaAbsBankBase.