### PR TITLE
dosdebug: Fix devs commands initialisation

### DIFF
--- a/src/dosext/mfs/mfs.h
+++ b/src/dosext/mfs/mfs.h
@@ -346,7 +346,6 @@ extern void register_cdrom(int drive, int device);
 extern void unregister_cdrom(int drive);
 extern int get_volume_label_cdrom(int drive, char *name);
 extern int get_drive_from_path(char *path, int *drive);
-extern far_t get_nuldev(void);
 
 /* returns drive number and any bits that are impossible for drive.
  * Should be checked against MAX_DRIVE to make sure it is actually

--- a/src/include/dos2linux.h
+++ b/src/include/dos2linux.h
@@ -305,6 +305,8 @@ extern int lol_nuldev_off;
 
 extern int com_errno;
 
+extern far_t get_nuldev(void);
+
 extern char *misc_e6_options (void);
 extern void misc_e6_store_options(char *str);
 

--- a/src/plugin/debugger/mhpdbgc.c
+++ b/src/plugin/debugger/mhpdbgc.c
@@ -1330,7 +1330,7 @@ static void mhp_devs(int argc, char *argv[])
 
   mhp_printf("DOS Devices\n\n");
 
-  for (p = lol_nuldev(lol), cnt = 0; FP_OFF16(p) != 0xffff && cnt < 256; p = dev->next, cnt++) {
+  for (p = MK_FP(get_nuldev()), cnt = 0; FP_OFF16(p) != 0xffff && cnt < 256; p = dev->next, cnt++) {
     int i;
 
     dev = FAR2PTR(p);


### PR DESCRIPTION
The 16 bit address of the NUL device was incorrectly initialised
from a 32 bit variable, this seemed to work whilst the kernel was
in low memory, but after it moved up into upper things got broken.