### PR TITLE
CI: Move test binary population to python

### DIFF
--- a/ci_test.sh
+++ b/ci_test.sh
@@ -2,10 +2,6 @@
 
 set -e
 
-# Get any test binaries we need
-TBINS="test-binaries"
-THOST="http://www.spheresystems.co.uk/test-binaries"
-
 if [ "${TRAVIS}" = "true" ] ; then
   export CI="true"
   export CI_BRANCH="${TRAVIS_BRANCH}"
@@ -23,24 +19,14 @@ elif [ "${GITHUB_ACTIONS}" = "true" ] ; then
   fi
 fi
 
+TBINS="test-binaries"
 if [ "${CI}" = "true" ] ; then
   [ -d "${HOME}"/cache ] || mkdir "${HOME}"/cache
   [ -h "${TBINS}" ] || ln -s "${HOME}"/cache "${TBINS}"
 else
   [ -d "${TBINS}"] || mkdir "${TBINS}"
 fi
-
-(
-  cd "${TBINS}" || exit 1
-  [ -f DR-DOS-7.01.tar ] || wget ${THOST}/DR-DOS-7.01.tar
-  [ -f FR-DOS-1.20.tar ] || wget ${THOST}/FR-DOS-1.20.tar
-  [ -f MS-DOS-6.22.tar ] || wget ${THOST}/MS-DOS-6.22.tar
-
-  [ -f VARIOUS.tar ] || wget ${THOST}/VARIOUS.tar
-  [ -f TEST_EMM286.tar ] || wget ${THOST}/TEST_EMM286.tar
-  [ -f TEST_CRYNWR.tar ] || wget ${THOST}/TEST_CRYNWR.tar
-  [ -f TEST_MTCP.tar ] || wget ${THOST}/TEST_MTCP.tar
-)
+python3 test/test_dos.py --get-test-binaries
 
 echo
 echo "====================================================="

--- a/test/test_dos.py
+++ b/test/test_dos.py
@@ -15,7 +15,7 @@ from subprocess import call, check_call, CalledProcessError, DEVNULL
 from sys import argv, exit, modules
 from time import mktime
 
-from common_framework import (BaseTestCase, main, mkstring,
+from common_framework import (BaseTestCase, get_test_binaries, main, mkstring,
                               IPROMPT, KNOWNFAIL, UNSUPPORTED)
 
 from func_cpu_trap_flag import cpu_trap_flag
@@ -5157,7 +5157,10 @@ if __name__ == '__main__':
 
     if len(argv) > 1:
         if argv[1] == "--help":
-            print("Usage: %s [--help | --list-cases | --list-tests] | [--require-attr=STRING TestCase ...] | [TestCase[.testname] ...]" % argv[0])
+            print("Usage: %s [--help | --get-test-binaries | --list-cases | --list-tests] | [--require-attr=STRING TestCase ...] | [TestCase[.testname] ...]" % argv[0])
+            exit(0)
+        elif argv[1] == "--get-test-binaries":
+            get_test_binaries()
             exit(0)
         elif argv[1] == "--list-cases":
             for m in cases:


### PR DESCRIPTION
1/ We now consider missing test binary as fatal.
2/ Added new command line option to populate the test-binaries directory.