### PR TITLE
int13: set transparent DMA flag

### DIFF
--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -2124,7 +2124,7 @@ int int13(void)
       break;
     }
 
-    WRITE_P(params->flags, IMEXT_INFOFLAG_CHSVALID);
+    WRITE_P(params->flags, IMEXT_INFOFLAG_CHSVALID | IMEXT_INFOFLAG_NODMAERR);
     if (dp->floppy)
       WRITE_P(params->flags, params->flags | IMEXT_INFOFLAG_REMOVABLE);
     WRITE_P(params->tracks, dp->tracks);

--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -1633,8 +1633,6 @@ int int13(void)
       break;
     }
 
-    if (dp->rdonly)
-      W_printf("CONTINUED!!!!!\n");
     res = write_sectors(dp, buffer,
 			DISK_OFFSET(dp, head, sect, track) / SECTOR_SIZE,
 			number);
@@ -1958,16 +1956,6 @@ int int13(void)
 	     disk, diskaddr->block, number,
 	     buffer, diskaddr->buf_seg, diskaddr->buf_ofs);
 
-    if (number > I13_MAX_ACCESS) {
-      error("Too large read, ah=0x42!\n");
-      error("DISK %02x ext read [LBA %"PRIu64"](%d)->%#x (%04x:%04x)\n",
-	    disk, diskaddr->block, number,
-	    buffer, diskaddr->buf_seg, diskaddr->buf_ofs);
-      HI(ax) = DERR_BOUNDARY;
-      CARRY;
-      break;
-    }
-
     if (checkdp_val) {
       d_printf("Sector not found, AH=0x42!\n");
       d_printf("DISK %02x ext read [LBA %"PRIu64"](%d)->%#x (%04x:%04x)\n",
@@ -2030,16 +2018,6 @@ int int13(void)
 	     disk, diskaddr->block, number,
 	     buffer, diskaddr->buf_seg, diskaddr->buf_ofs);
 
-    if (number > I13_MAX_ACCESS) {
-      error("Too large write, ah=0x43!\n");
-      error("DISK %02x ext write [LBA %"PRIu64"](%d)->%#x (%04x:%04x)\n",
-	    disk, diskaddr->block, number,
-	    buffer, diskaddr->buf_seg, diskaddr->buf_ofs);
-      HI(ax) = DERR_BOUNDARY;
-      CARRY;
-      break;
-    }
-
     if (checkdp_val) {
       error("Sector not found, AH=0x43!\n");
       error("DISK %02x ext write [LBA %"PRIu64"](%d)->%#x (%04x:%04x)\n",
@@ -2068,8 +2046,6 @@ int int13(void)
       break;
     }
 
-    if (dp->rdonly)
-      error("CONTINUED!!!!!\n");
     res = write_sectors(dp, buffer, diskaddr->block, number);
 
     if (res < 0) {

--- a/src/include/disks.h
+++ b/src/include/disks.h
@@ -270,7 +270,7 @@ struct ibm_ms_drive_params {
 } __attribute__((packed));
 
 /* Values for information flags */
-#define IMEXT_INFOFLAG_DMAERR     0x01
+#define IMEXT_INFOFLAG_NODMAERR   0x01
 #define IMEXT_INFOFLAG_CHSVALID   0x02
 #define IMEXT_INFOFLAG_REMOVABLE  0x04
 #define IMEXT_INFOFLAG_WVERIFY    0x08


### PR DESCRIPTION
See https://github.com/dosemu2/fdpp/discussions/178#discussioncomment-1094022

We do not have DMA boundary errors as we do not implement
the HDD driver, and all the drivers today use BM-DMA anyway.
So we need to tell the guest OS to not care about aligning
their buffers.

However, we still limit the transfer size to 64K max!
RBIL has this error code description:
 09h    data boundary error (attempted DMA across 64K boundary or >80h sectors)

So I suppose the 64K limit should stay.