### PR TITLE
ModemU: Temporary buffer too small

### DIFF
--- a/src/plugin/modemu/atcmd.c
+++ b/src/plugin/modemu/atcmd.c
@@ -381,7 +381,7 @@ atcmdPT(const char *s)
 int
 atcmdPTSet(const char *s)
 {
-    char buf[PT_MAX];
+    char buf[PT_MAX + 1];
     sscanf(s+4, "%" LIT(PT_MAX) "[^\"]", buf);
     /*strncpy(atcmd.pt.str, s+3, PT_MAX);*/
     atcmd.pt.len = strlen(buf);


### PR DESCRIPTION
Fixes this warning:

atcmd.c:385:42: warning: 'sscanf' may overflow; destination buffer in
        argument 3 has size 40, but the corresponding specifier may
        require size 41 [-Wfortify-source]
    sscanf(s+4, "%" LIT(PT_MAX) "[^\"]", buf);
                                         ^
1 warning generated.