### PR TITLE
Move two disruptive messages to the log

### DIFF
--- a/src/base/bios/int10.c
+++ b/src/base/bios/int10.c
@@ -477,7 +477,7 @@ boolean set_video_mode(int mode)
     return 0;
   }
   if (vmi->mode_class == GRAPH && config.term) {
-    error("Cannot set graphics mode under terminal!\n");
+    i10_msg("Cannot set graphics mode under terminal!\n");
     return 0;
   }
   if (!memcheck_is_reserved(vmi->buffer_start << 4, 0x8000, 'v')) {

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -2776,7 +2776,7 @@ repag0:
 				case 0: /* SGDT */
 				    /* Store Global Descriptor Table Register */
 				    PC++; PC += ModRM(opc, PC, mode|DATA16|MSTORE);
-				    error("SGDT not implemented\n");
+				    dbug_printf("SGDT not implemented\n");
 				    break;
 				case 1: /* SIDT */
 				    /* Store Interrupt Descriptor Table Register */


### PR DESCRIPTION
These two errors are written to the screen when 123R4D starts, putting
the terminal in an unpredictable state. The messages are not fatal
and 123 works fine.