### PR TITLE
simx86: Exec_x86(): create fast inner loop

### DIFF
--- a/src/base/emu-i386/simx86/codegen-x86.h
+++ b/src/base/emu-i386/simx86/codegen-x86.h
@@ -54,6 +54,7 @@
 
 extern unsigned int VgaAbsBankBase;
 extern unsigned int Exec_x86(TNode *G, int ln);
+extern unsigned int Exec_x86_fast(TNode *G);
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -393,8 +393,15 @@ static unsigned int FindExecCode(unsigned int PC)
 		NodesExecd++;
 #ifdef PROFILE
 		TotalNodesExecd++;
+#elif !defined(ASM_DUMP)
+		/* try fast inner loop if nothing special is going on */
+		if (!(CEmuStat & (CeS_INHI|CeS_MOVSS)) &&
+		    !debug_level('e') && eTimeCorrect < 0 &&
+		    G->cs == LONG_CS && !(G->flags & (F_FPOP|F_INHI)))
+			PC = Exec_x86_fast(G);
+		else
 #endif
-		PC = Exec_x86(G, __LINE__);
+			PC = Exec_x86(G, __LINE__);
 		if (G->seqlen == 0) {
 			error("CPU-EMU: Zero-len code node?\n");
 			break;


### PR DESCRIPTION
In the most common case (no debug output, no TSC usage, no FPU, no interrupt
inhibition and no trap flag use), the execution of generated code can be done
via a tight loop that checks for signals, finds the next node and checks for
links.

Execution zx_emul, this way Exec_x86 uses 12% instead of 20% of total execution
time and the total time drops by ~15%.