### PR TITLE
Test: Don't override FDPP kernel placement

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -36,8 +36,6 @@ jobs:
 
     - name: test
       id: test
-      env:
-        FDPP_KERNEL_DIR: /home/runner/work/dosemu2/dosemu2/localfdpp/lib/fdpp
       run: ./ci_test.sh
 
     - name: upload failure logs

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ cache:
   directories:
     - $HOME/cache
 
-env: FDPP_KERNEL_DIR="$(pwd)/localfdpp/share/fdpp"
-
 before_install:
   - ./ci_prereq.sh
 


### PR DESCRIPTION
No need for this, as it's found automatically and creates an unnecessary
burden to change it when the kernel location changes.