### PR TITLE
Introduce dosrc.d, but comcom32 doesn't do for loops yet

### DIFF
--- a/src/bindist/fdppauto.bat
+++ b/src/bindist/fdppauto.bat
@@ -10,4 +10,5 @@ echo Welcome to dosemu2!
 system -s DOSEMU_VERSION
 echo     Build %DOSEMU_VERSION%
 call exechlp.bat -ep
+if exist %DOSEMUDRV%:\dosemu\dosrc.d\sugfdusr.bat call %DOSEMUDRV%:\dosemu\dosrc.d\sugfdusr.bat
 if exist %USERDRV%:\userhook.bat call %USERDRV%:\userhook.bat


### PR DESCRIPTION
This contains the line to introduce `dosrc.d`. Without a for loop for now due to limitations in comcom32.