### PR TITLE
CI: Disable share tests that provoke failures

### DIFF
--- a/test/test_dos.py
+++ b/test/test_dos.py
@@ -4579,7 +4579,7 @@ $_floppy_a = ""
         """FAT DOSv3 share open twice"""
         ds3_share_open_twice(self, "FAT")
 
-    def test_mfs_ds3_share_open_delete_ds2(self):
+    def xtest_mfs_ds3_share_open_delete_ds2(self):
         """MFS DOSv3 share open delete DOSv2"""
         ds3_share_open_access(self, "MFS", "DELPTH")
 
@@ -4587,7 +4587,7 @@ $_floppy_a = ""
         """FAT DOSv3 share open delete DOSv2"""
         ds3_share_open_access(self, "FAT", "DELPTH")
 
-    def test_mfs_ds3_share_open_delete_fcb(self):
+    def xtest_mfs_ds3_share_open_delete_fcb(self):
         """MFS DOSv3 share open delete FCB"""
         ds3_share_open_access(self, "MFS", "DELFCB")
 
@@ -4611,7 +4611,7 @@ $_floppy_a = ""
         """FAT DOSv3 share open rename FCB"""
         ds3_share_open_access(self, "FAT", "RENFCB")
 
-    def test_mfs_ds3_share_open_setfattrs(self):
+    def xtest_mfs_ds3_share_open_setfattrs(self):
         """MFS DOSv3 share open set file attrs DOSv2"""
         ds3_share_open_access(self, "MFS", "SETATT")
 
@@ -5050,6 +5050,9 @@ class PPDOSGITTestCase(OurTestCase, unittest.TestCase):
         cls.actions = {
             "test_floppy_img": UNSUPPORTED,
             "test_floppy_vfs": UNSUPPORTED,
+            "test_fat_ds3_share_open_delete_ds2": KNOWNFAIL,
+            "test_fat_ds3_share_open_delete_fcb": KNOWNFAIL,
+            "test_fat_ds3_share_open_setfattrs": KNOWNFAIL,
         }
 
         # Use the default files that FDPP installed


### PR DESCRIPTION
1/ MFS doesn't follow the same semantics for delete / setfattrs when
referencing a file opened with SH_COMPAT. MS-DOS 6.22 share has
different behaviour whether the open file was opened by the same process
requesting the delete/setfattrs or not. MFS now allows deletion in both
cases regardless.

2/ FDPP's internal share operating on FAT does not respect the above
either, but it needs to be compatible with MS-DOS 6.22's share. For now
disable the failing tests only on FDPP, they can be reinstated as the
problem is fixed.