### PR TITLE
test: move 5056-line check to first cpu test only

### DIFF
--- a/test/test_dos.py
+++ b/test/test_dos.py
@@ -5836,13 +5836,13 @@ $_ignore_djgpp_null_derefs = (off)
         try:
             with open(join(WORKDIR, "test.log")) as f:
                 lines = list(f)
-                self.assertEqual(len(lines), 5056)
                 # compare or copy to reference file
                 try:
                     with open("test-i386.log") as g:
                         self.maxDiff = None
                         self.assertEqual(list(g), lines)
                 except IOError:
+                    self.assertEqual(len(lines), 5056)
                     # copy as reference file
                     with open("test-i386.log", "w") as g:
                         g.write("".join(lines))

--- a/test/test_dos.py
+++ b/test/test_dos.py
@@ -5835,13 +5835,13 @@ $_ignore_djgpp_null_derefs = (off)
 
         try:
             with open(join(WORKDIR, "test.log")) as f:
-                lines = list(f)
                 # compare or copy to reference file
                 try:
                     with open("test-i386.log") as g:
                         self.maxDiff = None
-                        self.assertEqual(list(g), lines)
+                        self.assertEqual(g.read(), f.read())
                 except IOError:
+                    lines = list(f)
                     self.assertEqual(len(lines), 5056)
                     # copy as reference file
                     with open("test-i386.log", "w") as g:


### PR DESCRIPTION
This way a full diff is done for later checks which gives more information
in the logs.