### PR TITLE
int: Adjust int1a:0 idle params

### DIFF
--- a/src/base/core/int.c
+++ b/src/base/core/int.c
@@ -1112,7 +1112,7 @@ increments AL so we *don't* lose a day if two consecutive midnights pass.
     case 0:			/* read time counter */
 	{
 	    int day_rollover;
-	    idle(0, 50, 0, "int1a:0");
+	    idle(50, 50, 0, "int1a:0");
 	    if (config.timemode == TM_LINUX) {
 		/* Set BIOS area flags to LINUX time computed values always */
 		last_ticks = get_linux_ticks(0, &day_rollover);


### PR DESCRIPTION
This tweak allows the DR-DOS tests to complete without timeout on both
my machine and Travis. The other int1a subfunctions aren't altered
because I have no stimulus to test with. Value suggested by @stsp, see
https://github.com/dosemu2/dosemu2/issues/1313#issuecomment-709353879