### PR TITLE
Drop essential dependencies from the Debian package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,6 @@ Maintainer: Stas Sergeev <stsp@users.sourceforge.net>
 Standards-Version: 4.1.5
 Build-Depends:
     git (>= 2.0),
-    bash,
     autoconf,
     autotools-dev,
     automake,
@@ -15,8 +14,6 @@ Build-Depends:
     debhelper (>= 9~),
     flex,
     gawk,
-    sed,
-    findutils,
     libx11-dev,
     libxext-dev,
     libslang2-dev,
@@ -49,7 +46,6 @@ Depends:
     ${misc:Depends},
     ${shlibs:Depends},
     udev (>= 240),
-    bash,
     fdpp,
     comcom32 (>= 0.1~alpha2)
 Recommends:${shlibs-:Recommends}, ladspa-sdk, gdb, kbd, fluid-soundfont-gm,


### PR DESCRIPTION
bash, findutils, and sed are essential packages, and thus are always
present. There's no need to either build-depend or depend on
them (unless a specific version is required).

Signed-off-by: Stephen Kitt <steve@sk2.org>