### PR TITLE
CI: MSDOS doesn't like unix line endings

### DIFF
--- a/test/func_pit_mode_2.py
+++ b/test/func_pit_mode_2.py
@@ -7,7 +7,7 @@ def pit_mode_2(self):
     self.mkfile("testit.bat", """\
 pitmode2
 rem end
-""")
+""", newline="\r\n")
 
 # compile sources
     self.mkcom_with_ia16("pitmode2", r"""


### PR DESCRIPTION
Batchfiles need to have proper DOS line endings to be processed properly
on MS-DOS.