### PR TITLE
umb.sys: return success when not loading driver [#1512]

### DIFF
--- a/src/plugin/dosdrv/umb.s
+++ b/src/plugin/dosdrv/umb.s
@@ -141,6 +141,8 @@ Init:
 1:
 	call	HookHimem
 	jc	Error
+	orw	%ax, %ax
+	jnz	SuccessNoload
 
 	movb	$9, %ah
 	movw	$UmbInstalledMsg, %dx
@@ -168,13 +170,17 @@ Init:
 	jmp	Error
 
 Error:
+	movw	$0x800c, %ax		# error
+	jmp 4f
+
+SuccessNoload:
+	xorw    %ax, %ax		# okay
+
+4:
 	movw	$0, %cs:HdrAttr		# Set to block type
 	movb	$0, %es:13(%di)		# Units = 0
-
 	movw	$0,%es:14(%di)		# Break addr = cs:0000
 	movw	%cs,%es:16(%di)
-
-	movw	$0x800c, %ax		# error
 	ret
 
 DosemuTooOldMsg:

--- a/src/plugin/dosdrv/xms.inc
+++ b/src/plugin/dosdrv/xms.inc
@@ -48,8 +48,9 @@ HookHimem:
 	movb	$9, %ah
 	movw	$XMSMsg, %dx
 	int	$0x21
-	/* internal driver installed - go out with error */
-	jmp	9f
+	/* internal driver installed - go out */
+	mov	$1, %ax    # indicate no-load
+	jmp	10f
 1:
 	/* get entry point */
 	movw	$0xffff, %bx
@@ -102,6 +103,7 @@ HookHimem:
 	int	$0x21
 	/* all done, UMB should work */
 	clc
+	mov	$0, %ax    # indicate load
 	jmp	10f
 
 27:


### PR DESCRIPTION
If there is no external himem, then there is no need to load
any driver. But the return code should still indicate success.