### PR TITLE
Dosdebug: Remove load_address from Gnu LD map parser

### DIFF
--- a/src/plugin/debugger/mhpdbgc.c
+++ b/src/plugin/debugger/mhpdbgc.c
@@ -371,30 +371,19 @@ int mhp_usermap_load_gnuld(const char *fname, uint16_t origin)
   FILE *fp;
   char bytebuf[IBUFS];
   int num;
-  char *p;
-  unsigned int load_address, offset, tmp1, tmp2;
+  unsigned int offset, tmp1, tmp2;
 
   if (!(fp = fopen(fname, "re"))) {
     return 0;
   }
 
-  for (num = 0, load_address = 0; num < MAXSYM; /* */) {
+  for (num = 0; num < MAXSYM; /* */) {
     if (user_symbol[num].name[0]) { // Already set
       num++;
       continue;
     }
     if (!fgets(bytebuf, sizeof bytebuf, fp))
       break;
-
-    // Set the current load address to be applied to the following symbols
-/*.data           0x0000000000000000     0x12b8 load address 0x0000000000000790 */
-    p = strstr(bytebuf, "load address");
-    if (p) {
-      if (!sscanf(p + 13, "%x", &load_address)) {
-        return 0;
-      }
-      continue;
-    }
 
 /*                0x0000000000000600                MEMOFS = (DOS_PSP * 0x10)*/
     if (index(bytebuf, '='))
@@ -415,11 +404,8 @@ int mhp_usermap_load_gnuld(const char *fname, uint16_t origin)
 /*                0x000000000000000e                _NetBios */
     if (sscanf(bytebuf, "%x %48s", &offset, user_symbol[num].name) == 2) {
       user_symbol[num].type = DYN;
-      user_symbol[num].seg = load_address >> 4;
+      user_symbol[num].seg = origin;
       user_symbol[num].off = offset;
-
-      user_symbol[num].seg += origin;
-
       num++;
     }
   }


### PR DESCRIPTION
Apparently load_address isn't what I expected it to be. Instead
of it being the target segment in memory, it's the location that
the section ends up in the output file. In the simple case they
may be the same, but for instance if sections are moved around
after initial load the symbols represent the final position.

Note:
  1/ The Gnu LD mapfile has no concept of segments, only a flat
     address space, of which we don't process any further once
     addresses exceed the size of a segment. For this reason
     loading symbols from a Gnu LD mapfile is probably useful only
     if the program makes use of a single segment.
  2/ The FreeDOS kernel does have load_address statements in its
     map file and has symbols in the respective section that start
     again from zero. It's likely that each section is tied to a
     specific segment in memory, but there's no data in the map
     file to indicate which final segment that might be. As the
     kernel uses multiple segments, the symbols loaded via this
     method will probably overlap and so be of limited value.
  3/ FDPP currently has no load_address statements in its map file
     so would be unaffected by this change, but in any case FDPP
     and Dosemu cooperate to load kernel symbols and move chunks
     of them as the boot process proceeds.