### PR TITLE
add -kernelcommandline switch for RxDOS.3, FreeDOS

### DIFF
--- a/src/base/init/config.c
+++ b/src/base/init/config.c
@@ -272,6 +272,8 @@ void dump_config_status(void (*printfunc)(const char *, ...))
         (*print) ("keytable not setup yet\n");
     }
     (*print)("pre_stroke \"%s\"\n", (config.pre_stroke ? config.pre_stroke : ""));
+    (*print)("kernelcommandline \"%s\"\n",
+	(config.kernelcommandline ? config.kernelcommandline : "@none@"));
     (*print)("irqpassing= ");
     if (config.sillyint) {
       int i;

--- a/src/base/init/lexer.l
+++ b/src/base/init/lexer.l
@@ -313,6 +313,7 @@ mouse			RETURN(MOUSE);
 serial			RETURN(SERIAL);
 keyboard		RETURN(KEYBOARD);
 keystroke		RETURN(PRESTROKE);
+kernelcommandline	RETURN(KERNELCOMMANDLINE);
 terminal		RETURN(TERMINAL);
 video			RETURN(VIDEO);
 emuretrace		RETURN(EMURETRACE);

--- a/src/base/init/parser.y
+++ b/src/base/init/parser.y
@@ -252,6 +252,7 @@ enum {
 	/* keyboard */
 %token RAWKEYBOARD
 %token PRESTROKE
+%token KERNELCOMMANDLINE
 %token KEYTABLE SHIFT_MAP ALT_MAP NUMPAD_MAP DUMP LAYOUT
 %token DGRAVE DACUTE DCIRCUM DTILDE DBREVE DABOVED DDIARES DABOVER DDACUTE DCEDILLA DIOTA DOGONEK DCARON
 	/* ipx */
@@ -728,6 +729,12 @@ line:		CHARSET '{' charset_flags '}' {}
 		    {
 		    append_pre_strokes($2);
 		    c_printf("CONF: appending pre-strokes '%s'\n", $2);
+		    free($2);
+		    }
+		| KERNELCOMMANDLINE string_expr
+		    {
+		    set_kernelcommandline($2);
+		    c_printf("CONF: setting kernel command line '%s'\n", $2);
 		    free($2);
 		    }
 		| KEYTABLE DUMP string_expr {

--- a/src/base/misc/fatfs.h
+++ b/src/base/misc/fatfs.h
@@ -30,6 +30,7 @@ struct sys_dsc {
 #define FLG_NOREAD 8
 
 void fatfs_set_sys_hook(void (*hook)(struct sys_dsc *, fatfs_t *));
+void set_kernelcommandline(char *s);
 
 enum { IO_IDX, MSD_IDX, DRB_IDX, DRD_IDX,
        IBMB_IDX, IBMD_IDX, EDRB_IDX, EDRD_IDX,

--- a/src/dosemu
+++ b/src/dosemu
@@ -24,7 +24,7 @@ USAGE:
 THISDIR="$PWD"
 ARG0="$0"
 
-unset STRING_I USE_SUDO INPUT OPTS
+unset STRING_I USE_SUDO INPUT KERNELCOMMANDLINE OPTS
 
 mkdir -p ~/.dosemu
 
@@ -82,6 +82,14 @@ while [ $# -gt 0 ] ; do
       INPUT=1
       if [ -n "$2" -a -n "${2%%-*}" ]; then
         STRING_I="$STRING_I keystroke "'"'"$2"'"'
+        shift
+      fi
+      shift
+      ;;
+    -kernelcommandline)
+      KERNELCOMMANDLINE=1
+      if [ -n "$2" ]; then
+        STRING_I="$STRING_I kernelcommandline "'"'"$2"'"'
         shift
       fi
       shift

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -278,6 +278,7 @@ typedef struct config_info {
        unsigned short detach;
        char *debugout;
        char *pre_stroke;        /* pointer to keyboard pre strokes */
+	char * kernelcommandline;
 
        /* Lock File business */
        int file_lock_limit;


### PR DESCRIPTION
Upcoming patches to ldosboot and the FreeDOS kernel allow
to receive a kernel command line when loaded under the
FreeDOS load protocol. (RxDOS.3 load protocol has had
support for the kernel command line for a while already.)

The script src/dosemu seems to run into problems when the
-kernelcommandline switch's contents contain double quotes.
This is shared by the -input switch's handling, which was
largely used as the base for this commit.

The behaviour of the kernel command line depends on the
particular kernel:

* RxDOS (with lDOS init) does not yet use it.

* testpl displays the contents.

* lDebug enters the contents into its command line buffer,
with unescaped semicolons converted to linebreaks.

* The FreeDOS kernel patch being prepared will allow to
specify up to three different CONFIG.SYS filenames that
are tried in order. (This is useful to quickly switch a
particular dosemu2 instance to another configuration file
without having to modify any files or impacting other
uses of the same drive C: on the system.)

The string "@none@" is handled specifically to indicate
that no command line should be passed. (This differs from
passing an empty command line, as the kernel can tell. In
particular, lDebug will load its startup script file if it
receives no command line.)

The protocol for passing the command line is based on how
existing bootable lDebug handles a BOOT command with the
PROTOCOL=FREEDOS and a CMDLINE=1 switch, or with either of
the RxDOS.3 or lDOS protocols which allow a command line by
default. The FreeDOS extension therefore mirrors the stack
frame layout used for the lDOS load protocol.