### PR TITLE
Dosdebug: Add HMA parsing to mcbs [skip ci]

### DIFF
--- a/src/include/dos2linux.h
+++ b/src/include/dos2linux.h
@@ -18,6 +18,17 @@ struct MCB {
 	char name[8];			/* 8 */
 } __attribute__((packed));
 
+#define HMCB_SIG 0x534d
+struct HMCB {
+  uint16_t signature;  // "MS"
+  uint16_t owner;      // 0000=free, 0001=DOS, FF33=IO.SYS, FFFF=MSDOS.SYS
+  uint16_t size;       // bytes not including this header
+  uint16_t next;       // offset of next memory block in segment FFFFh, or 0000h if last
+  uint8_t reserved[8]; // unused (explicitly set to 0 for MS-DOS 7.10)
+} __attribute__((packed));
+
+extern struct HMCB *hma_start;
+
 struct DSCB {
   char stype;           /* 0 (subsegment type)
                           'D'  device driver

--- a/src/plugin/debugger/mhpdbgc.c
+++ b/src/plugin/debugger/mhpdbgc.c
@@ -1109,9 +1109,9 @@ static const char *get_name_from_mcb(struct MCB *mcb, int *is_lnk)
   p1 = mcb;
   p2 = MK_FP32(p1->owner_psp - 1, 0);
   if (p1 == p2) {
-    if (!is_printable(p1->name))
-      goto out;
     strlcpy(name, p1->name, 8 + 1); // Source not null terminated if 8 chars
+    if (!is_printable(name))
+      goto out;
     return name;
   }
 
@@ -1119,9 +1119,9 @@ static const char *get_name_from_mcb(struct MCB *mcb, int *is_lnk)
   p1 = MK_FP32(mcb->owner_psp - 1, 0);
   p2 = MK_FP32(p1->owner_psp - 1, 0);
   if (p1 == p2) {
-    if (!is_printable(p1->name))
-      goto out;
     strlcpy(name, p1->name, 8 + 1); // Source not null terminated if 8 chars
+    if (!is_printable(name))
+      goto out;
     strlcat(name, " - ", sizeof name);
     strlcat(name, get_type_from_mcb(mcb), sizeof name);
     return name;


### PR DESCRIPTION
If the HMA layout is in Win95 format we can follow the chain of MCBs and display each in turn.

Sample output from Win95:

~~~
ADDR(HMA) PARAS  OWNER
ffff:0030 0x0321 [MSDOS.SYS]
ffff:3250 0x09f6 [IO.SYS]
ffff:d1c0 0x0025 [fffb]
ffff:d420 0x00b8 [026e]
ffff:dfb0 0x0003 [028d]
ffff:dff0 0x00ad [FREE]
ffff:ea70 0x0005 [028d]
ffff:ead0 0x0002 [028d]
ffff:eb00 (END)
~~~