### PR TITLE
Test: Build CPU tests with -gdwarf-2 [fixes #1657]

### DIFF
--- a/test/cpu/Makefile
+++ b/test/cpu/Makefile
@@ -1,6 +1,6 @@
 #CC=clang -fno-integrated-as -fverbose-asm
 CC=gcc
-CFLAGS=-Wall -O2 -g -fno-strict-aliasing -fno-pic -fno-pie -no-pie
+CFLAGS=-Wall -O2 -g -gdwarf-2 -fno-strict-aliasing -fno-pic -fno-pie -no-pie
 DJGPP = i586-pc-msdosdjgpp-gcc
 SOURCES = test-i386.c test-i386-code16.S test-i386-vm86.S
 ALL_SRC = $(SOURCES) $(wildcard *.h)


### PR DESCRIPTION
It seems that at present DJGPP wants to use -gdwarf-5 but its 'as' doesn't
know about it, so for now let's override.