### PR TITLE
mapping: add MAPPING_NULL type

### DIFF
--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -568,7 +568,7 @@ char *decode_mapping_cap(int cap)
   if (cap & MAPPING_LOWMEM) p += sprintf(p, " LOWMEM");
   if (cap & MAPPING_SCRATCH) p += sprintf(p, " SCRATCH");
   if (cap & MAPPING_SINGLE) p += sprintf(p, " SINGLE");
-  if (cap & MAPPING_MAYSHARE) p += sprintf(p, " MAYSHARE");
+  if (cap & MAPPING_NULL) p += sprintf(p, " NULL");
   return dbuf;
 }
 

--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -304,7 +304,7 @@ static void *mem_reserve(void **base2, void **r_dpmi_base)
 
 #ifdef __i386__
   if (config.cpu_vm == CPUVM_VM86) {
-    result = mmap_mapping_ux(MAPPING_INIT_LOWRAM | MAPPING_SCRATCH,
+    result = mmap_mapping_ux(MAPPING_NULL | MAPPING_SCRATCH,
 			     NULL, memsize, PROT_NONE);
     if (result == MAP_FAILED) {
       const char *msg =

--- a/src/include/mapping.h
+++ b/src/include/mapping.h
@@ -51,7 +51,7 @@
 #define MAPPING_LOWMEM		0x020000
 #define MAPPING_SCRATCH		0x040000
 #define MAPPING_SINGLE		0x080000
-#define MAPPING_MAYSHARE	0x100000
+#define MAPPING_NULL		0x100000
 #define MAPPING_NOOVERLAP	0x200000
 
 typedef int open_mapping_type(int cap);


### PR DESCRIPTION
This fixes vm86+kvm_dpmi setup.