### PR TITLE
simx86: disable special case for TB followed by INT where compiled

### DIFF
--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -3111,11 +3111,13 @@ static unsigned int CloseAndExec_x86(unsigned int PC, int mode, int ln)
 	 * this node */
 	seqlen = G->seqlen;
 	/* Special case: translated block followed by int instruction.
-	   Ints are always interpreted, but sometimes (e.g. for FPU emulators,
+	   Outside V86MODE with IOPL3 and VME (the usual case),
+	   ints are interpreted, but sometimes (e.g. for FPU emulators,
 	   INT 3x) the int instruction is modified by the int handler to
 	   become an actual FPU instruction). This makes sure that then
 	   the whole block is retranslated so it is as long as possible */
-	if (Fetch(G->seqbase+seqlen) == INT)
+	if (!(V86MODE() && (TheCPU.cr[4] & CR4_VME) && IOPL == 3) &&
+	    Fetch(G->seqbase+seqlen) == INT)
 	  seqlen += 2;
 	e_markpage(G->seqbase, seqlen);
 	e_mprotect(G->seqbase, seqlen);


### PR DESCRIPTION
In response to https://sourceforge.net/p/dosemu/support-requests/264/
in commit c1ddb275 I sped up dynamic patching of INT 3x for FPU:
by including the INT instruction in the region it would be recompiled
as one block.

But since 6f16dbf3 INTs are compiled in VM86 mode so it no longer makes
sense to extend the region, and then accidentally marks untranslated code
as translated which can cause buggy behaviour.

It still makes sense in 16-bit protected mode (those INTs are used in Win16
code too, see #982).