### PR TITLE
Travis ci 32

### DIFF
--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -326,14 +326,17 @@ class MyTestResult(unittest.TextTestResult):
         super(MyTestResult, self).startTest(test)
         name = test.id().replace('__main__', test.pname)
         test.logname = name + ".log"
+        test.logdisp = "dosemu.log"
         test.xptname = name + ".xpt"
+        test.xptdisp = "expect.log"
         test.firstsub = True
 
     def addFailure(self, test, err):
         super(MyTestResult, self).addFailure(test, err)
         if not test.nologs:
             self.stream.writeln("")
-            self.stream.writeln(">>>>>>>>>>>>>>>>>>>>>>>>>>>> dosemu.log <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<")
+            name = '{:^16}'.format(test.logdisp)
+            self.stream.writeln('{:*^80}'.format(name))
             try:
                 with open(test.logname) as f:
                     self.stream.writeln(f.read())
@@ -342,7 +345,8 @@ class MyTestResult(unittest.TextTestResult):
             self.stream.writeln("")
 
             self.stream.writeln("")
-            self.stream.writeln(">>>>>>>>>>>>>>>>>>>>>>>>>>>> expect.log <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<")
+            name = '{:^16}'.format(test.xptdisp)
+            self.stream.writeln('{:*^80}'.format(name))
             try:
                 with open(test.xptname) as f:
                     self.stream.writeln(f.read())

--- a/test/test_dos.py
+++ b/test/test_dos.py
@@ -8,7 +8,7 @@ from os import (makedirs, statvfs, listdir, symlink, uname, remove,
                 getcwd, mkdir, utime, rename, environ, access, R_OK, W_OK)
 from os.path import exists, isdir, join
 from shutil import copy
-from subprocess import call, check_call, CalledProcessError, STDOUT, TimeoutExpired
+from subprocess import call, check_call, CalledProcessError, DEVNULL, STDOUT, TimeoutExpired
 from time import mktime
 
 from common_framework import (BaseTestCase, main,
@@ -6161,7 +6161,8 @@ $_ignore_djgpp_null_derefs = (off)
         i86repo = 'https://github.com/tkchia/libi86.git'
         i86root = join(getcwd(), 'test-imagedir', 'i86root.git')
 
-        call(["git", "clone", "-q", "--depth=1", i86repo, i86root])
+        call(["git", "clone", "-q", "--single-branch", "--branch=20201003", i86repo, i86root],
+                stdout=DEVNULL, stderr=DEVNULL)
 
         mkfile("dosemu.conf", """\
 $_hdimage = "dXXXXs/c:hdtype1 +1"
@@ -6176,6 +6177,9 @@ $_floppy_a = ""
 
         if environ.get("CC"):
             del environ["CC"]
+
+        self.logdisp = "testsuite.log"
+        self.xptdisp = "cmdline.log"
 
         with open(self.xptname, "w") as f:
             check_call(['../configure', '--host=ia16-elf', '--disable-elks-libc'],
@@ -6192,8 +6196,10 @@ $_floppy_a = ""
                         cwd=build, env=environ, timeout=600, stdout=f, stderr=STDOUT)
                 self.duration = datetime.utcnow() - starttime
             except CalledProcessError:
+                copy(join(build, "tests", "testsuite.log"), self.logname)
                 raise self.failureException("Test error") from None
             except TimeoutExpired:
+                copy(join(build, "tests", "testsuite.log"), self.logname)
                 raise self.failureException("Test timeout") from None
 
     def test_pcmos_build(self):

--- a/test/test_dos.py
+++ b/test/test_dos.py
@@ -6359,6 +6359,7 @@ class FRDOS120TestCase(OurTestCase, unittest.TestCase):
             "test_fat_ds3_share_open_rename_fcb": KNOWNFAIL,
             "test_create_new_psp": KNOWNFAIL,
             "test_pcmos_build": KNOWNFAIL,
+            "test_libi86_build": KNOWNFAIL,
         }
 
         cls.setUpClassPost()


### PR DESCRIPTION
1. Avoid testing on FreeDOS 1.20 due to the drive problem
2. libi86 updates
   1. Checkout a known good version of libi86 (will need updating periodically) to test against
   2. I made sure that on failure tkchia's log file is displayed and captured by travis. This purposefully broken run [here](https://travis-ci.com/github/andrewbird/dosemu2/builds/188173463) shows what you see in that event.