### PR TITLE
Travis ci 23

### DIFF
--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -238,7 +238,7 @@ class BaseTestCase(object):
 
     def runDosemu(self, cmd, opts=None, outfile=None, config=None, timeout=5):
         # Note: if debugging is turned on then times increase 10x
-        dbin = "bin/dosemu.bin"
+        dbin = "bin/dosemu"
         args = ["-f", join(self.imagedir, "dosemu.conf"),
                 "-n",
                 "-o", self.logname,

--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -4,6 +4,7 @@ import random
 import re
 import unittest
 
+from datetime import datetime
 from hashlib import sha1
 from os import makedirs, mkdir, rename, unlink
 from os.path import exists, join
@@ -82,6 +83,7 @@ class BaseTestCase(object):
             mkdir("test-libdir/dosemu2-cmds-0.2")
 
         cls.nologs = False
+        cls.duration = None
 
     @classmethod
     def setUpClassPost(cls):
@@ -250,6 +252,7 @@ class BaseTestCase(object):
         if config is not None:
             mkfile("dosemu.conf", config, dname=self.imagedir, writemode="a")
 
+        starttime = datetime.utcnow()
         child = pexpect.spawn(dbin, args)
         with open(self.xptname, "wb") as fout:
             child.logfile = fout
@@ -275,6 +278,7 @@ class BaseTestCase(object):
         except PtyProcessError:
             pass
 
+        self.duration = datetime.utcnow() - starttime
         return ret
 
 
@@ -314,7 +318,15 @@ class MyTestResult(unittest.TextTestResult):
             self.stream.writeln("")
 
     def addSuccess(self, test):
-        super(MyTestResult, self).addSuccess(test)
+        super(unittest.TextTestResult, self).addSuccess(test)
+        if self.showAll:
+            if test.duration is not None:
+                self.stream.writeln("ok ({:>6.2f}s)".format(test.duration.total_seconds()))
+            else:
+                self.stream.writeln("ok")
+        elif self.dots:
+            self.stream.write('.')
+            self.stream.flush()
         try:
             unlink(test.logname)
             unlink(test.xptname)

--- a/test/test_dos.py
+++ b/test/test_dos.py
@@ -5886,7 +5886,9 @@ $_floppy_a = ""\r
                 r"path=%D\bin;%O"]
 
         try:
+            starttime = datetime.utcnow()
             results = check_output(args, cwd=mosroot, stderr=STDOUT, timeout=300)
+            self.duration = datetime.utcnow() - starttime
             with open(self.xptname, "w") as f:
                 f.write(results.decode('ASCII'))
         except TimeoutExpired as e:

--- a/test/test_dos.py
+++ b/test/test_dos.py
@@ -5873,7 +5873,7 @@ $_floppy_a = ""\r
         #        shell but the binary doesn't die.
 
         # Run the equivalent of the MOSROOT/build.sh script from MOSROOT
-        args = ["../../bin/dosemu.bin",
+        args = ["../../bin/dosemu",
                 "--Fimagedir", "..",
                 "--Flibdir", "../../test-libdir",
                 "-f", "../dosemu.conf",


### PR DESCRIPTION
I think this should do the trick. It shows elapsed time between start and stop of dosemu itself, not the build up and tear down of the test environment.