### PR TITLE
simx86: JumpGen must use P0 for NewIMeta, not P2 (=PC)

### DIFF
--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -332,7 +332,7 @@ static unsigned int _JumpGen(unsigned int P2, int mode, int opc,
 	_P1 = _JumpGen(P2, mode, opc, pskip, &_P0); \
 	if (_P1 == (unsigned)-1) { \
 		if (!CONFIG_CPUSIM) \
-			NewIMeta(P2, &_rc); \
+			NewIMeta(P0, &_rc); \
 		_P1 = CloseAndExec(_P0, mode, __LINE__); \
 		NewNode=0; \
 	} \


### PR DESCRIPTION
Since cfdff90 indirect jmps and calls use JumpGen, but those can use segment
overrides, e.g. "jmp far cs:[bp]". The cs: prefix was not taken into account
by PC but P0 points to it. This meant the saved value (in dnpc) was off by one
which could cause issues with BreakNode putting the return PC from the
tail code at "jmp far [bp]", losing the prefix and jumping to the wrong place.