### PR TITLE
CI: Rework libi86 tests

### DIFF
--- a/ci_prereq.sh
+++ b/ci_prereq.sh
@@ -22,5 +22,6 @@ sudo apt install -y \
   valgrind \
   gcc-ia16-elf \
   libi86-ia16-elf \
+  libi86-testsuite-ia16-elf \
   gcc-multilib \
   dos2unix

--- a/test/func_libi86_testsuite.py
+++ b/test/func_libi86_testsuite.py
@@ -1,0 +1,70 @@
+
+import re
+
+from datetime import datetime
+from shutil import copy
+from subprocess import check_call, check_output, CalledProcessError, DEVNULL, TimeoutExpired
+
+
+TESTSUITE = "/usr/ia16-elf/libexec/libi86/tests/testsuite"
+
+
+def libi86_create_items(testcase):
+
+    # Enumerate the tests
+    tests = []
+    listing = check_output([TESTSUITE, '--list'])
+    for l in listing.split(b'\n'):
+        # b'  12: bios.h.at:83       _bios_equiplist'
+        t = re.search("\s*(\d+): (.+):\d+\s+([^']+)", str(l))
+        if t:
+            tests += [t.groups(),]
+
+    def create_test(test):
+        def do_test_libi86(self):
+            libi86_test_item(self, test[0])
+        docstring = """libi86 test % 3s %s""" % (test[0], test[2])
+        setattr(do_test_libi86, '__doc__', docstring)
+        setattr(do_test_libi86, 'libi86test', True)
+        return do_test_libi86
+
+    # Insert each test into the testcase
+    for test in tests:
+        name = 'test_libi86_item_%03d' % int(test[0])
+        setattr(testcase, name, create_test(test))
+
+
+def libi86_test_item(self, test):
+    self.mkfile("dosemu.conf", """\
+$_hdimage = "dXXXXs/c:hdtype1 +1"
+$_floppy_a = ""
+""", dname=self.imagedir, mode="a")
+
+    build = self.imagedir / "libi86-test"
+    build.mkdir()
+
+    dosemu = self.topdir / "bin" / "dosemu"
+    options = '-f {0}/dosemu.conf -n --Fimagedir {0} -o {1}'.format(self.imagedir, self.logfiles['log'][0])
+    args = [
+        '--x-installcheck',
+        '--x-test-underlying',
+        '--x-with-dosemu=%s' % dosemu,
+        '--x-with-dosemu-options=%s' % options,
+    ]
+
+    # Do just one
+    try:
+        starttime = datetime.utcnow()
+        check_call([TESTSUITE, *args, test[0]], cwd=build, timeout=60, stdout=DEVNULL, stderr=DEVNULL)
+        self.duration = datetime.utcnow() - starttime
+    except CalledProcessError:
+        raise self.failureException("Test error") from None
+    except TimeoutExpired:
+        raise self.failureException("Test timeout") from None
+    finally:
+        #  The libi86 test suite has its own log file called 'testsuite.log',
+        #  so we will present it as our usual expect log
+        logfile = build / "tests" / "testsuite.log"
+        if logfile.is_file():
+            copy(logfile, self.logfiles['xpt'][0])
+            self.logfiles['xpt'][1] = "testsuite.log"


### PR DESCRIPTION
Calling the libi86 tests singly has the following advantages.
  a/ we are able to collect the dosemu log for each test.
  b/ allows us to set a sensible per test timeout.
  c/ we get feedback at each test stage, so we can see progress.
  d/ we can generate the tests dynamically.

Although the tests are individual we are able to select them all to
be run by using a new 'libi86test' attribute, e.g.
~~~
$ ./test/test_dos.py --require-attr=libi86test PPDOSGITTestCase
Test PP-DOS-GIT  libi86 test   1 dos2unix                                        ... ok (  3.60s)
Test PP-DOS-GIT  libi86 test   2 unix2dos                                        ... ok (  3.17s)
<snip>
~~~

We no longer track a specific tagged version of libi86, we just
enumerate the tests defined.

We use the newly packaged libi86 testsuite, so it's no longer necessary
to git clone libi86 and compile it as part of the test. I had hoped that
this would reduce the overall test time, but at present the old and new
times are comparable.