### PR TITLE
simx86: initialize flags for new IMeta's

### DIFF
--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -2300,7 +2300,7 @@ static void AddrGen_x86(int op, int mode, ...)
 #endif
 
 	if (CurrIMeta<0) {
-		CurrIMeta=0; InstrMeta[0].ngen=0;
+		CurrIMeta=0; InstrMeta[0].ngen=0; InstrMeta[0].flags=0;
 	}
 	I = &InstrMeta[CurrIMeta];
 	if (I->ngen >= NUMGENS) leavedos_main(0xbac1);
@@ -2378,7 +2378,7 @@ static void Gen_x86(int op, int mode, ...)
 #endif
 
 	if (CurrIMeta<0) {
-		CurrIMeta=0; InstrMeta[0].ngen=0;
+		CurrIMeta=0; InstrMeta[0].ngen=0; InstrMeta[0].flags=0;
 	}
 	I = &InstrMeta[CurrIMeta];
 	if (I->ngen >= NUMGENS) leavedos_main(0xbac2);

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -1390,6 +1390,7 @@ int NewIMeta(int npc, int *rc)
 		CurrIMeta++;
 		*rc = 1; I++;
 		I->ngen = 0;
+		I->flags = 0;
 		return CurrIMeta;
 	}
 	*rc = 0;
@@ -1407,7 +1408,7 @@ quit:
 		*rc = -1;
 		return -1;
 	}
-	CurrIMeta++; InstrMeta[CurrIMeta].ngen=0;
+	CurrIMeta++; InstrMeta[CurrIMeta].ngen=0; InstrMeta[CurrIMeta].flags=0;
 	return CurrIMeta;
 }
 


### PR DESCRIPTION
This is a regression from 5411f5b21: old flags were now erroneously kept.