### PR TITLE
mfs: add 64-bit seek support, using EDR-DOS's int21.7142 [patch v2]

### DIFF
--- a/src/base/bios/x86/bios.s
+++ b/src/base/bios/x86/bios.s
@@ -687,31 +687,42 @@ do_int21:
         popw	%ds
         lret
 
+        .globl LFN_42_HELPER_OFF
+LFN_42_HELPER_OFF:
+        movw	$0x1142, %ax
+	jmp	LFN_42_A6_HELPER_COMMON
+
         .globl LFN_A6_HELPER_OFF
 LFN_A6_HELPER_OFF:
+        movw	$0x11a6, %ax
+
+LFN_42_A6_HELPER_COMMON:
         pushw	%es
         pushw	%di
         pushw	%bx
+        pushw	%ax
         movw	$0x1220, %ax
         int	$0x2f
         jc	1f
         movzbw	%es:(%di), %bx
         cmpb	$0xff, %bl
-        je	2f
+        movw	$6, %ax		/* error code: invalid handle */
+        stc			/* initialise CY if jumping */
+        je	1f
         movw	$0x1216, %ax
         int	$0x2f
         jc	1f
         stc
-        movw	$0x11a6, %ax
+        popw	%ax		/* restore function number */
         int	$0x2f
+        jmp	3f
 1:
+	popw	%bx		/* discard ax on stack */
+3:
         popw	%bx
         popw	%di
         popw	%es
         lret
-2:
-        stc
-        jmp	1b
 /* ----------------------------------------------------------------- */
 
 	.globl DBGload_OFF

--- a/src/dosext/mfs/lfn.c
+++ b/src/dosext/mfs/lfn.c
@@ -837,6 +837,9 @@ static int mfs_lfn_(void)
 		if (unlink(fpath) != 0)
 			return lfn_error(FILE_NOT_FOUND);
 		break;
+	case 0x42: /* long seek (EDR-DOS compatible) */
+		fake_call_to(LFN_HELPER_SEG, LFN_42_HELPER_OFF);
+		break;
 	case 0x43: /* get/set file attributes */
 		d_printf("LFN: attribute %s %d\n", src, _BL);
 		drive = build_posix_path(fpath, src, 0);


### PR DESCRIPTION
In a forum post on DOS standards [1] the Enhanced DR-DOS
extension interrupt 21h service 7142h "long seek" was
mentioned [2]. There was a prior dosemu2 PR revision with
some discussion about it [3]. The changes since the first
revision include file size change detection as added to
the seek from EOF service too, and a change in how the
new and old style seeking interfaces are handled.

This commit makes mfs hook interrupt 21h service 7142h.
This new-style hook is handled to allow 64-bit seeking
with the same API as supported by Enhanced DR-DOS for
its FAT+ implementation.

The hook occurs in lfn.c and just passes the call to a
new interface, the redirector interrupt 2Fh service 1142h.
The handling is similar to that of service 71A6h. The
new redirector service is handled in mfs.c as usual.

Additionally we use new fields for size and seek offset in
the mfs file structure. The seek offset is updated from DOS's
idea of it if the latter changed independently from us;
DOS may seek through the file without notifying the redirector.

The old-style seek is not hooked because the developers of
dosemu2 decided against such a hook. There is a companion
TSR application [4] that does add such a hook, to allow
re-interpreting the 32-bit seek offsets: absolute unsigned
seek for SEEK_SET, relative signed seek for SEEK_CUR and
SEEK_EOF, and return FFFFffffh if the new position is
below - (4 GiB - 1 B) or above 4 GiB - 1 B. (This is to
behave in a manner compatible to EDR-DOS. The purpose is
to allow non-aware applications to work sequentially on
large files, if they do not seek with absolute values.)

[1]: https://www.bttr-software.de/forum/forum_entry.php?id=17254
[2]: https://web.archive.org/web/20201211155254/https://groups.google.com/g/comp.os.msdos.djgpp/c/jlxRjYzYiI4/m/wruOJMMdurwJ
[3]: https://github.com/dosemu2/dosemu2/pull/1363
[4]: https://hg.ulukai.org/ecm/seekext/