### PR TITLE
X: Implement window noclose option

### DIFF
--- a/etc/dosemu.conf
+++ b/etc/dosemu.conf
@@ -868,6 +868,10 @@
 
 # $_X_background_pause = (off)
 
+# Hide the Close button and disable the Close menu item
+
+# $_X_noclose = (off)
+
 ##############################################################################
 ## Settings specific to SDL video driver (dosemu -S)
 

--- a/etc/global.conf
+++ b/etc/global.conf
@@ -190,6 +190,7 @@ else
       fixed_aspect $_X_fixed_aspect vgaemu_memsize $_X_vgaemu_memsize
       lfb $_X_lfb  pm_interface $_X_pm_interface mitshm $_X_mitshm
       background_pause $_X_background_pause fullscreen $_X_fullscreen
+      noclose $_X_noclose
       $$xxx
     }
 

--- a/src/base/init/config.c
+++ b/src/base/init/config.c
@@ -219,6 +219,7 @@ void dump_config_status(void (*printfunc)(const char *, ...))
     (*print)("vga_fonts %i\n", config.vga_fonts);
     (*print)("X_mgrab_key \"%s\"\n",  config.X_mgrab_key);
     (*print)("X_background_pause %d\n", config.X_background_pause);
+    (*print)("X_noclose %d\n", config.X_noclose);
 
     switch (config.chipset) {
       case PLAINVGA: s = "plainvga"; break;

--- a/src/base/init/lexer.l
+++ b/src/base/init/lexer.l
@@ -531,6 +531,7 @@ pm_interface		RETURN(X_PM_INTERFACE);
 mgrab_key		RETURN(X_MGRAB_KEY);
 background_pause	RETURN(X_BACKGROUND_PAUSE);
 fullscreen		RETURN(X_FULLSCREEN);
+noclose			RETURN(X_NOCLOSE);
 
 	/* SDL stuff */
 sdl_hwrend		RETURN(SDL_HWREND);

--- a/src/base/init/parser.y
+++ b/src/base/init/parser.y
@@ -265,7 +265,7 @@ enum {
 %token INTERNALDRIVER EMULATE3BUTTONS CLEARDTR UNGRAB_TWEAK
 	/* x-windows */
 %token L_DISPLAY L_TITLE X_TITLE_SHOW_APPNAME ICON_NAME X_BLINKRATE X_SHARECMAP X_MITSHM X_FONT
-%token X_FIXED_ASPECT X_ASPECT_43 X_LIN_FILT X_BILIN_FILT X_MODE13FACT X_WINSIZE
+%token X_FIXED_ASPECT X_ASPECT_43 X_LIN_FILT X_BILIN_FILT X_MODE13FACT X_WINSIZE X_NOCLOSE
 %token X_GAMMA X_FULLSCREEN VGAEMU_MEMSIZE VESAMODE X_LFB X_PM_INTERFACE X_MGRAB_KEY X_BACKGROUND_PAUSE
 	/* sdl */
 %token SDL_HWREND SDL_FONTS SDL_WCONTROLS
@@ -1096,6 +1096,7 @@ x_flag		: L_DISPLAY string_expr	{ free(config.X_display); config.X_display = $2;
                    }
 		| X_GAMMA expression  { config.X_gamma = $2; }
 		| X_FULLSCREEN bool   { config.X_fullscreen = $2; }
+		| X_NOCLOSE bool   { config.X_noclose = ($2!=0); }
 		| VGAEMU_MEMSIZE expression	{ config.vgaemu_memsize = $2; }
 		| VESAMODE INTEGER INTEGER { set_vesamodes($2,$3,0);}
 		| VESAMODE INTEGER INTEGER INTEGER { set_vesamodes($2,$3,$4);}

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -204,6 +204,7 @@ typedef struct config_info {
        int     X_lfb;			/* support VESA LFB modes */
        int     X_pm_interface;		/* support protected mode interface */
        int     X_background_pause;	/* pause xdosemu if it loses focus */
+       boolean X_noclose;		/* hide the window close button, disable close menu entry */
        boolean sdl_hwrend;		/* accelerate SDL with OpenGL */
        boolean sdl_wcontrols;		/* enable window controls */
        char    *sdl_fonts;		/* TTF font used in SDL2 */


### PR DESCRIPTION
1/ Indicate to the window manager that we don't want the user to be able to
click the close icon, or choose the close menu item, essentially to
guide the user into exiting the DOS application in a proper manner.

2/ Remove the reference to the sdl_wcontrols config option, it's
unneeded and its use interferes with noclose.