### PR TITLE
mfs: remove trailing / on get redirection

### DIFF
--- a/src/base/core/int.c
+++ b/src/base/core/int.c
@@ -2504,16 +2504,12 @@ static int add_redir_group(int redirIdx, int mfs_idx)
 {
     char dStr[MAX_DEVICE_STRING_LENGTH];
     char resourceStr[MAX_RESOURCE_LENGTH_EXT];
-    char *p;
     uint16_t rc, opts;
 
     rc = get_redirection_ux(redirIdx, dStr, sizeof(dStr),
             resourceStr, sizeof(resourceStr), NULL, &opts, NULL);
     if (rc != CC_SUCCESS)
         return -1;
-    p = &resourceStr[strlen(resourceStr) - 1];
-    if (*p == '/')
-        *p = '\0';
     return add_drive_group(resourceStr, mfs_idx);
 }
 

--- a/src/dosext/mfs/mfs.c
+++ b/src/dosext/mfs/mfs.c
@@ -2959,6 +2959,9 @@ static int GetRedirection(struct vm86_regs *state, int rSize, int subfunc)
         } else {
           snprintf(resourceName, rSize, "%s", drives[dd].root);
         }
+        /* remove trailing / */
+        if (drives[dd].root_len > 1)
+          resourceName[drives[dd].root_len - 1] = '\0';
         Debug0((dbg_fd, "resource name =%s\n", resourceName));
 
         /* have to return BX, and CX on the user return stack */


### PR DESCRIPTION
Much easier to deal with.

In lfn.c add a compatibility wrapper that adds / back.