### PR TITLE
simx86: invalidate node only for aliased (vm86) memory

### DIFF
--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -1294,8 +1294,15 @@ void e_invalidate(unsigned data, int cnt)
 	if (!e_querymprotrange(data, cnt))
 		return;
 	/* for low mappings only invalidate if code, not if data */
-	if (LINEAR2UNIX(data) != MEM_BASE32(data) && !e_querymark(data, cnt))
+	if (LINEAR2UNIX(data) != MEM_BASE32(data)) {
+#ifdef HOST_ARCH_X86
+		if (!CONFIG_CPUSIM && e_querymark(data, cnt))
+			// no need to invalidate the whole page here,
+			// as the page does not need to be unprotected
+			InvalidateNodeRange(data, cnt, 0);
+#endif
 		return;
+	}
 	e_invalidate_full(data, cnt);
 }
 


### PR DESCRIPTION
If code is invalidated for aliased memory it's not necessary to invalidate
the whole page, as just the node needs to be recompiled, keeping the page
protected.

Booting FreeDOS this helps with dynamically modifying intxx instructions and
reduces the number of page faults and recompilations by about 3-4% (info
from compiling with PROFILE and running -D+e).