### PR TITLE
simx86: let e_unmarkpage call munprotect on demand

### DIFF
--- a/src/base/emu-i386/simx86/cpatch.c
+++ b/src/base/emu-i386/simx86/cpatch.c
@@ -60,7 +60,6 @@ void m_munprotect(unsigned int addr, unsigned int len, unsigned char *eip)
 	len = PAGE_ALIGN(addr+len-1) - (addr & PAGE_MASK);
 	addr &= PAGE_MASK;
 	InvalidateNodeRange(addr,len,eip);
-	e_munprotect(addr,len);
 }
 
 #define repmovs(std,letter,cld)			       \

--- a/src/base/emu-i386/simx86/emu86.h
+++ b/src/base/emu-i386/simx86/emu86.h
@@ -733,7 +733,6 @@ char *showmode(unsigned int m);
 void Cpu2Reg (void);
 int e_debug_check(unsigned int PC);
 int e_mprotect(unsigned int addr, size_t len);
-int e_munprotect(unsigned int addr, size_t len);
 int e_querymprotrange(unsigned int addr, size_t len);
 int e_markpage(unsigned int addr, size_t len);
 int e_unmarkpage(unsigned int addr, size_t len);

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -1308,7 +1308,6 @@ void e_invalidate_full(unsigned data, int cnt)
 		return;
 	cnt = PAGE_ALIGN(data+cnt-1) - (data & PAGE_MASK);
 	data &= PAGE_MASK;
-	e_munprotect(data, cnt);
 #ifdef HOST_ARCH_X86
 	if (!CONFIG_CPUSIM)
 		InvalidateNodeRange(data, cnt, 0);


### PR DESCRIPTION
Instead of calling e_munprotect explicitly, let e_unmarkpage check if
any code is left and if not, unprotect the relevant pages.

This way multiple partial e_unmarkpage calls that only affect parts of
pages can now still cause the page to be unprotected, thereby avoiding
unnecessary faults.