### PR TITLE
introduce virtual timer device [#1588]

### DIFF
--- a/src/base/bios/setup.c
+++ b/src/base/bios/setup.c
@@ -16,6 +16,7 @@
 #include "int.h"
 #include "iodev.h"
 #include "virq.h"
+#include "vtmr.h"
 #include "emm.h"
 #include "xms.h"
 #include "hma.h"
@@ -104,6 +105,7 @@ static void late_init_thr(void *arg)
   /* if something else is to be added here,
    * add the "late_init" member into dev_list instead */
   virq_setup();
+  vtmr_setup();
   video_late_init();
   mouse_late_init();
   mouse_client_post_init();

--- a/src/base/core/ports.c
+++ b/src/base/core/ports.c
@@ -1065,6 +1065,7 @@ int port_register_handler(emu_iodev_t device, int flags)
 		error("PORT: conflicting devices: %s & %s for port %#x\n",
 		      port_handler[handle].handler_name,
 		      EMU_HANDLER(i).handler_name, i);
+		config.exitearly = 1;
 		return 4;
 	}
 	port_handle_table[i] = handle;

--- a/src/base/dev/misc/Makefile
+++ b/src/base/dev/misc/Makefile
@@ -7,7 +7,7 @@ include $(top_builddir)/Makefile.conf
 
 
 CFILES = cmos.c timers.c lpt.c rtc.c pci.c joystick.c chipset.c 8042.c kbd.c \
-  virq.c
+  virq.c vtmr.c
 
 include $(REALTOPDIR)/src/Makefile.common
 

--- a/src/base/dev/misc/chipset.c
+++ b/src/base/dev/misc/chipset.c
@@ -28,18 +28,43 @@ static void port92h_io_write(ioport_t port, Bit8u val)
   set_a20(enA20);
 }
 
+static Bit8u picext_io_read(ioport_t port)
+{
+  Bit8u val = 0xff;
+
+  switch (port) {
+  case PIC0_VECBASE_PORT:
+    val = pic0_get_base();
+    break;
+  case PIC1_VECBASE_PORT:
+    val = pic1_get_base();
+    break;
+  }
+  return val;
+}
+
 void chipset_init(void)
 {
-  emu_iodev_t io_dev;
+  emu_iodev_t io_dev = {};
 
   io_dev.read_portb = port92h_io_read;
   io_dev.write_portb = port92h_io_write;
-  io_dev.read_portw = NULL;
-  io_dev.write_portw = NULL;
-  io_dev.read_portd = NULL;
-  io_dev.write_portd = NULL;
   io_dev.start_addr = 0x92;
   io_dev.end_addr = 0x92;
   io_dev.handler_name = "Chipset Control Port A";
+  port_register_handler(io_dev, 0);
+
+  memset(&io_dev, 0, sizeof(io_dev));
+  io_dev.read_portb = picext_io_read;
+  io_dev.start_addr = PIC0_EXTPORT_START;
+  io_dev.end_addr = PIC0_EXTPORT_START + PICx_EXT_PORTS;
+  io_dev.handler_name = "PIC0 extensions";
+  port_register_handler(io_dev, 0);
+
+  memset(&io_dev, 0, sizeof(io_dev));
+  io_dev.read_portb = picext_io_read;
+  io_dev.start_addr = PIC1_EXTPORT_START;
+  io_dev.end_addr = PIC1_EXTPORT_START + PICx_EXT_PORTS;
+  io_dev.handler_name = "PIC1 extensions";
   port_register_handler(io_dev, 0);
 }

--- a/src/base/dev/misc/vtmr.c
+++ b/src/base/dev/misc/vtmr.c
@@ -1,0 +1,155 @@
+/*
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+/*
+ * Purpose: virtual timer device extension
+ *
+ * Author: Stas Sergeev.
+ *
+ */
+#include <stdint.h>
+#include <assert.h>
+#include "port.h"
+#include "pic.h"
+#include "hlt.h"
+#include "cpu.h"
+#include "int.h"
+#include "bitops.h"
+#include "emu.h"
+#include "timers.h"
+#include "chipset.h"
+#include "vtmr.h"
+
+#define VTMR_FIRST_PORT 0x550
+#define VTMR_VPEND_PORT VTMR_FIRST_PORT
+#define VTMR_IRR_PORT (VTMR_FIRST_PORT + 2)
+#define VTMR_ACK_PORT (VTMR_FIRST_PORT + 3)
+#define VTMR_TOTAL_PORTS 4
+#define VTMR_IRQ_NUM 0xb
+
+static uint16_t vtmr_irr;
+static uint8_t last_acked;
+static uint16_t vtmr_hlt;
+
+static void vtmr_lower(int vtmr_num);
+
+static Bit8u vtmr_irr_read(ioport_t port)
+{
+    return vtmr_irr;
+}
+
+static Bit16u vtmr_vpend_read(ioport_t port)
+{
+    return timer_get_vpend(last_acked);
+}
+
+static void vtmr_ack_write(ioport_t port, Bit8u value)
+{
+    if (value >= 8)
+        return;
+    vtmr_lower(value);
+    timer_irq_ack(value);
+    last_acked = value;
+}
+
+static void do_pre(void)
+{
+    /* FIXME: use polling mode instead! */
+    port_outb(0xa0, 0x20);
+}
+
+static void do_ack(void)
+{
+    uint8_t irr = port_inb(VTMR_IRR_PORT);
+    int timer = find_bit(irr);
+
+    port_outb(VTMR_ACK_PORT, timer);
+}
+
+static void vtmr_handler(uint16_t idx, HLT_ARG(arg))
+{
+    uint8_t imr = port_inb(0x21);
+
+    if (imr & 1) {
+        do_ack();
+        do_eoi2_iret();
+    } else {
+        uint8_t inum = port_inb(PIC0_VECBASE_PORT);
+        do_pre();
+        do_ack();
+        jmp_to(ISEG(inum), IOFF(inum));
+    }
+}
+
+void vtmr_pre_irq_dpmi(int masked)
+{
+    if (masked) {
+        port_outb(0xa0, 0x20);
+        port_outb(0x20, 0x20);
+    } else {
+        do_pre();
+    }
+}
+
+void vtmr_post_irq_dpmi(void)
+{
+    do_ack();
+}
+
+void vtmr_init(void)
+{
+    emu_iodev_t io_dev = {};
+    emu_hlt_t hlt_hdlr = HLT_INITIALIZER;
+
+    io_dev.write_portb = vtmr_ack_write;
+    io_dev.read_portb = vtmr_irr_read;
+    io_dev.read_portw = vtmr_vpend_read;
+    io_dev.start_addr = VTMR_FIRST_PORT;
+    io_dev.end_addr = VTMR_FIRST_PORT + VTMR_TOTAL_PORTS;
+    io_dev.handler_name = "virtual timer";
+    port_register_handler(io_dev, 0);
+
+    hlt_hdlr.name = "vtmr";
+    hlt_hdlr.func = vtmr_handler;
+    vtmr_hlt = hlt_register_handler_vm86(hlt_hdlr);
+}
+
+void vtmr_reset(void)
+{
+    vtmr_irr = 0;
+    pic_untrigger(pic_irq_list[VTMR_IRQ_NUM]);
+}
+
+void vtmr_setup(void)
+{
+    SETIVEC(VTMR_INTERRUPT, BIOS_HLT_BLK_SEG, vtmr_hlt);
+}
+
+void vtmr_raise(int vtmr_num)
+{
+    if (vtmr_num >= 8 || (vtmr_irr & (1 << vtmr_num)))
+        return;
+    vtmr_irr |= (1 << vtmr_num);
+    pic_request(pic_irq_list[VTMR_IRQ_NUM]);
+}
+
+static void vtmr_lower(int vtmr_num)
+{
+    if (vtmr_num >= 8 || !(vtmr_irr & (1 << vtmr_num)))
+        return;
+    vtmr_irr &= ~(1 << vtmr_num);
+    pic_untrigger(pic_irq_list[VTMR_IRQ_NUM]);
+}

--- a/src/base/dev/pic/pic.c
+++ b/src/base/dev/pic/pic.c
@@ -812,3 +812,15 @@ void pic_reset(void)
 {
   pic_set_mask;
 }
+
+/* PIC extensions */
+
+Bit8u pic0_get_base(void)
+{
+  return pic_iinfo[PIC_IRQ0].ivec;
+}
+
+Bit8u pic1_get_base(void)
+{
+  return pic_iinfo[PIC_IRQ8].ivec;
+}

--- a/src/base/init/dev_list.c
+++ b/src/base/init/dev_list.c
@@ -43,6 +43,7 @@
 #include "xms.h"
 #include "emudpmi.h"
 #include "virq.h"
+#include "vtmr.h"
 
 struct io_dev_struct {
   const char *name;
@@ -61,7 +62,6 @@ struct owned_devices_struct {
 static int current_device = -1;
 
 static struct io_dev_struct io_devices[MAX_IO_DEVICES] = {
-  { "pit",     NULL,         pit_reset,     NULL },
   { "cmos",    cmos_init,    cmos_reset,    NULL },
   { "video",   video_post_init, NULL, NULL },
   { "internal_mouse",  dosemu_mouse_init,   NULL, dosemu_mouse_close },
@@ -69,6 +69,8 @@ static struct io_dev_struct io_devices[MAX_IO_DEVICES] = {
   { "pic",     pic_init,     pic_reset,     NULL },
   { "chipset", chipset_init, NULL,          NULL },
   { "virq",    virq_init,    virq_reset,    NULL },
+  { "vtmr",    vtmr_init,    vtmr_reset,    NULL },
+  { "pit",     pit_init,     pit_reset,     NULL },
   { "lpt",     printer_init, NULL,	    NULL },
   { "dma",     dma_init,     dma_reset,     NULL },
 #if 0

--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -266,7 +266,6 @@ void memory_init(void)
  */
 void device_init(void)
 {
-  pit_init();		/* for native speaker */
   video_config_init();	/* privileged part of video init */
   keyb_priv_init();
   mouse_priv_init();

--- a/src/dosext/dpmi/dpmisel.S
+++ b/src/dosext/dpmi/dpmisel.S
@@ -101,7 +101,6 @@ DPMI_return_from_LDTcall:
 	.globl DPMI_return_from_LDTExitCall
 DPMI_return_from_LDTExitCall:
 	hlt
-/* ======================= Addr = dpmi_sel():0172 */
 	.globl DPMI_sel_end
 DPMI_sel_end:
 
@@ -230,6 +229,21 @@ DPMI_call:
 DPMI_msdos:
 	int $0x21
 	lretl
+
+	.globl DPMI_vtmr_irq
+DPMI_vtmr_irq:
+	hlt
+	jc 1f
+	int $8
+	# IRQ0 is not requested at that point (its not used at all).
+	# We disable interrupts and then allow timer to tick.
+	cli
+1:
+	.globl DPMI_vtmr_post_irq
+DPMI_vtmr_post_irq:
+	hlt
+	sti
+	iretl
 
 	.globl DPMI_sel_code_end
 DPMI_sel_code_end:

--- a/src/dosext/dpmi/dpmisel.h
+++ b/src/dosext/dpmi/dpmisel.h
@@ -43,6 +43,8 @@ extern unsigned char	DPMI_exception[];
 extern unsigned char	DPMI_ext_exception[];
 extern unsigned char	DPMI_rm_exception[];
 extern unsigned char	DPMI_interrupt[];
+extern unsigned char	DPMI_vtmr_irq[];
+extern unsigned char	DPMI_vtmr_post_irq[];
 extern unsigned char	DPMI_sel_end[];
 
 extern unsigned char	DPMI_VXD_start[];

--- a/src/include/chipset.h
+++ b/src/include/chipset.h
@@ -9,4 +9,10 @@
 
 void chipset_init(void);
 
+#define PIC0_EXTPORT_START 0x560
+#define PIC0_VECBASE_PORT 0x560
+#define PIC1_EXTPORT_START 0x570
+#define PIC1_VECBASE_PORT 0x570
+#define PICx_EXT_PORTS 1
+
 #endif

--- a/src/include/pic.h
+++ b/src/include/pic.h
@@ -82,6 +82,8 @@ void write_pic1(ioport_t port, Bit8u value); /* write to PIC 1 */
 Bit8u read_pic0(ioport_t port);             /* read from PIC 0 */
 Bit8u read_pic1(ioport_t port);             /* read from PIC 1 */
 void pic_seti(unsigned int, int (*)(int), unsigned int, void (*)(void));
+Bit8u pic0_get_base(void);
+Bit8u pic1_get_base(void);
                                        /* set function and interrupt vector */
 void run_irqs(void);                                  /* run requested irqs */
 #define pic_run() run_irqs()   /* the right way to call run_irqs */

--- a/src/include/timers.h
+++ b/src/include/timers.h
@@ -52,6 +52,8 @@ int idle_enable(int threshold1, int threshold, int threshold2,
     const char *who);
 void dosemu_sleep(void);
 void cpu_idle(void);
+int timer_get_vpend(int timer);
+void timer_irq_ack(int timer);
 
 /* --------------------------------------------------------------------- */
 /*	New unified timing macros with/without Pentium rdtsc - AV 8/97	 */

--- a/src/include/vtmr.h
+++ b/src/include/vtmr.h
@@ -1,0 +1,13 @@
+#ifndef VTMR_H
+#define VTMR_H
+
+void vtmr_init(void);
+void vtmr_reset(void);
+void vtmr_setup(void);
+void vtmr_raise(int vtmr_num);
+void vtmr_pre_irq_dpmi(int masked);
+void vtmr_post_irq_dpmi(void);
+
+#define VTMR_INTERRUPT 0x73
+
+#endif


### PR DESCRIPTION
IRQ0 is no longer used.
Virtual timer sits on IRQ11 and invokes the IRQ0 handler by hands.

This completely unbinds our pic from timer code.
Reentrancy problems in RM are not addressed by this patch.