### PR TITLE
Vtdpmi

### DIFF
--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -3703,7 +3703,9 @@ void dpmi_init(void)
     inherit_idt = 0;
 
   for (i=0;i<0x100;i++) {
-    if (inherit_idt) {
+    if (inherit_idt &&
+        /* do not inherit internal vectors */
+        PREV_DPMI_CLIENT.Interrupt_Table[i].selector != dpmi_sel()) {
       desc.offset32 = PREV_DPMI_CLIENT.Interrupt_Table[i].offset;
       desc.selector = PREV_DPMI_CLIENT.Interrupt_Table[i].selector;
     } else {

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -72,9 +72,6 @@ static int current_client;
 #define DEFAULT_INT(i) ( \
     DPMI_CLIENT.Interrupt_Table[i].selector == dpmi_sel() && \
     DPMI_CLIENT.Interrupt_Table[i].offset < DPMI_SEL_OFF(DPMI_sel_end))
-#define DEFAULT_INT_EX(i) ( \
-    DPMI_CLIENT.DPMIInterrupt_Table[dpmi_pm][i].selector == dpmi_sel() && \
-    DPMI_CLIENT.DPMIInterrupt_Table[dpmi_pm][i].offset < DPMI_SEL_OFF(DPMI_sel_end))
 
 #define _isset_IF() (!!(_eflags & IF))
 #define dpmi_cli() (_eflags &= ~IF)
@@ -124,8 +121,7 @@ struct DPMIclient_struct {
   RealModeCallBack realModeCallBack[DPMI_MAX_RMCBS];
   Bit16u rmcb_seg;
   Bit16u rmcb_off;
-  INTDESC DPMIInterrupt_Table[2][0x100];
-#define Interrupt_Table DPMIInterrupt_Table[1]
+  INTDESC Interrupt_Table[0x100];
   INTDESC Exception_Table[0x20];
   INTDESC Exception_Table_PM[0x20];
   INTDESC Exception_Table_RM[0x20];
@@ -1544,11 +1540,10 @@ DPMI_INTDESC dpmi_get_interrupt_vector(unsigned char num)
     return desc;
 }
 
-static void dpmi_set_interrupt_vector_pm(unsigned char num, DPMI_INTDESC desc)
+void dpmi_set_interrupt_vector(unsigned char num, DPMI_INTDESC desc)
 {
-    DPMI_CLIENT.DPMIInterrupt_Table[1][num].selector = desc.selector;
-    DPMI_CLIENT.DPMIInterrupt_Table[1][num].offset = desc.offset32;
-
+    DPMI_CLIENT.Interrupt_Table[num].selector = desc.selector;
+    DPMI_CLIENT.Interrupt_Table[num].offset = desc.offset32;
     switch (config.cpu_vm_dpmi) {
       case CPUVM_KVM:
         /* KVM: we can directly use the IDT but don't do it when debugging */
@@ -1571,18 +1566,6 @@ static void dpmi_set_interrupt_vector_pm(unsigned char num, DPMI_INTDESC desc)
     }
     D_printf("DPMI: Put Prot. vec. bx=%x sel=%x, off=%x\n", num,
       desc.selector, desc.offset32);
-}
-
-static void dpmi_set_interrupt_vector_rm(unsigned char num, DPMI_INTDESC desc)
-{
-    DPMI_CLIENT.DPMIInterrupt_Table[0][num].selector = desc.selector;
-    DPMI_CLIENT.DPMIInterrupt_Table[0][num].offset = desc.offset32;
-}
-
-void dpmi_set_interrupt_vector(unsigned char num, DPMI_INTDESC desc)
-{
-    dpmi_set_interrupt_vector_rm(num, desc);
-    dpmi_set_interrupt_vector_pm(num, desc);
 }
 
 DPMI_INTDESC dpmi_get_exception_handler(unsigned char num)
@@ -3721,24 +3704,20 @@ void dpmi_init(void)
 
   for (i=0;i<0x100;i++) {
     if (inherit_idt) {
-      desc.offset32 = PREV_DPMI_CLIENT.DPMIInterrupt_Table[0][i].offset;
-      desc.selector = PREV_DPMI_CLIENT.DPMIInterrupt_Table[0][i].selector;
-      dpmi_set_interrupt_vector_rm(i, desc);
-      desc.offset32 = PREV_DPMI_CLIENT.DPMIInterrupt_Table[1][i].offset;
-      desc.selector = PREV_DPMI_CLIENT.DPMIInterrupt_Table[1][i].selector;
-      dpmi_set_interrupt_vector_pm(i, desc);
+      desc.offset32 = PREV_DPMI_CLIENT.Interrupt_Table[i].offset;
+      desc.selector = PREV_DPMI_CLIENT.Interrupt_Table[i].selector;
     } else {
       desc.offset32 = DPMI_SEL_OFF(DPMI_interrupt) + i;
       desc.selector = dpmi_sel();
-      dpmi_set_interrupt_vector(i, desc);
     }
+    dpmi_set_interrupt_vector(i, desc);
   }
   desc.selector = dpmi_sel();
   desc.offset32 = DPMI_SEL_OFF(DPMI_vtmr_irq);
-  dpmi_set_interrupt_vector_pm(VTMR_INTERRUPT, desc);
+  dpmi_set_interrupt_vector(VTMR_INTERRUPT, desc);
   desc.selector = dpmi_sel();
   desc.offset32 = DPMI_SEL_OFF(DPMI_vrtc_irq);
-  dpmi_set_interrupt_vector_pm(VRTC_INTERRUPT, desc);
+  dpmi_set_interrupt_vector(VRTC_INTERRUPT, desc);
 
   DPMI_CLIENT.orig_imr = port_inb(0x21);
 

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -69,14 +69,12 @@ static int current_client;
 #define DPMI_CLIENT (DPMIclient[current_client])
 #define PREV_DPMI_CLIENT (DPMIclient[current_client-1])
 
-static uint8_t int_map[256];
-
 #define DEFAULT_INT(i) ( \
     DPMI_CLIENT.Interrupt_Table[i].selector == dpmi_sel() && \
     DPMI_CLIENT.Interrupt_Table[i].offset < DPMI_SEL_OFF(DPMI_sel_end))
 #define DEFAULT_INT_EX(i) ( \
-    DPMI_CLIENT.DPMIInterrupt_Table[!DEFAULT_INT(int_map[i])][i].selector == dpmi_sel() && \
-    DPMI_CLIENT.DPMIInterrupt_Table[!DEFAULT_INT(int_map[i])][i].offset < DPMI_SEL_OFF(DPMI_sel_end))
+    DPMI_CLIENT.DPMIInterrupt_Table[dpmi_pm][i].selector == dpmi_sel() && \
+    DPMI_CLIENT.DPMIInterrupt_Table[dpmi_pm][i].offset < DPMI_SEL_OFF(DPMI_sel_end))
 
 #define _isset_IF() (!!(_eflags & IF))
 #define dpmi_cli() (_eflags &= ~IF)
@@ -3539,11 +3537,6 @@ void dpmi_setup(void)
     if (!config.dpmi) return;
 
     dpmi_set_map_flags(0);
-
-    for (i = 0; i < ARRAY_SIZE(int_map); i++)
-        int_map[i] = i;
-    int_map[VTMR_INTERRUPT] = 8;
-    int_map[VRTC_INTERRUPT] = 0x70;
 
     get_ldt(ldt_buffer);
     memset(Segments, 0, sizeof(Segments));


### PR DESCRIPTION
Reduction of vtmr bindings in dpmi.
Namely, split inthandlers removed.
DPMI_interrupt entry now works
differently than before. That should
be properly tested.