### PR TITLE
Build the dosemu2 Debian package with clang

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -38,7 +38,8 @@ Build-Depends:
     libjson-c-dev,
     binutils-dev,
     pkg-config,
-    fdpp-dev
+    fdpp-dev,
+    clang
 Homepage: https://github.com/dosemu2/dosemu2
 
 Package: dosemu2

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,7 @@
 #!/usr/bin/make -f
 
 export DH_ALWAYS_EXCLUDE=fonts.dir:fonts.alias
+export CC=clang
 
 %:
 	dh $@ --parallel --builddirectory=build


### PR DESCRIPTION
Given the current breakage with gcc-10 in Debian and some derivatives,
where it can't build dosemu2 (see
https://bugs.launchpad.net/dosemu2/+bug/1978504 for details), force
the use of clang when building the Debian package. This breaks
cross-compilation but that's less of a concern than the whole build
being broken.

Signed-off-by: Stephen Kitt <steve@sk2.org>