### PR TITLE
simx86: don't use TheCPU.mode for sequence flags.

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -2919,8 +2919,7 @@ void Gen_sim(int op, int mode, ...)
 //	    if (debug_level('e')==9) dbug_printf("\n%s",e_print_regs());
 	}
 
-	/* was there at least one FP op in the sequence? */
-	if (TheCPU.mode & M_FPOP) {
+	if (op == O_FOP) {
 		int exs = TheCPU.fpus & 0x7f;
 		if (debug_level('e')>3) {
 		    e_printf("  %s\n", e_trace_fp());

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -2558,8 +2558,10 @@ static void Gen_x86(int op, int mode, ...)
 		}
 		break;
 
-	case O_INT:
-	case O_FOP: {
+	case O_FOP:
+		I->flags |= F_FPOP;
+		// fall through
+	case O_INT: {
 		unsigned char exop = (unsigned char)va_arg(ap,int);
 		IG->p0 = exop;
 		IG->p1 = va_arg(ap,int);	// reg

--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -186,13 +186,9 @@
 #define MREPCOND 0x01000000	// this is SCASx or CMPSx, REP can be terminated
 				// by flags
 
-// as seqflg takes mode>>16, these must go together in pairs
-// (bits 0-3 are accumulated in the sequence head node):
-#define M_FPOP	0x00010000
+// values for TNode.flags and IMeta.flags
 #define F_FPOP	0x0001
-#define M_HITC	0x00020000
 #define F_HITC	0x0002
-#define M_SLFL	0x00040000
 #define F_SLFL	0x0004
 
 /////////////////////////////////////////////////////////////////////////////
@@ -276,7 +272,7 @@ static __inline__ void POP_ONLY(int m)
 }
 
 void InitGen(void);
-int  NewIMeta(int newa, int mode, int *rc);
+int  NewIMeta(int npc, int *rc);
 extern void (*Gen)(int op, int mode, ...);
 extern void (*AddrGen)(int op, int mode, ...);
 extern int  (*Fp87_op)(int exop, int reg);

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -332,7 +332,7 @@ static unsigned int _JumpGen(unsigned int P2, int mode, int opc,
 	_P1 = _JumpGen(P2, mode, opc, pskip, &_P0); \
 	if (_P1 == (unsigned)-1) { \
 		if (!CONFIG_CPUSIM) \
-			NewIMeta(P2, mode, &_rc); \
+			NewIMeta(P2, &_rc); \
 		_P1 = CloseAndExec(_P0, mode, __LINE__); \
 		NewNode=0; \
 	} \
@@ -2130,7 +2130,7 @@ repag0:
 				   up IP */
 				int rc = 0;
 				if (!CONFIG_CPUSIM) {
-					NewIMeta(P0, repmod, &rc);
+					NewIMeta(P0, &rc);
 					CODE_FLUSH();
 					/* don't cache intermediate nodes */
 					InvalidateNodePage(P0, PC - P0, NULL, NULL);
@@ -2693,7 +2693,6 @@ repag0:
 				}
 			}
 			b &= 7;
-			TheCPU.mode |= M_FPOP;
 			if (TheCPU.fpstate) {
 				/* For simulator, only need to mask all
 				   exceptions; for JIT, load emulated FPU state
@@ -3320,12 +3319,12 @@ repag0:
 		if (NewNode) {
 			int rc=0;
 			if (!CONFIG_CPUSIM && !(TheCPU.mode&SKIPOP)) {
-				NewIMeta(P0, TheCPU.mode, &rc);
+				NewIMeta(P0, &rc);
 				if (rc < 0) {
 					if (debug_level('e')>2)
 						e_printf("============ Tab full:cannot close sequence\n");
 					CODE_FLUSH();
-					NewIMeta(P0, TheCPU.mode, &rc);
+					NewIMeta(P0, &rc);
 					NewNode = 1;
 				}
 			}

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -1346,7 +1346,7 @@ static void CleanIMeta(void)
 /////////////////////////////////////////////////////////////////////////////
 
 
-int NewIMeta(int npc, int mode, int *rc)
+int NewIMeta(int npc, int *rc)
 {
 #ifdef HOST_ARCH_X86
     if (!CONFIG_CPUSIM) {
@@ -1373,13 +1373,12 @@ int NewIMeta(int npc, int mode, int *rc)
 
 		I0->ncount += 1;
 		I->npc = npc;
-		I->flags = mode>>16;		// FP and flags affected
 
 		if (CurrIMeta>0) {
 			I0->flags |= I->flags;
 		}
 		if (debug_level('e')>4) {
-			e_printf("Metadata %03d PC=%08x mode=%x(%x) ng=%d\n",
+			e_printf("Metadata %03d PC=%08x flags=%x(%x) ng=%d\n",
 				CurrIMeta,I->npc,I->flags,I0->flags,I->ngen);
 		}
 #ifdef PROFILE


### PR DESCRIPTION
The code generator can set those directly, no reason to use the global TheCPU.mode
and then shift right by 16.