### PR TITLE
allow use of rdtsc on machines with tsc_reliable

### DIFF
--- a/src/base/init/config.c
+++ b/src/base/init/config.c
@@ -670,8 +670,7 @@ static void read_cpu_info(void)
         if (cpuflags && strstr(cpuflags, "tsc")) {
           /* bogospeed currently returns 0; should it deny
            * pentium features, fall back into 486 case */
-          if ((strstr(cpuflags, "constant_tsc") && strstr(cpuflags, "nonstop_tsc"))
-                || strstr(cpuflags, "tsc_reliable")) {
+          if ((strstr(cpuflags, "constant_tsc") && strstr(cpuflags, "nonstop_tsc"))) {
               config.reliable_tsc = 1;
           }
 	  if ((cpumhz = get_proc_string_by_key("cpu MHz"))) {
@@ -722,9 +721,9 @@ static void read_cpu_info(void)
           }
         }
         /* fall thru */
-      case 4: config.realcpu = CPU_486;
+      case CPU_486: config.realcpu = CPU_486;
         /* fall thru */
-      case 3:
+      case CPU_386:
       	break;
       default:
         error("Unknown CPU type!\n");

--- a/src/base/init/config.c
+++ b/src/base/init/config.c
@@ -670,7 +670,8 @@ static void read_cpu_info(void)
         if (cpuflags && strstr(cpuflags, "tsc")) {
           /* bogospeed currently returns 0; should it deny
            * pentium features, fall back into 486 case */
-          if (strstr(cpuflags, "tsc_reliable")) {
+          if ((strstr(cpuflags, "constant_tsc") && strstr(cpuflags, "nonstop_tsc"))
+                || strstr(cpuflags, "tsc_reliable")) {
               config.reliable_tsc = 1;
           }
 	  if ((cpumhz = get_proc_string_by_key("cpu MHz"))) {

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -227,6 +227,7 @@ typedef struct config_info {
        boolean ne2k;
        boolean emuretrace;
        boolean rdtsc;
+       boolean reliable_tsc;
        boolean mapped_bios;	/* video BIOS */
        char *vbios_file;	/* loaded VBIOS file */
        char *vgaemubios_file;	/* loaded VBIOS file */


### PR DESCRIPTION
See #1313 

dosemu traditionally disables the use of rdtsc on machines with more
than one processor, this is because older machines would not keep the
tsc synchronized across cores.

There were also machines that stepped down to save power but not
increment the tsc at the same rate, confusing anything using it. This
has not been a problem for several hardware generations, and modern
machines will get the reliable_tsc flag if they can be used for timing.

This patch checks for that flag, and then allows rdtsc on SMP machines,
which can be a big performance win.

Additionally, some logic was removed that supported old kernels before
2.1.74. The code wont break on a kernel that old - just fall back to CPU_386.

The code used to check of the cpuinfo contained a "features" line, but I
checked all the way back to 2.0.39 and it was still called "flags", so
that must predate the 2.x kernel series (1996 or so).