### PR TITLE
simx86: make sure page mark bitmaps are kept in sync

### DIFF
--- a/src/base/emu-i386/simx86/econfig.h
+++ b/src/base/emu-i386/simx86/econfig.h
@@ -41,6 +41,7 @@
 #undef	SINGLEBLOCK
 #undef	PROFILE
 #undef	DBG_TIME
+#undef	SKIP_CPATCH
 
 #define	FAKE_INS_TIME	20
 

--- a/src/base/emu-i386/simx86/memory.c
+++ b/src/base/emu-i386/simx86/memory.c
@@ -256,7 +256,7 @@ int e_querymark(unsigned int addr, size_t len)
 	return 0;
 found:
 	if (debug_level('e')>1) {
-		if (len > 1) abeg += ffs(M->subpage[idx] & mask) - 1;
+		if (len > 1) abeg += ffsll(M->subpage[idx] & mask) - 1;
 		dbug_printf("QUERY MARK found code at "
 			    "%08x to %08x for %08x\n",
 			    abeg<<CGRAN, ((abeg+1)<<CGRAN)-1,

--- a/src/base/emu-i386/simx86/memory.c
+++ b/src/base/emu-i386/simx86/memory.c
@@ -433,8 +433,10 @@ int e_handle_pagefault(sigcontext_t *scp)
 	 * linked by Cpatch will do it */
 	/* ACH: we can set up a data patch for code
 	 * which has not yet been executed! */
+#ifndef SKIP_CPATCH
 	if (InCompiledCode && Cpatch(scp))
 		return 1;
+#endif
 	/* We HAVE to invalidate all the code in the page
 	 * if the page is going to be unprotected */
 	addr &= PAGE_MASK;

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -1276,6 +1276,9 @@ void InvalidateNodeRange(int al, int len, unsigned char *eip)
   }
 quit:
   LastXNode = NULL;
+  if (debug_level('e') && e_querymark(al, len))
+    error("simx86: InvalidateNodeRange did not clear all code for %#08x, len=%x\n",
+	  al, len);
 #ifdef PROFILE
   if (debug_level('e')) CleanupTime += (GETTSC() - t0);
 #endif

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -907,6 +907,7 @@ static int TraverseAndClean(void)
       G->alive -= AGENODE;
       if (G->alive <= 0) {
 	if (debug_level('e')>2) e_printf("TraverseAndClean: node at %08x decayed\n",G->key);
+	e_unmarkpage(G->seqbase, G->seqlen);
 	NodeUnlinker(G);
       }
   }


### PR DESCRIPTION
e_querymark must return false for the range touched by InvalidateNodeRange,
otherwise the relevant bitmaps are out of sync and pages that must be
unprotected can remain protected.

(The tests will fail with this commit).