### PR TITLE
Travis: Add cpu trap flag tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ addons:
       - clang
       - nasm
       - libstdc++-5-dev
+      - python3-cpuinfo
       - python3-pexpect
       - gcc-djgpp
       - qemu-system-common

--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -79,6 +79,7 @@ class BaseTestCase(object):
         cls.confsys = "config.sys"
 
         cls.nologs = False
+        cls.msg = None
 
     @classmethod
     def setUpClassPost(cls):
@@ -146,6 +147,9 @@ class BaseTestCase(object):
     def shortDescription(self):
         doc = super(BaseTestCase, self).shortDescription()
         return "Test %s %s" % (self.prettyname, doc)
+
+    def setMessage(self, msg):
+        self.msg = msg
 
 # helpers
 
@@ -322,6 +326,7 @@ class MyTestResult(unittest.TextTestResult):
         test.xptname = name + ".xpt"
         test.xptdisp = "expect.log"
         test.firstsub = True
+        test.msg = None
 
     def addFailure(self, test, err):
         super(MyTestResult, self).addFailure(test, err)
@@ -351,7 +356,8 @@ class MyTestResult(unittest.TextTestResult):
         if self.showAll:
             if self.starttime is not None:
                 duration = datetime.utcnow() - self.starttime
-                self.stream.writeln("ok ({:>6.2f}s)".format(duration.total_seconds()))
+                msg = (" " + test.msg) if test.msg else ""
+                self.stream.writeln("ok ({:>6.2f}s){}".format(duration.total_seconds(), msg))
             else:
                 self.stream.writeln("ok")
         elif self.dots:

--- a/test/func_cpu_trap_flag.py
+++ b/test/func_cpu_trap_flag.py
@@ -1,0 +1,96 @@
+
+from common_framework import mkfile, mkcom
+from cpuinfo import get_cpu_info
+
+
+def cpu_trap_flag(self, cpu_vm):
+
+    config = '$_hdimage = "dXXXXs/c:hdtype1 +1"\n$_floppy_a = ""\n'
+    if cpu_vm == 'kvm':
+        config += '$_cpu_vm = "kvm"\n'
+    elif cpu_vm == 'emulated':
+        config += '$_cpu_vm = "emulated"\n'
+    else:
+        raise ValueError('invalid argument')
+
+    mkfile("testit.bat", """\
+c:\\cputrapf
+rem end
+""", newline="\r\n")
+
+    # compile sources
+    mkcom("cputrapf", r"""
+.text
+.code16
+
+    .globl  _start16
+_start16:
+
+    push    %cs
+    pop     %ds
+
+    movw    $0x2501, %ax
+    movw    $int1, %dx
+    int     $0x21
+    pushw   $0x3003
+    pushw   $0x3303
+    popfw
+    popfw
+    nop
+
+    movb    $0x9, %ah              # print string
+    movw    $result, %dx
+    int     $0x21
+
+exit:
+    movw    $0x4c00, %ax
+    int     $0x21
+    ret
+
+int1:
+    incb    %cs:cnt
+    iret
+
+result:
+    .ascii "Result is ("
+cnt:
+    .byte '0'
+    .ascii ")\r\n$"
+
+""")
+
+    results = self.runDosemu("testit.bat", config=config)
+
+    self.assertIn("Result is (1)", results)
+
+    if cpu_vm != 'kvm':
+        return
+
+    # check for fixup
+    fixupmsg = "KVM: applying TF fixup"
+    knownbad = (
+        'AMD FX(tm)-8350 Eight-Core Processor',
+    )
+
+    # get log content
+    logcontents = 'Missing'
+    with open(self.logname, "r") as f:
+        logcontents = f.read()
+
+    cpu = get_cpu_info()
+    try:
+        name = cpu['brand']
+    except KeyError:
+        try:
+            name = cpu['brand_raw']
+        except KeyError:
+            name = str(cpu)
+
+    if name in knownbad:
+        if fixupmsg in results or fixupmsg in logcontents:
+            self.setMessage("known bad cpu '%s'" % name)
+        else:
+            self.fail("Unexpected success with cpu '%s'" % name)
+    else:
+        if fixupmsg in results or fixupmsg in logcontents:
+            self.fail("Fail with unknown cpu '%s'" % name)

--- a/test/test_dos.py
+++ b/test/test_dos.py
@@ -19,6 +19,7 @@ from common_framework import (BaseTestCase, main,
                               mkfile, mkexe, mkcom, mkstring, WORKDIR,
                               IPROMPT, KNOWNFAIL, UNSUPPORTED)
 
+from func_cpu_trap_flag import cpu_trap_flag
 from func_ds2_set_fattrs import ds2_set_fattrs
 from func_ds3_lock_two_handles import ds3_lock_two_handles
 from func_ds3_lock_readlckd import ds3_lock_readlckd
@@ -5302,6 +5303,14 @@ $_ignore_djgpp_null_derefs = (off)
     def test_cpu_sim(self):
         """CPU test: simulated vm86 + simulated DPMI"""
         self._test_cpu("emulated", "emulated", "fullsim")
+
+    def test_cpu_trap_flag_emulated(self):
+        """CPU Trap Flag emulated"""
+        cpu_trap_flag(self, 'emulated')
+
+    def test_cpu_trap_flag_kvm(self):
+        """CPU Trap Flag KVM"""
+        cpu_trap_flag(self, 'kvm')
 
     def xtest_libi86_build(self):
         """libi86 build and test script"""


### PR DESCRIPTION
Run as `python3 test/test_dos.py PPDOSGITTestCase.test_cpu_trap_flag`

1. Can you review my changes to your test case?
1. Can you check this fails on your system with current devel (should fail due to fixup message)?
2. Then if you roll back devel to before the 'fixup' commit, check that it still fails. (should fail due to incorrect value)?

Thanks!