### PR TITLE
Travis: Log file handling

### DIFF
--- a/test/func_cpu_trap_flag.py
+++ b/test/func_cpu_trap_flag.py
@@ -74,7 +74,7 @@ cnt:
 
     # get log content
     logcontents = 'Missing'
-    with open(self.logname, "r") as f:
+    with open(self.logfiles['log'][0], "r") as f:
         logcontents = f.read()
 
     cpu = get_cpu_info()


### PR DESCRIPTION
  1/ Allow tests to specify which and how many logs to display on
test failure.

  2/ Change the display of our logs to occur after all tests have
been run rather than at individual test failure time. This is how
python unittest normally works and means that they are grouped
alongside any stdout or stderr that occured and the primary results
table is undisturbed on failure.

  3/ Change the tests that use unusual logging practices to use the
new mechanism.