### PR TITLE
UBsan: Fix type issue [fixes #1713]

### DIFF
--- a/src/base/core/int.c
+++ b/src/base/core/int.c
@@ -1766,7 +1766,7 @@ static void msdos_xtra(uint16_t old_ax, uint16_t old_flags)
     di_printf("int_rvc 0x21 call for ax=0x%04x %x\n", LWORD(eax), old_ax);
 
     CARRY;
-    switch (HI_BYTE_d(old_ax)) {
+    switch (HI_BYTE(old_ax)) {
     case 0x71:
 	if (LWORD(eax) != 0x7100)
 	    break;


### PR DESCRIPTION
int.c:1769:13: runtime error: member access within address 0x7f5cfe9b3ece with insufficient space for an object of type 'union dword'
0x7f5cfe9b3ece: note: pointer points here
   1f 00 00 00 4e 71  38 07 00 00 00 00 00 00  00 83 8c ea a5 55 00 00  60 98 2f ea a5 55 00 00  49 ed

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior int.c:1769:13 in
int.c:1769:13: runtime error: member access within address 0x7f5cfe9b3ece with insufficient space for an object of type 'struct (anonymous struct at ../../../src/include/cpu.h:56:3)'
0x7f5cfe9b3ece: note: pointer points here
   1f 00 00 00 4e 71  38 07 00 00 00 00 00 00  00 83 8c ea a5 55 00 00  60 98 2f ea a5 55 00 00  49 ed