### PR TITLE
KVM: prevent mapping zero-maps from vm86 into KVM memory

### DIFF
--- a/src/base/emu-i386/kvm.c
+++ b/src/base/emu-i386/kvm.c
@@ -468,6 +468,13 @@ void mmap_kvm(int cap, void *addr, size_t mapsize, int protect)
     return;
   if (cap & MAPPING_INIT_LOWRAM) {
     targ = 0;
+#ifdef __i386__
+    /* only relevant for VM86 + KVM-DPMI: the 1GB+64k memory mapped at NULL
+       is only used inside vm86(); non-zero based aliases are used by KVM and
+       DOSEMU2 itself */
+    if (addr == NULL && config.cpu_vm == CPUVM_VM86)
+      return;
+#endif
   }
   else {
     targ = DOSADDR_REL(addr);


### PR DESCRIPTION
Since e6a1f0c (create extra lowmem alias for base 0) this alias
is only used for native vm86 on i386; dosemu2 itself and KVM use
higher-mapped memory already. KVM refuses to map zero-based mappings
and they are not needed so we can safely skip them, and therefore
prevent the native vm86() + KVM dpmi from error-ing out.