### PR TITLE
Hardware Rendering Band Aid

### DIFF
--- a/src/arch/linux/async/signal.c
+++ b/src/arch/linux/async/signal.c
@@ -1165,6 +1165,11 @@ static void sigasync0(int sig, sigcontext_t *scp, siginfo_t *si)
 {
   pthread_t tid = pthread_self();
   if (!pthread_equal(tid, dosemu_pthread_self)) {
+    /* Nvidia libGL creates a thread ("CPMMListener") which sends
+     * SIGVTALARM to itself. Don't bother spawning gdb for a backtrace.
+     */
+    if (sig == SIGVTALRM || sig == SIGALRM)
+        return;
 #if defined(HAVE_PTHREAD_GETNAME_NP) && defined(__GLIBC__)
     char name[128];
     pthread_getname_np(tid, name, sizeof(name));
@@ -1182,6 +1187,11 @@ static void sigasync0_std(int sig, sigcontext_t *scp, siginfo_t *si)
 {
   pthread_t tid = pthread_self();
   if (!pthread_equal(tid, dosemu_pthread_self)) {
+    /* Nvidia libGL creates a thread ("CPMMListener") which sends
+     * SIGVTALARM to itself. Don't bother spawning gdb for a backtrace.
+     */
+    if (sig == SIGVTALRM || sig == SIGALRM)
+        return;
 #if defined(HAVE_PTHREAD_GETNAME_NP) && defined(__GLIBC__)
     char name[128];
     pthread_getname_np(tid, name, sizeof(name));

--- a/src/plugin/sdl/sdl.c
+++ b/src/plugin/sdl/sdl.c
@@ -884,6 +884,14 @@ static void SDL_put_image(int x, int y, unsigned width, unsigned height)
 
   SDL_UpdateTexture(texture_buf, &rect, surface->pixels + offs,
       surface->pitch);
+
+  /* We have to synchronize resource updates across contexts manually.
+   *
+   * Could use a glSync object here, if available, but I doubt it is worth
+   * it. Uploading the screen data is the biggest chunk of work we do. */
+  if (update_ctx)
+      glFinish();
+
   tmp_rects_num++;
   pthread_mutex_unlock(&tex_mtx);
   pthread_mutex_unlock(&rend_mtx);


### PR DESCRIPTION
These commits get sdl.hwrend working on Nvidia drivers, although only by abusing some lucky coincidences. Please review this, especially patch 1, before merging.

The fundamental issue is that dosemu's two screen update threads (one in sdl.c, the other in video/render.c) don't work with OpenGL's per-thread context state machine. These patches create extra contexts for the two other threads to allow OpenGL operations (loading the texture and drawing/presenting) to happen.

The lucky coincidence is that SDL tries to activate the first context, fails, and proceeds anyway, thus using my other contexts and succeeds doing the work it wants to do.

In the long run we'll probably want to separate software from hardware rendering. That would allow the HW renderer to use a more GL-friendly thread setup, use pixel buffer objects for faster upload (ideally just mmap'ing video or GART memory and writing to it) and shaders to do pixel format conversions and palette lookups. Furthermore hooking up vsync and double buffer between GL and emulated VGA might be an idea, but I have to look into the details whenever I have time.

TTF rendering is and remains broken with hwrend on all drivers because it only updates part of the double-buffered screen, flips, and flickers between two half-updated versions.