### PR TITLE
Ci 53

### DIFF
--- a/ci_prereq.sh
+++ b/ci_prereq.sh
@@ -50,5 +50,6 @@ sudo apt install -y \
   gdb \
   valgrind \
   gcc-ia16-elf \
+  libi86-ia16-elf \
   gcc-multilib \
   dos2unix

--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -1608,29 +1608,24 @@ int int13(void)
       } else {
 	  error("DISK %02x undefined.\n", disk);
       }
-      show_regs();
       HI(ax) = DERR_NOTFOUND;
       REG(eflags) |= CF;
       break;
     }
 
     if (dp->rdonly) {
-      W_printf("write protect!\n");
-      show_regs();
+      W_printf("DISK %02x write protected!\n", disk);
       if (dp->floppy)
-	HI(ax) = DERR_WP;
+        HI(ax) = DERR_WP;
       else
-	HI(ax) = DERR_WRITEFLT;
+        HI(ax) = DERR_WRITEFLT;
       REG(eflags) |= CF;
       break;
     }
 
-    if (dp->rdonly)
-      W_printf("CONTINUED!!!!!\n");
     res = write_sectors(dp, buffer,
 			DISK_OFFSET(dp, head, sect, track) / SECTOR_SIZE,
 			number);
-
     if (res < 0) {
       W_printf("DISK write error: %d\n", -res);
       HI(ax) = -res;
@@ -2043,27 +2038,22 @@ int int13(void)
       } else {
 	  error("DISK %02x undefined.\n", disk);
       }
-      show_regs();
       HI(ax) = DERR_NOTFOUND;
       REG(eflags) |= CF;
       break;
     }
 
     if (dp->rdonly) {
-      d_printf("DISK is write protected!\n");
-      show_regs();
+      d_printf("DISK %02x is write protected!\n", disk);
       if (dp->floppy)
-	HI(ax) = DERR_WP;
+        HI(ax) = DERR_WP;
       else
-	HI(ax) = DERR_WRITEFLT;
+        HI(ax) = DERR_WRITEFLT;
       REG(eflags) |= CF;
       break;
     }
 
-    if (dp->rdonly)
-      error("CONTINUED!!!!!\n");
     res = write_sectors(dp, buffer, diskaddr->block, number);
-
     if (res < 0) {
       HI(ax) = -res;
       CARRY;

--- a/src/dosext/mfs/mfs.c
+++ b/src/dosext/mfs/mfs.c
@@ -4911,7 +4911,7 @@ do_create_truncate:
         do_update_sft(f, fname, fext, sft, drive, 0, FCBcall, 1);
         return TRUE;
       }
-      if (read_only(drives[drive]) && dos_mode != READ_ACC) {
+      if (read_only(drives[drive]) && dos_mode == WRITE_ACC) {
         SETWORD(&state->eax, ACCESS_DENIED);
         return FALSE;
       }

--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -185,6 +185,18 @@ class BaseTestCase(object):
                     basename + ".com"])
         check_call(["rm", basename + ".o", basename + ".com.elf"])
 
+    def mkcom_with_ia16(self, fname, content, dname=None):
+        if dname is None:
+            p = self.workdir
+        else:
+            p = Path(dname).resolve()
+        basename = str(p / fname)
+
+        with open(basename + ".c", "w") as f:
+            f.write(content)
+        check_call(["ia16-elf-gcc", "-mcmodel=small",
+                    "-o", basename + ".com", basename + ".c", "-li86"])
+
     def mkexe_with_djgpp(self, fname, content, dname=None):
         if dname is None:
             p = self.workdir

--- a/test/func_ds3_file_access.py
+++ b/test/func_ds3_file_access.py
@@ -1,0 +1,151 @@
+
+
+# Opens a file READ/WRITE even on a READONLY filesystem
+# fstype = FAT, FATRO, MFS, MFSRO
+# optype = READ, WRITE
+
+def ds3_file_access(self, fstype, optype):
+
+    testdir = self.mkworkdir('d')
+
+    self.mkfile("testit.bat", """\
+d:
+%s
+c:\\fileaccs %s
+rem end
+""" % ("rem Internal share" if self.version == "FDPP kernel" else "c:\\share", optype), newline="\r\n")
+
+# compile sources
+    self.mkcom_with_ia16("fileaccs", r"""
+
+#include <dos.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+
+#define FNAME "FOO.DAT"
+#define FDATA "0123456789abcdef\n"
+char ibuf[32];
+
+void __far __interrupt (*oldint24)(void);
+
+volatile uint16_t int24_ax;
+
+void __far __interrupt myint24(void); /* Prototype */
+__asm (
+  "myint24:\n"
+  "  pushw %bp\n"
+  "  movw  %sp, %bp\n"
+
+  "  pushw %ds\n"
+  "  pushw 22(%bp)\n"   /* int21 caller's DS on stack */
+  "  popw  %ds\n"
+  "  movw %ax, int24_ax\n"
+  "  popw  %ds\n"
+
+  "  popw  %bp\n"
+
+  "  movb $0x03, %al\n" /* 0=Ignore, 1=Retry, 2=Terminate, 3=Fail */
+  "  iretw\n"
+);
+
+
+int main(int argc, char *argv[])
+{
+
+  int handle;
+  unsigned int ret, num;
+
+  if (argc < 2) {
+    printf("Error: missing optype (READ|WRITE) argument\n");
+    return -1;
+  }
+
+  // Setup int24 handler
+  int24_ax = 0;
+  oldint24 = _dos_getvect(0x24);
+  _dos_setvect(0x24, myint24);
+
+  ret = _dos_open(FNAME, O_RDWR, &handle);
+  if (ret != 0) {
+    printf("Error: File Open failed(ret = 0x%02x)\n", ret);
+    _dos_setvect(0x24, oldint24);
+    return -1;
+  }
+  printf("Info: File Open success\n");
+
+  if (strcmp(argv[1], "WRITE") == 0) {
+    // It's unlikely this write will fail on a write to readonly disk
+    // due to DOS buffering, so use commit to force the error.
+    printf("Info: About to write\n");
+    ret = _dos_write(handle, FDATA, strlen(FDATA), &num);
+    if (ret != 0) {
+      printf("Info: File Write failed(ret = 0x%02x)\n", ret);
+      // The file is in error condition, so _dos_close() causes another int24
+      _dos_close(handle);
+      _dos_setvect(0x24, oldint24);
+      return -1;
+    }
+    printf("Info: About to commit\n");
+    ret = _dos_commit(handle);
+    if (ret != 0) {
+      printf("Info: File Commit failed(ret=0x%02x, int24_ax=0x%04x)\n", ret, int24_ax);
+      // The file is in error condition, so _dos_close() causes another int24
+      _dos_close(handle);
+      _dos_setvect(0x24, oldint24);
+      return -1;
+    }
+    printf("Info: File Write/Commit success(num=%u)\n", num);
+
+  } else {
+    ret = _dos_read(handle, ibuf, strlen(FDATA), &num);
+    if (ret != 0) {
+      printf("Info: File Read failed(ret = 0x%02x)\n", ret);
+      _dos_close(handle);
+      _dos_setvect(0x24, oldint24);
+      return -1;
+    }
+    printf("Info: File Read success(num=%u)\n", num);
+  }
+
+  ret = _dos_close(handle);
+  if (ret != 0) {
+    printf("Error: File Close returned(ret = %02x)\n", ret);
+    _dos_setvect(0x24, oldint24);
+    return -1;
+  }
+  printf("Info: File Close success\n");
+
+  _dos_setvect(0x24, oldint24);
+  return 0;
+}
+""")
+
+    self.mkfile("FOO.DAT", "xxxxxxxx", dname=testdir)
+
+    if fstype.startswith("MFS"):
+        name = "dXXXXs/d"
+    else:
+        name = self.mkimage("12", cwd=testdir)
+
+    if fstype.endswith("RO"):
+        name += ":ro"
+
+    results = self.runDosemu("testit.bat", config="""\
+$_hdimage = "dXXXXs/c:hdtype1 %s +1"
+$_floppy_a = ""
+""" % name, timeout=10)
+
+    self.assertIn("File Open success", results)
+    if fstype.endswith("RO"):
+        if optype == "WRITE":
+            self.assertNotIn("File Write/Commit success", results)
+        else:
+            self.assertIn("File Read success", results)
+            self.assertIn("File Close success", results)
+    else:
+        if optype == "WRITE":
+            self.assertIn("File Write/Commit success", results)
+        else:
+            self.assertIn("File Read success", results)
+        self.assertIn("File Close success", results)

--- a/test/test_dos.py
+++ b/test/test_dos.py
@@ -22,6 +22,7 @@ from func_cpu_trap_flag import cpu_trap_flag
 from func_ds2_file_seek_tell import ds2_file_seek_tell
 from func_ds2_file_seek_read import ds2_file_seek_read
 from func_ds2_set_fattrs import ds2_set_fattrs
+from func_ds3_file_access import ds3_file_access
 from func_ds3_lock_concurrent import ds3_lock_concurrent
 from func_ds3_lock_two_handles import ds3_lock_two_handles
 from func_ds3_lock_readlckd import ds3_lock_readlckd
@@ -4414,6 +4415,38 @@ $_floppy_a = ""
         for t in tests:
             with self.subTest(t=t):
                 ds2_set_fattrs(self, "FAT", t)
+
+    def test_fat_ds3_file_access_read(self):
+        """FAT DOSv3 file access read"""
+        ds3_file_access(self, "FAT", "READ")
+
+    def test_mfs_ds3_file_access_read(self):
+        """MFS DOSv3 file access read"""
+        ds3_file_access(self, "MFS", "READ")
+
+    def test_fat_ds3_file_access_write(self):
+        """FAT DOSv3 file access write"""
+        ds3_file_access(self, "FAT", "WRITE")
+
+    def test_mfs_ds3_file_access_write(self):
+        """MFS DOSv3 file access write"""
+        ds3_file_access(self, "MFS", "WRITE")
+
+    def test_fat_ds3_file_access_read_device_readonly(self):
+        """FAT DOSv3 file access read device readonly"""
+        ds3_file_access(self, "FATRO", "READ")
+
+    def test_mfs_ds3_file_access_read_device_readonly(self):
+        """MFS DOSv3 file access read device readonly"""
+        ds3_file_access(self, "MFSRO", "READ")
+
+    def test_fat_ds3_file_access_write_device_readonly(self):
+        """FAT DOSv3 file access write device readonly"""
+        ds3_file_access(self, "FATRO", "WRITE")
+
+    def test_mfs_ds3_file_access_write_device_readonly(self):
+        """MFS DOSv3 file access write device readonly"""
+        ds3_file_access(self, "MFSRO", "WRITE")
 
     def test_mfs_ds3_lock_readonly(self):
         """MFS DOSv3 lock file readonly"""


### PR DESCRIPTION
So finally here is the test of opening a file on a readonly filesystem in R/W mode. The behaviour of trying to then write to that file is slightly different between MFS and FAT. On FAT the `write()` succeeds, and is only reported to the caller when the kernel does the write to disk, and so in this test we trigger that event by doing `commit()`. However on MFS the redirector reports the error immediately upon `write()`