### PR TITLE
Travis: Make command line usage a little better

### DIFF
--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -379,7 +379,7 @@ class MyTestRunner(unittest.TextTestRunner):
     resultclass = MyTestResult
 
 
-def main():
+def main(argv=None):
     if version_info < (3, 0):
         exit("Python 3.0 or later is required.")
-    unittest.main(testRunner=MyTestRunner, verbosity=2)
+    unittest.main(testRunner=MyTestRunner, argv=argv, verbosity=2)


### PR DESCRIPTION
I added a little naive option handling and we gained the ability to list the DOS flavours plus the test names, and to finally be able to run the same test on all DOS flavours easily.

$ python3 test/test_dos.py --help
Usage: test/test_dos.py [--help | --list-cases | --list-tests] | [TestCase[.testname]]

$ python3 test/test_dos.py --list-cases
DRDOS701TestCase
FRDOS120TestCase
MSDOS622TestCase
PPDOSGITTestCase

$ python3 test/test_dos.py --list-tests
test_cpu_1_vm86native
test_cpu_2_jitnative
test_cpu_jit
test_cpu_jitkvm
test_cpu_kvm
test_cpu_kvmjit
test_cpu_kvmnative
< snip >

$ python3 test/test_dos.py DRDOS701TestCase.test_systype
< runs one specific test on one specific DOS type >

$ python3 test/test_dos.py DRDOS701TestCase
< runs all tests on DR-DOS >

$ python3 test/test_dos.py test_systype
< runs one specific test on all DOS variants >

Test DR-DOS-7.01 SysType                                                         ... ok (  2.75s)
Test FR-DOS-1.20 SysType                                                         ... ok (  2.31s)
Test MS-DOS-6.22 SysType                                                         ... ok (  2.68s)
Test PP-DOS-GIT SysType                                                          ... ok (  2.25s)

----------------------------------------------------------------------
Ran 4 tests in 10.056s

OK

python3 test/test_dos.py
< runs all tests on all DOS variants >