### PR TITLE
CI: Add label create tests

### DIFF
--- a/test/func_label_create.py
+++ b/test/func_label_create.py
@@ -1,0 +1,262 @@
+# Note label setting is currently disabled on MFS
+
+from common_framework import IMAGEDIR
+
+
+def label_create(self, fstype, itype):
+    testdir = self.mkworkdir('d')
+
+    name = 'sentinel'
+    preop = ''
+    postop = ''
+    fat = '12'
+    if itype is None or itype == 'bpb12':
+        pass
+    elif itype == 'bpb16':
+        fat = '16'
+    elif itype == 'bpb32':
+        fat = '32'
+    elif itype == 'prefile':
+        preop += 'echo a >> %s' % name
+    elif itype == 'predir':
+        preop += 'mkdir %s' % name
+    elif itype == 'postfile':
+        postop += 'echo a >> %s' % name
+    elif itype == 'postdir':
+        postop += 'mkdir %s' % name
+    else:
+        raise ValueError
+
+    if fstype == "MFS":
+        config = """\
+$_hdimage = "dXXXXs/c:hdtype1 dXXXXs/d:hdtype1 +1"
+$_floppy_a = ""
+"""
+    else:       # FAT
+        config = """\
+$_hdimage = "dXXXXs/c:hdtype1 %s:partition +1"
+$_floppy_a = ""
+""" % self.mkimage_vbr(fat, cwd=testdir)
+
+    self.mkfile("testit.bat", """\
+d:
+%s
+c:\\labcreat
+%s
+DIR
+rem end
+""" % (preop, postop), newline="\r\n")
+
+    self.mkcom_with_ia16("labcreat", r"""
+
+#include <dos.h>
+#include <stdio.h>
+#include <string.h>
+
+struct {
+  uint8_t sig;
+  uint8_t pad[5];
+  uint8_t attr;
+  struct _fcb x;
+  /*
+    char _fcb_drive;
+    char _fcb_name[8];
+    char _fcb_ext[3];
+    short _fcb_curblk;
+    short _fcb_recsize;
+    long _fcb_filsize;
+    short _fcb_date;
+    char _fcb_resv[10];
+    char _fcb_currec;
+    long _fcb_random;
+  */
+} __attribute__((packed)) xfcb;
+
+
+int main(int argc, char *argv[])
+{
+  union REGS r;
+
+  xfcb.sig = 0xff;
+  xfcb.attr = _A_VOLID;
+  xfcb.x._fcb_drive = 0;
+
+  memcpy(xfcb.x._fcb_name, "????????", 8);      // delete
+  memcpy(xfcb.x._fcb_ext, "???", 3);
+  r.x.ax = 0x1300;
+  r.x.dx = FP_OFF(&xfcb);
+  intdos(&r, &r);
+  /* don't check result, there might not be anything to delete */
+
+  memcpy(xfcb.x._fcb_name, "%s", 8);            // create
+  memcpy(xfcb.x._fcb_ext, "   ", 3);
+  r.x.ax = 0x1600;
+  r.x.dx = FP_OFF(&xfcb);
+  intdos(&r, &r);
+  if (r.h.al != 0) {
+    printf("FAIL: On creation\n");
+    return 1;
+  }
+
+  r.x.ax = 0x1000;                              // close
+  r.x.dx = FP_OFF(&xfcb);
+  intdos(&r, &r);
+  if (r.h.al != 0) {
+    printf("FAIL: On close\n");
+    return 1;
+  }
+
+  printf("PASS: Operation success\n");
+  return 0;
+}
+
+""" % name)
+
+    results = self.runDosemu("testit.bat", config=config)
+
+    self.assertIn("PASS: Operation success", results)
+    self.assertRegex(results, "Volume in drive [Dd] is %s" % name.upper())
+
+    if itype in ['prefile', 'postfile']:
+        # 2022-09-03 12:59             4 SENTINEL
+        # SENTINEL            4 09-03-22  1:00p
+        # SENTINEL            4  9-03-22  1:01p
+        # SENTINEL            4  9-03-22 11:01
+        self.assertRegex(results.upper(),
+            r"\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}\s+4\s+%s"
+            r"|"
+            r"%s\s+4\s+\d{1,2}-\d{1,2}-\d{2}\s+\d+:\d+[AaPp]?" %
+            (name.upper(), name.upper()))
+    elif itype in ['predir', 'postdir']:
+        # 2019-06-27 11:29 <DIR>         DOSEMU
+        # DOSEMU       <DIR>    06-27-19  5:33p
+        # TESTB        <DIR>     8-17-20  2:03p
+        # TESTB        <DIR>     8-17-20 12:03
+        self.assertRegex(results.upper(),
+            r"\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}\s<DIR>\s+%s"
+            r"|"
+            r"%s\s+<DIR>\s+\d{1,2}-\d{1,2}-\d{2}\s+\d+:\d+[AaPp]?" %
+            (name.upper(), name.upper()))
+    elif itype in ['bpb12', 'bpb16', 'bpb32']:
+        fat = itype[3:5]
+        img = self.topdir / IMAGEDIR / ("fat%s.img" % fat)
+        data = img.read_bytes()
+        if data[0x26] == 0x29:      # v4 BPB
+            v1 = 0x2b
+            v2 = v1 + len(name)
+            self.assertEqual(data[v1:v2], bytes(name.upper(), encoding='ascii'))
+        elif data[0x42] == 0x29:  # v7.1 BPB
+            v1 = 0x47
+            v2 = v1 + len(name)
+            self.assertEqual(data[v1:v2], bytes(name.upper(), encoding='ascii'))
+        else:
+            self.fail("No BPB signature found")
+
+
+def label_create_noduplicate(self, fstype):
+    testdir = self.mkworkdir('d')
+
+    if fstype == "MFS":
+        config = """\
+$_hdimage = "dXXXXs/c:hdtype1 dXXXXs/d:hdtype1 +1"
+$_floppy_a = ""
+"""
+    else:       # FAT
+        config = """\
+$_hdimage = "dXXXXs/c:hdtype1 %s:partition +1"
+$_floppy_a = ""
+""" % self.mkimage_vbr("12", cwd=testdir)
+
+    self.mkfile("testit.bat", """\
+d:
+c:\\labdupli
+DIR
+rem end
+""", newline="\r\n")
+
+    self.mkcom_with_ia16("labdupli", r"""
+
+#include <dos.h>
+#include <stdio.h>
+#include <string.h>
+
+struct {
+  uint8_t sig;
+  uint8_t pad[5];
+  uint8_t attr;
+  struct _fcb x;
+  /*
+    char _fcb_drive;
+    char _fcb_name[8];
+    char _fcb_ext[3];
+    short _fcb_curblk;
+    short _fcb_recsize;
+    long _fcb_filsize;
+    short _fcb_date;
+    char _fcb_resv[10];
+    char _fcb_currec;
+    long _fcb_random;
+  */
+} __attribute__((packed)) xfcb;
+
+
+int main(int argc, char *argv[])
+{
+  union REGS r;
+
+  xfcb.sig = 0xff;
+  xfcb.attr = _A_VOLID;
+  xfcb.x._fcb_drive = 0;
+
+  memcpy(xfcb.x._fcb_name, "????????", 8);      // delete
+  memcpy(xfcb.x._fcb_ext, "???", 3);
+  r.x.ax = 0x1300;
+  r.x.dx = FP_OFF(&xfcb);
+  intdos(&r, &r);
+  /* don't check result, there might not be anything to delete */
+
+  memcpy(xfcb.x._fcb_name, "INITIAL ", 8);      // create
+  memcpy(xfcb.x._fcb_ext, "   ", 3);
+  r.x.ax = 0x1600;
+  r.x.dx = FP_OFF(&xfcb);
+  intdos(&r, &r);
+  if (r.h.al != 0) {
+    printf("FAIL: On initial creation\n");
+    return 1;
+  }
+
+  r.x.ax = 0x1000;                              // close
+  r.x.dx = FP_OFF(&xfcb);
+  intdos(&r, &r);
+  if (r.h.al != 0) {
+    printf("FAIL: On initial close\n");
+    return 1;
+  }
+
+  memcpy(xfcb.x._fcb_name, "DUPLICAT", 8);      // create duplicate
+  memcpy(xfcb.x._fcb_ext, "   ", 3);
+  r.x.ax = 0x1600;
+  r.x.dx = FP_OFF(&xfcb);
+  intdos(&r, &r);
+  if (r.h.al == 0) {
+    printf("FAIL: Allowed duplicate creation\n");
+    r.x.ax = 0x1000;                            // close
+    r.x.dx = FP_OFF(&xfcb);
+    intdos(&r, &r);
+    /* don't check result, there's nothing we can do about it. */
+    return 1;
+  } else {
+    printf("INFO: Denied duplicate creation (0x%02x)\n", r.h.al);
+  }
+
+  printf("PASS: Operation success\n");
+  return 0;
+}
+
+""")
+
+    results = self.runDosemu("testit.bat", config=config)
+
+    self.assertIn("PASS: Operation success", results)
+    self.assertRegex(results, "Volume in drive [Dd] is INITIAL")
+    self.assertIn("INFO: Denied duplicate creation (0xff)", results)

--- a/test/func_memory_hma.py
+++ b/test/func_memory_hma.py
@@ -25,7 +25,7 @@ def memory_hma_freespace(self):
 
 int main(int argc, char *argv[])
 {
-  union REGS r;
+  union REGS r = {};
   struct SREGS rs;
   int ret = 0;
 
@@ -74,7 +74,7 @@ def memory_hma_alloc(self):
 
 int main(int argc, char *argv[])
 {
-  union REGS r;
+  union REGS r = {};
   struct SREGS rs;
   int ret = 0;
 
@@ -165,7 +165,7 @@ DL = subfunction
 
 int main(int argc, char *argv[])
 {
-  union REGS r;
+  union REGS r = {};
   struct SREGS rs;
   int ret;
   struct HMCB hmcb;
@@ -393,7 +393,7 @@ struct HMCB {
 
 int main(int argc, char *argv[])
 {
-  union REGS r;
+  union REGS r = {};
   struct SREGS rs;
   int ret;
   struct HMCB hmcb;

--- a/test/test_dos.py
+++ b/test/test_dos.py
@@ -33,6 +33,7 @@ from func_ds3_share_open_access import ds3_share_open_access
 from func_ds3_share_open_twice import ds3_share_open_twice
 from func_lfn_voln_info import lfn_voln_info
 from func_lfs_disk_info import lfs_disk_info
+from func_label_create import label_create, label_create_noduplicate
 from func_lfs_file_info import lfs_file_info
 from func_lfs_file_seek_tell import lfs_file_seek_tell
 from func_libi86_testsuite import libi86_create_items
@@ -66,7 +67,8 @@ PRGFIL_LFN = "Program Files"
 
 class OurTestCase(BaseTestCase):
 
-    attrs = ['cputest', 'dpmitest', 'hmatest', 'nettest', 'umatest', 'xmstest']
+    attrs = ['cputest', 'dpmitest', 'hmatest', 'nettest', 'umatest', 'xmstest',
+             'labeltest']
     pname = "test_dos"
 
     # Tests using assembler
@@ -777,6 +779,51 @@ altdta:
     def test_mfs_fcb_read_alt_dta(self):
         """MFS FCB file read alternate DTA"""
         self._test_fcb_read_alt_dta("MFS")
+
+    def test_fat_label_create_simple(self):
+        """FAT FCB label create simple"""
+        label_create(self, "FAT", None)
+    test_fat_label_create_simple.labeltest = True
+
+    def test_fat_label_create_bpb12(self):
+        """FAT FCB label create BPB FAT12"""
+        label_create(self, "FAT", 'bpb12')
+    test_fat_label_create_bpb12.labeltest = True
+
+    def test_fat_label_create_bpb16(self):
+        """FAT FCB label create BPB FAT16"""
+        label_create(self, "FAT", 'bpb16')
+    test_fat_label_create_bpb16.labeltest = True
+
+    def test_fat_label_create_bpb32(self):
+        """FAT FCB label create BPB FAT32"""
+        label_create(self, "FAT", 'bpb32')
+    test_fat_label_create_bpb32.labeltest = True
+
+    def test_fat_label_create_prefile(self):
+        """FAT FCB label create file beforehand"""
+        label_create(self, "FAT", 'prefile')
+    test_fat_label_create_prefile.labeltest = True
+
+    def test_fat_label_create_predir(self):
+        """FAT FCB label create directory beforehand"""
+        label_create(self, "FAT", 'predir')
+    test_fat_label_create_predir.labeltest = True
+
+    def test_fat_label_create_postfile(self):
+        """FAT FCB label create file afterwards"""
+        label_create(self, "FAT", 'postfile')
+    test_fat_label_create_postfile.labeltest = True
+
+    def test_fat_label_create_postdir(self):
+        """FAT FCB label create directory afterwards"""
+        label_create(self, "FAT", 'postdir')
+    test_fat_label_create_postdir.labeltest = True
+
+    def test_fat_label_create_noduplicate(self):
+        """FAT FCB label create no duplicate"""
+        label_create_noduplicate(self, "FAT")
+    test_fat_label_create_noduplicate.labeltest = True
 
     def _test_fcb_write(self, fstype):
         testdir = self.mkworkdir('d')
@@ -4874,6 +4921,9 @@ class DRDOS701TestCase(OurTestCase, unittest.TestCase):
             "test_memory_hma_chain": UNSUPPORTED,
             "test_pcmos_build": KNOWNFAIL,
             "test_passing_dos_errorlevel_back": KNOWNFAIL,
+            "test_fat_label_create_bpb12": KNOWNFAIL,
+            "test_fat_label_create_bpb16": KNOWNFAIL,
+            "test_fat_label_create_bpb32": UNSUPPORTED,
         }
 
         cls.setUpClassPost()
@@ -4968,6 +5018,11 @@ class FRDOS120TestCase(OurTestCase, unittest.TestCase):
             "test_pcmos_build": KNOWNFAIL,
             r"test_libi86_item_\d+": KNOWNFAIL,
             "test_passing_dos_errorlevel_back": KNOWNFAIL,
+            "test_fat_label_create_bpb12": KNOWNFAIL,
+            "test_fat_label_create_bpb16": KNOWNFAIL,
+            "test_fat_label_create_bpb32": KNOWNFAIL,
+            "test_fat_label_create_prefile": KNOWNFAIL,
+            "test_fat_label_create_predir": KNOWNFAIL,
         }
 
         cls.setUpClassPost()
@@ -5029,6 +5084,12 @@ class FRDOS130TestCase(OurTestCase, unittest.TestCase):
             "test_fat_fcb_rename_wild_2": KNOWNFAIL,
             "test_fat_fcb_rename_wild_3": KNOWNFAIL,
             "test_fat_fcb_rename_wild_4": KNOWNFAIL,
+            "test_fat_label_create_bpb12": KNOWNFAIL,
+            "test_fat_label_create_bpb16": KNOWNFAIL,
+            "test_fat_label_create_bpb32": KNOWNFAIL,
+            "test_fat_label_create_noduplicate": KNOWNFAIL,
+            "test_fat_label_create_predir": KNOWNFAIL,
+            "test_fat_label_create_prefile": KNOWNFAIL,
             "test_memory_emm286_borland": KNOWNFAIL,
             "test_memory_hma_alloc": KNOWNFAIL,
             "test_memory_hma_alloc3": UNSUPPORTED,
@@ -5092,6 +5153,7 @@ class MSDOS622TestCase(OurTestCase, unittest.TestCase):
             "test_memory_hma_alloc3": UNSUPPORTED,
             "test_memory_hma_chain": UNSUPPORTED,
             "test_passing_dos_errorlevel_back": KNOWNFAIL,
+            "test_fat_label_create_bpb32": UNSUPPORTED,
         }
 
         cls.setUpClassPost()
@@ -5142,6 +5204,7 @@ class MSDOS700TestCase(OurTestCase, unittest.TestCase):
         ]
         cls.actions = {
             "test_fat32_img_d_writable": UNSUPPORTED,
+            "test_fat_label_create_bpb32": UNSUPPORTED,
             "test_lfn_volume_info_fat32": UNSUPPORTED,
             "test_lfs_disk_info_fat32": UNSUPPORTED,
             "test_lfs_disk_info_mfs": KNOWNFAIL,

--- a/test/test_dos.py
+++ b/test/test_dos.py
@@ -33,7 +33,9 @@ from func_ds3_share_open_access import ds3_share_open_access
 from func_ds3_share_open_twice import ds3_share_open_twice
 from func_lfn_voln_info import lfn_voln_info
 from func_lfs_disk_info import lfs_disk_info
-from func_label_create import label_create, label_create_noduplicate
+from func_label_create import (label_create, label_create_on_lfns,
+                                label_create_noduplicate, label_create_nonrootdir,
+                                label_delete_wildcard, label_delete_recreate)
 from func_lfs_file_info import lfs_file_info
 from func_lfs_file_seek_tell import lfs_file_seek_tell
 from func_libi86_testsuite import libi86_create_items
@@ -819,6 +821,11 @@ altdta:
         """FAT FCB label create directory afterwards"""
         label_create(self, "FAT", 'postdir')
     test_fat_label_create_postdir.labeltest = True
+
+    def test_fat_label_create_on_lfns(self):
+        """FAT FCB label create on top of LFNs"""
+        label_create_on_lfns(self)
+    test_fat_label_create_on_lfns.labeltest = True
 
     def test_fat_label_create_noduplicate(self):
         """FAT FCB label create no duplicate"""
@@ -4924,6 +4931,7 @@ class DRDOS701TestCase(OurTestCase, unittest.TestCase):
             "test_fat_label_create_bpb12": KNOWNFAIL,
             "test_fat_label_create_bpb16": KNOWNFAIL,
             "test_fat_label_create_bpb32": UNSUPPORTED,
+            "test_fat_label_create_on_lfns": UNSUPPORTED,
         }
 
         cls.setUpClassPost()
@@ -5154,6 +5162,7 @@ class MSDOS622TestCase(OurTestCase, unittest.TestCase):
             "test_memory_hma_chain": UNSUPPORTED,
             "test_passing_dos_errorlevel_back": KNOWNFAIL,
             "test_fat_label_create_bpb32": UNSUPPORTED,
+            "test_fat_label_create_on_lfns": UNSUPPORTED,
         }
 
         cls.setUpClassPost()


### PR DESCRIPTION
Note: These tests identify the following problems:

1/ FreeDOS 1.3 on FAT does:
   a) With existing file, volume is set but the existing file is deleted
   b) With existing directory, the function returns failure.
   c) No Volume field is set in the BPB.

2/ MS-DOS 6.22 does:
   a) No support for FAT32

3/ DR-DOS 7.01 does:
   a) No support for FAT32
   b) No Volume field is set in the BPB.

Note: Currently MFS does not allow setting of volume label