### PR TITLE
vtmr: add smi handler [fixes #1607]

### DIFF
--- a/src/base/bios/setup.c
+++ b/src/base/bios/setup.c
@@ -106,6 +106,7 @@ static void late_init_thr(void *arg)
    * add the "late_init" member into dev_list instead */
   virq_setup();
   vint_setup();
+  pit_late_init();
   video_late_init();
   mouse_late_init();
   mouse_client_post_init();

--- a/src/base/dev/misc/rtc.c
+++ b/src/base/dev/misc/rtc.c
@@ -277,8 +277,6 @@ static void rtc_vint(int masked)
 {
   if (masked)
     pic_request(PIC_IRQ8);
-  else
-    pic_untrigger(PIC_IRQ8);
 }
 
 void rtc_init(void)

--- a/src/base/dev/misc/timers.c
+++ b/src/base/dev/misc/timers.c
@@ -800,7 +800,11 @@ void pit_reset(void)
   pit[3].write_state = 3;
 
   port61 = 0x0c;
+}
 
+void pit_late_init(void)
+{
+  pic_ltime[0] = pic_itime[0] = pic_sys_time;
   vtmr_raise(0);  /* start timer */
 }
 

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -69,12 +69,14 @@ static int current_client;
 #define DPMI_CLIENT (DPMIclient[current_client])
 #define PREV_DPMI_CLIENT (DPMIclient[current_client-1])
 
+static uint8_t int_map[256];
+
 #define DEFAULT_INT(i) ( \
     DPMI_CLIENT.Interrupt_Table[i].selector == dpmi_sel() && \
     DPMI_CLIENT.Interrupt_Table[i].offset < DPMI_SEL_OFF(DPMI_sel_end))
 #define DEFAULT_INT_EX(i) ( \
-    DPMI_CLIENT.DPMIInterrupt_Table[dpmi_pm][i].selector == dpmi_sel() && \
-    DPMI_CLIENT.DPMIInterrupt_Table[dpmi_pm][i].offset < DPMI_SEL_OFF(DPMI_sel_end))
+    DPMI_CLIENT.DPMIInterrupt_Table[!DEFAULT_INT(int_map[i])][i].selector == dpmi_sel() && \
+    DPMI_CLIENT.DPMIInterrupt_Table[!DEFAULT_INT(int_map[i])][i].offset < DPMI_SEL_OFF(DPMI_sel_end))
 
 #define _isset_IF() (!!(_eflags & IF))
 #define dpmi_cli() (_eflags &= ~IF)
@@ -3537,6 +3539,11 @@ void dpmi_setup(void)
     if (!config.dpmi) return;
 
     dpmi_set_map_flags(0);
+
+    for (i = 0; i < ARRAY_SIZE(int_map); i++)
+        int_map[i] = i;
+    int_map[VTMR_INTERRUPT] = 8;
+    int_map[VRTC_INTERRUPT] = 0x70;
 
     get_ldt(ldt_buffer);
     memset(Segments, 0, sizeof(Segments));

--- a/src/include/timers.h
+++ b/src/include/timers.h
@@ -53,6 +53,7 @@ int idle_enable(int threshold1, int threshold, int threshold2,
 void dosemu_sleep(void);
 void cpu_idle(void);
 int timer_get_vpend(int timer);
+void pit_late_init(void);
 
 int CAN_SLEEP(void);
 

--- a/src/include/vint.h
+++ b/src/include/vint.h
@@ -5,7 +5,9 @@ void vint_init(void);
 void vint_setup(void);
 int vint_is_masked(int vi_num, uint8_t *imr);
 void vint_post_irq_dpmi(int vi_num, int masked);
-int vint_register(void (*handler)(int, int), int irq, int orig_irq, int inum);
+int vint_register(void (*ack_handler)(int, int),
+                  void (*mask_handler)(int, int), 
+                  int irq, int orig_irq, int inum);
 void vint_set_tweaked(int vi_num, int on, unsigned flags);
 
 #endif


### PR DESCRIPTION
That handler (just a coopthread with async context) checks if
vtmr is masked, and if so - requests the timer interrupts directly.

This fixes WP62 that masks all irqs except timer.
Fortunately SMI ignores any masking.

So as a matter of fact, this vtmr subsystem is not free of troubles.
It required lots of bindings to DPMI, and now also smi...