### PR TITLE
add documentation subheading with link to wiki

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,10 @@ daily-built binary packages for fedora</a>
 daily-built binary packages for openSUSE</a>
 
 <h3>
+<a name="documentation" class="anchor" href="#documentation"><span class="octicon octicon-link"></span></a>Documentation</h3>
+<p>Visit the <a href="https://github.com/dosemu2/dosemu2/wiki">the dosemu2 wiki</a> for documentation on how to install, run, and configure dosemu2.</p>
+
+<h3>
 <a name="support-or-contact" class="anchor" href="#support-or-contact"><span class="octicon octicon-link"></span></a>Support or Contact</h3>
 
 <p>If you have any problem, you can


### PR DESCRIPTION
Add a "Documentation" subheading to the GitHub Pages website, with a link to the dosemu2 GitHub wiki. This is intended to improve discoverability of existing documentation, as the GitHub Pages site is highly ranked when searching for dosemu2 on major search engines.