### PR TITLE
mfs: add 64-bit seek support, using EDR-DOS's int21.7142

### DIFF
--- a/src/base/core/int.c
+++ b/src/base/core/int.c
@@ -1436,7 +1436,16 @@ static int msdos(void)
 	    idle(2, 100, 0, "dos_time");
 	    return 0;
 	}
-
+    case 0x42:{
+	return mfs_old_seek();		// old-style 32-bit seek
+	//  (need to handle because we use 64-bit size and seek internally)
+    }
+    case 0x71:{
+	if (LO(ax) == 0x42) {
+	  return mfs_new_seek();	// EDR-DOS 64-bit seek
+	}
+	break;
+    }
     case 0x4B:{		/* program load */
 	    char *ptr;
 	    const char *tmp_ptr;
@@ -1762,6 +1771,9 @@ static int msdos_chainrevect(int stk_offs)
 {
     switch (HI(ax)) {
     case 0x71:
+	if (LO(ax) == 0x42) {
+	  break;		// EDR-DOS 64-bit seek (handled in msdos())
+	}
 	if (config.lfn)
 	    return I_SECOND_REVECT;
 	break;

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -379,6 +379,8 @@ extern void mfs_reset(void);
 extern int mfs_redirector(void);
 extern int mfs_fat32(void);
 extern int mfs_lfn(void);
+extern int mfs_old_seek(void);
+extern int mfs_new_seek(void);
 extern int int10(void);
 extern int int13(void);
 extern int int16(void);


### PR DESCRIPTION
Reference: https://www.bttr-software.de/forum/forum_entry.php?id=17254

Reference: http://web.archive.org/web/20201211155254/https://groups.google.com/g/comp.os.msdos.djgpp/c/jlxRjYzYiI4/m/wruOJMMdurwJ

This makes mfs hook interrupt 21h services 42h and 7142h.

The old-style seek is hooked to allow re-interpreting the
32-bit seek offsets: absolute unsigned seek for SEEK_SET,
relative signed seek for SEEK_CUR and SEEK_EOF, and return
FFFFffffh if the new position is >= 4 GiB.

The new-style hook is hooked to allow 64-bit seeking with
the same API as supported by Enhanced DR-DOS for its FAT+
implementation.

In both cases, we check that the handle is open and refers to
an mfs file before we handle the call.

Additionally we use new fields for size and seek offset in
the mfs file structure. The seek offset is updated from DOS's
idea of it if the latter changed independently from us;
DOS may seek through the file without notifying the redirector.