### PR TITLE
simx86: fix two contiguous inhibiting instructions [#1214]

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -453,7 +453,7 @@ void AddrGen_sim(int op, int mode, ...)
 		GTRACE1("A_SR_SH4",o);
 		SetSegReal(CPUWORD(o), o);
 		if (o == Ofs_SS)
-			CEmuStat |= CeS_INHI;
+			CEmuStat |= CeS_MOVSS;
 		}
 		break;
 	}
@@ -2968,10 +2968,11 @@ static unsigned int CloseAndExec_sim(unsigned int PC, int mode, int ln)
 	    }
 	}
 
-	if (signal_pending()) {
+	if (!(CEmuStat & CeS_INHI)) {
+	    if (signal_pending())
 		CEmuStat|=CeS_SIGPEND;
+	    TheCPU.sigalrm_pending = 0;
 	}
-	TheCPU.sigalrm_pending = 0;
 	if (eTimeCorrect >= 0)
 	    TheCPU.EMUtime = GETTSC();
 	if (P0 == (unsigned)-1)

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -1376,9 +1376,13 @@ int NewIMeta(int npc, int *rc)
 
 		if (CurrIMeta>0) {
 			/* F_INHI (pop ss/mov ss) only applies to the last
-			   instruction in the sequence */
-			I0->flags &= ~F_INHI;
-			I0->flags |= I->flags;
+			   instruction in the sequence and not twice in
+			   a row */
+			if ((I->flags & F_INHI) && !(I0->flags & F_INHI))
+				I0->flags |= F_INHI;
+			else
+				I0->flags &= ~F_INHI;
+			I0->flags |= I->flags & ~F_INHI;
 		}
 		if (debug_level('e')>4) {
 			e_printf("Metadata %03d PC=%08x flags=%x(%x) ng=%d\n",

--- a/src/include/cpu-emu.h
+++ b/src/include/cpu-emu.h
@@ -57,6 +57,7 @@ extern void e_priv_iopl(int);
 #define CeS_SIGACT	0x02	/* signal active mask */
 #define CeS_RPIC	0x04	/* pic asks for interruption */
 #define CeS_STI		0x08	/* IF active was popped */
+#define CeS_MOVSS	0x10	/* mov ss or pop ss interpreted */
 #define CeS_INHI	0x800	/* inhibit interrupts(pop ss; pop sp et sim.) */
 #define CeS_TRAP	0x1000	/* INT01 Sstep active */
 #define CeS_DRTRAP	0x2000	/* Debug Registers active */


### PR DESCRIPTION
if we have two "mov ss" or "pop ss" instructions in a row, the second one
should not inhibit interrupts again. For the interpreter this was most
easily done using a new CeS_MOVSS flag, which can then be checked in
combination with CeS_INHI, which is then set for the first instruction,
and checked and reset for the second.

The logic now handles CeS_TRAP/CeS_SIGPEND itself so HandleEmuSignals no
longer needs to fiddle with CeS_INHI.