### PR TITLE
configure.ac:add condition for '-Wno-string-plus-int'

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -154,11 +154,9 @@ machine=`"$CC" -dumpmachine | cut -d- -f1`
 DOSEMU_CPPFLAGS="-imacros config.hh"
 DOSEMU_CFLAGS="-Wall -Wstrict-prototypes -Wmissing-declarations \
 -Wnested-externs -fms-extensions -pthread \
--Wno-unused-result -Wcast-qual -Wwrite-strings"
-AX_CHECK_COMPILE_FLAG([-Waddress-of-packed-member -Werror],
-  [DOSEMU_CFLAGS="$DOSEMU_CFLAGS -Wno-address-of-packed-member"])
-AX_CHECK_COMPILE_FLAG([-Wno-string-plus-int],
-  [DOSEMU_CFLAGS="$DOSEMU_CFLAGS -Wno-string-plus-int"],, [-Werror])
+-Wno-unused-result -Wcast-qual -Wwrite-strings -Wno-string-plus-int"
+AX_CHECK_COMPILE_FLAG([-Waddress-of-packed-member],
+  [DOSEMU_CFLAGS="$DOSEMU_CFLAGS -Wno-address-of-packed-member"],, [-Werror])
 DOSEMU_LDFLAGS="-pthread"
 
 AC_CHECK_LIB(m, pow)

--- a/configure.ac
+++ b/configure.ac
@@ -154,9 +154,11 @@ machine=`"$CC" -dumpmachine | cut -d- -f1`
 DOSEMU_CPPFLAGS="-imacros config.hh"
 DOSEMU_CFLAGS="-Wall -Wstrict-prototypes -Wmissing-declarations \
 -Wnested-externs -fms-extensions -pthread \
--Wno-unused-result -Wcast-qual -Wwrite-strings -Wno-string-plus-int"
+-Wno-unused-result -Wcast-qual -Wwrite-strings"
 AX_CHECK_COMPILE_FLAG([-Waddress-of-packed-member -Werror],
   [DOSEMU_CFLAGS="$DOSEMU_CFLAGS -Wno-address-of-packed-member"])
+AX_CHECK_COMPILE_FLAG([-Wno-string-plus-int],
+  [DOSEMU_CFLAGS="$DOSEMU_CFLAGS -Wno-string-plus-int"],, [-Werror])
 DOSEMU_LDFLAGS="-pthread"
 
 AC_CHECK_LIB(m, pow)


### PR DESCRIPTION
Building on Ubuntu Focal (in a docker container), make threw an error
that `-Wno-string-plus-int` was an unrecognized option.

```
## --------- ##
## Platform. ##
## --------- ##

hostname = e1620c26eb2d
uname -m = x86_64
uname -r = 4.19.0-16-amd64
uname -s = Linux
uname -v = #1 SMP Debian 4.19.181-1 (2021-03-19)

/usr/bin/uname -p = x86_64
/bin/uname -X     = unknown

/bin/arch              = x86_64
/usr/bin/arch -k       = unknown
/usr/convex/getsysinfo = unknown
/usr/bin/hostinfo      = unknown
/bin/machine           = unknown
/usr/bin/oslevel       = unknown
/bin/universe          = unknown

PATH: /usr/local/sbin
PATH: /usr/local/bin
PATH: /usr/sbin
PATH: /usr/bin
PATH: /sbin
PATH: /bin


## ----------- ##
## Core tests. ##
## ----------- ##

configure:2303: checking whether make supports nested variables
configure:2320: result: yes
configure:2351: checking whether to enable maintainer-specific portions of Makefiles
configure:2360: result: no
configure:2428: checking for gcc
configure:2444: found /usr/bin/gcc
configure:2455: result: gcc
configure:2684: checking for C compiler version
configure:2693: gcc --version >&5
gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0
Copyright (C) 2019 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```