### PR TITLE
simx86: check iniflag for leave_cpu_emu.

### DIFF
--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -956,7 +956,7 @@ void leave_cpu_emu(void)
 {
 	struct itimerval itv;
 
-	if (config.cpuemu > 1) {
+	if (config.cpuemu > 1 && iniflag) {
 		iniflag = 0;
 #ifdef SKIP_EMU_VBIOS
 		if (IOFF(0x10)==CPUEMU_WATCHER_OFF)


### PR DESCRIPTION
This prevents a potential null dereference for exitemu if you use KVM vm86 +
JIT DPMI but DPMI has never been used.