### PR TITLE
simx86: move e_querymark/InterOps checks past FindTree cache

### DIFF
--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -346,7 +346,6 @@ static unsigned int _JumpGen(unsigned int P2, int mode, int opc,
 static unsigned int FindExecCode(unsigned int PC)
 {
 	int mode = TheCPU.mode;
-	int first = 1;
 	TNode *G;
 
 	if (CurrIMeta > 0) {		// open code?
@@ -362,7 +361,6 @@ static unsigned int FindExecCode(unsigned int PC)
 	 * a 'descheduling point' for checking signals.
 	 */
 	while (!(CEmuStat & (CeS_TRAP|CeS_DRTRAP|CeS_SIGPEND)) &&
-	       ((InterOps[Fetch(PC)]&1)==0) && (first || e_querymark(PC, 1)) &&
 	       (G=FindTree(PC))) {
 		if (G->cs != LONG_CS) {
 			/* CS mismatch can confuse relative jump/call */
@@ -402,7 +400,6 @@ static unsigned int FindExecCode(unsigned int PC)
 			break;
 		}
 		if (TheCPU.err) return PC;
-		first = 0;
 	}
 	return PC;
 }

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -1086,6 +1086,8 @@ TNode *FindTree(int key)
 	I->alive = NODELIFE(I);
 	return I;
   }
+  if (!e_querymark(key, 1))
+	return NULL;
 
 #ifdef PROFILE
   if (debug_level('e')) t0 = GETTSC();


### PR DESCRIPTION
Since FindTree's cache hits are the most common case it's cheaper to move
the e_querymark checks past the cache check, just to avoid the more expensive
tree search if there is no code. The "first" check (from 431f6778) is not
worth the extra logic then.

This speeds up zx_emul by ~30%.