### PR TITLE
separate sigcontext type from cpu state type

### DIFF
--- a/src/base/core/dump.c
+++ b/src/base/core/dump.c
@@ -154,7 +154,7 @@ show_ints(int min, int max)
 
 void dump_state(void)
 {
-    sigcontext_t *scp = dpmi_get_scp();
+    cpuctx_t *scp = dpmi_get_scp();
     show_regs();
     if (scp)
         dbug_printf("\nProtected-mode state dump:\n%s\n", DPMI_show_state(scp));

--- a/src/base/dev/vga/vgaemu.c
+++ b/src/base/dev/vga/vgaemu.c
@@ -1018,7 +1018,7 @@ void vga_memsetl(dosaddr_t dst, unsigned val, size_t len)
  *
  */
 
-int vga_emu_fault(dosaddr_t lin_addr, unsigned err, sigcontext_t *scp)
+int vga_emu_fault(dosaddr_t lin_addr, unsigned err, cpuctx_t *scp)
 {
   int i, j, pmode = scp != NULL;
   unsigned page_fault, vga_page = 0, u;

--- a/src/base/emu-i386/cpu.c
+++ b/src/base/emu-i386/cpu.c
@@ -108,7 +108,7 @@ static void fpu_reset(void);
  * DANG_END_FUNCTION
  *
  */
-int cpu_trap_0f (unsigned char *csp, sigcontext_t *scp)
+int cpu_trap_0f (unsigned char *csp, cpuctx_t *scp)
 {
 	int increment_ip = 0;
 	g_printf("CPU: TRAP op 0F %02x %02x\n",csp[1],csp[2]);

--- a/src/base/emu-i386/cpu.c
+++ b/src/base/emu-i386/cpu.c
@@ -93,7 +93,7 @@ static unsigned int TRs[2] =
 #endif
 
 /* fpu_state needs to be paragraph aligned for fxrstor/fxsave */
-fpregset_t vm86_fpu_state;
+struct emu_fpstate vm86_fpu_state __attribute__((aligned(16)));
 fenv_t dosemu_fenv;
 static void fpu_reset(void);
 
@@ -242,13 +242,13 @@ static void fpu_init(void)
 static void fpu_reset(void)
 {
 #ifdef __x86_64__
-  vm86_fpu_state->cwd = 0x0040;
-  vm86_fpu_state->swd = 0;
-  vm86_fpu_state->ftw = 0x5555;       //bochs
+  vm86_fpu_state.cwd = 0x0040;
+  vm86_fpu_state.swd = 0;
+  vm86_fpu_state.ftw = 0x5555;       //bochs
 #else
-  vm86_fpu_state->cw = 0x40;
-  vm86_fpu_state->sw = 0;
-  vm86_fpu_state->tag = 0x5555;       // bochs
+  vm86_fpu_state.cw = 0x40;
+  vm86_fpu_state.sw = 0;
+  vm86_fpu_state.tag = 0x5555;       // bochs
 #endif
 }
 
@@ -263,9 +263,9 @@ static void fpu_io_write(ioport_t port, Bit8u val)
   case 0xf0:
     /* not sure about this */
 #ifdef __x86_64__
-    vm86_fpu_state->swd &= ~0x8000;
+    vm86_fpu_state.swd &= ~0x8000;
 #else
-    vm86_fpu_state->sw &= ~0x8000;
+    vm86_fpu_state.sw &= ~0x8000;
 #endif
     break;
   case 0xf1:
@@ -300,8 +300,7 @@ void cpu_setup(void)
   io_dev.handler_name = "Math Coprocessor";
   port_register_handler(io_dev, 0);
 
-  vm86_fpu_state = aligned_alloc(16, sizeof(*vm86_fpu_state));
-  savefpstate(*vm86_fpu_state);
+  savefpstate(vm86_fpu_state);
 #ifdef FE_NOMASK_ENV
   feenableexcept(FE_DIVBYZERO | FE_OVERFLOW);
 #endif

--- a/src/base/emu-i386/do_vm86.c
+++ b/src/base/emu-i386/do_vm86.c
@@ -446,7 +446,7 @@ static int true_vm86(union vm86_union *x)
     int ret;
     uint32_t old_flags = REG(eflags);
 
-    loadfpstate(*vm86_fpu_state);
+    loadfpstate(vm86_fpu_state);
 again:
 #if 0
     ret = vm86(&x->vm86ps);
@@ -464,7 +464,7 @@ again:
      * TODO: check kernel version */
     REG(eflags) |= (old_flags & VIP);
 
-    savefpstate(*vm86_fpu_state);
+    savefpstate(vm86_fpu_state);
     /* there is no real need to save and restore the FPU state of the
        emulator itself: savefpstate (fnsave) also resets the current FPU
        state using fninit; fesetenv then restores trapping of division by

--- a/src/base/emu-i386/kvm.c
+++ b/src/base/emu-i386/kvm.c
@@ -1006,7 +1006,7 @@ int kvm_vm86(struct vm86_struct *info)
 }
 
 /* Emulate do_dpmi_control() using KVM */
-int kvm_dpmi(sigcontext_t *scp)
+int kvm_dpmi(cpuctx_t *scp)
 {
   struct vm86_regs *regs;
   int ret;
@@ -1097,7 +1097,7 @@ int kvm_dpmi(sigcontext_t *scp)
         __fpstate->datasel = _ds;
 #endif
         dbug_printf("coprocessor exception, calling IRQ13\n");
-        print_exception_info(scp);
+//        print_exception_info(scp);
         pic_untrigger(13);
         pic_request(13);
         ret = DPMI_RET_DOSEMU;
@@ -1107,7 +1107,7 @@ int kvm_dpmi(sigcontext_t *scp)
 	    e_invalidate_page_full(monitor->cr2))))
 	ret = DPMI_RET_CLIENT;
       else
-	ret = dpmi_fault(scp);
+	ret = DPMI_RET_FAULT;
     }
   } while (!signal_pending() && ret == DPMI_RET_CLIENT);
   return ret;

--- a/src/base/emu-i386/kvm.c
+++ b/src/base/emu-i386/kvm.c
@@ -1075,6 +1075,7 @@ int kvm_dpmi(cpuctx_t *scp)
       }
 
       if (_trapno == 0x10) {
+#if 0
         struct kvm_fpu fpu;
         ioctl(vcpufd, KVM_GET_FPU, &fpu);
 #ifdef __x86_64__
@@ -1096,8 +1097,9 @@ int kvm_dpmi(cpuctx_t *scp)
         __fpstate->dataoff = fpu.last_dp;
         __fpstate->datasel = _ds;
 #endif
+        print_exception_info(scp);
+#endif
         dbug_printf("coprocessor exception, calling IRQ13\n");
-//        print_exception_info(scp);
         pic_untrigger(13);
         pic_request(13);
         ret = DPMI_RET_DOSEMU;

--- a/src/base/emu-i386/simx86/codegen-x86.h
+++ b/src/base/emu-i386/simx86/codegen-x86.h
@@ -39,8 +39,6 @@
 #include "trees.h"
 #include "vgaemu.h"
 
-#define HOST_ARCH_X86
-
 #define TAILSIZE	7
 #define TAILFIX		1
 

--- a/src/base/emu-i386/simx86/cpatch.c
+++ b/src/base/emu-i386/simx86/cpatch.c
@@ -466,7 +466,7 @@ int Cpatch(sigcontext_t *scp)
     unsigned char *p;
     int w16;
     unsigned int v;
-    unsigned char *eip = (unsigned char *)_rip;
+    unsigned char *eip = (unsigned char *)_scp_rip;
 
     if (in_cpatch)
 	return 0;
@@ -477,7 +477,7 @@ int Cpatch(sigcontext_t *scp)
 	if (debug_level('e')>1) e_printf("### REP patch at %p\n",eip);
 	p-=2;
 	G2M(0xff,0x13,p); /* call (%ebx) */
-	_rip -= 2; /* make sure call (%ebx) is performed the first time */
+	_scp_rip -= 2; /* make sure call (%ebx) is performed the first time */
 	return 1;
     }
 

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -269,10 +269,10 @@ char *e_print_scp_regs(cpuctx_t *scp, int pmode)
 	unsigned short *stk;
 	int i, j;
 
-	i = sprintf(buf, "RAX: %08"PRI_RG"  RBX: %08"PRI_RG"  RCX: %08"PRI_RG"  RDX: %08"PRI_RG
+	i = sprintf(buf, "RAX: %08x  RBX: %08x  RCX: %08x  RDX: %08x"
 		"  VFLAGS(h): %08x\n",
 		_rax, _rbx, _rcx, _rdx, _eflags);
-	i += sprintf(buf + i, "RSI: %08"PRI_RG"  RDI: %08"PRI_RG"  RBP: %08"PRI_RG"  RSP: %08"PRI_RG"\n",
+	i += sprintf(buf + i, "RSI: %08x  RDI: %08x  RBP: %08x  RSP: %08x\n",
 		_rsi, _rdi, _rbp, _rsp);
 	i += sprintf(buf + i, "CS: %04x  DS: %04x  ES: %04x  FS: %04x  GS: %04x  SS: %04x\n",
 		_cs, _ds, _es, _fs, _gs, _ss);

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -138,7 +138,7 @@ FILE *aLog = NULL;
  * 20	unsigned short gs, __gsh;
  * --------------------------------------------------------------
  */
-sigcontext_t e_scp; /* initialized to 0 */
+cpuctx_t e_scp; /* initialized to 0 */
 
 /* ======================================================================= */
 
@@ -263,7 +263,7 @@ char *e_print_regs(void)
 #define GetSegmentBaseAddress(s)	GetSegmentBase(s)
 #define IsSegment32(s)			dpmi_segment_is32(s)
 
-char *e_print_scp_regs(sigcontext_t *scp, int pmode)
+char *e_print_scp_regs(cpuctx_t *scp, int pmode)
 {
 	static char buf[300];
 	unsigned short *stk;
@@ -332,7 +332,7 @@ char *e_emu_disasm(unsigned char *org, int is32, unsigned int refseg)
 }
 
 #ifdef TRACE_DPMI
-char *e_scp_disasm(sigcontext_t *scp, int pmode)
+char *e_scp_disasm(cpuctx_t *scp, int pmode)
 {
    static char insrep = 0;
    static unsigned char buf[1024];
@@ -574,7 +574,7 @@ void Cpu2Reg (void)
 
 /* ======================================================================= */
 
-static void Scp2Cpu (sigcontext_t *scp)
+static void Scp2Cpu (cpuctx_t *scp)
 {
   TheCPU.eax = _eax;
   TheCPU.ebx = _ebx;
@@ -607,7 +607,7 @@ static void Scp2Cpu (sigcontext_t *scp)
 /*
  * Build a sigcontext structure to enter fault handling from DPMI
  */
-static void Cpu2Scp (sigcontext_t *scp, int trapno)
+static void Cpu2Scp (cpuctx_t *scp, int trapno)
 {
   if (debug_level('e')>1) e_printf("Cpu2Scp> scp=%08x dpm=%08x fl=%08x\n",
 	_eflags,get_FLAGS(TheCPU.eflags),TheCPU.eflags);
@@ -667,7 +667,7 @@ static void Cpu2Scp (sigcontext_t *scp, int trapno)
 /*
  * Enter emulator in DPMI mode (context_switch)
  */
-static int Scp2CpuD(sigcontext_t *scp)
+static int Scp2CpuD(cpuctx_t *scp)
 {
   unsigned char big; int mode=0;
 
@@ -1066,7 +1066,7 @@ int e_vm86(void)
 /* ======================================================================= */
 
 
-int e_dpmi(sigcontext_t *scp)
+int e_dpmi(cpuctx_t *scp)
 {
   int xval,retval,mode;
 
@@ -1132,7 +1132,7 @@ int e_dpmi(sigcontext_t *scp)
     else if (xval == EXCP0E_PAGE && vga_emu_fault(DOSADDR_REL(LINP(_cr2)),_err,scp)==True) {
 	retval = DPMI_RET_CLIENT;
     } else {
-	retval = dpmi_fault(scp);
+	retval = DPMI_RET_FAULT;
     }
   }
   while (!signal_pending() && retval == DPMI_RET_CLIENT);
@@ -1145,7 +1145,7 @@ int e_dpmi(sigcontext_t *scp)
 /* ======================================================================= */
 /* file: src/cwsdpmi/exphdlr.c */
 
-void e_dpmi_b0x(int op,sigcontext_t *scp)
+void e_dpmi_b0x(int op,cpuctx_t *scp)
 {
   switch (op) {
     case 0: {	/* set */

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -601,7 +601,8 @@ static void Scp2Cpu (cpuctx_t *scp)
   TheCPU.df_increments = (TheCPU.eflags&DF)?0xfcfeff:0x040201;
 
   /* __fpstate is loaded later on demand for JIT, not used for simulator */
-  TheCPU.fpstate = __fpstate;
+  TheCPU.fpstate = &TheCPU._fpstate;
+  TheCPU._fpstate = *__fpstate;
 }
 
 /*
@@ -641,7 +642,10 @@ static void Cpu2Scp (cpuctx_t *scp, int trapno)
    */
   if (!TheCPU.err) _err = 0;		//???
   if (TheCPU.fpstate == NULL) {
-    if (!CONFIG_CPUSIM) savefpstate(*__fpstate);
+    if (!CONFIG_CPUSIM) {
+      savefpstate(TheCPU._fpstate);
+      *get_fpstate(scp) = TheCPU._fpstate;
+    }
     /* there is no real need to save and restore the FPU state of the
        emulator itself: savefpstate (fnsave) also resets the current FPU
        state using fninit; fesetenv then restores trapping of division by

--- a/src/base/emu-i386/simx86/emu86.h
+++ b/src/base/emu-i386/simx86/emu86.h
@@ -712,7 +712,7 @@ int ModGetReg1(unsigned int PC, int mode);
 //
 char *e_emu_disasm(unsigned char *org, int is32, unsigned int refseg);
 char *e_print_regs(void);
-char *e_print_scp_regs(sigcontext_t *scp, int pmode);
+char *e_print_scp_regs(cpuctx_t *scp, int pmode);
 const char *e_trace_fp(void);
 void GCPrint(unsigned char *cp, unsigned char *cbase, int len);
 char *showreg(signed char r);

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -2725,6 +2725,7 @@ repag0:
 				}
 			}
 			b &= 7;
+#ifdef HOST_ARCH_X86
 			if (TheCPU.fpstate) {
 				/* For simulator, only need to mask all
 				   exceptions; for JIT, load emulated FPU state
@@ -2735,6 +2736,7 @@ repag0:
 					loadfpstate(*TheCPU.fpstate);
 				TheCPU.fpstate = NULL;
 			}
+#endif
 			if (sim) {
 			    if (Fp87_op(exop,b)) { TheCPU.err = -96; return P0; }
 			}

--- a/src/base/emu-i386/simx86/protmode.c
+++ b/src/base/emu-i386/simx86/protmode.c
@@ -371,8 +371,8 @@ void emu_mhp_SetTypebyte (unsigned short selector, int typebyte)
 
 int emu_ldt_write(unsigned char *paddr, uint32_t op, int len)
 {
-	static sigcontext_t sc = {0};
-	sigcontext_t *scp = &sc;
+	static cpuctx_t sc = {0};
+	cpuctx_t *scp = &sc;
 
 	if (!(msdos_ldt_access(paddr)))
 		return 0;

--- a/src/base/emu-i386/simx86/syncpu.h
+++ b/src/base/emu-i386/simx86/syncpu.h
@@ -158,6 +158,7 @@ typedef struct {
 
 	/* should be moved to TSS once implemented */
 	struct revectored_struct int_revectored;
+	struct _libc_fpstate _fpstate __attribute__((aligned(16)));
 } SynCPU;
 
 union _SynCPU {

--- a/src/base/emu-i386/simx86/syncpu.h
+++ b/src/base/emu-i386/simx86/syncpu.h
@@ -147,18 +147,17 @@ typedef struct {
 	unsigned short TR_SEL;
 	DTR  TR;
 
-	/* if not NULL, points to emulated FPU state
-	   if NULL, emulator uses FPU instructions, so flags that
-	   dosemu needs to restore its own FPU environment. */
-	fpregset_t fpstate;
-
 	void (*stub_read_8)(void);
 	void (*stub_read_16)(void);
 	void (*stub_read_32)(void);
 
 	/* should be moved to TSS once implemented */
 	struct revectored_struct int_revectored;
-	struct _libc_fpstate _fpstate __attribute__((aligned(16)));
+
+	/* if not NULL, points to emulated FPU state
+	   if NULL, emulator uses FPU instructions, so flags that
+	   dosemu needs to restore its own FPU environment. */
+	emu_fpregset_t fpstate;
 } SynCPU;
 
 union _SynCPU {

--- a/src/base/init/config.c
+++ b/src/base/init/config.c
@@ -728,7 +728,7 @@ static void read_cpu_info(void)
 #endif
 #ifdef __i386__
         if (cpuflags && (strstr(cpuflags, "fxsr")) &&
-	    sizeof(*vm86_fpu_state) == (112+512)) {
+	    sizeof(vm86_fpu_state) == (112+512)) {
           config.cpufxsr = 1;
 	  if (cpuflags && strstr(cpuflags, "sse"))
 	    config.cpusse = 1;

--- a/src/base/video/instremu.c
+++ b/src/base/video/instremu.c
@@ -2383,7 +2383,7 @@ static inline int instr_sim(x86_regs *x86, int pmode)
   return 1;
 }
 
-static void scp_to_x86_regs(x86_regs *x86, sigcontext_t *scp, int pmode)
+static void scp_to_x86_regs(x86_regs *x86, cpuctx_t *scp, int pmode)
 {
   if(pmode) {
     x86->eax = _eax;
@@ -2438,7 +2438,7 @@ static void scp_to_x86_regs(x86_regs *x86, sigcontext_t *scp, int pmode)
   prepare_x86(x86);
 }
 
-static void x86_regs_to_scp(x86_regs *x86, sigcontext_t *scp, int pmode)
+static void x86_regs_to_scp(x86_regs *x86, cpuctx_t *scp, int pmode)
 {
   if(pmode) {
     _cs = x86->cs;
@@ -2480,14 +2480,14 @@ static void x86_regs_to_scp(x86_regs *x86, sigcontext_t *scp, int pmode)
  * state in the x86 structure.
  *
  * arguments:
- * scp - A pointer to a sigcontext_t holding some relevant data.
+ * scp - A pointer to a cpuctx_t holding some relevant data.
  * pmode - flags protected mode
  * cnt - number of instructions to be simulated
  *
  * DANG_END_FUNCTION
  */
 
-int instr_emu(sigcontext_t *scp, int pmode, int cnt)
+int instr_emu(cpuctx_t *scp, int pmode, int cnt)
 {
 #if DEBUG_INSTR >= 1
   int refseg, rc;
@@ -2528,7 +2528,7 @@ int instr_emu(sigcontext_t *scp, int pmode, int cnt)
   return True;
 }
 
-int decode_modify_segreg_insn(sigcontext_t *scp, int pmode,
+int decode_modify_segreg_insn(cpuctx_t *scp, int pmode,
     unsigned int *new_val)
 {
   struct rm mem = {};

--- a/src/dosext/dpmi/coopth_pm.c
+++ b/src/dosext/dpmi/coopth_pm.c
@@ -35,7 +35,7 @@
 struct co_pm {
     Bit16u hlt_off;
     unsigned offs;
-    void (*post)(sigcontext_t *);
+    void (*post)(cpuctx_t *);
     int leader:1;
 };
 
@@ -50,7 +50,7 @@ static struct co_pm_pth coopthpm_pth[COOPTH_POOL_SIZE];
 
 static int is_active(int tid, int idx)
 {
-    sigcontext_t *scp = dpmi_get_scp();
+    cpuctx_t *scp = dpmi_get_scp();
     return (_cs == dpmi_sel() && _eip == coopthpm_pth[idx].hlt_off);
 }
 
@@ -90,7 +90,7 @@ static const struct coopth_be_ops ops = {
     .id = COOPTH_BE_PM,
 };
 
-static int do_start_custom(int tid, sigcontext_t *scp)
+static int do_start_custom(int tid, cpuctx_t *scp)
 {
     int idx = coopth_start_custom_internal(tid, scp);
     if (idx == -1)
@@ -102,7 +102,7 @@ static int do_start_custom(int tid, sigcontext_t *scp)
 
 static void coopth_auto_hlt_pm(Bit16u offs, void *sc, void *arg)
 {
-    sigcontext_t *scp = sc;
+    cpuctx_t *scp = sc;
     struct co_pm *thr = arg;
     int tid = (thr - coopthpm) + (offs >> 1);
 
@@ -138,7 +138,7 @@ static int register_handler(void *hlt_state, const char *name,
 }
 
 int coopth_create_pm(const char *name, coopth_func_t func,
-	void (*post)(sigcontext_t *), void *hlt_state, unsigned offs,
+	void (*post)(cpuctx_t *), void *hlt_state, unsigned offs,
 	unsigned int *hlt_off)
 {
     int num;
@@ -159,7 +159,7 @@ int coopth_create_pm(const char *name, coopth_func_t func,
 }
 
 int coopth_create_pm_multi(const char *name, coopth_func_t func,
-	void (*post)(sigcontext_t *), void *hlt_state, unsigned offs,
+	void (*post)(cpuctx_t *), void *hlt_state, unsigned offs,
 	int len, unsigned int *hlt_off, int r_offs[])
 {
     int num;

--- a/src/dosext/dpmi/coopth_pm.h
+++ b/src/dosext/dpmi/coopth_pm.h
@@ -2,11 +2,11 @@
 #define COOPTH_PM
 
 int coopth_create_pm(const char *name, coopth_func_t func,
-	void (*post)(sigcontext_t *), void *hlt_state, unsigned offs,
+	void (*post)(cpuctx_t *), void *hlt_state, unsigned offs,
 	unsigned int *hlt_off);
 
 int coopth_create_pm_multi(const char *name, coopth_func_t func,
-	void (*post)(sigcontext_t *), void *hlt_state, unsigned offs,
+	void (*post)(cpuctx_t *), void *hlt_state, unsigned offs,
 	int len, unsigned int *hlt_off, int r_offs[]);
 
 #endif

--- a/src/dosext/dpmi/dnative.c
+++ b/src/dosext/dpmi/dnative.c
@@ -85,7 +85,8 @@ static void copy_to_dpmi(sigcontext_t *scp, cpuctx_t *s)
   _C(trapno);
   _C(err);
   _C(cr2);
-  _scp_fpstate = (struct _fpstate *)get_fpstate(s);
+  if (scp->fpstate)
+    memcpy(scp->fpstate, get_fpstate(s), sizeof(struct _fpstate));
 }
 
 static void copy_to_emu(cpuctx_t *d, sigcontext_t *scp)
@@ -110,7 +111,8 @@ static void copy_to_emu(cpuctx_t *d, sigcontext_t *scp)
   _D(trapno);
   _D(err);
   _D(cr2);
-  memcpy(get_fpstate(d), _scp_fpstate, sizeof(*get_fpstate(d)));
+  if (scp->fpstate)
+    memcpy(get_fpstate(d), _scp_fpstate, sizeof(*get_fpstate(d)));
 }
 
 #if WANT_SIGRETURN_WA

--- a/src/dosext/dpmi/dnative.h
+++ b/src/dosext/dpmi/dnative.h
@@ -5,8 +5,8 @@
 
 int native_dpmi_setup(void);
 void native_dpmi_done(void);
-int native_dpmi_control(sigcontext_t *scp);
-int native_dpmi_exit(sigcontext_t *scp);
+int native_dpmi_control(cpuctx_t *scp);
+int native_dpmi_exit(cpuctx_t *scp);
 void native_dpmi_enter(void);
 void native_dpmi_leave(void);
 void dpmi_return(sigcontext_t *scp, int retcode);
@@ -25,12 +25,12 @@ static inline void native_dpmi_done(void)
 {
 }
 
-static inline int native_dpmi_control(sigcontext_t *scp)
+static inline int native_dpmi_control(cpuctx_t *scp)
 {
     return 0;
 }
 
-static inline int native_dpmi_exit(sigcontext_t *scp)
+static inline int native_dpmi_exit(cpuctx_t *scp)
 {
     return 0;
 }

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -4328,7 +4328,7 @@ static void do_legacy_cpu_exception(cpuctx_t *scp, INTDESC entry)
 
 static void do_cpu_exception(cpuctx_t *scp)
 {
-  D_printf("DPMI: do_cpu_exception(0x%02x) at %#x:%#x, ss:esp=%x:%x, cr2=%#"PRI_RG", err=%#x\n",
+  D_printf("DPMI: do_cpu_exception(0x%02x) at %#x:%#x, ss:esp=%x:%x, cr2=%#lx, err=%#x\n",
 	_trapno, _cs, _eip, _ss, _esp, _cr2, _err);
   if (debug_level('M') > 5)
     D_printf("DPMI: %s\n", DPMI_show_state(scp));
@@ -5871,7 +5871,7 @@ char *DPMI_show_state(cpuctx_t *scp)
     unsigned char *csp2, *ssp2;
     dosaddr_t daddr, saddr;
     pos += sprintf(buf + pos, "eip: 0x%08x  esp: 0x%08x  eflags: 0x%08x\n"
-	     "\ttrapno: 0x%02x  errorcode: 0x%08x  cr2: 0x%08"PRI_RG"\n"
+	     "\ttrapno: 0x%02x  errorcode: 0x%08x  cr2: 0x%08lx\n"
 	     "\tcs: 0x%04x  ds: 0x%04x  es: 0x%04x  ss: 0x%04x  fs: 0x%04x  gs: 0x%04x\n",
 	     _eip, _esp, _eflags, _trapno, _err, _cr2, _cs, _ds, _es, _ss, _fs, _gs);
     pos += sprintf(buf + pos, "EAX: %08x  EBX: %08x  ECX: %08x  EDX: %08x\n",

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -100,17 +100,17 @@ static int cli_blacklisted = 0;
 static int find_cli_in_blacklist(unsigned char *addr);
 static void add_cli_to_blacklist(unsigned char *addr);
 #ifdef USE_MHPDBG
-static int dpmi_mhp_intxx_check(sigcontext_t *scp, int intno);
+static int dpmi_mhp_intxx_check(cpuctx_t *scp, int intno);
 #endif
-static int dpmi_fault1(sigcontext_t *scp);
-static void do_dpmi_retf(sigcontext_t *scp, void * const sp);
+static int dpmi_fault1(cpuctx_t *scp);
+static void do_dpmi_retf(cpuctx_t *scp, void * const sp);
 static far_t s_i1c, s_i23, s_i24;
 
 static struct RealModeCallStructure DPMI_rm_stack[DPMI_max_rec_rm_func];
 static int DPMI_rm_procedure_running = 0;
 
 struct DPMIclient_struct {
-  sigcontext_t stack_frame;
+  cpuctx_t stack_frame;
   int is_32;
   dpmi_pm_block_root pm_block_root;
   unsigned short private_data_segment;
@@ -152,7 +152,7 @@ struct RSP_s {
 };
 
 #define DPMI_max_rec_pm_func 16
-static sigcontext_t DPMI_pm_stack[DPMI_max_rec_pm_func];
+static cpuctx_t DPMI_pm_stack[DPMI_max_rec_pm_func];
 static int DPMI_pm_procedure_running = 0;
 
 static struct DPMIclient_struct DPMIclient[DPMI_MAX_CLIENTS];
@@ -173,12 +173,12 @@ static int RSP_num = 0;
 static struct RSP_s RSP_callbacks[DPMI_MAX_CLIENTS];
 static int ext__thunk_16_32;	// thunk extension
 
-static void make_retf_frame(sigcontext_t *scp, void *sp,
+static void make_retf_frame(cpuctx_t *scp, void *sp,
 	uint32_t cs, uint32_t eip);
-static void make_xretf_frame(sigcontext_t *scp, void *sp,
+static void make_xretf_frame(cpuctx_t *scp, void *sp,
 	uint32_t cs, uint32_t eip);
-static void do_pm_int(sigcontext_t *scp, int i);
-static void msdos_set_client(sigcontext_t *scp, int num);
+static void do_pm_int(cpuctx_t *scp, int i);
+static void msdos_set_client(cpuctx_t *scp, int num);
 static int rsp_get_para(void);
 
 static uint32_t ldt_bitmap[LDT_ENTRIES / 32];
@@ -201,7 +201,7 @@ static void ldt_bitmap_update(unsigned short selector, int num)
     }
     ldt_bitmap_cnt += num;
 }
-static void dpmi_ldt_call(sigcontext_t *scp);
+static void dpmi_ldt_call(cpuctx_t *scp);
 
 static int dpmi_not_supported;
 
@@ -221,7 +221,7 @@ static int dpmi_not_supported;
     } \
 }
 
-static void quit_dpmi(sigcontext_t *scp, unsigned short errcode,
+static void quit_dpmi(cpuctx_t *scp, unsigned short errcode,
     int tsr, unsigned short tsr_para, int dos_exit);
 
 #ifdef DNATIVE
@@ -483,7 +483,7 @@ int dpmi_write_access(dosaddr_t addr)
 
 /* client_esp return the proper value of client\'s esp, if scp != 0, */
 /* get esp from scp, otherwise get esp from dpmi_stack_frame         */
-static uint32_t client_esp(sigcontext_t *scp)
+static uint32_t client_esp(cpuctx_t *scp)
 {
     if( Segments[_ss >> 3].is_32)
 	return _esp;
@@ -491,7 +491,7 @@ static uint32_t client_esp(sigcontext_t *scp)
 	return (_esp)&0xffff;
 }
 
-static uint32_t client_eip(sigcontext_t *scp)
+static uint32_t client_eip(cpuctx_t *scp)
 {
     if( Segments[_cs >> 3].is_32)
 	return _eip;
@@ -499,7 +499,7 @@ static uint32_t client_eip(sigcontext_t *scp)
 	return (_eip)&0xffff;
 }
 
-static int do_dpmi_switch(sigcontext_t *scp)
+static int do_dpmi_switch(cpuctx_t *scp)
 {
   int ret;
 
@@ -526,7 +526,7 @@ static int do_dpmi_switch(sigcontext_t *scp)
   return ret;
 }
 
-static void dpmi_pic_run(sigcontext_t *scp)
+static void dpmi_pic_run(cpuctx_t *scp)
 {
   int inum;
 
@@ -539,7 +539,7 @@ static void dpmi_pic_run(sigcontext_t *scp)
 static int _dpmi_control(void)
 {
     int ret;
-    sigcontext_t *scp = &DPMI_CLIENT.stack_frame;
+    cpuctx_t *scp = &DPMI_CLIENT.stack_frame;
 
     do {
 #ifdef USE_MHPDBG
@@ -784,7 +784,7 @@ unsigned short AllocateDescriptors(int number_of_descriptors)
   return selector;
 }
 
-void FreeSegRegs(sigcontext_t *scp, unsigned short selector)
+void FreeSegRegs(cpuctx_t *scp, unsigned short selector)
 {
     if ((_ds | 7) == (selector | 7)) _ds = 0;
     if ((_es | 7) == (selector | 7)) _es = 0;
@@ -892,7 +892,7 @@ THEN
    Clear descriptor valid bit;
 FI;
 */
-static inline int CheckDataSelector(sigcontext_t *scp,
+static inline int CheckDataSelector(cpuctx_t *scp,
 				    unsigned short selector,
 				    char letter, int in_dosemu)
 {
@@ -920,7 +920,7 @@ static inline int CheckDataSelector(sigcontext_t *scp,
   return 1;
 }
 
-int CheckSelectors(sigcontext_t *scp, int in_dosemu)
+int CheckSelectors(cpuctx_t *scp, int in_dosemu)
 {
 #ifdef TRACE_DPMI
   if (debug_level('t') == 0 || _trapno!=1)
@@ -1160,38 +1160,14 @@ void GetFreeMemoryInformation(unsigned int *lp)
   /*2ch*/	lp[0xb] = 0xffffffff;
 }
 
-void copy_to_dpmi(sigcontext_t *d, sigcontext_t *s)
-{
-  *d = *s;
-}
-
-void copy_context(sigcontext_t *d, sigcontext_t *s)
-{
-#ifdef __linux__
-  fpregset_t fptr = d->fpregs;
-#endif
-  *d = *s;
-#ifdef __linux__
-  if (fptr == s->fpregs)
-    dosemu_error("Copy FPU context between the same locations?\n");
-  *fptr = *s->fpregs;
-  d->fpregs = fptr;
-#endif
-}
-
-void copy_to_emu(sigcontext_t *d, sigcontext_t *s)
-{
-  copy_context(d, s);
-}
-
-static void save_context_nofpu(sigcontext_t *d, sigcontext_t *s)
+static void save_context_nofpu(cpuctx_t *d, cpuctx_t *s)
 {
   *d = *s;
   assert(d->fpregs);
   d->fpregs = NULL;
 }
 
-static void restore_context_nofpu(sigcontext_t *d, sigcontext_t *s)
+static void restore_context_nofpu(cpuctx_t *d, cpuctx_t *s)
 {
   fpregset_t fptr = d->fpregs;
   assert(fptr && !s->fpregs);
@@ -1199,7 +1175,7 @@ static void restore_context_nofpu(sigcontext_t *d, sigcontext_t *s)
   d->fpregs = fptr;
 }
 
-static void *enter_lpms(sigcontext_t *scp)
+static void *enter_lpms(cpuctx_t *scp)
 {
   unsigned short pmstack_sel;
   uint32_t pmstack_esp;
@@ -1234,7 +1210,7 @@ static void *enter_lpms(sigcontext_t *scp)
   return SEL_ADR_CLNT(pmstack_sel, pmstack_esp, DPMI_CLIENT.is_32);
 }
 
-static void leave_lpms(sigcontext_t *scp)
+static void leave_lpms(cpuctx_t *scp)
 {
   if (DPMI_CLIENT.in_dpmi_pm_stack) {
     DPMI_CLIENT.in_dpmi_pm_stack--;
@@ -1253,7 +1229,7 @@ static void leave_lpms(sigcontext_t *scp)
  * register words in protected mode, and zero out high register
  * words in real mode. The preserving may be needed because some
  * realmode int handlers may trash the high register words. */
-static void pm_to_rm_regs(sigcontext_t *scp, unsigned mask)
+static void pm_to_rm_regs(cpuctx_t *scp, unsigned mask)
 {
   if (mask & (1 << eflags_INDEX))
     REG(eflags) = flags_to_e_rm(_eflags);
@@ -1273,7 +1249,7 @@ static void pm_to_rm_regs(sigcontext_t *scp, unsigned mask)
     REG(ebp) = D_16_32(_ebp);
 }
 
-static void rm_to_pm_regs(sigcontext_t *scp, unsigned mask)
+static void rm_to_pm_regs(cpuctx_t *scp, unsigned mask)
 {
   /* NDN insists on full 32bit copy. It sets up its own
    * int handlers in real mode, using those not covered
@@ -1437,7 +1413,7 @@ static int post_rm_call(int old_client)
   return ret;
 }
 
-static void save_pm_regs(sigcontext_t *scp)
+static void save_pm_regs(cpuctx_t *scp)
 {
   if (DPMI_pm_procedure_running >= DPMI_max_rec_pm_func) {
     error("DPMI: DPMI_pm_procedure_running = 0x%x\n",DPMI_pm_procedure_running);
@@ -1446,7 +1422,7 @@ static void save_pm_regs(sigcontext_t *scp)
   save_context_nofpu(&DPMI_pm_stack[DPMI_pm_procedure_running++], scp);
 }
 
-static void restore_pm_regs(sigcontext_t *scp)
+static void restore_pm_regs(cpuctx_t *scp)
 {
   if (DPMI_pm_procedure_running > DPMI_max_rec_pm_func ||
     DPMI_pm_procedure_running < 1) {
@@ -1456,7 +1432,7 @@ static void restore_pm_regs(sigcontext_t *scp)
   restore_context_nofpu(scp, &DPMI_pm_stack[--DPMI_pm_procedure_running]);
 }
 
-static void __fake_pm_int(sigcontext_t *scp)
+static void __fake_pm_int(cpuctx_t *scp)
 {
   D_printf("DPMI: fake_pm_int() called, dpmi_pm=0x%02x\n", in_dpmi_pm());
   save_rm_regs();
@@ -1478,7 +1454,7 @@ void fake_pm_int(void)
   __fake_pm_int(&DPMI_CLIENT.stack_frame);
 }
 
-static void get_ext_API(sigcontext_t *scp)
+static void get_ext_API(cpuctx_t *scp)
 {
       char *ptr = SEL_ADR_CLNT(_ds, _esi, DPMI_CLIENT.is_32);
       D_printf("DPMI: GetVendorAPIEntryPoint: %s\n", ptr);
@@ -1510,7 +1486,7 @@ static void get_ext_API(sigcontext_t *scp)
       }
 }
 
-static int ResizeDescriptorBlock(sigcontext_t *scp,
+static int ResizeDescriptorBlock(cpuctx_t *scp,
  unsigned short begin_selector, unsigned long length)
 {
     unsigned short num_descs, old_num_descs;
@@ -1709,7 +1685,7 @@ static int set_dr(pid_t pid, int i, unsigned long dri)
 }
 #endif
 
-static int dpmi_debug_breakpoint(int op, sigcontext_t *scp)
+static int dpmi_debug_breakpoint(int op, cpuctx_t *scp)
 {
 #ifdef DNATIVE
   pid_t pid, vpid;
@@ -1989,7 +1965,7 @@ void dpmi_ext_ldt_monitor_enable(int on)
     ldt_bitmap_cnt = 0;
 }
 
-static void _do_ldt_call(sigcontext_t *scp, ldt_calldesc call, int ent,
+static void _do_ldt_call(cpuctx_t *scp, ldt_calldesc call, int ent,
         int num)
 {
     _ebx = (ent << 3) | 7;
@@ -2002,7 +1978,7 @@ static void _do_ldt_call(sigcontext_t *scp, ldt_calldesc call, int ent,
     _gs = 0;
 }
 
-static void do_ldt_call(sigcontext_t *scp, ldt_calldesc call, int ent,
+static void do_ldt_call(cpuctx_t *scp, ldt_calldesc call, int ent,
         int num, int cnt)
 {
     void *sp;
@@ -2016,7 +1992,7 @@ static void do_ldt_call(sigcontext_t *scp, ldt_calldesc call, int ent,
                     cnt, _cs, _eip, _ebx, _ecx);
 }
 
-static void do_ldt_call_b(sigcontext_t *scp, ldt_calldesc call, int ent,
+static void do_ldt_call_b(cpuctx_t *scp, ldt_calldesc call, int ent,
         int num, int cnt)
 {
     void *sp;
@@ -2037,7 +2013,7 @@ struct chunk_state {
     int cnt;
 };
 
-static void ldt_process_chunk(sigcontext_t *scp, ldt_calldesc call,
+static void ldt_process_chunk(cpuctx_t *scp, ldt_calldesc call,
         int i, struct chunk_state *state)
 {
     int j;
@@ -2069,7 +2045,7 @@ static void ldt_process_chunk(sigcontext_t *scp, ldt_calldesc call,
     }
 }
 
-static void ldt_process_chunk_c(sigcontext_t *scp, ldt_calldesc call,
+static void ldt_process_chunk_c(cpuctx_t *scp, ldt_calldesc call,
         int i, struct chunk_state *state)
 {
     int j;
@@ -2101,7 +2077,7 @@ static void ldt_process_chunk_c(sigcontext_t *scp, ldt_calldesc call,
     }
 }
 
-static void ldt_process_end(sigcontext_t *scp, ldt_calldesc call,
+static void ldt_process_end(cpuctx_t *scp, ldt_calldesc call,
         struct chunk_state *state)
 {
     if (state->carry) {
@@ -2113,7 +2089,7 @@ static void ldt_process_end(sigcontext_t *scp, ldt_calldesc call,
     }
 }
 
-static void dpmi_ldt_call(sigcontext_t *scp)
+static void dpmi_ldt_call(cpuctx_t *scp)
 {
     ldt_calldesc call = DPMI_CLIENT.is_32 ? ldt_call32 : ldt_call16;
     int i;
@@ -2163,7 +2139,7 @@ static void ldt_process_chunk_b_c(int i, struct chunk_state *state)
     ldt_bitmap[i] = 0;
 }
 
-static void ldt_process_end_b(sigcontext_t *scp, ldt_calldesc call,
+static void ldt_process_end_b(cpuctx_t *scp, ldt_calldesc call,
         struct chunk_state *state)
 {
     assert(state->carry);
@@ -2174,7 +2150,7 @@ static void ldt_process_end_b(sigcontext_t *scp, ldt_calldesc call,
     state->cnt++;
 }
 
-static void dpmi_ldt_exitcall(sigcontext_t *scp)
+static void dpmi_ldt_exitcall(cpuctx_t *scp)
 {
     ldt_calldesc call = DPMI_CLIENT.is_32 ? ldt_call32 : ldt_call16;
     int i;
@@ -2216,7 +2192,7 @@ int dpmi_install_rsp(struct RSPcall_s *callback)
     return 0;
 }
 
-static void do_int31(sigcontext_t *scp)
+static void do_int31(cpuctx_t *scp)
 {
 #if 0
 /* old way to use DPMI API, as per specs */
@@ -3022,7 +2998,7 @@ err:
     D_printf("DPMI: dpmi function failed, CF=1\n");
 }
 
-static void make_iret_frame(sigcontext_t *scp, void *sp,
+static void make_iret_frame(cpuctx_t *scp, void *sp,
 	uint32_t cs, uint32_t eip)
 {
   if (DPMI_CLIENT.is_32) {
@@ -3040,7 +3016,7 @@ static void make_iret_frame(sigcontext_t *scp, void *sp,
   }
 }
 
-static void make_retf_frame(sigcontext_t *scp, void *sp,
+static void make_retf_frame(cpuctx_t *scp, void *sp,
 	uint32_t cs, uint32_t eip)
 {
   if (DPMI_CLIENT.is_32) {
@@ -3056,7 +3032,7 @@ static void make_retf_frame(sigcontext_t *scp, void *sp,
   }
 }
 
-static void make_xretf_frame(sigcontext_t *scp, void *sp,
+static void make_xretf_frame(cpuctx_t *scp, void *sp,
 	uint32_t cs, uint32_t eip)
 {
   if (DPMI_CLIENT.is_32) {
@@ -3075,7 +3051,7 @@ static void make_xretf_frame(sigcontext_t *scp, void *sp,
   dpmi_set_pm(1);
 }
 
-static void remove_xretf_frame(sigcontext_t *scp, void *sp)
+static void remove_xretf_frame(cpuctx_t *scp, void *sp)
 {
   if (DPMI_CLIENT.is_32) {
     unsigned int *ssp = sp;
@@ -3099,7 +3075,7 @@ static void remove_xretf_frame(sigcontext_t *scp, void *sp)
 static void dpmi_realmode_callback(int rmcb_client, int num)
 {
     void *sp;
-    sigcontext_t *scp = &DPMI_CLIENT.stack_frame;
+    cpuctx_t *scp = &DPMI_CLIENT.stack_frame;
 
     if (rmcb_client >= in_dpmi || num >= DPMI_MAX_RMCBS)
       return;
@@ -3146,7 +3122,7 @@ static int is_same_desc(unsigned short sel, unsigned desc[2])
     return (memcmp(lp, desc, 8) == 0);
 }
 
-static void do_RSP_call(sigcontext_t *scp, int num, int clnt,
+static void do_RSP_call(cpuctx_t *scp, int num, int clnt,
 	int terminating, int inh_or_prv)
 {
   unsigned char *code, *data;
@@ -3205,7 +3181,7 @@ static void do_RSP_call(sigcontext_t *scp, int num, int clnt,
   _esi = DPMI_CLIENT.initial_psp;
 }
 
-static void dpmi_RSP_call(sigcontext_t *scp, int clnt, int terminating,
+static void dpmi_RSP_call(cpuctx_t *scp, int clnt, int terminating,
 	int inh_or_prv)
 {
     int i;
@@ -3228,7 +3204,7 @@ static int rsp_get_para(void)
     return cnt;
 }
 
-static void msdos_set_client(sigcontext_t *scp, int num)
+static void msdos_set_client(cpuctx_t *scp, int num)
 {
     dpmi_RSP_call(scp, num, 2, -1);
 }
@@ -3271,7 +3247,7 @@ static void dpmi_cleanup(void)
   DPMI_free(&host_pm_block_root, DPMI_CLIENT.pm_stack->handle);
   hlt_unregister_handler_vm86(DPMI_CLIENT.rmcb_off);
   if (!DPMI_CLIENT.RSP_installed) {
-    sigcontext_t *scp = &DPMI_CLIENT.stack_frame;
+    cpuctx_t *scp = &DPMI_CLIENT.stack_frame;
     DPMIfreeAll();
     free(__fpstate);
   }
@@ -3302,7 +3278,7 @@ static void dpmi_soft_cleanup(void)
   }
 }
 
-static void quit_dpmi(sigcontext_t *scp, unsigned short errcode,
+static void quit_dpmi(cpuctx_t *scp, unsigned short errcode,
     int tsr, unsigned short tsr_para, int dos_exit)
 {
   int have_tsr = tsr && DPMI_CLIENT.RSP_installed;
@@ -3346,7 +3322,7 @@ static void quit_dpmi(sigcontext_t *scp, unsigned short errcode,
   }
 }
 
-static void chain_rm_int(sigcontext_t *scp, int i)
+static void chain_rm_int(cpuctx_t *scp, int i)
 {
   D_printf("DPMI: Calling real mode handler for int 0x%02x\n", i);
   save_rm_regs();
@@ -3356,7 +3332,7 @@ static void chain_rm_int(sigcontext_t *scp, int i)
   do_int(i);
 }
 
-static void chain_hooked_int(sigcontext_t *scp, int i)
+static void chain_hooked_int(cpuctx_t *scp, int i)
 {
   far_t iaddr;
   D_printf("DPMI: Calling real mode handler for int 0x%02x\n", i);
@@ -3383,7 +3359,7 @@ static void chain_hooked_int(sigcontext_t *scp, int i)
   fake_int_to(iaddr.segment, iaddr.offset);
 }
 
-static void do_dpmi_int(sigcontext_t *scp, int i)
+static void do_dpmi_int(cpuctx_t *scp, int i)
 {
   switch (i) {
     case 0x2f:
@@ -3459,7 +3435,7 @@ static void do_dpmi_int(sigcontext_t *scp, int i)
  * DANG_END_FUNCTION
  */
 
-static void do_pm_int(sigcontext_t *scp, int i)
+static void do_pm_int(cpuctx_t *scp, int i)
 {
   void *sp;
   unsigned short old_ss;
@@ -3563,7 +3539,7 @@ static void run_pm_dos_int(int i)
 {
   void  *sp;
   uint32_t ret_eip;
-  sigcontext_t *scp = &DPMI_CLIENT.stack_frame;
+  cpuctx_t *scp = &DPMI_CLIENT.stack_frame;
 
   D_printf("DPMI: run_pm_dos_int(0x%02x) called\n",i);
 
@@ -3825,7 +3801,7 @@ static void setup_int_exc(int inherit_idt)
   }
 }
 
-static void dpmi_reinit(sigcontext_t *scp)
+static void dpmi_reinit(cpuctx_t *scp)
 {
   unsigned short DS, ES, SS, rights;
   int i;
@@ -3884,7 +3860,7 @@ void dpmi_init(void)
   unsigned int my_ip, i;
   unsigned char *cp;
   int inherit_idt;
-  sigcontext_t *scp;
+  cpuctx_t *scp;
   emu_hlt_t hlt_hdlr = HLT_INITIALIZER;
 
   CARRY;
@@ -4076,7 +4052,7 @@ err:
   finish_clnt_switch();
 }
 
-static void return_from_exception(sigcontext_t *scp)
+static void return_from_exception(cpuctx_t *scp)
 {
   void *sp;
   leave_lpms(scp);
@@ -4107,7 +4083,7 @@ static void return_from_exception(sigcontext_t *scp)
   }
 }
 
-static void cpu_exception_rm(sigcontext_t *scp, int trapno)
+static void cpu_exception_rm(cpuctx_t *scp, int trapno)
 {
   switch (trapno) {
     case 0x01: /* debug */
@@ -4136,7 +4112,7 @@ static void cpu_exception_rm(sigcontext_t *scp, int trapno)
  * DANG_END_FUNCTION
  */
 
-static void do_default_cpu_exception(sigcontext_t *scp, int trapno)
+static void do_default_cpu_exception(cpuctx_t *scp, int trapno)
 {
     void * sp;
     sp = (us *)SEL_ADR(_ss,_esp);
@@ -4187,7 +4163,7 @@ static void do_default_cpu_exception(sigcontext_t *scp, int trapno)
  *
  * DANG_END_FUNCTION
  */
-static void do_pm_cpu_exception(sigcontext_t *scp, INTDESC entry)
+static void do_pm_cpu_exception(cpuctx_t *scp, INTDESC entry)
 {
   unsigned int *ssp;
   unsigned short old_ss;
@@ -4249,7 +4225,7 @@ static void do_pm_cpu_exception(sigcontext_t *scp, INTDESC entry)
 
 int dpmi_realmode_exception(unsigned trapno, unsigned err, uint32_t cr2)
 {
-  sigcontext_t *scp = &DPMI_CLIENT.stack_frame;
+  cpuctx_t *scp = &DPMI_CLIENT.stack_frame;
   unsigned int *ssp;
 
   if (DEFAULT_INT(trapno))
@@ -4313,7 +4289,7 @@ int dpmi_realmode_exception(unsigned trapno, unsigned err, uint32_t cr2)
   return 1;
 }
 
-static void do_legacy_cpu_exception(sigcontext_t *scp, INTDESC entry)
+static void do_legacy_cpu_exception(cpuctx_t *scp, INTDESC entry)
 {
   unsigned int *ssp;
   unsigned short old_ss;
@@ -4350,7 +4326,7 @@ static void do_legacy_cpu_exception(sigcontext_t *scp, INTDESC entry)
   _eflags &= ~(TF | NT | AC);
 }
 
-static void do_cpu_exception(sigcontext_t *scp)
+static void do_cpu_exception(cpuctx_t *scp)
 {
   D_printf("DPMI: do_cpu_exception(0x%02x) at %#x:%#x, ss:esp=%x:%x, cr2=%#"PRI_RG", err=%#x\n",
 	_trapno, _cs, _eip, _ss, _esp, _cr2, _err);
@@ -4371,7 +4347,7 @@ static void do_cpu_exception(sigcontext_t *scp)
   do_default_cpu_exception(scp, _trapno);
 }
 
-static void do_dpmi_retf(sigcontext_t *scp, void * const sp)
+static void do_dpmi_retf(cpuctx_t *scp, void * const sp)
 {
   if (DPMI_CLIENT.is_32) {
     unsigned int *ssp = sp;
@@ -4387,7 +4363,7 @@ static void do_dpmi_retf(sigcontext_t *scp, void * const sp)
 }
 
 /* rough iret emulation for HW handlers only */
-static void do_dpmi_iret(sigcontext_t *scp, void * const sp)
+static void do_dpmi_iret(cpuctx_t *scp, void * const sp)
 {
   if (DPMI_CLIENT.is_32) {
     unsigned int *ssp = sp;
@@ -4405,7 +4381,7 @@ static void do_dpmi_iret(sigcontext_t *scp, void * const sp)
 }
 
 /* more precise iret emulation suitable for SW handlers */
-static void emu_dpmi_iret(sigcontext_t *scp, void * const sp)
+static void emu_dpmi_iret(cpuctx_t *scp, void * const sp)
 {
   int stk32 = Segments[_ss >> 3].is_32;
 
@@ -4430,7 +4406,7 @@ static void emu_dpmi_iret(sigcontext_t *scp, void * const sp)
   }
 }
 
-static void return_from_hwint(sigcontext_t *scp, void * const sp)
+static void return_from_hwint(cpuctx_t *scp, void * const sp)
 {
 #ifdef USE_MHPDBG
   int tf = _isset_TF();
@@ -4482,7 +4458,7 @@ static void return_from_hwint(sigcontext_t *scp, void * const sp)
 #endif
 }
 
-static void do_dpmi_hlt(sigcontext_t *scp, uint8_t *lina, void *sp)
+static void do_dpmi_hlt(cpuctx_t *scp, uint8_t *lina, void *sp)
 {
       _eip += 1;
       if (_cs == dpmi_sel()) {
@@ -4631,7 +4607,7 @@ static void do_dpmi_hlt(sigcontext_t *scp, uint8_t *lina, void *sp)
 	  dpmi_set_pm(0);
 
         } else if (_eip==1+DPMI_SEL_OFF(DPMI_return_from_int_23)) {
-	  sigcontext_t old_ctx = {}, *curscp;
+	  cpuctx_t old_ctx = {}, *curscp;
 	  unsigned int old_esp;
 	  int esp_delta;
 	  int killed = 0;
@@ -4817,7 +4793,7 @@ static void do_dpmi_hlt(sigcontext_t *scp, uint8_t *lina, void *sp)
       }
 }
 
-static void unprot_stack_page(sigcontext_t *scp)
+static void unprot_stack_page(cpuctx_t *scp)
 {
   dosaddr_t p;
 
@@ -4832,7 +4808,7 @@ static void unprot_stack_page(sigcontext_t *scp)
     e_invalidate(p - PAGE_SIZE, PAGE_SIZE);
 }
 
-static int dpmi_gpf_simple(sigcontext_t *scp, uint8_t *lina, void *sp, int *rv)
+static int dpmi_gpf_simple(cpuctx_t *scp, uint8_t *lina, void *sp, int *rv)
 {
     int hlt_cnt = 0;
 
@@ -4984,7 +4960,7 @@ static int dpmi_gpf_simple(sigcontext_t *scp, uint8_t *lina, void *sp, int *rv)
  *
  * DANG_END_FUNCTION
  */
-static int dpmi_fault1(sigcontext_t *scp)
+static int dpmi_fault1(cpuctx_t *scp)
 {
 #define LWORD32(x,y) {if (Segments[_cs >> 3].is_32) _##x y; else _LWORD(x) y;}
 #define ASIZE_IS_32 (Segments[_cs >> 3].is_32 ^ prefix67)
@@ -5377,24 +5353,9 @@ out:
   return ret;
 }
 
-int dpmi_fault(sigcontext_t *scp)
-{
-  /* If this is an exception 0x11, we have to ignore it. The reason is that
-   * under real DOS the AM bit of CR0 is not set.
-   * Also clear the AC flag to prevent it from re-occuring.
-   */
-  if (_trapno == 0x11) {
-    g_printf("Exception 0x11 occurred, clearing AC\n");
-    _eflags &= ~AC;
-    return DPMI_RET_CLIENT;
-  }
-
-  return DPMI_RET_FAULT;	// process the rest in dosemu context
-}
-
 void dpmi_realmode_hlt(unsigned int lina)
 {
-  sigcontext_t *scp;
+  cpuctx_t *scp;
   if (!in_dpmi) {
     D_printf("ERROR: DPMI call while not in dpmi!\n");
     LWORD(eip)++;
@@ -5642,7 +5603,7 @@ int dpmi_segment_is32(int sel)
 
 int dpmi_mhp_regs(void)
 {
-  sigcontext_t *scp;
+  cpuctx_t *scp;
   if (!in_dpmi || !in_dpmi_pm()) return 0;
   scp=&DPMI_CLIENT.stack_frame;
   mhp_printf("\nEAX: %08x EBX: %08x ECX: %08x EDX: %08x eflags: %08x",
@@ -5655,7 +5616,7 @@ int dpmi_mhp_regs(void)
 
 void dpmi_mhp_getcseip(unsigned int *seg, unsigned int *off)
 {
-  sigcontext_t *scp = &DPMI_CLIENT.stack_frame;
+  cpuctx_t *scp = &DPMI_CLIENT.stack_frame;
 
   *seg = _cs;
   *off = _eip;
@@ -5663,13 +5624,13 @@ void dpmi_mhp_getcseip(unsigned int *seg, unsigned int *off)
 
 void dpmi_mhp_modify_eip(int delta)
 {
-  sigcontext_t *scp = &DPMI_CLIENT.stack_frame;
+  cpuctx_t *scp = &DPMI_CLIENT.stack_frame;
   _eip +=delta;
 }
 
 void dpmi_mhp_getssesp(unsigned int *seg, unsigned int *off)
 {
-  sigcontext_t *scp = &DPMI_CLIENT.stack_frame;
+  cpuctx_t *scp = &DPMI_CLIENT.stack_frame;
 
   *seg = _ss;
   *off = _esp;
@@ -5677,7 +5638,7 @@ void dpmi_mhp_getssesp(unsigned int *seg, unsigned int *off)
 
 int dpmi_mhp_getcsdefault(void)
 {
-  sigcontext_t *scp = &DPMI_CLIENT.stack_frame;
+  cpuctx_t *scp = &DPMI_CLIENT.stack_frame;
   return dpmi_segment_is32(_cs);
 }
 
@@ -5688,7 +5649,7 @@ void dpmi_mhp_GetDescriptor(unsigned short selector, unsigned int *lp)
 
 uint32_t dpmi_mhp_getreg(regnum_t regnum)
 {
-  sigcontext_t *scp;
+  cpuctx_t *scp;
 
   assert(in_dpmi && in_dpmi_pm());
 
@@ -5727,7 +5688,7 @@ uint32_t dpmi_mhp_getreg(regnum_t regnum)
 
 void dpmi_mhp_setreg(regnum_t regnum, uint32_t val)
 {
-  sigcontext_t *scp;
+  cpuctx_t *scp;
 
   assert(in_dpmi && in_dpmi_pm());
 
@@ -5764,7 +5725,7 @@ void dpmi_mhp_setreg(regnum_t regnum, uint32_t val)
   }
 }
 
-static int dpmi_mhp_intxx_pending(sigcontext_t *scp, int intno)
+static int dpmi_mhp_intxx_pending(cpuctx_t *scp, int intno)
 {
   if (dpmi_mhp_intxxtab[intno] & 1) {
     if (dpmi_mhp_intxxtab[intno] & 0x80) {
@@ -5775,7 +5736,7 @@ static int dpmi_mhp_intxx_pending(sigcontext_t *scp, int intno)
   return 0;
 }
 
-static int dpmi_mhp_intxx_check(sigcontext_t *scp, int intno)
+static int dpmi_mhp_intxx_check(cpuctx_t *scp, int intno)
 {
   switch (dpmi_mhp_intxx_pending(scp,intno)) {
     case -1: return DPMI_RET_CLIENT;
@@ -5790,7 +5751,7 @@ static int dpmi_mhp_intxx_check(sigcontext_t *scp, int intno)
 
 int dpmi_mhp_setTF(int on)
 {
-  sigcontext_t *scp;
+  cpuctx_t *scp;
   if (!in_dpmi_pm())
     return 0;
   scp=&DPMI_CLIENT.stack_frame;
@@ -5801,7 +5762,7 @@ int dpmi_mhp_setTF(int on)
 
 int dpmi_mhp_issetTF(void)
 {
-  sigcontext_t *scp;
+  cpuctx_t *scp;
   if (!in_dpmi_pm())
     return 0;
   scp=&DPMI_CLIENT.stack_frame;
@@ -5866,14 +5827,14 @@ void dpmi_done(void)
 }
 
 /* for debug only */
-sigcontext_t *dpmi_get_scp(void)
+cpuctx_t *dpmi_get_scp(void)
 {
   if (!in_dpmi)
     return NULL;
   return &DPMI_CLIENT.stack_frame;
 }
 
-static uint16_t decode_selector(sigcontext_t *scp)
+static uint16_t decode_selector(cpuctx_t *scp)
 {
     int done, pref_seg;
     uint8_t *csp;
@@ -5903,7 +5864,7 @@ static uint16_t decode_selector(sigcontext_t *scp)
     return pref_seg;
 }
 
-char *DPMI_show_state(sigcontext_t *scp)
+char *DPMI_show_state(cpuctx_t *scp)
 {
     static char buf[4096];
     int pos = 0;
@@ -6020,7 +5981,7 @@ void dpmi_timer(void)
 {
   if (dpmi_pm && !DPMI_CLIENT.in_dpmi_pm_stack &&
       config.cli_timeout && dpmi_is_cli) {
-    sigcontext_t *scp = &DPMI_CLIENT.stack_frame;
+    cpuctx_t *scp = &DPMI_CLIENT.stack_frame;
     /*
      XXX as IF is not set by popf, we have to set it explicitly after a
      reasonable delay. This will allow Doom to work with sound one day.

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -1162,17 +1162,12 @@ void GetFreeMemoryInformation(unsigned int *lp)
 
 static void save_context_nofpu(cpuctx_t *d, cpuctx_t *s)
 {
-  *d = *s;
-  assert(d->fpregs);
-  d->fpregs = NULL;
+  memcpy(d, s, REGS_SIZE);
 }
 
 static void restore_context_nofpu(cpuctx_t *d, cpuctx_t *s)
 {
-  fpregset_t fptr = d->fpregs;
-  assert(fptr && !s->fpregs);
-  *d = *s;
-  d->fpregs = fptr;
+  memcpy(d, s, REGS_SIZE);  // copy w/o fpstate
 }
 
 static void *enter_lpms(cpuctx_t *scp)
@@ -3247,9 +3242,8 @@ static void dpmi_cleanup(void)
   DPMI_free(&host_pm_block_root, DPMI_CLIENT.pm_stack->handle);
   hlt_unregister_handler_vm86(DPMI_CLIENT.rmcb_off);
   if (!DPMI_CLIENT.RSP_installed) {
-    cpuctx_t *scp = &DPMI_CLIENT.stack_frame;
     DPMIfreeAll();
-    free(__fpstate);
+//    free(__fpstate);
   }
 
   if (win3x_mode != INACTIVE) {
@@ -4005,7 +3999,7 @@ void dpmi_init(void)
   _gs	= 0;
 #ifdef __linux__
   /* fpu_state needs to be paragraph aligned for fxrstor/fxsave */
-  __fpstate = aligned_alloc(16, sizeof(*__fpstate));
+//  __fpstate = aligned_alloc(16, sizeof(*__fpstate));
   *__fpstate = *vm86_fpu_state;
 #endif
   NOCARRY;

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -3997,11 +3997,6 @@ void dpmi_init(void)
   _es	= ES;
   _fs	= 0;
   _gs	= 0;
-#ifdef __linux__
-  /* fpu_state needs to be paragraph aligned for fxrstor/fxsave */
-//  __fpstate = aligned_alloc(16, sizeof(*__fpstate));
-  *__fpstate = *vm86_fpu_state;
-#endif
   NOCARRY;
   rm_to_pm_regs(&DPMI_CLIENT.stack_frame, ~0);
   /* on cpu-emu we work with IOPL=3 to avoid doom work-around */
@@ -4611,7 +4606,6 @@ static void do_dpmi_hlt(cpuctx_t *scp, uint8_t *lina, void *sp)
 	    DPMI_CLIENT.in_dpmi_pm_stack);
 
 	  pm_to_rm_regs(scp, ~0);
-	  old_ctx.fpregs = scp->fpregs;
 	  restore_pm_regs(&old_ctx);
 	  curscp = scp;
 	  scp = &old_ctx;

--- a/src/dosext/dpmi/dpmi_api.c
+++ b/src/dosext/dpmi/dpmi_api.c
@@ -35,7 +35,7 @@ static smpool apool;
 
 #define POOL_OFS(p) ((unsigned char *)(p) - pool_base)
 
-static void do_callf(sigcontext_t *scp, int is_32, struct pmaddr_s pma)
+static void do_callf(cpuctx_t *scp, int is_32, struct pmaddr_s pma)
 {
     void *sp = SEL_ADR(_ss, _esp);
     if (is_32) {
@@ -53,162 +53,162 @@ static void do_callf(sigcontext_t *scp, int is_32, struct pmaddr_s pma)
     _eip = pma.offset;
 }
 
-void _dpmi_yield(sigcontext_t *scp, int is_32)
+void _dpmi_yield(cpuctx_t *scp, int is_32)
 {									/* INT 0x2F AX=1680 */
 }
 
-int _dpmi_allocate_ldt_descriptors(sigcontext_t *scp, int is_32, int _count)
+int _dpmi_allocate_ldt_descriptors(cpuctx_t *scp, int is_32, int _count)
 {						/* DPMI 0.9 AX=0000 */
     return 0;
 }
 
-int _dpmi_free_ldt_descriptor(sigcontext_t *scp, int is_32, int _descriptor)
+int _dpmi_free_ldt_descriptor(cpuctx_t *scp, int is_32, int _descriptor)
 {						/* DPMI 0.9 AX=0001 */
     return 0;
 }
 
-int _dpmi_segment_to_descriptor(sigcontext_t *scp, int is_32, int _segment)
+int _dpmi_segment_to_descriptor(cpuctx_t *scp, int is_32, int _segment)
 {						/* DPMI 0.9 AX=0002 */
     return 0;
 }
 
-int _dpmi_get_selector_increment_value(sigcontext_t *scp, int is_32)
+int _dpmi_get_selector_increment_value(cpuctx_t *scp, int is_32)
 {						/* DPMI 0.9 AX=0003 */
     return 0;
 }
 
-int _dpmi_get_segment_base_address(sigcontext_t *scp, int is_32, int _selector, ULONG *_addr)
+int _dpmi_get_segment_base_address(cpuctx_t *scp, int is_32, int _selector, ULONG *_addr)
 {			/* DPMI 0.9 AX=0006 */
     return 0;
 }
 
-int _dpmi_set_segment_base_address(sigcontext_t *scp, int is_32, int _selector, ULONG _address)
+int _dpmi_set_segment_base_address(cpuctx_t *scp, int is_32, int _selector, ULONG _address)
 {			/* DPMI 0.9 AX=0007 */
     return 0;
 }
 
-ULONG _dpmi_get_segment_limit(sigcontext_t *scp, int is_32, int _selector)
+ULONG _dpmi_get_segment_limit(cpuctx_t *scp, int is_32, int _selector)
 {						/* LSL instruction  */
     return 0;
 }
 
-int _dpmi_set_segment_limit(sigcontext_t *scp, int is_32, int _selector, ULONG _limit)
+int _dpmi_set_segment_limit(cpuctx_t *scp, int is_32, int _selector, ULONG _limit)
 {				/* DPMI 0.9 AX=0008 */
     return 0;
 }
 
-int _dpmi_get_descriptor_access_rights(sigcontext_t *scp, int is_32, int _selector)
+int _dpmi_get_descriptor_access_rights(cpuctx_t *scp, int is_32, int _selector)
 {					/* LAR instruction  */
     return 0;
 }
 
-int _dpmi_set_descriptor_access_rights(sigcontext_t *scp, int is_32, int _selector, int _rights)
+int _dpmi_set_descriptor_access_rights(cpuctx_t *scp, int is_32, int _selector, int _rights)
 {			/* DPMI 0.9 AX=0009 */
     return 0;
 }
 
-int _dpmi_create_alias_descriptor(sigcontext_t *scp, int is_32, int _selector)
+int _dpmi_create_alias_descriptor(cpuctx_t *scp, int is_32, int _selector)
 {						/* DPMI 0.9 AX=000a */
     return 0;
 }
 
-int _dpmi_get_descriptor(sigcontext_t *scp, int is_32, int _selector, void *_buffer)
+int _dpmi_get_descriptor(cpuctx_t *scp, int is_32, int _selector, void *_buffer)
 {					/* DPMI 0.9 AX=000b */
     return 0;
 }
 
-int _dpmi_set_descriptor(sigcontext_t *scp, int is_32, int _selector, void *_buffer)
+int _dpmi_set_descriptor(cpuctx_t *scp, int is_32, int _selector, void *_buffer)
 {					/* DPMI 0.9 AX=000c */
     return 0;
 }
 
-int _dpmi_allocate_specific_ldt_descriptor(sigcontext_t *scp, int is_32, int _selector)
+int _dpmi_allocate_specific_ldt_descriptor(cpuctx_t *scp, int is_32, int _selector)
 {					/* DPMI 0.9 AX=000d */
     return 0;
 }
 
-int _dpmi_get_multiple_descriptors(sigcontext_t *scp, int is_32, int _count, void *_buffer)
+int _dpmi_get_multiple_descriptors(cpuctx_t *scp, int is_32, int _count, void *_buffer)
 {				/* DPMI 1.0 AX=000e */
     return 0;
 }
 
-int _dpmi_set_multiple_descriptors(sigcontext_t *scp, int is_32, int _count, void *_buffer)
+int _dpmi_set_multiple_descriptors(cpuctx_t *scp, int is_32, int _count, void *_buffer)
 {				/* DPMI 1.0 AX=000f */
     return 0;
 }
 
-int _dpmi_allocate_dos_memory(sigcontext_t *scp, int is_32, int _paragraphs, int *_ret_selector_or_max)
+int _dpmi_allocate_dos_memory(cpuctx_t *scp, int is_32, int _paragraphs, int *_ret_selector_or_max)
 {			/* DPMI 0.9 AX=0100 */
     return 0;
 }
 
-int _dpmi_free_dos_memory(sigcontext_t *scp, int is_32, int _selector)
+int _dpmi_free_dos_memory(cpuctx_t *scp, int is_32, int _selector)
 {							/* DPMI 0.9 AX=0101 */
     return 0;
 }
 
-int _dpmi_resize_dos_memory(sigcontext_t *scp, int is_32, int _selector, int _newpara, int *_ret_max)
+int _dpmi_resize_dos_memory(cpuctx_t *scp, int is_32, int _selector, int _newpara, int *_ret_max)
 {			/* DPMI 0.9 AX=0102 */
     return 0;
 }
 
-int _dpmi_get_real_mode_interrupt_vector(sigcontext_t *scp, int is_32, int _vector, __dpmi_raddr *_address)
+int _dpmi_get_real_mode_interrupt_vector(cpuctx_t *scp, int is_32, int _vector, __dpmi_raddr *_address)
 {		/* DPMI 0.9 AX=0200 */
     return 0;
 }
 
-int _dpmi_set_real_mode_interrupt_vector(sigcontext_t *scp, int is_32, int _vector, __dpmi_raddr *_address)
+int _dpmi_set_real_mode_interrupt_vector(cpuctx_t *scp, int is_32, int _vector, __dpmi_raddr *_address)
 {		/* DPMI 0.9 AX=0201 */
     return 0;
 }
 
-int _dpmi_get_processor_exception_handler_vector(sigcontext_t *scp, int is_32, int _vector, __dpmi_paddr *_address)
+int _dpmi_get_processor_exception_handler_vector(cpuctx_t *scp, int is_32, int _vector, __dpmi_paddr *_address)
 {	/* DPMI 0.9 AX=0202 */
     return 0;
 }
 
-int _dpmi_set_processor_exception_handler_vector(sigcontext_t *scp, int is_32, int _vector, __dpmi_paddr *_address)
+int _dpmi_set_processor_exception_handler_vector(cpuctx_t *scp, int is_32, int _vector, __dpmi_paddr *_address)
 {	/* DPMI 0.9 AX=0203 */
     return 0;
 }
 
-int _dpmi_get_protected_mode_interrupt_vector(sigcontext_t *scp, int is_32, int _vector, __dpmi_paddr *_address)
+int _dpmi_get_protected_mode_interrupt_vector(cpuctx_t *scp, int is_32, int _vector, __dpmi_paddr *_address)
 {	/* DPMI 0.9 AX=0204 */
     return 0;
 }
 
-int _dpmi_set_protected_mode_interrupt_vector(sigcontext_t *scp, int is_32, int _vector, __dpmi_paddr *_address)
+int _dpmi_set_protected_mode_interrupt_vector(cpuctx_t *scp, int is_32, int _vector, __dpmi_paddr *_address)
 {	/* DPMI 0.9 AX=0205 */
     return 0;
 }
 
-int _dpmi_get_extended_exception_handler_vector_pm(sigcontext_t *scp, int is_32, int _vector, __dpmi_paddr *_address)
+int _dpmi_get_extended_exception_handler_vector_pm(cpuctx_t *scp, int is_32, int _vector, __dpmi_paddr *_address)
 {	/* DPMI 1.0 AX=0210 */
     return 0;
 }
 
-int _dpmi_get_extended_exception_handler_vector_rm(sigcontext_t *scp, int is_32, int _vector, __dpmi_paddr *_address)
+int _dpmi_get_extended_exception_handler_vector_rm(cpuctx_t *scp, int is_32, int _vector, __dpmi_paddr *_address)
 {	/* DPMI 1.0 AX=0211 */
     return 0;
 }
 
-int _dpmi_set_extended_exception_handler_vector_pm(sigcontext_t *scp, int is_32, int _vector, __dpmi_paddr *_address)
+int _dpmi_set_extended_exception_handler_vector_pm(cpuctx_t *scp, int is_32, int _vector, __dpmi_paddr *_address)
 {	/* DPMI 1.0 AX=0212 */
     return 0;
 }
 
-int _dpmi_set_extended_exception_handler_vector_rm(sigcontext_t *scp, int is_32, int _vector, __dpmi_paddr *_address)
+int _dpmi_set_extended_exception_handler_vector_rm(cpuctx_t *scp, int is_32, int _vector, __dpmi_paddr *_address)
 {	/* DPMI 1.0 AX=0213 */
     return 0;
 }
 
-int _dpmi_simulate_real_mode_interrupt(sigcontext_t *scp, int is_32, int _vector, __dpmi_regs *__regs)
+int _dpmi_simulate_real_mode_interrupt(cpuctx_t *scp, int is_32, int _vector, __dpmi_regs *__regs)
 {			/* DPMI 0.9 AX=0300 */
     struct pmaddr_s pma = {
 	.offset = DPMI_SEL_OFF(DPMI_call),
 	.selector = dpmi_sel(),
     };
-    sigcontext_t sa = *scp;
+    cpuctx_t sa = *scp;
     __dpmi_regs *regs = smalloc(&apool, sizeof(*regs));
 
     _eax = 0x300;
@@ -227,13 +227,13 @@ int _dpmi_simulate_real_mode_interrupt(sigcontext_t *scp, int is_32, int _vector
     return 0;
 }
 
-int _dpmi_int(sigcontext_t *scp, int is_32, int _vector, __dpmi_regs *__regs)
+int _dpmi_int(cpuctx_t *scp, int is_32, int _vector, __dpmi_regs *__regs)
 { /* like above, but sets ss sp fl */	/* DPMI 0.9 AX=0300 */
     struct pmaddr_s pma = {
 	.offset = DPMI_SEL_OFF(DPMI_call),
 	.selector = dpmi_sel(),
     };
-    sigcontext_t sa = *scp;
+    cpuctx_t sa = *scp;
     __dpmi_regs *regs = smalloc(&apool, sizeof(*regs));
 
     _eax = 0x300;
@@ -255,7 +255,7 @@ int _dpmi_int(sigcontext_t *scp, int is_32, int _vector, __dpmi_regs *__regs)
     return 0;
 }
 
-static void do_procedure_retf(sigcontext_t *scp,
+static void do_procedure_retf(cpuctx_t *scp,
 	int is_32, __dpmi_regs *__regs, int words)
 {				/* DPMI 0.9 AX=0301 */
     struct pmaddr_s pma = {
@@ -266,7 +266,7 @@ static void do_procedure_retf(sigcontext_t *scp,
 	.offset = DPMI_SEL_OFF(DPMI_call_args16),
 	.selector = dpmi_sel(),
     };
-    sigcontext_t sa = *scp;
+    cpuctx_t sa = *scp;
     __dpmi_regs *regs = smalloc(&apool, sizeof(*regs));
 
     _eax = 0x301;
@@ -285,14 +285,14 @@ static void do_procedure_retf(sigcontext_t *scp,
     *scp = sa;
 }
 
-int _dpmi_simulate_real_mode_procedure_retf(sigcontext_t *scp, int is_32,
+int _dpmi_simulate_real_mode_procedure_retf(cpuctx_t *scp, int is_32,
 	__dpmi_regs *__regs)
 {				/* DPMI 0.9 AX=0301 */
     do_procedure_retf(scp, is_32, __regs, 0);
     return 0;
 }
 
-int _dpmi_simulate_real_mode_procedure_retf_stack(sigcontext_t *scp, int is_32,
+int _dpmi_simulate_real_mode_procedure_retf_stack(cpuctx_t *scp, int is_32,
 	__dpmi_regs *__regs, int stack_words_to_copy, const void *stack_data)
 { /* DPMI 0.9 AX=0301 */
     unsigned short *sp = SEL_ADR_CLNT(_ss, _esp, is_32);
@@ -313,13 +313,13 @@ int _dpmi_simulate_real_mode_procedure_retf_stack(sigcontext_t *scp, int is_32,
     return 0;
 }
 
-int _dpmi_simulate_real_mode_procedure_iret(sigcontext_t *scp, int is_32, __dpmi_regs *__regs)
+int _dpmi_simulate_real_mode_procedure_iret(cpuctx_t *scp, int is_32, __dpmi_regs *__regs)
 {				/* DPMI 0.9 AX=0302 */
     struct pmaddr_s pma = {
 	.offset = DPMI_SEL_OFF(DPMI_call),
 	.selector = dpmi_sel(),
     };
-    sigcontext_t sa = *scp;
+    cpuctx_t sa = *scp;
     __dpmi_regs *regs = smalloc(&apool, sizeof(*regs));
 
     _eax = 0x302;
@@ -339,223 +339,223 @@ int _dpmi_simulate_real_mode_procedure_iret(sigcontext_t *scp, int is_32, __dpmi
     return 0;
 }
 
-int _dpmi_allocate_real_mode_callback(sigcontext_t *scp, int is_32, void (*_handler)(void), __dpmi_regs *__regs, __dpmi_raddr *_ret)
+int _dpmi_allocate_real_mode_callback(cpuctx_t *scp, int is_32, void (*_handler)(void), __dpmi_regs *__regs, __dpmi_raddr *_ret)
 { /* DPMI 0.9 AX=0303 */
     return 0;
 }
 
-int _dpmi_free_real_mode_callback(sigcontext_t *scp, int is_32, __dpmi_raddr *_addr)
+int _dpmi_free_real_mode_callback(cpuctx_t *scp, int is_32, __dpmi_raddr *_addr)
 {					/* DPMI 0.9 AX=0304 */
     return 0;
 }
 
-int _dpmi_get_state_save_restore_addr(sigcontext_t *scp, int is_32, __dpmi_raddr *_rm, __dpmi_paddr *_pm)
+int _dpmi_get_state_save_restore_addr(cpuctx_t *scp, int is_32, __dpmi_raddr *_rm, __dpmi_paddr *_pm)
 {		/* DPMI 0.9 AX=0305 */
     return 0;
 }
 
-int _dpmi_get_raw_mode_switch_addr(sigcontext_t *scp, int is_32, __dpmi_raddr *_rm, __dpmi_paddr *_pm)
+int _dpmi_get_raw_mode_switch_addr(cpuctx_t *scp, int is_32, __dpmi_raddr *_rm, __dpmi_paddr *_pm)
 {			/* DPMI 0.9 AX=0306 */
     return 0;
 }
 
-int _dpmi_get_version(sigcontext_t *scp, int is_32, __dpmi_version_ret *_ret)
+int _dpmi_get_version(cpuctx_t *scp, int is_32, __dpmi_version_ret *_ret)
 {						/* DPMI 0.9 AX=0400 */
     return 0;
 }
 
-int _dpmi_get_capabilities(sigcontext_t *scp, int is_32, int *_flags, char *vendor_info)
+int _dpmi_get_capabilities(cpuctx_t *scp, int is_32, int *_flags, char *vendor_info)
 {				/* DPMI 1.0 AX=0401 */
     return 0;
 }
 
-int _dpmi_get_free_memory_information(sigcontext_t *scp, int is_32, __dpmi_free_mem_info *_info)
+int _dpmi_get_free_memory_information(cpuctx_t *scp, int is_32, __dpmi_free_mem_info *_info)
 {			/* DPMI 0.9 AX=0500 */
     return 0;
 }
 
-int _dpmi_allocate_memory(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info)
+int _dpmi_allocate_memory(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info)
 {						/* DPMI 0.9 AX=0501 */
     return 0;
 }
 
-int _dpmi_free_memory(sigcontext_t *scp, int is_32, ULONG _handle)
+int _dpmi_free_memory(cpuctx_t *scp, int is_32, ULONG _handle)
 {						/* DPMI 0.9 AX=0502 */
     return 0;
 }
 
-int _dpmi_resize_memory(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info)
+int _dpmi_resize_memory(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info)
 {						/* DPMI 0.9 AX=0503 */
     return 0;
 }
 
-int _dpmi_allocate_linear_memory(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info, int _commit)
+int _dpmi_allocate_linear_memory(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info, int _commit)
 {			/* DPMI 1.0 AX=0504 */
     return 0;
 }
 
-int _dpmi_resize_linear_memory(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info, int _commit)
+int _dpmi_resize_linear_memory(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info, int _commit)
 {			/* DPMI 1.0 AX=0505 */
     return 0;
 }
 
-int _dpmi_get_page_attributes(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info, short *_buffer)
+int _dpmi_get_page_attributes(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info, short *_buffer)
 {			/* DPMI 1.0 AX=0506 */
     return 0;
 }
 
-int _dpmi_set_page_attributes(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info, short *_buffer)
+int _dpmi_set_page_attributes(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info, short *_buffer)
 {			/* DPMI 1.0 AX=0507 */
     return 0;
 }
 
-int _dpmi_map_device_in_memory_block(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info, ULONG _physaddr)
+int _dpmi_map_device_in_memory_block(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info, ULONG _physaddr)
 {	/* DPMI 1.0 AX=0508 */
     return 0;
 }
 
-int _dpmi_map_conventional_memory_in_memory_block(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info, ULONG _physaddr)
+int _dpmi_map_conventional_memory_in_memory_block(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info, ULONG _physaddr)
 { /* DPMI 1.0 AX=0509 */
     return 0;
 }
 
-int _dpmi_get_memory_block_size_and_base(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info)
+int _dpmi_get_memory_block_size_and_base(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info)
 {				/* DPMI 1.0 AX=050a */
     return 0;
 }
 
-int _dpmi_get_memory_information(sigcontext_t *scp, int is_32, __dpmi_memory_info *_buffer)
+int _dpmi_get_memory_information(cpuctx_t *scp, int is_32, __dpmi_memory_info *_buffer)
 {				/* DPMI 1.0 AX=050b */
     return 0;
 }
 
-int _dpmi_lock_linear_region(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info)
+int _dpmi_lock_linear_region(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info)
 {					/* DPMI 0.9 AX=0600 */
     return 0;
 }
 
-int _dpmi_unlock_linear_region(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info)
+int _dpmi_unlock_linear_region(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info)
 {					/* DPMI 0.9 AX=0601 */
     return 0;
 }
 
-int _dpmi_mark_real_mode_region_as_pageable(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info)
+int _dpmi_mark_real_mode_region_as_pageable(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info)
 {			/* DPMI 0.9 AX=0602 */
     return 0;
 }
 
-int _dpmi_relock_real_mode_region(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info)
+int _dpmi_relock_real_mode_region(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info)
 {					/* DPMI 0.9 AX=0603 */
     return 0;
 }
 
-int _dpmi_get_page_size(sigcontext_t *scp, int is_32, ULONG *_size)
+int _dpmi_get_page_size(cpuctx_t *scp, int is_32, ULONG *_size)
 {						/* DPMI 0.9 AX=0604 */
     return 0;
 }
 
-int _dpmi_mark_page_as_demand_paging_candidate(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info)
+int _dpmi_mark_page_as_demand_paging_candidate(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info)
 {			/* DPMI 0.9 AX=0702 */
     return 0;
 }
 
-int _dpmi_discard_page_contents(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info)
+int _dpmi_discard_page_contents(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info)
 {					/* DPMI 0.9 AX=0703 */
     return 0;
 }
 
-int _dpmi_physical_address_mapping(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info)
+int _dpmi_physical_address_mapping(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info)
 {					/* DPMI 0.9 AX=0800 */
     return 0;
 }
 
-int _dpmi_free_physical_address_mapping(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info)
+int _dpmi_free_physical_address_mapping(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info)
 {				/* DPMI 0.9 AX=0801 */
     return 0;
 }
 
 /* These next four functions return the old state */
-int _dpmi_get_and_disable_virtual_interrupt_state(sigcontext_t *scp, int is_32)
+int _dpmi_get_and_disable_virtual_interrupt_state(cpuctx_t *scp, int is_32)
 {					/* DPMI 0.9 AX=0900 */
     return 0;
 }
 
-int _dpmi_get_and_enable_virtual_interrupt_state(sigcontext_t *scp, int is_32)
+int _dpmi_get_and_enable_virtual_interrupt_state(cpuctx_t *scp, int is_32)
 {					/* DPMI 0.9 AX=0901 */
     return 0;
 }
 
-int _dpmi_get_and_set_virtual_interrupt_state(sigcontext_t *scp, int is_32, int _old_state)
+int _dpmi_get_and_set_virtual_interrupt_state(cpuctx_t *scp, int is_32, int _old_state)
 {				/* DPMI 0.9 AH=09   */
     return 0;
 }
 
-int _dpmi_get_virtual_interrupt_state(sigcontext_t *scp, int is_32)
+int _dpmi_get_virtual_interrupt_state(cpuctx_t *scp, int is_32)
 {						/* DPMI 0.9 AX=0902 */
     return 0;
 }
 
-int _dpmi_get_vendor_specific_api_entry_point(sigcontext_t *scp, int is_32, char *_id, __dpmi_paddr *_api)
+int _dpmi_get_vendor_specific_api_entry_point(cpuctx_t *scp, int is_32, char *_id, __dpmi_paddr *_api)
 {		/* DPMI 0.9 AX=0a00 */
     return 0;
 }
 
-int _dpmi_set_debug_watchpoint(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info, int _type)
+int _dpmi_set_debug_watchpoint(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info, int _type)
 {				/* DPMI 0.9 AX=0b00 */
     return 0;
 }
 
-int _dpmi_clear_debug_watchpoint(sigcontext_t *scp, int is_32, ULONG _handle)
+int _dpmi_clear_debug_watchpoint(cpuctx_t *scp, int is_32, ULONG _handle)
 {					/* DPMI 0.9 AX=0b01 */
     return 0;
 }
 
-int _dpmi_get_state_of_debug_watchpoint(sigcontext_t *scp, int is_32, ULONG _handle, int *_status)
+int _dpmi_get_state_of_debug_watchpoint(cpuctx_t *scp, int is_32, ULONG _handle, int *_status)
 {		/* DPMI 0.9 AX=0b02 */
     return 0;
 }
 
-int _dpmi_reset_debug_watchpoint(sigcontext_t *scp, int is_32, ULONG _handle)
+int _dpmi_reset_debug_watchpoint(cpuctx_t *scp, int is_32, ULONG _handle)
 {					/* DPMI 0.9 AX=0b03 */
     return 0;
 }
 
-int _dpmi_install_resident_service_provider_callback(sigcontext_t *scp, int is_32, __dpmi_callback_info *_info)
+int _dpmi_install_resident_service_provider_callback(cpuctx_t *scp, int is_32, __dpmi_callback_info *_info)
 {		/* DPMI 1.0 AX=0c00 */
     return 0;
 }
 
-int _dpmi_terminate_and_stay_resident(sigcontext_t *scp, int is_32, int return_code, int paragraphs_to_keep)
+int _dpmi_terminate_and_stay_resident(cpuctx_t *scp, int is_32, int return_code, int paragraphs_to_keep)
 {		/* DPMI 1.0 AX=0c01 */
     return 0;
 }
 
-int _dpmi_allocate_shared_memory(sigcontext_t *scp, int is_32, __dpmi_shminfo *_info)
+int _dpmi_allocate_shared_memory(cpuctx_t *scp, int is_32, __dpmi_shminfo *_info)
 {					/* DPMI 1.0 AX=0d00 */
     return 0;
 }
 
-int _dpmi_free_shared_memory(sigcontext_t *scp, int is_32, ULONG _handle)
+int _dpmi_free_shared_memory(cpuctx_t *scp, int is_32, ULONG _handle)
 {					/* DPMI 1.0 AX=0d01 */
     return 0;
 }
 
-int _dpmi_serialize_on_shared_memory(sigcontext_t *scp, int is_32, ULONG _handle, int _flags)
+int _dpmi_serialize_on_shared_memory(cpuctx_t *scp, int is_32, ULONG _handle, int _flags)
 {			/* DPMI 1.0 AX=0d02 */
     return 0;
 }
 
-int _dpmi_free_serialization_on_shared_memory(sigcontext_t *scp, int is_32, ULONG _handle, int _flags)
+int _dpmi_free_serialization_on_shared_memory(cpuctx_t *scp, int is_32, ULONG _handle, int _flags)
 {		/* DPMI 1.0 AX=0d03 */
     return 0;
 }
 
-int _dpmi_get_coprocessor_status(sigcontext_t *scp, int is_32)
+int _dpmi_get_coprocessor_status(cpuctx_t *scp, int is_32)
 {							/* DPMI 1.0 AX=0e00 */
     return 0;
 }
 
-int _dpmi_set_coprocessor_emulation(sigcontext_t *scp, int is_32, int _flags)
+int _dpmi_set_coprocessor_emulation(cpuctx_t *scp, int is_32, int _flags)
 {						/* DPMI 1.0 AX=0e01 */
     return 0;
 }

--- a/src/dosext/dpmi/dpmi_api.h
+++ b/src/dosext/dpmi/dpmi_api.h
@@ -1,110 +1,110 @@
 #ifndef DPMI_API_H
 #define DPMI_API_H
 
-#include "sig.h"
+#include "cpu.h"
 #include "memory.h"
 #include "djdpmi.h"
 
-void	_dpmi_yield(sigcontext_t *scp, int is_32);									/* INT 0x2F AX=1680 */
+void	_dpmi_yield(cpuctx_t *scp, int is_32);									/* INT 0x2F AX=1680 */
 
-int	_dpmi_allocate_ldt_descriptors(sigcontext_t *scp, int is_32, int _count);						/* DPMI 0.9 AX=0000 */
-int	_dpmi_free_ldt_descriptor(sigcontext_t *scp, int is_32, int _descriptor);						/* DPMI 0.9 AX=0001 */
-int	_dpmi_segment_to_descriptor(sigcontext_t *scp, int is_32, int _segment);						/* DPMI 0.9 AX=0002 */
-int	_dpmi_get_selector_increment_value(sigcontext_t *scp, int is_32);						/* DPMI 0.9 AX=0003 */
-int	_dpmi_get_segment_base_address(sigcontext_t *scp, int is_32, int _selector, ULONG *_addr);			/* DPMI 0.9 AX=0006 */
-int	_dpmi_set_segment_base_address(sigcontext_t *scp, int is_32, int _selector, ULONG _address);			/* DPMI 0.9 AX=0007 */
-ULONG _dpmi_get_segment_limit(sigcontext_t *scp, int is_32, int _selector);						/* LSL instruction  */
-int	_dpmi_set_segment_limit(sigcontext_t *scp, int is_32, int _selector, ULONG _limit);				/* DPMI 0.9 AX=0008 */
-int	_dpmi_get_descriptor_access_rights(sigcontext_t *scp, int is_32, int _selector);					/* LAR instruction  */
-int	_dpmi_set_descriptor_access_rights(sigcontext_t *scp, int is_32, int _selector, int _rights);			/* DPMI 0.9 AX=0009 */
-int	_dpmi_create_alias_descriptor(sigcontext_t *scp, int is_32, int _selector);						/* DPMI 0.9 AX=000a */
-int	_dpmi_get_descriptor(sigcontext_t *scp, int is_32, int _selector, void *_buffer);					/* DPMI 0.9 AX=000b */
-int	_dpmi_set_descriptor(sigcontext_t *scp, int is_32, int _selector, void *_buffer);					/* DPMI 0.9 AX=000c */
-int	_dpmi_allocate_specific_ldt_descriptor(sigcontext_t *scp, int is_32, int _selector);					/* DPMI 0.9 AX=000d */
+int	_dpmi_allocate_ldt_descriptors(cpuctx_t *scp, int is_32, int _count);						/* DPMI 0.9 AX=0000 */
+int	_dpmi_free_ldt_descriptor(cpuctx_t *scp, int is_32, int _descriptor);						/* DPMI 0.9 AX=0001 */
+int	_dpmi_segment_to_descriptor(cpuctx_t *scp, int is_32, int _segment);						/* DPMI 0.9 AX=0002 */
+int	_dpmi_get_selector_increment_value(cpuctx_t *scp, int is_32);						/* DPMI 0.9 AX=0003 */
+int	_dpmi_get_segment_base_address(cpuctx_t *scp, int is_32, int _selector, ULONG *_addr);			/* DPMI 0.9 AX=0006 */
+int	_dpmi_set_segment_base_address(cpuctx_t *scp, int is_32, int _selector, ULONG _address);			/* DPMI 0.9 AX=0007 */
+ULONG _dpmi_get_segment_limit(cpuctx_t *scp, int is_32, int _selector);						/* LSL instruction  */
+int	_dpmi_set_segment_limit(cpuctx_t *scp, int is_32, int _selector, ULONG _limit);				/* DPMI 0.9 AX=0008 */
+int	_dpmi_get_descriptor_access_rights(cpuctx_t *scp, int is_32, int _selector);					/* LAR instruction  */
+int	_dpmi_set_descriptor_access_rights(cpuctx_t *scp, int is_32, int _selector, int _rights);			/* DPMI 0.9 AX=0009 */
+int	_dpmi_create_alias_descriptor(cpuctx_t *scp, int is_32, int _selector);						/* DPMI 0.9 AX=000a */
+int	_dpmi_get_descriptor(cpuctx_t *scp, int is_32, int _selector, void *_buffer);					/* DPMI 0.9 AX=000b */
+int	_dpmi_set_descriptor(cpuctx_t *scp, int is_32, int _selector, void *_buffer);					/* DPMI 0.9 AX=000c */
+int	_dpmi_allocate_specific_ldt_descriptor(cpuctx_t *scp, int is_32, int _selector);					/* DPMI 0.9 AX=000d */
 
-int	_dpmi_get_multiple_descriptors(sigcontext_t *scp, int is_32, int _count, void *_buffer);				/* DPMI 1.0 AX=000e */
-int	_dpmi_set_multiple_descriptors(sigcontext_t *scp, int is_32, int _count, void *_buffer);				/* DPMI 1.0 AX=000f */
+int	_dpmi_get_multiple_descriptors(cpuctx_t *scp, int is_32, int _count, void *_buffer);				/* DPMI 1.0 AX=000e */
+int	_dpmi_set_multiple_descriptors(cpuctx_t *scp, int is_32, int _count, void *_buffer);				/* DPMI 1.0 AX=000f */
 
-int	_dpmi_allocate_dos_memory(sigcontext_t *scp, int is_32, int _paragraphs, int *_ret_selector_or_max);			/* DPMI 0.9 AX=0100 */
-int	_dpmi_free_dos_memory(sigcontext_t *scp, int is_32, int _selector);							/* DPMI 0.9 AX=0101 */
-int	_dpmi_resize_dos_memory(sigcontext_t *scp, int is_32, int _selector, int _newpara, int *_ret_max);			/* DPMI 0.9 AX=0102 */
+int	_dpmi_allocate_dos_memory(cpuctx_t *scp, int is_32, int _paragraphs, int *_ret_selector_or_max);			/* DPMI 0.9 AX=0100 */
+int	_dpmi_free_dos_memory(cpuctx_t *scp, int is_32, int _selector);							/* DPMI 0.9 AX=0101 */
+int	_dpmi_resize_dos_memory(cpuctx_t *scp, int is_32, int _selector, int _newpara, int *_ret_max);			/* DPMI 0.9 AX=0102 */
 
-int	_dpmi_get_real_mode_interrupt_vector(sigcontext_t *scp, int is_32, int _vector, __dpmi_raddr *_address);		/* DPMI 0.9 AX=0200 */
-int	_dpmi_set_real_mode_interrupt_vector(sigcontext_t *scp, int is_32, int _vector, __dpmi_raddr *_address);		/* DPMI 0.9 AX=0201 */
-int	_dpmi_get_processor_exception_handler_vector(sigcontext_t *scp, int is_32, int _vector, __dpmi_paddr *_address);	/* DPMI 0.9 AX=0202 */
-int	_dpmi_set_processor_exception_handler_vector(sigcontext_t *scp, int is_32, int _vector, __dpmi_paddr *_address);	/* DPMI 0.9 AX=0203 */
-int	_dpmi_get_protected_mode_interrupt_vector(sigcontext_t *scp, int is_32, int _vector, __dpmi_paddr *_address);	/* DPMI 0.9 AX=0204 */
-int	_dpmi_set_protected_mode_interrupt_vector(sigcontext_t *scp, int is_32, int _vector, __dpmi_paddr *_address);	/* DPMI 0.9 AX=0205 */
+int	_dpmi_get_real_mode_interrupt_vector(cpuctx_t *scp, int is_32, int _vector, __dpmi_raddr *_address);		/* DPMI 0.9 AX=0200 */
+int	_dpmi_set_real_mode_interrupt_vector(cpuctx_t *scp, int is_32, int _vector, __dpmi_raddr *_address);		/* DPMI 0.9 AX=0201 */
+int	_dpmi_get_processor_exception_handler_vector(cpuctx_t *scp, int is_32, int _vector, __dpmi_paddr *_address);	/* DPMI 0.9 AX=0202 */
+int	_dpmi_set_processor_exception_handler_vector(cpuctx_t *scp, int is_32, int _vector, __dpmi_paddr *_address);	/* DPMI 0.9 AX=0203 */
+int	_dpmi_get_protected_mode_interrupt_vector(cpuctx_t *scp, int is_32, int _vector, __dpmi_paddr *_address);	/* DPMI 0.9 AX=0204 */
+int	_dpmi_set_protected_mode_interrupt_vector(cpuctx_t *scp, int is_32, int _vector, __dpmi_paddr *_address);	/* DPMI 0.9 AX=0205 */
 
-int	_dpmi_get_extended_exception_handler_vector_pm(sigcontext_t *scp, int is_32, int _vector, __dpmi_paddr *_address);	/* DPMI 1.0 AX=0210 */
-int	_dpmi_get_extended_exception_handler_vector_rm(sigcontext_t *scp, int is_32, int _vector, __dpmi_paddr *_address);	/* DPMI 1.0 AX=0211 */
-int	_dpmi_set_extended_exception_handler_vector_pm(sigcontext_t *scp, int is_32, int _vector, __dpmi_paddr *_address);	/* DPMI 1.0 AX=0212 */
-int	_dpmi_set_extended_exception_handler_vector_rm(sigcontext_t *scp, int is_32, int _vector, __dpmi_paddr *_address);	/* DPMI 1.0 AX=0213 */
+int	_dpmi_get_extended_exception_handler_vector_pm(cpuctx_t *scp, int is_32, int _vector, __dpmi_paddr *_address);	/* DPMI 1.0 AX=0210 */
+int	_dpmi_get_extended_exception_handler_vector_rm(cpuctx_t *scp, int is_32, int _vector, __dpmi_paddr *_address);	/* DPMI 1.0 AX=0211 */
+int	_dpmi_set_extended_exception_handler_vector_pm(cpuctx_t *scp, int is_32, int _vector, __dpmi_paddr *_address);	/* DPMI 1.0 AX=0212 */
+int	_dpmi_set_extended_exception_handler_vector_rm(cpuctx_t *scp, int is_32, int _vector, __dpmi_paddr *_address);	/* DPMI 1.0 AX=0213 */
 
-int	_dpmi_simulate_real_mode_interrupt(sigcontext_t *scp, int is_32, int _vector, __dpmi_regs *__regs);			/* DPMI 0.9 AX=0300 */
-int	_dpmi_int(sigcontext_t *scp, int is_32, int _vector, __dpmi_regs *__regs); /* like above, but sets ss sp fl */	/* DPMI 0.9 AX=0300 */
+int	_dpmi_simulate_real_mode_interrupt(cpuctx_t *scp, int is_32, int _vector, __dpmi_regs *__regs);			/* DPMI 0.9 AX=0300 */
+int	_dpmi_int(cpuctx_t *scp, int is_32, int _vector, __dpmi_regs *__regs); /* like above, but sets ss sp fl */	/* DPMI 0.9 AX=0300 */
 
-int	_dpmi_simulate_real_mode_procedure_retf(sigcontext_t *scp, int is_32, __dpmi_regs *__regs);				/* DPMI 0.9 AX=0301 */
-int	_dpmi_simulate_real_mode_procedure_retf_stack(sigcontext_t *scp, int is_32, __dpmi_regs *__regs, int stack_words_to_copy, const void *stack_data); /* DPMI 0.9 AX=0301 */
-int	_dpmi_simulate_real_mode_procedure_iret(sigcontext_t *scp, int is_32, __dpmi_regs *__regs);				/* DPMI 0.9 AX=0302 */
-int	_dpmi_allocate_real_mode_callback(sigcontext_t *scp, int is_32, void (*_handler)(void), __dpmi_regs *__regs, __dpmi_raddr *_ret); /* DPMI 0.9 AX=0303 */
-int	_dpmi_free_real_mode_callback(sigcontext_t *scp, int is_32, __dpmi_raddr *_addr);					/* DPMI 0.9 AX=0304 */
-int	_dpmi_get_state_save_restore_addr(sigcontext_t *scp, int is_32, __dpmi_raddr *_rm, __dpmi_paddr *_pm);		/* DPMI 0.9 AX=0305 */
-int	_dpmi_get_raw_mode_switch_addr(sigcontext_t *scp, int is_32, __dpmi_raddr *_rm, __dpmi_paddr *_pm);			/* DPMI 0.9 AX=0306 */
+int	_dpmi_simulate_real_mode_procedure_retf(cpuctx_t *scp, int is_32, __dpmi_regs *__regs);				/* DPMI 0.9 AX=0301 */
+int	_dpmi_simulate_real_mode_procedure_retf_stack(cpuctx_t *scp, int is_32, __dpmi_regs *__regs, int stack_words_to_copy, const void *stack_data); /* DPMI 0.9 AX=0301 */
+int	_dpmi_simulate_real_mode_procedure_iret(cpuctx_t *scp, int is_32, __dpmi_regs *__regs);				/* DPMI 0.9 AX=0302 */
+int	_dpmi_allocate_real_mode_callback(cpuctx_t *scp, int is_32, void (*_handler)(void), __dpmi_regs *__regs, __dpmi_raddr *_ret); /* DPMI 0.9 AX=0303 */
+int	_dpmi_free_real_mode_callback(cpuctx_t *scp, int is_32, __dpmi_raddr *_addr);					/* DPMI 0.9 AX=0304 */
+int	_dpmi_get_state_save_restore_addr(cpuctx_t *scp, int is_32, __dpmi_raddr *_rm, __dpmi_paddr *_pm);		/* DPMI 0.9 AX=0305 */
+int	_dpmi_get_raw_mode_switch_addr(cpuctx_t *scp, int is_32, __dpmi_raddr *_rm, __dpmi_paddr *_pm);			/* DPMI 0.9 AX=0306 */
 
-int	_dpmi_get_version(sigcontext_t *scp, int is_32, __dpmi_version_ret *_ret);						/* DPMI 0.9 AX=0400 */
+int	_dpmi_get_version(cpuctx_t *scp, int is_32, __dpmi_version_ret *_ret);						/* DPMI 0.9 AX=0400 */
 
-int	_dpmi_get_capabilities(sigcontext_t *scp, int is_32, int *_flags, char *vendor_info);				/* DPMI 1.0 AX=0401 */
+int	_dpmi_get_capabilities(cpuctx_t *scp, int is_32, int *_flags, char *vendor_info);				/* DPMI 1.0 AX=0401 */
 
-int	_dpmi_get_free_memory_information(sigcontext_t *scp, int is_32, __dpmi_free_mem_info *_info);			/* DPMI 0.9 AX=0500 */
-int	_dpmi_allocate_memory(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info);						/* DPMI 0.9 AX=0501 */
-int	_dpmi_free_memory(sigcontext_t *scp, int is_32, ULONG _handle);						/* DPMI 0.9 AX=0502 */
-int	_dpmi_resize_memory(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info);						/* DPMI 0.9 AX=0503 */
+int	_dpmi_get_free_memory_information(cpuctx_t *scp, int is_32, __dpmi_free_mem_info *_info);			/* DPMI 0.9 AX=0500 */
+int	_dpmi_allocate_memory(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info);						/* DPMI 0.9 AX=0501 */
+int	_dpmi_free_memory(cpuctx_t *scp, int is_32, ULONG _handle);						/* DPMI 0.9 AX=0502 */
+int	_dpmi_resize_memory(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info);						/* DPMI 0.9 AX=0503 */
 
-int	_dpmi_allocate_linear_memory(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info, int _commit);			/* DPMI 1.0 AX=0504 */
-int	_dpmi_resize_linear_memory(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info, int _commit);			/* DPMI 1.0 AX=0505 */
-int	_dpmi_get_page_attributes(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info, short *_buffer);			/* DPMI 1.0 AX=0506 */
-int	_dpmi_set_page_attributes(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info, short *_buffer);			/* DPMI 1.0 AX=0507 */
-int	_dpmi_map_device_in_memory_block(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info, ULONG _physaddr);	/* DPMI 1.0 AX=0508 */
-int	_dpmi_map_conventional_memory_in_memory_block(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info, ULONG _physaddr); /* DPMI 1.0 AX=0509 */
-int	_dpmi_get_memory_block_size_and_base(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info);				/* DPMI 1.0 AX=050a */
-int	_dpmi_get_memory_information(sigcontext_t *scp, int is_32, __dpmi_memory_info *_buffer);				/* DPMI 1.0 AX=050b */
+int	_dpmi_allocate_linear_memory(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info, int _commit);			/* DPMI 1.0 AX=0504 */
+int	_dpmi_resize_linear_memory(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info, int _commit);			/* DPMI 1.0 AX=0505 */
+int	_dpmi_get_page_attributes(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info, short *_buffer);			/* DPMI 1.0 AX=0506 */
+int	_dpmi_set_page_attributes(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info, short *_buffer);			/* DPMI 1.0 AX=0507 */
+int	_dpmi_map_device_in_memory_block(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info, ULONG _physaddr);	/* DPMI 1.0 AX=0508 */
+int	_dpmi_map_conventional_memory_in_memory_block(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info, ULONG _physaddr); /* DPMI 1.0 AX=0509 */
+int	_dpmi_get_memory_block_size_and_base(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info);				/* DPMI 1.0 AX=050a */
+int	_dpmi_get_memory_information(cpuctx_t *scp, int is_32, __dpmi_memory_info *_buffer);				/* DPMI 1.0 AX=050b */
 
-int	_dpmi_lock_linear_region(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info);					/* DPMI 0.9 AX=0600 */
-int	_dpmi_unlock_linear_region(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info);					/* DPMI 0.9 AX=0601 */
-int	_dpmi_mark_real_mode_region_as_pageable(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info);			/* DPMI 0.9 AX=0602 */
-int	_dpmi_relock_real_mode_region(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info);					/* DPMI 0.9 AX=0603 */
-int	_dpmi_get_page_size(sigcontext_t *scp, int is_32, ULONG *_size);						/* DPMI 0.9 AX=0604 */
+int	_dpmi_lock_linear_region(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info);					/* DPMI 0.9 AX=0600 */
+int	_dpmi_unlock_linear_region(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info);					/* DPMI 0.9 AX=0601 */
+int	_dpmi_mark_real_mode_region_as_pageable(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info);			/* DPMI 0.9 AX=0602 */
+int	_dpmi_relock_real_mode_region(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info);					/* DPMI 0.9 AX=0603 */
+int	_dpmi_get_page_size(cpuctx_t *scp, int is_32, ULONG *_size);						/* DPMI 0.9 AX=0604 */
 
-int	_dpmi_mark_page_as_demand_paging_candidate(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info);			/* DPMI 0.9 AX=0702 */
-int	_dpmi_discard_page_contents(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info);					/* DPMI 0.9 AX=0703 */
+int	_dpmi_mark_page_as_demand_paging_candidate(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info);			/* DPMI 0.9 AX=0702 */
+int	_dpmi_discard_page_contents(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info);					/* DPMI 0.9 AX=0703 */
 
-int	_dpmi_physical_address_mapping(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info);					/* DPMI 0.9 AX=0800 */
-int	_dpmi_free_physical_address_mapping(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info);				/* DPMI 0.9 AX=0801 */
+int	_dpmi_physical_address_mapping(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info);					/* DPMI 0.9 AX=0800 */
+int	_dpmi_free_physical_address_mapping(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info);				/* DPMI 0.9 AX=0801 */
 
 /* These next four functions return the old state */
-int	_dpmi_get_and_disable_virtual_interrupt_state(sigcontext_t *scp, int is_32);					/* DPMI 0.9 AX=0900 */
-int	_dpmi_get_and_enable_virtual_interrupt_state(sigcontext_t *scp, int is_32);					/* DPMI 0.9 AX=0901 */
-int	_dpmi_get_and_set_virtual_interrupt_state(sigcontext_t *scp, int is_32, int _old_state);				/* DPMI 0.9 AH=09   */
-int	_dpmi_get_virtual_interrupt_state(sigcontext_t *scp, int is_32);						/* DPMI 0.9 AX=0902 */
+int	_dpmi_get_and_disable_virtual_interrupt_state(cpuctx_t *scp, int is_32);					/* DPMI 0.9 AX=0900 */
+int	_dpmi_get_and_enable_virtual_interrupt_state(cpuctx_t *scp, int is_32);					/* DPMI 0.9 AX=0901 */
+int	_dpmi_get_and_set_virtual_interrupt_state(cpuctx_t *scp, int is_32, int _old_state);				/* DPMI 0.9 AH=09   */
+int	_dpmi_get_virtual_interrupt_state(cpuctx_t *scp, int is_32);						/* DPMI 0.9 AX=0902 */
 
-int	_dpmi_get_vendor_specific_api_entry_point(sigcontext_t *scp, int is_32, char *_id, __dpmi_paddr *_api);		/* DPMI 0.9 AX=0a00 */
+int	_dpmi_get_vendor_specific_api_entry_point(cpuctx_t *scp, int is_32, char *_id, __dpmi_paddr *_api);		/* DPMI 0.9 AX=0a00 */
 
-int	_dpmi_set_debug_watchpoint(sigcontext_t *scp, int is_32, __dpmi_meminfo *_info, int _type);				/* DPMI 0.9 AX=0b00 */
-int	_dpmi_clear_debug_watchpoint(sigcontext_t *scp, int is_32, ULONG _handle);					/* DPMI 0.9 AX=0b01 */
-int	_dpmi_get_state_of_debug_watchpoint(sigcontext_t *scp, int is_32, ULONG _handle, int *_status);		/* DPMI 0.9 AX=0b02 */
-int	_dpmi_reset_debug_watchpoint(sigcontext_t *scp, int is_32, ULONG _handle);					/* DPMI 0.9 AX=0b03 */
+int	_dpmi_set_debug_watchpoint(cpuctx_t *scp, int is_32, __dpmi_meminfo *_info, int _type);				/* DPMI 0.9 AX=0b00 */
+int	_dpmi_clear_debug_watchpoint(cpuctx_t *scp, int is_32, ULONG _handle);					/* DPMI 0.9 AX=0b01 */
+int	_dpmi_get_state_of_debug_watchpoint(cpuctx_t *scp, int is_32, ULONG _handle, int *_status);		/* DPMI 0.9 AX=0b02 */
+int	_dpmi_reset_debug_watchpoint(cpuctx_t *scp, int is_32, ULONG _handle);					/* DPMI 0.9 AX=0b03 */
 
-int	_dpmi_install_resident_service_provider_callback(sigcontext_t *scp, int is_32, __dpmi_callback_info *_info);		/* DPMI 1.0 AX=0c00 */
-int	_dpmi_terminate_and_stay_resident(sigcontext_t *scp, int is_32, int return_code, int paragraphs_to_keep);		/* DPMI 1.0 AX=0c01 */
+int	_dpmi_install_resident_service_provider_callback(cpuctx_t *scp, int is_32, __dpmi_callback_info *_info);		/* DPMI 1.0 AX=0c00 */
+int	_dpmi_terminate_and_stay_resident(cpuctx_t *scp, int is_32, int return_code, int paragraphs_to_keep);		/* DPMI 1.0 AX=0c01 */
 
-int	_dpmi_allocate_shared_memory(sigcontext_t *scp, int is_32, __dpmi_shminfo *_info);					/* DPMI 1.0 AX=0d00 */
-int	_dpmi_free_shared_memory(sigcontext_t *scp, int is_32, ULONG _handle);					/* DPMI 1.0 AX=0d01 */
-int	_dpmi_serialize_on_shared_memory(sigcontext_t *scp, int is_32, ULONG _handle, int _flags);			/* DPMI 1.0 AX=0d02 */
-int	_dpmi_free_serialization_on_shared_memory(sigcontext_t *scp, int is_32, ULONG _handle, int _flags);		/* DPMI 1.0 AX=0d03 */
+int	_dpmi_allocate_shared_memory(cpuctx_t *scp, int is_32, __dpmi_shminfo *_info);					/* DPMI 1.0 AX=0d00 */
+int	_dpmi_free_shared_memory(cpuctx_t *scp, int is_32, ULONG _handle);					/* DPMI 1.0 AX=0d01 */
+int	_dpmi_serialize_on_shared_memory(cpuctx_t *scp, int is_32, ULONG _handle, int _flags);			/* DPMI 1.0 AX=0d02 */
+int	_dpmi_free_serialization_on_shared_memory(cpuctx_t *scp, int is_32, ULONG _handle, int _flags);		/* DPMI 1.0 AX=0d03 */
 
-int	_dpmi_get_coprocessor_status(sigcontext_t *scp, int is_32);							/* DPMI 1.0 AX=0e00 */
-int	_dpmi_set_coprocessor_emulation(sigcontext_t *scp, int is_32, int _flags);						/* DPMI 1.0 AX=0e01 */
+int	_dpmi_get_coprocessor_status(cpuctx_t *scp, int is_32);							/* DPMI 1.0 AX=0e00 */
+int	_dpmi_set_coprocessor_emulation(cpuctx_t *scp, int is_32, int _flags);						/* DPMI 1.0 AX=0e01 */
 
 void dpmi_api_init(uint16_t selector, dosaddr_t  pool, int pool_size);
 

--- a/src/dosext/dpmi/emudpmi.h
+++ b/src/dosext/dpmi/emudpmi.h
@@ -133,7 +133,6 @@ typedef enum {
 } regnum_t;
 
 void dpmi_get_entry_point(void);
-int dpmi_fault(sigcontext_t *scp);
 void dpmi_realmode_hlt(unsigned int lina);
 void run_pm_int(int inum);
 void fake_pm_int(void);
@@ -145,7 +144,7 @@ int dpmi_isset_IF(void);
 /* currently eflags are stored with IF reflecting the actual interrupt state,
  * so no translation is needed */
 #define dpmi_flags_to_stack(flags) (flags)
-static inline unsigned dpmi_flags_from_stack_iret(const sigcontext_t *scp,
+static inline unsigned dpmi_flags_from_stack_iret(const cpuctx_t *scp,
     unsigned flags)
 {
   int iopl = ((_eflags_ & IOPL_MASK) >> IOPL_SHIFT);
@@ -190,13 +189,13 @@ int GetDescriptor(u_short selector, unsigned int *lp);
 unsigned int GetSegmentBase(unsigned short sel);
 unsigned int GetSegmentLimit(unsigned short sel);
 unsigned int GetSegmentType(unsigned short selector);
-int CheckSelectors(sigcontext_t *scp, int in_dosemu);
+int CheckSelectors(cpuctx_t *scp, int in_dosemu);
 int ValidAndUsedSelector(unsigned int selector);
 int dpmi_is_valid_range(dosaddr_t addr, int len);
 int dpmi_read_access(dosaddr_t addr);
 int dpmi_write_access(dosaddr_t addr);
 
-extern char *DPMI_show_state(sigcontext_t *scp);
+extern char *DPMI_show_state(cpuctx_t *scp);
 extern void run_dpmi(void);
 
 extern int ConvertSegmentToDescriptor(unsigned short segment);
@@ -219,7 +218,7 @@ extern int SetSelector(unsigned short selector, dosaddr_t base_addr, unsigned in
                        unsigned char is_big, unsigned char seg_not_present, unsigned char useable);
 extern int SetDescriptor(unsigned short selector, unsigned int *lp);
 extern int FreeDescriptor(unsigned short selector);
-extern void FreeSegRegs(sigcontext_t *scp, unsigned short selector);
+extern void FreeSegRegs(cpuctx_t *scp, unsigned short selector);
 extern far_t DPMI_allocate_realmode_callback(u_short sel, int offs, u_short rm_sel,
 	int rm_offs);
 extern int DPMI_free_realmode_callback(u_short seg, u_short off);
@@ -237,9 +236,6 @@ extern void dpmi_reset(void);
 extern void dpmi_done(void);
 extern int get_ldt(void *buffer);
 void dpmi_init(void);
-void copy_to_dpmi(sigcontext_t *d, sigcontext_t *s);
-void copy_to_emu(sigcontext_t *d, sigcontext_t *s);
-void copy_context(sigcontext_t *d, sigcontext_t *s);
 extern unsigned short dpmi_sel(void);
 extern unsigned short dpmi_sel16(void);
 extern unsigned short dpmi_sel32(void);
@@ -250,7 +246,7 @@ void dump_maps(void);
 int DPMIValidSelector(unsigned short selector);
 uint8_t *dpmi_get_ldt_buffer(void);
 
-sigcontext_t *dpmi_get_scp(void);
+cpuctx_t *dpmi_get_scp(void);
 
 int dpmi_realmode_exception(unsigned trapno, unsigned err, dosaddr_t cr2);
 
@@ -375,7 +371,7 @@ static inline int DPMIValidSelector(unsigned short selector)
     return 0;
 }
 
-static inline sigcontext_t *dpmi_get_scp(void)
+static inline cpuctx_t *dpmi_get_scp(void)
 {
     return NULL;
 }
@@ -403,7 +399,7 @@ static inline void dpmi_get_entry_point(void)
 {
 }
 
-static inline char *DPMI_show_state(sigcontext_t *scp)
+static inline char *DPMI_show_state(cpuctx_t *scp)
 {
     return "";
 }

--- a/src/dosext/dpmi/msdos/callbacks.c
+++ b/src/dosext/dpmi/msdos/callbacks.c
@@ -43,13 +43,13 @@ static void do_retf(struct RealModeCallStructure *rmreg, int rmask)
     RMREG(sp) += 4;
 }
 
-static void rmcb_ret_handler(sigcontext_t *scp,
+static void rmcb_ret_handler(cpuctx_t *scp,
 		      struct RealModeCallStructure *rmreg, int is_32)
 {
     do_retf(rmreg, (1 << ss_INDEX) | (1 << esp_INDEX));
 }
 
-static void rmcb_ret_from_ps2(sigcontext_t *scp,
+static void rmcb_ret_from_ps2(cpuctx_t *scp,
 		       struct RealModeCallStructure *rmreg, int is_32)
 {
     if (is_32)
@@ -59,7 +59,7 @@ static void rmcb_ret_from_ps2(sigcontext_t *scp,
     do_retf(rmreg, (1 << ss_INDEX) | (1 << esp_INDEX));
 }
 
-static void rm_to_pm_regs(sigcontext_t *scp,
+static void rm_to_pm_regs(cpuctx_t *scp,
 			  const struct RealModeCallStructure *rmreg,
 			  unsigned int mask)
 {
@@ -83,7 +83,7 @@ static void rm_to_pm_regs(sigcontext_t *scp,
 	_LWORD(ebp) = RMLWORD(bp);
 }
 
-static void pm_to_rm_regs(const sigcontext_t *scp,
+static void pm_to_rm_regs(const cpuctx_t *scp,
 			  struct RealModeCallStructure *rmreg,
 			  unsigned int mask)
 {
@@ -105,7 +105,7 @@ static void pm_to_rm_regs(const sigcontext_t *scp,
     X_RMREG(ebp) = _LWORD_(ebp_);
 }
 
-static void mouse_callback(sigcontext_t *scp,
+static void mouse_callback(cpuctx_t *scp,
 		    const struct RealModeCallStructure *rmreg,
 		    int is_32, void *arg)
 {
@@ -137,7 +137,7 @@ static void mouse_callback(sigcontext_t *scp,
     _eip = mouseCallBack->offset;
 }
 
-static void ps2_mouse_callback(sigcontext_t *scp,
+static void ps2_mouse_callback(cpuctx_t *scp,
 			const struct RealModeCallStructure *rmreg,
 			int is_32, void *arg)
 {
@@ -185,7 +185,7 @@ static void ps2_mouse_callback(sigcontext_t *scp,
     _eip = PS2mouseCallBack->offset;
 }
 
-struct pmrm_ret msdos_ext_call(sigcontext_t *scp,
+struct pmrm_ret msdos_ext_call(cpuctx_t *scp,
 	struct RealModeCallStructure *rmreg,
 	unsigned short rm_seg, void *(*arg)(int), int off)
 {
@@ -201,7 +201,7 @@ struct pmrm_ret msdos_ext_call(sigcontext_t *scp,
     return ret;
 }
 
-struct pext_ret msdos_ext_ret(sigcontext_t *scp,
+struct pext_ret msdos_ext_ret(cpuctx_t *scp,
 	const struct RealModeCallStructure *rmreg,
 	unsigned short rm_seg, int off)
 {
@@ -214,7 +214,7 @@ struct pext_ret msdos_ext_ret(sigcontext_t *scp,
     return ret;
 }
 
-void msdos_api_call(sigcontext_t *scp, void *arg)
+void msdos_api_call(cpuctx_t *scp, void *arg)
 {
     u_short *(*cb)(void) = arg;
     const u_short *ldt_alias = cb();
@@ -233,7 +233,7 @@ void msdos_api_call(sigcontext_t *scp, void *arg)
     }
 }
 
-void msdos_api_winos2_call(sigcontext_t *scp, void *arg)
+void msdos_api_winos2_call(cpuctx_t *scp, void *arg)
 {
     u_short *(*cb)(void) = arg;
     const u_short *ldt_alias_winos2 = cb();
@@ -252,14 +252,14 @@ void msdos_api_winos2_call(sigcontext_t *scp, void *arg)
     }
 }
 
-static void (*rmcb_handlers[])(sigcontext_t *scp,
+static void (*rmcb_handlers[])(cpuctx_t *scp,
 		 const struct RealModeCallStructure *rmreg,
 		 int is_32, void *arg) = {
     [RMCB_MS] = mouse_callback,
     [RMCB_PS2MS] = ps2_mouse_callback,
 };
 
-static void (*rmcb_ret_handlers[])(sigcontext_t *scp,
+static void (*rmcb_ret_handlers[])(cpuctx_t *scp,
 		 struct RealModeCallStructure *rmreg, int is_32) = {
     [RMCB_MS] = rmcb_ret_handler,
     [RMCB_PS2MS] = rmcb_ret_from_ps2,

--- a/src/dosext/dpmi/msdos/callbacks.h
+++ b/src/dosext/dpmi/msdos/callbacks.h
@@ -3,13 +3,13 @@
 
 #include <assert.h>
 
-void msdos_api_call(sigcontext_t *scp, void *arg);
-void msdos_api_winos2_call(sigcontext_t *scp, void *arg);
+void msdos_api_call(cpuctx_t *scp, void *arg);
+void msdos_api_winos2_call(cpuctx_t *scp, void *arg);
 
-struct pmrm_ret msdos_ext_call(sigcontext_t *scp,
+struct pmrm_ret msdos_ext_call(cpuctx_t *scp,
 	struct RealModeCallStructure *rmreg,
 	unsigned short rm_seg, void *(*arg)(int), int off);
-struct pext_ret msdos_ext_ret(sigcontext_t *scp,
+struct pext_ret msdos_ext_ret(cpuctx_t *scp,
 	const struct RealModeCallStructure *rmreg,
 	unsigned short rm_seg, int off);
 

--- a/src/dosext/dpmi/msdos/emm.c
+++ b/src/dosext/dpmi/msdos/emm.c
@@ -34,7 +34,7 @@
 
 #define EMM_INT                 0x67
 
-int emm_allocate_handle(sigcontext_t *scp, int is_32, int pages_needed)
+int emm_allocate_handle(cpuctx_t *scp, int is_32, int pages_needed)
 {
   __dpmi_regs regs = {0};
   regs.h.ah = ALLOCATE_PAGES;
@@ -45,7 +45,7 @@ int emm_allocate_handle(sigcontext_t *scp, int is_32, int pages_needed)
   return regs.x.dx;
 }
 
-int emm_save_handle_state(sigcontext_t *scp, int is_32, int handle)
+int emm_save_handle_state(cpuctx_t *scp, int is_32, int handle)
 {
   __dpmi_regs regs = {0};
   regs.h.ah = SAVE_PAGE_MAP;
@@ -56,7 +56,7 @@ int emm_save_handle_state(sigcontext_t *scp, int is_32, int handle)
   return 0;
 }
 
-int emm_restore_handle_state(sigcontext_t *scp, int is_32, int handle)
+int emm_restore_handle_state(cpuctx_t *scp, int is_32, int handle)
 {
   __dpmi_regs regs = {0};
   regs.h.ah = RESTORE_PAGE_MAP;
@@ -67,7 +67,7 @@ int emm_restore_handle_state(sigcontext_t *scp, int is_32, int handle)
   return 0;
 }
 
-int emm_map_unmap_multi(sigcontext_t *scp, int is_32, const u_short *array,
+int emm_map_unmap_multi(cpuctx_t *scp, int is_32, const u_short *array,
     int handle, int map_len)
 {
   uint16_t buf_seg = get_scratch_seg();
@@ -89,7 +89,7 @@ int emm_map_unmap_multi(sigcontext_t *scp, int is_32, const u_short *array,
   return 0;
 }
 
-int emm_get_mpa_len(sigcontext_t *scp, int is_32)
+int emm_get_mpa_len(cpuctx_t *scp, int is_32)
 {
   __dpmi_regs regs = {0};
   regs.h.ah = GET_MPA_ARRAY;
@@ -100,7 +100,7 @@ int emm_get_mpa_len(sigcontext_t *scp, int is_32)
   return regs.x.cx;
 }
 
-int emm_get_mpa_array(sigcontext_t *scp, int is_32,
+int emm_get_mpa_array(cpuctx_t *scp, int is_32,
     struct emm_phys_page_desc *array, int max_len)
 {
   uint16_t buf_seg = get_scratch_seg();

--- a/src/dosext/dpmi/msdos/emm_msdos.h
+++ b/src/dosext/dpmi/msdos/emm_msdos.h
@@ -2,19 +2,19 @@
 #ifndef EMM_MSDOS_H
 #define EMM_MSDOS_H
 
-int emm_allocate_handle(sigcontext_t *scp, int is_32, int pages_needed);
-int emm_deallocate_handle(sigcontext_t *scp, int is_32, int handle);
-int emm_save_handle_state(sigcontext_t *scp, int is_32, int handle);
-int emm_restore_handle_state(sigcontext_t *scp, int is_32, int handle);
-int emm_map_unmap_multi(sigcontext_t *scp, int is_32, const u_short *array,
+int emm_allocate_handle(cpuctx_t *scp, int is_32, int pages_needed);
+int emm_deallocate_handle(cpuctx_t *scp, int is_32, int handle);
+int emm_save_handle_state(cpuctx_t *scp, int is_32, int handle);
+int emm_restore_handle_state(cpuctx_t *scp, int is_32, int handle);
+int emm_map_unmap_multi(cpuctx_t *scp, int is_32, const u_short *array,
     int handle, int map_len);
-int emm_get_mpa_len(sigcontext_t *scp, int is_32);
+int emm_get_mpa_len(cpuctx_t *scp, int is_32);
 
 struct emm_phys_page_desc {
     uint16_t seg;
     uint16_t num;
 };
-int emm_get_mpa_array(sigcontext_t *scp, int is_32,
+int emm_get_mpa_array(cpuctx_t *scp, int is_32,
 	struct emm_phys_page_desc *array, int max_len);
 
 #endif

--- a/src/dosext/dpmi/msdos/hlpmisc.c
+++ b/src/dosext/dpmi/msdos/hlpmisc.c
@@ -1,7 +1,7 @@
 #include "dpmi_api.h"
 #include "hlpmisc.h"
 
-void do_call_to(sigcontext_t *scp, int is_32, far_t dst, __dpmi_regs *rmreg)
+void do_call_to(cpuctx_t *scp, int is_32, far_t dst, __dpmi_regs *rmreg)
 {
     RMREG(ss) = 0;
     RMREG(sp) = 0;

--- a/src/dosext/dpmi/msdos/hlpmisc.h
+++ b/src/dosext/dpmi/msdos/hlpmisc.h
@@ -11,7 +11,7 @@
 #define X_RMREG(r) (rmreg->d.r)
 #endif
 
-static inline void pm_to_rm_regs(const sigcontext_t *scp,
+static inline void pm_to_rm_regs(const cpuctx_t *scp,
 			  __dpmi_regs *rmreg, unsigned int mask)
 {
   if (mask & (1 << eflags_INDEX))
@@ -32,7 +32,7 @@ static inline void pm_to_rm_regs(const sigcontext_t *scp,
     X_RMREG(ebp) = _LWORD_(ebp_);
 }
 
-static inline void rm_to_pm_regs(sigcontext_t *scp,
+static inline void rm_to_pm_regs(cpuctx_t *scp,
 			  const __dpmi_regs *rmreg, unsigned int mask)
 {
     /* WARNING - realmode flags can contain the dreadful NT flag
@@ -61,6 +61,6 @@ static inline void rm_to_pm_regs(sigcontext_t *scp,
 #define SET_RMREG(rg, val) (RMPRESERVE1(rg), RMREG(rg) = (val))
 #define SET_RMLWORD(rg, val) (E_RMPRESERVE1(rg), RMREG(rg) = (val))
 
-void do_call_to(sigcontext_t *scp, int is_32, far_t dst, __dpmi_regs *rmreg);
+void do_call_to(cpuctx_t *scp, int is_32, far_t dst, __dpmi_regs *rmreg);
 
 #endif

--- a/src/dosext/dpmi/msdos/instr_dec.c
+++ b/src/dosext/dpmi/msdos/instr_dec.c
@@ -239,7 +239,7 @@ static int _instr_len(unsigned char *p, int is_32)
   return p - p0;
 }
 
-static uint32_t x86_pop(sigcontext_t *scp, x86_ins *x86)
+static uint32_t x86_pop(cpuctx_t *scp, x86_ins *x86)
 {
   unsigned ss_base = GetSegmentBase(_ss);
   unsigned char *mem = MEM_BASE32(ss_base + (_esp & wordmask[(x86->_32bit+1)*2]));
@@ -250,7 +250,7 @@ static uint32_t x86_pop(sigcontext_t *scp, x86_ins *x86)
   return (x86->operand_size == 4 ? READ_DWORDP(mem) : READ_WORDP(mem));
 }
 
-static int x86_handle_prefixes(sigcontext_t *scp, unsigned cs_base,
+static int x86_handle_prefixes(cpuctx_t *scp, unsigned cs_base,
 	x86_ins *x86)
 {
   unsigned eip = _eip;
@@ -314,7 +314,7 @@ static int x86_handle_prefixes(sigcontext_t *scp, unsigned cs_base,
   return prefix;
 }
 
-int decode_segreg(sigcontext_t *scp)
+int decode_segreg(cpuctx_t *scp)
 {
   unsigned cs, eip;
   unsigned char *csp, *orig_csp;
@@ -411,7 +411,7 @@ int decode_segreg(sigcontext_t *scp)
   return ret;
 }
 
-uint16_t decode_selector(sigcontext_t *scp)
+uint16_t decode_selector(cpuctx_t *scp)
 {
     unsigned cs;
     int pfx;
@@ -434,7 +434,7 @@ uint16_t decode_selector(sigcontext_t *scp)
     return _ds;
 }
 
-static uint8_t reg8(sigcontext_t *scp, int reg)
+static uint8_t reg8(cpuctx_t *scp, int reg)
 {
 #define RG8(x, r) ((_e##x >> ((r & 4) << 1)) & 0xff)
     switch (reg & 3) {
@@ -450,7 +450,7 @@ static uint8_t reg8(sigcontext_t *scp, int reg)
     return -1;
 }
 
-static uint32_t reg(sigcontext_t *scp, int reg)
+static uint32_t reg(cpuctx_t *scp, int reg)
 {
     switch (reg & 7) {
     case 0:
@@ -473,7 +473,7 @@ static uint32_t reg(sigcontext_t *scp, int reg)
     return -1;
 }
 
-int decode_memop(sigcontext_t *scp, uint32_t *op, unsigned char *cr2)
+int decode_memop(cpuctx_t *scp, uint32_t *op, unsigned char *cr2)
 {
     unsigned cs, eip, seg_base;
     unsigned char *csp, *orig_csp;

--- a/src/dosext/dpmi/msdos/instr_dec.h
+++ b/src/dosext/dpmi/msdos/instr_dec.h
@@ -1,8 +1,8 @@
 #ifndef INSTR_DEC_H
 #define INSTR_DEC_H
 
-int decode_segreg(sigcontext_t *scp);
-uint16_t decode_selector(sigcontext_t *scp);
-int decode_memop(sigcontext_t *scp, uint32_t *op, unsigned char *cr2);
+int decode_segreg(cpuctx_t *scp);
+uint16_t decode_selector(cpuctx_t *scp);
+int decode_memop(cpuctx_t *scp, uint32_t *op, unsigned char *cr2);
 
 #endif

--- a/src/dosext/dpmi/msdos/lio.h
+++ b/src/dosext/dpmi/msdos/lio.h
@@ -1,10 +1,10 @@
 #ifndef LIO_H
 #define LIO_H
 
-void msdos_lr_helper(sigcontext_t *scp, int is_32,
-	unsigned short rm_seg, void (*post)(sigcontext_t *));
-void msdos_lw_helper(sigcontext_t *scp, int is_32,
-	unsigned short rm_seg, void (*post)(sigcontext_t *));
+void msdos_lr_helper(cpuctx_t *scp, int is_32,
+	unsigned short rm_seg, void (*post)(cpuctx_t *));
+void msdos_lw_helper(cpuctx_t *scp, int is_32,
+	unsigned short rm_seg, void (*post)(cpuctx_t *));
 void lio_init(void);
 
 #endif

--- a/src/dosext/dpmi/msdos/msdos_ldt.c
+++ b/src/dosext/dpmi/msdos/msdos_ldt.c
@@ -52,7 +52,7 @@ static unsigned short d16, d32;
 
 static void msdos_ldt_update(int selector, int num);
 
-static void msdos_ldt_handler(sigcontext_t *scp, void *arg)
+static void msdos_ldt_handler(cpuctx_t *scp, void *arg)
 {
     msdos_ldt_update(_LWORD(ebx), _LWORD(ecx));
 }
@@ -145,7 +145,7 @@ void msdos_ldt_done(void)
     DPMIFreeShared(ldt_h);
 }
 
-int msdos_ldt_fault(sigcontext_t *scp, uint16_t sel)
+int msdos_ldt_fault(cpuctx_t *scp, uint16_t sel)
 {
     unsigned limit;
 #if LDT_UPDATE_LIM
@@ -199,7 +199,7 @@ static void msdos_ldt_update(int selector, int num)
   }
 }
 
-static void direct_ldt_write(sigcontext_t *scp, int offset,
+static void direct_ldt_write(cpuctx_t *scp, int offset,
     char *buffer, int length)
 {
   int ldt_entry = offset / LDT_ENTRY_SIZE;
@@ -266,7 +266,7 @@ int msdos_ldt_access(unsigned char *cr2)
     return cr2 >= ldt_alias && cr2 < ldt_alias + LDT_ENTRIES * LDT_ENTRY_SIZE;
 }
 
-void msdos_ldt_write(sigcontext_t *scp, uint32_t op, int len,
+void msdos_ldt_write(cpuctx_t *scp, uint32_t op, int len,
     unsigned char *cr2)
 {
     if (!len) {
@@ -277,7 +277,7 @@ void msdos_ldt_write(sigcontext_t *scp, uint32_t op, int len,
     direct_ldt_write(scp, cr2 - ldt_alias, (char *)&op, len);
 }
 
-int msdos_ldt_pagefault(sigcontext_t *scp)
+int msdos_ldt_pagefault(cpuctx_t *scp)
 {
     uint32_t op;
     int len;

--- a/src/dosext/dpmi/msdos/msdos_ldt.h
+++ b/src/dosext/dpmi/msdos/msdos_ldt.h
@@ -3,11 +3,11 @@
 
 unsigned short msdos_ldt_init(void);
 void msdos_ldt_done(void);
-int msdos_ldt_fault(sigcontext_t *scp, uint16_t sel);
+int msdos_ldt_fault(cpuctx_t *scp, uint16_t sel);
 int msdos_ldt_access(unsigned char *cr2);
-void msdos_ldt_write(sigcontext_t *scp, uint32_t op, int len,
+void msdos_ldt_write(cpuctx_t *scp, uint32_t op, int len,
     unsigned char *cr2);
-int msdos_ldt_pagefault(sigcontext_t *scp);
+int msdos_ldt_pagefault(cpuctx_t *scp);
 int msdos_ldt_is32(unsigned short selector);
 
 #endif

--- a/src/dosext/dpmi/msdos/msdos_priv.h
+++ b/src/dosext/dpmi/msdos/msdos_priv.h
@@ -9,18 +9,18 @@ unsigned short ConvertSegmentToDescriptor_lim(unsigned short segment,
 dosaddr_t msdos_malloc(unsigned long size);
 int msdos_free(unsigned int addr);
 
-int msdos_pre_extender(sigcontext_t *scp,
+int msdos_pre_extender(cpuctx_t *scp,
 			struct RealModeCallStructure *rmreg,
 			int intr, unsigned short rm_seg,
 			int *r_mask, far_t *r_rma);
-int msdos_post_extender(sigcontext_t *scp,
+int msdos_post_extender(cpuctx_t *scp,
 			const struct RealModeCallStructure *rmreg,
 			int intr, unsigned short rm_seg, int *rmask,
 			unsigned *arg);
 
 int msdos_get_int_num(int off);
 unsigned short get_scratch_seg(void);
-unsigned short scratch_seg(sigcontext_t *scp, int off, void *arg);
+unsigned short scratch_seg(cpuctx_t *scp, int off, void *arg);
 far_t get_xms_call(void);
 int msdos_is_32(void);
 

--- a/src/dosext/dpmi/msdos/segreg_priv.h
+++ b/src/dosext/dpmi/msdos/segreg_priv.h
@@ -3,7 +3,7 @@
 
 enum MfRet { MFR_HANDLED, MFR_NOT_HANDLED, MFR_ERROR };
 
-void msdos_fault_handler(sigcontext_t *scp, void *arg);
-void msdos_pagefault_handler(sigcontext_t *scp, void *arg);
+void msdos_fault_handler(cpuctx_t *scp, void *arg);
+void msdos_pagefault_handler(cpuctx_t *scp, void *arg);
 
 #endif

--- a/src/dosext/dpmi/msdos/xms.c
+++ b/src/dosext/dpmi/msdos/xms.c
@@ -29,7 +29,7 @@
 
 static struct dos_helper_s helper;
 
-static void msdos_pre_xms(const sigcontext_t *scp,
+static void msdos_pre_xms(const cpuctx_t *scp,
 	__dpmi_regs *rmreg, unsigned short rm_seg, int *r_mask)
 {
     int rm_mask = *r_mask;
@@ -52,7 +52,7 @@ static void msdos_pre_xms(const sigcontext_t *scp,
     *r_mask = rm_mask;
 }
 
-static void msdos_post_xms(sigcontext_t *scp,
+static void msdos_post_xms(cpuctx_t *scp,
 	const __dpmi_regs *rmreg, int *r_mask)
 {
     int rm_mask = *r_mask;
@@ -73,7 +73,7 @@ static void msdos_post_xms(sigcontext_t *scp,
     *r_mask = rm_mask;
 }
 
-static void xms_call(const sigcontext_t *scp,
+static void xms_call(const cpuctx_t *scp,
 	__dpmi_regs *rmreg, unsigned short rm_seg)
 {
     int rmask = (1 << cs_INDEX) |
@@ -82,7 +82,7 @@ static void xms_call(const sigcontext_t *scp,
     pm_to_rm_regs(scp, rmreg, ~rmask);
 }
 
-static void xms_ret(sigcontext_t *scp, const __dpmi_regs *rmreg)
+static void xms_ret(cpuctx_t *scp, const __dpmi_regs *rmreg)
 {
     int rmask = 0;
     msdos_post_xms(scp, rmreg, &rmask);
@@ -92,8 +92,8 @@ static void xms_ret(sigcontext_t *scp, const __dpmi_regs *rmreg)
 
 static void xmshlp_thr(void *arg)
 {
-    sigcontext_t *scp = arg;
-    sigcontext_t sa = *scp;
+    cpuctx_t *scp = arg;
+    cpuctx_t sa = *scp;
     __dpmi_regs rmreg = {};
     unsigned short rm_seg = helper.rm_seg(scp, 0, helper.rm_arg);
     int is_32 = msdos_is_32();

--- a/src/dosext/dpmi/msdoshlp.h
+++ b/src/dosext/dpmi/msdoshlp.h
@@ -15,16 +15,16 @@ enum MsdOpIds { MSDOS_FAULT, MSDOS_PAGEFAULT, API_CALL, API_WINOS2_CALL,
 enum { MSDOS_NONE, MSDOS_RMINT, MSDOS_RM, MSDOS_PM, MSDOS_DONE };
 enum { POSTEXT_NONE, POSTEXT_PUSH };
 
-void msdos_pm_call(sigcontext_t *scp);
+void msdos_pm_call(cpuctx_t *scp);
 
-struct pmaddr_s get_pmcb_handler(void (*handler)(sigcontext_t *,
+struct pmaddr_s get_pmcb_handler(void (*handler)(cpuctx_t *,
 	const struct RealModeCallStructure *, int, void *),
 	void *arg,
-	void (*ret_handler)(sigcontext_t *,
+	void (*ret_handler)(cpuctx_t *,
 	struct RealModeCallStructure *, int),
 	int num);
 struct pmaddr_s get_pm_handler(enum MsdOpIds id,
-	void (*handler)(sigcontext_t *, void *), void *arg);
+	void (*handler)(cpuctx_t *, void *), void *arg);
 struct pmrm_ret {
     int ret;
     far_t faddr;
@@ -37,13 +37,13 @@ struct pext_ret {
 };
 struct pmaddr_s get_pmrm_handler_m(enum MsdOpIds id,
 	struct pmrm_ret (*handler)(
-	sigcontext_t *, struct RealModeCallStructure *,
+	cpuctx_t *, struct RealModeCallStructure *,
 	unsigned short, void *(*)(int), int),
 	void *(*arg)(int),
 	struct pext_ret (*ret_handler)(
-	sigcontext_t *, const struct RealModeCallStructure *,
+	cpuctx_t *, const struct RealModeCallStructure *,
 	unsigned short, int),
-	unsigned short (*rm_seg)(sigcontext_t *, int, void *),
+	unsigned short (*rm_seg)(cpuctx_t *, int, void *),
 	void *rm_arg, int len, int r_offs[]);
 far_t get_exec_helper(void);
 far_t get_term_helper(void);
@@ -53,24 +53,24 @@ void msdoshlp_init(int (*is_32)(void), int len);
 struct dos_helper_s {
     int tid;
     unsigned entry;
-    unsigned short (*rm_seg)(sigcontext_t *, int, void *);
+    unsigned short (*rm_seg)(cpuctx_t *, int, void *);
     void *rm_arg;
     int e_offs[256];
 };
 void doshlp_setup_retf(struct dos_helper_s *h,
 	const char *name, void (*thr)(void *),
-	unsigned short (*rm_seg)(sigcontext_t *, int, void *),
+	unsigned short (*rm_seg)(cpuctx_t *, int, void *),
 	void *rm_arg);
 void doshlp_setup(struct dos_helper_s *h,
 	const char *name, void (*thr)(void *),
-	void (*post)(sigcontext_t *));
+	void (*post)(cpuctx_t *));
 
 struct pmaddr_s doshlp_get_entry(unsigned entry);
 struct pmaddr_s doshlp_get_entry16(unsigned entry);
 struct pmaddr_s doshlp_get_entry32(unsigned entry);
 
-void doshlp_quit_dpmi(sigcontext_t *scp);
-void doshlp_call_reinit(sigcontext_t *scp);
+void doshlp_quit_dpmi(cpuctx_t *scp);
+void doshlp_call_reinit(cpuctx_t *scp);
 int doshlp_idle(void);
 
 #endif

--- a/src/dosext/dpmi/vxd.c
+++ b/src/dosext/dpmi/vxd.c
@@ -36,7 +36,7 @@
 
 static UINT W32S_offset = 0;
 
-void get_VXD_entry( sigcontext_t *scp )
+void get_VXD_entry(cpuctx_t *scp )
 {
     switch (_LWORD(ebx)) {
 	case 0x01:
@@ -1819,7 +1819,7 @@ static void WINAPI VXD_Win32s( CONTEXT86 *scp )
 }
 #endif
 
-void vxd_call(sigcontext_t *scp)
+void vxd_call(cpuctx_t *scp)
 {
     if (_eip==1+DPMI_SEL_OFF(DPMI_VXD_VMM)) {
       D_printf("DPMI: VMM VxD called, ax=%#x\n", _LWORD(eax));

--- a/src/dosext/dpmi/vxd.h
+++ b/src/dosext/dpmi/vxd.h
@@ -4,5 +4,5 @@
  * for details see file COPYING in the DOSEMU distribution
  */
 
-void get_VXD_entry( sigcontext_t *scp );
-void vxd_call(sigcontext_t *scp);
+void get_VXD_entry(cpuctx_t *scp );
+void vxd_call(cpuctx_t *scp);

--- a/src/dosext/dpmi/windefs.h
+++ b/src/dosext/dpmi/windefs.h
@@ -293,7 +293,7 @@ typedef struct _IMAGE_NT_HEADERS {
 #define W32S_APP2WINE(addr) ((addr)? (uintptr_t)(addr) + W32S_offset : 0)
 #define W32S_WINE2APP(addr) ((addr)? (uintptr_t)(addr) - W32S_offset : 0)
 
-#define CONTEXT86 sigcontext_t
+#define CONTEXT86 cpuctx_t
 
 #define GetTickCount() GETtickTIME(0)
 

--- a/src/include/cpu-emu.h
+++ b/src/include/cpu-emu.h
@@ -73,7 +73,7 @@ int e_vm86(void);
 /* called from dpmi.c */
 void emu_mhp_SetTypebyte (unsigned short selector, int typebyte);
 unsigned short emu_do_LAR (unsigned short selector);
-char *e_scp_disasm(sigcontext_t *scp, int pmode);
+char *e_scp_disasm(cpuctx_t *scp, int pmode);
 
 /* called from mfs.c, fatfs.c and some places that memcpy */
 #ifdef X86_JIT
@@ -91,8 +91,8 @@ void init_emu_cpu (void);
 void reset_emu_cpu (void);
 
 /* called/used from dpmi.c */
-int e_dpmi(sigcontext_t *scp);
-void e_dpmi_b0x(int op,sigcontext_t *scp);
+int e_dpmi(cpuctx_t *scp);
+void e_dpmi_b0x(int op,cpuctx_t *scp);
 extern int in_dpmi_emu;
 
 /* called from emu-ldt.c */

--- a/src/include/cpu.h
+++ b/src/include/cpu.h
@@ -490,9 +490,10 @@ struct pm_regs {
 	unsigned trapno;
 	unsigned err;
 	unsigned long cr2;
-	struct _libc_fpstate *fpregs;
+	struct _libc_fpstate fpregs;
 };
 typedef struct pm_regs cpuctx_t;
+#define REGS_SIZE offsetof(struct pm_regs, fpregs)
 
 #define _es     (scp->es)
 #define _ds     (scp->ds)
@@ -517,7 +518,7 @@ typedef struct pm_regs cpuctx_t;
 #define get_trapno(s) ((s)->trapno)
 #define get_err(s)    ((s)->err)
 #define get_cr2(s)    ((s)->cr2)
-#define get_fpstate(s) ((s)->fpregs)
+#define get_fpstate(s) (&(s)->fpregs)
 #define _edi    get_edi(scp)
 #define _esi    get_esi(scp)
 #define _ebp    get_ebp(scp)
@@ -546,7 +547,7 @@ typedef struct pm_regs cpuctx_t;
 #define _eflags_ (scp->eflags)
 #define _cr2    (scp->cr2)
 #define _trapno (scp->trapno)
-#define __fpstate (scp->fpregs)
+#define __fpstate (&scp->fpregs)
 /* compatibility */
 #define _rdi    _edi
 #define _rsi    _esi

--- a/src/include/cpu.h
+++ b/src/include/cpu.h
@@ -469,78 +469,54 @@ EXTERN struct vec_t *ivecs;
 #define WORD(i) (unsigned short)(i)
 */
 
-typedef mcontext_t cpuctx_t;
+struct pm_regs {
+	unsigned ebx;
+	unsigned ecx;
+	unsigned edx;
+	unsigned esi;
+	unsigned edi;
+	unsigned ebp;
+	unsigned eax;
+	unsigned eip;
+	unsigned short cs;
+	unsigned eflags;
+	unsigned esp;
+	unsigned short ss;
+	unsigned short es;
+	unsigned short ds;
+	unsigned short fs;
+	unsigned short gs;
 
-#if defined(__x86_64__)
-#define _es     (((union g_reg *)&(scp->gregs[REG_TRAPNO]))->w[1])
-#define _ds     (((union g_reg *)&(scp->gregs[REG_TRAPNO]))->w[2])
-#define _es_    (((const union g_reg *)&(scp->gregs[REG_TRAPNO]))->w[1])
-#define _ds_    (((const union g_reg *)&(scp->gregs[REG_TRAPNO]))->w[2])
-#define get_rdi(s)    ((s)->gregs[REG_RDI])
-#define get_rsi(s)    ((s)->gregs[REG_RSI])
-#define get_rbp(s)    ((s)->gregs[REG_RBP])
-#define get_rsp(s)    ((s)->gregs[REG_RSP])
-#define get_rbx(s)    ((s)->gregs[REG_RBX])
-#define get_rdx(s)    ((s)->gregs[REG_RDX])
-#define get_rcx(s)    ((s)->gregs[REG_RCX])
-#define get_rax(s)    ((s)->gregs[REG_RAX])
-#define get_rip(s)    ((s)->gregs[REG_RIP])
-#define get_rflags(s) ((s)->gregs[REG_EFL])
-#define get_es(s)     (((union g_reg *)&((s)->gregs[REG_TRAPNO]))->w[1])
-#define get_ds(s)     (((union g_reg *)&((s)->gregs[REG_TRAPNO]))->w[2])
-#define get_ss(s)     (((union g_reg *)&(s)->gregs[REG_CSGSFS])->w[3])
-#define get_fs(s)     (((union g_reg *)&(s)->gregs[REG_CSGSFS])->w[2])
-#define get_gs(s)     (((union g_reg *)&(s)->gregs[REG_CSGSFS])->w[1])
-#define get_cs(s)     (((union g_reg *)&(s)->gregs[REG_CSGSFS])->w[0])
-#define get_trapno(s) (((union g_reg *)&((s)->gregs[REG_TRAPNO]))->w[0])
-#define get_err(s)    DWORD_((s)->gregs[REG_ERR])
-#define get_cr2(s)    ((s)->gregs[REG_CR2])
-#define get_fpstate(s) ((s)->fpregs)
-#define _rdi    get_rdi(scp)
-#define _rsi    get_rsi(scp)
-#define _rbp    get_rbp(scp)
-#define _rsp    get_rsp(scp)
-#define _rbx    get_rbx(scp)
-#define _rdx    get_rdx(scp)
-#define _rcx    get_rcx(scp)
-#define _rax    get_rax(scp)
-#define _rip    get_rip(scp)
-#define _cs     (((union g_reg *)&scp->gregs[REG_CSGSFS])->w[0])
-#define _cs_    (((const union g_reg *)&scp->gregs[REG_CSGSFS])->w[0])
-#define _gs     (((union g_reg *)&scp->gregs[REG_CSGSFS])->w[1])
-#define _fs     (((union g_reg *)&scp->gregs[REG_CSGSFS])->w[2])
-#define _ss     (((union g_reg *)&scp->gregs[REG_CSGSFS])->w[3])
-#define _err    DWORD_(scp->gregs[REG_ERR])
-#define _eflags DWORD_(scp->gregs[REG_EFL])
-#define _eflags_ DWORD__(scp->gregs[REG_EFL], const)
-#define _cr2    (scp->gregs[REG_CR2])
-#define _trapno (((union g_reg *)&(scp->gregs[REG_TRAPNO]))->w[0])
-#define __fpstate (scp->fpregs)
-#define PRI_RG  "llx"
-#elif defined(__i386__)
-#define _es     (scp->gregs[REG_ES])
-#define _ds     (scp->gregs[REG_DS])
-#define _es_    (scp->gregs[REG_ES])
-#define _ds_    (scp->gregs[REG_DS])
-#define get_edi(s)    (*(uint32_t *)&(s)->gregs[REG_EDI])
-#define get_esi(s)    (*(uint32_t *)&(s)->gregs[REG_ESI])
-#define get_ebp(s)    (*(uint32_t *)&(s)->gregs[REG_EBP])
-#define get_esp(s)    (*(uint32_t *)&(s)->gregs[REG_ESP])
-#define get_ebx(s)    (*(uint32_t *)&(s)->gregs[REG_EBX])
-#define get_edx(s)    (*(uint32_t *)&(s)->gregs[REG_EDX])
-#define get_ecx(s)    (*(uint32_t *)&(s)->gregs[REG_ECX])
-#define get_eax(s)    (*(uint32_t *)&(s)->gregs[REG_EAX])
-#define get_eip(s)    (*(uint32_t *)&(s)->gregs[REG_EIP])
-#define get_eflags(s) (*(uint32_t *)&(s)->gregs[REG_EFL])
-#define get_es(s)     ((s)->gregs[REG_ES])
-#define get_ds(s)     ((s)->gregs[REG_DS])
-#define get_ss(s)     ((s)->gregs[REG_SS])
-#define get_fs(s)     ((s)->gregs[REG_FS])
-#define get_gs(s)     ((s)->gregs[REG_GS])
-#define get_cs(s)     ((s)->gregs[REG_CS])
-#define get_trapno(s) (((union g_reg *)&((s)->gregs[REG_TRAPNO]))->w[0])
-#define get_err(s)    DWORD_((s)->gregs[REG_ERR])
-#define get_cr2(s)    (((union dword *)&(s)->cr2)->d)
+	unsigned trapno;
+	unsigned err;
+	unsigned long cr2;
+	struct _libc_fpstate *fpregs;
+};
+typedef struct pm_regs cpuctx_t;
+
+#define _es     (scp->es)
+#define _ds     (scp->ds)
+#define _es_    (scp->es)
+#define _ds_    (scp->ds)
+#define get_edi(s)    ((s)->edi)
+#define get_esi(s)    ((s)->esi)
+#define get_ebp(s)    ((s)->ebp)
+#define get_esp(s)    ((s)->esp)
+#define get_ebx(s)    ((s)->ebx)
+#define get_edx(s)    ((s)->edx)
+#define get_ecx(s)    ((s)->ecx)
+#define get_eax(s)    ((s)->eax)
+#define get_eip(s)    ((s)->eip)
+#define get_eflags(s) ((s)->eflags)
+#define get_es(s)     ((s)->es)
+#define get_ds(s)     ((s)->ds)
+#define get_ss(s)     ((s)->ss)
+#define get_fs(s)     ((s)->fs)
+#define get_gs(s)     ((s)->gs)
+#define get_cs(s)     ((s)->cs)
+#define get_trapno(s) ((s)->trapno)
+#define get_err(s)    ((s)->err)
+#define get_cr2(s)    ((s)->cr2)
 #define get_fpstate(s) ((s)->fpregs)
 #define _edi    get_edi(scp)
 #define _esi    get_esi(scp)
@@ -551,66 +527,26 @@ typedef mcontext_t cpuctx_t;
 #define _ecx    get_ecx(scp)
 #define _eax    get_eax(scp)
 #define _eip    get_eip(scp)
-#define _edi_   (*(const uint32_t *)&scp->gregs[REG_EDI])
-#define _esi_   (*(const uint32_t *)&scp->gregs[REG_ESI])
-#define _ebp_   (*(const uint32_t *)&scp->gregs[REG_EBP])
-#define _esp_   (*(const uint32_t *)&scp->gregs[REG_ESP])
-#define _ebx_   (*(const uint32_t *)&scp->gregs[REG_EBX])
-#define _edx_   (*(const uint32_t *)&scp->gregs[REG_EDX])
-#define _ecx_   (*(const uint32_t *)&scp->gregs[REG_ECX])
-#define _eax_   (*(const uint32_t *)&scp->gregs[REG_EAX])
-#define _eip_   (*(const uint32_t *)&scp->gregs[REG_EIP])
-#define _cs     (scp->gregs[REG_CS])
-#define _cs_    (scp->gregs[REG_CS])
-#define _gs     (scp->gregs[REG_GS])
-#define _fs     (scp->gregs[REG_FS])
-#define _ss     (scp->gregs[REG_SS])
-#define _err    (scp->gregs[REG_ERR])
-#define _eflags (scp->gregs[REG_EFL])
-#define _eflags_ (scp->gregs[REG_EFL])
-#define _cr2    (((union dword *)&scp->cr2)->d)
-#define _trapno (((union g_reg *)&(scp->gregs[REG_TRAPNO]))->w[0])
+#define _edi_   (scp->edi)
+#define _esi_   (scp->esi)
+#define _ebp_   (scp->ebp)
+#define _esp_   (scp->esp)
+#define _ebx_   (scp->ebx)
+#define _edx_   (scp->edx)
+#define _ecx_   (scp->ecx)
+#define _eax_   (scp->eax)
+#define _eip_   (scp->eip)
+#define _cs     (scp->cs)
+#define _cs_    (scp->cs)
+#define _gs     (scp->gs)
+#define _fs     (scp->fs)
+#define _ss     (scp->ss)
+#define _err    (scp->err)
+#define _eflags (scp->eflags)
+#define _eflags_ (scp->eflags)
+#define _cr2    (scp->cr2)
+#define _trapno (scp->trapno)
 #define __fpstate (scp->fpregs)
-#define PRI_RG  PRIx32
-#else
-#error unsupported arch
-#endif
-#ifdef __x86_64__
-#define get_edi(s)    DWORD_(get_rdi(s))
-#define get_esi(s)    DWORD_(get_rsi(s))
-#define get_ebp(s)    DWORD_(get_rbp(s))
-#define get_esp(s)    DWORD_(get_rsp(s))
-#define get_ebx(s)    DWORD_(get_rbx(s))
-#define get_edx(s)    DWORD_(get_rdx(s))
-#define get_ecx(s)    DWORD_(get_rcx(s))
-#define get_eax(s)    DWORD_(get_rax(s))
-#define get_eip(s)    DWORD_(get_rip(s))
-#define get_eax(s)    DWORD_(get_rax(s))
-#define get_eip(s)    DWORD_(get_rip(s))
-#define get_eflags(s) DWORD_(get_rflags(s))
-#define _edi    DWORD_(get_rdi(scp))
-#define _esi    DWORD_(get_rsi(scp))
-#define _ebp    DWORD_(get_rbp(scp))
-#define _esp    DWORD_(get_rsp(scp))
-#define _ebx    DWORD_(get_rbx(scp))
-#define _edx    DWORD_(get_rdx(scp))
-#define _ecx    DWORD_(get_rcx(scp))
-#define _eax    DWORD_(get_rax(scp))
-#define _eip    DWORD_(get_rip(scp))
-#define _eax    DWORD_(get_rax(scp))
-#define _eip    DWORD_(get_rip(scp))
-#define _edi_   DWORD__(_rdi, const)
-#define _esi_   DWORD__(_rsi, const)
-#define _ebp_   DWORD__(_rbp, const)
-#define _esp_   DWORD__(_rsp, const)
-#define _ebx_   DWORD__(_rbx, const)
-#define _edx_   DWORD__(_rdx, const)
-#define _ecx_   DWORD__(_rcx, const)
-#define _eax_   DWORD__(_rax, const)
-#define _eip_   DWORD__(_rip, const)
-#define _eax_   DWORD__(_rax, const)
-#define _eip_   DWORD__(_rip, const)
-#else
 /* compatibility */
 #define _rdi    _edi
 #define _rsi    _esi
@@ -623,7 +559,6 @@ typedef mcontext_t cpuctx_t;
 #define _rip    _eip
 #define _rax    _eax
 #define _rip    _eip
-#endif
 
 void show_regs(void);
 void show_ints(int, int);

--- a/src/include/cpu.h
+++ b/src/include/cpu.h
@@ -469,6 +469,8 @@ EXTERN struct vec_t *ivecs;
 #define WORD(i) (unsigned short)(i)
 */
 
+typedef mcontext_t cpuctx_t;
+
 #ifdef __APPLE__
 extern uint16_t _es;
 extern uint16_t _ds;
@@ -554,6 +556,10 @@ extern uint16_t _trapno;
 #define get_fs(s)     (((union g_reg *)&(s)->gregs[REG_CSGSFS])->w[2])
 #define get_gs(s)     (((union g_reg *)&(s)->gregs[REG_CSGSFS])->w[1])
 #define get_cs(s)     (((union g_reg *)&(s)->gregs[REG_CSGSFS])->w[0])
+#define get_trapno(s) (((union g_reg *)&((s)->gregs[REG_TRAPNO]))->w[0])
+#define get_err(s)    DWORD_((s)->gregs[REG_ERR])
+#define get_cr2(s)    ((s)->gregs[REG_CR2])
+#define get_fpstate(s) ((s)->fpregs)
 #define _rdi    get_rdi(scp)
 #define _rsi    get_rsi(scp)
 #define _rbp    get_rbp(scp)
@@ -596,6 +602,10 @@ extern uint16_t _trapno;
 #define get_fs(s)     ((s)->gregs[REG_FS])
 #define get_gs(s)     ((s)->gregs[REG_GS])
 #define get_cs(s)     ((s)->gregs[REG_CS])
+#define get_trapno(s) (((union g_reg *)&((s)->gregs[REG_TRAPNO]))->w[0])
+#define get_err(s)    DWORD_((s)->gregs[REG_ERR])
+#define get_cr2(s)    (((union dword *)&(s)->cr2)->d)
+#define get_fpstate(s) ((s)->fpregs)
 #define _edi    get_edi(scp)
 #define _esi    get_esi(scp)
 #define _ebp    get_ebp(scp)
@@ -684,7 +694,7 @@ void show_ints(int, int);
 char *emu_disasm(unsigned int ip);
 void dump_state(void);
 
-int cpu_trap_0f (unsigned char *, sigcontext_t *);
+int cpu_trap_0f (unsigned char *, cpuctx_t *);
 
 #ifndef PAGE_MASK
 #define PAGE_MASK	(~(PAGE_SIZE-1))

--- a/src/include/cpu.h
+++ b/src/include/cpu.h
@@ -471,71 +471,7 @@ EXTERN struct vec_t *ivecs;
 
 typedef mcontext_t cpuctx_t;
 
-#ifdef __APPLE__
-extern uint16_t _es;
-extern uint16_t _ds;
-#define _rdi    ((*scp)->__ss.__rdi)
-#define _rsi    ((*scp)->__ss.__rsi)
-#define _rbp    ((*scp)->__ss.__rbp)
-#define _rsp    ((*scp)->__ss.__rsp)
-#define _rbx    ((*scp)->__ss.__rbx)
-#define _rdx    ((*scp)->__ss.__rdx)
-#define _rcx    ((*scp)->__ss.__rcx)
-#define _rax    ((*scp)->__ss.__rax)
-#define _rip    ((*scp)->__ss.__rip)
-extern uint16_t _cs;
-extern uint16_t _gs;
-extern uint16_t _fs;
-extern uint16_t _ss;
-extern uint64_t _err;
-extern uint64_t _eflags;
-#define _eflags_ _eflags
-extern uint64_t _cr2;
-extern uint16_t _trapno;
-#define __fpstate (&(*scp)->__fs)
-#define PRI_RG  PRIx64
-#elif defined(__FreeBSD__)
-#ifdef __x86_64__
-#define _rax scp->mc_rax
-#define _rbx scp->mc_rbx
-#define _rcx scp->mc_rcx
-#define _rdx scp->mc_rdx
-#define _rbp scp->mc_rbp
-#define _rsp scp->mc_rsp
-#define _rsi scp->mc_rsi
-#define _rdi scp->mc_rdi
-#define _rip scp->mc_rip
-#define _eflags (*(unsigned *)&scp->mc_rflags)
-#define _eflags_ (*(const unsigned *)&scp->mc_rflags)
-#define _cr2 (*(uint64_t *)&scp->mc_spare[0])
-#define PRI_RG PRIx64
-#else
-#define _eax scp->mc_eax
-#define _ebx scp->mc_ebx
-#define _ecx scp->mc_ecx
-#define _edx scp->mc_edx
-#define _ebp scp->mc_ebp
-#define _esp scp->mc_esp
-#define _esi scp->mc_esi
-#define _edi scp->mc_edi
-#define _eip scp->mc_eip
-#define _eflags scp->mc_eflags
-#define _eflags_ scp->mc_eflags
-#define _cr2 scp->mc_spare[0]
-#define PRI_RG PRIx32
-#endif
-#define _cs (*(unsigned *)&scp->mc_cs)
-#define _ds (*(unsigned *)&scp->mc_ds)
-#define _es (*(unsigned *)&scp->mc_es)
-#define _ds_ (*(const unsigned *)&scp->mc_ds)
-#define _es_ (*(const unsigned *)&scp->mc_es)
-#define _fs (*(unsigned *)&scp->mc_fs)
-#define _gs (*(unsigned *)&scp->mc_gs)
-#define _ss (*(unsigned *)&scp->mc_ss)
-#define _trapno scp->mc_trapno
-#define _err (*(unsigned *)&scp->mc_err)
-#define __fpstate scp->mc_fpstate
-#elif defined(__x86_64__)
+#if defined(__x86_64__)
 #define _es     (((union g_reg *)&(scp->gregs[REG_TRAPNO]))->w[1])
 #define _ds     (((union g_reg *)&(scp->gregs[REG_TRAPNO]))->w[2])
 #define _es_    (((const union g_reg *)&(scp->gregs[REG_TRAPNO]))->w[1])

--- a/src/include/instremu.h
+++ b/src/include/instremu.h
@@ -3,8 +3,8 @@
 
 #ifdef INSTREMU
 int instr_len(unsigned char *, int);
-int instr_emu(sigcontext_t *scp, int pmode, int cnt);
-int decode_modify_segreg_insn(sigcontext_t *scp, int pmode,
+int instr_emu(cpuctx_t *scp, int pmode, int cnt);
+int decode_modify_segreg_insn(cpuctx_t *scp, int pmode,
     unsigned int *new_val);
 unsigned char instr_binary_byte(unsigned char op, unsigned char op1,
                                    unsigned char op2, unsigned *eflags);

--- a/src/include/kvm.h
+++ b/src/include/kvm.h
@@ -24,7 +24,7 @@
 int init_kvm_cpu(void);
 void init_kvm_monitor(void);
 int kvm_vm86(struct vm86_struct *info);
-int kvm_dpmi(sigcontext_t *scp);
+int kvm_dpmi(cpuctx_t *scp);
 void mprotect_kvm(int cap, dosaddr_t targ, size_t mapsize, int protect);
 void mmap_kvm(int cap, void *addr, size_t mapsize, int protect);
 void munmap_kvm(int cap, dosaddr_t targ, size_t mapsize);
@@ -39,7 +39,7 @@ void kvm_done(void);
 static inline int init_kvm_cpu(void) { return -1; }
 static inline void init_kvm_monitor(void) {}
 static inline int kvm_vm86(struct vm86_struct *info) { return -1; }
-static inline int kvm_dpmi(sigcontext_t *scp) { return -1; }
+static inline int kvm_dpmi(cpuctx_t *scp) { return -1; }
 static inline void mprotect_kvm(int cap, dosaddr_t targ, size_t mapsize, int protect) {}
 static inline void mmap_kvm(int cap, void *addr, size_t mapsize, int protect) {}
 static inline void munmap_kvm(int cap, dosaddr_t targ, size_t mapsize) {}

--- a/src/include/sig.h
+++ b/src/include/sig.h
@@ -50,6 +50,46 @@ extern void SIG_close(void);
 
 typedef struct sigcontext sigcontext_t;
 
+#if defined(__FreeBSD__)
+#ifdef __x86_64__
+#define _scp_rax scp->mc_rax
+#define _scp_rbx scp->mc_rbx
+#define _scp_rcx scp->mc_rcx
+#define _scp_rdx scp->mc_rdx
+#define _scp_rbp scp->mc_rbp
+#define _scp_rsp scp->mc_rsp
+#define _scp_rsi scp->mc_rsi
+#define _scp_rdi scp->mc_rdi
+#define _scp_rip scp->mc_rip
+#define _scp_eflags (*(unsigned *)&scp->mc_rflags)
+#define _scp_eflags_ (*(const unsigned *)&scp->mc_rflags)
+#define _scp_cr2 (*(uint64_t *)&scp->mc_spare[0])
+#else
+#define _scp_eax scp->mc_eax
+#define _scp_ebx scp->mc_ebx
+#define _scp_ecx scp->mc_ecx
+#define _scp_edx scp->mc_edx
+#define _scp_ebp scp->mc_ebp
+#define _scp_esp scp->mc_esp
+#define _scp_esi scp->mc_esi
+#define _scp_edi scp->mc_edi
+#define _scp_eip scp->mc_eip
+#define _scp_eflags scp->mc_eflags
+#define _scp_eflags_ scp->mc_eflags
+#define _scp_cr2 scp->mc_spare[0]
+#endif
+#define _cs (*(unsigned *)&scp->mc_cs)
+#define _ds (*(unsigned *)&scp->mc_ds)
+#define _es (*(unsigned *)&scp->mc_es)
+#define _ds_ (*(const unsigned *)&scp->mc_ds)
+#define _es_ (*(const unsigned *)&scp->mc_es)
+#define _fs (*(unsigned *)&scp->mc_fs)
+#define _gs (*(unsigned *)&scp->mc_gs)
+#define _ss (*(unsigned *)&scp->mc_ss)
+#define _trapno scp->mc_trapno
+#define _err (*(unsigned *)&scp->mc_err)
+#define __fpstate scp->mc_fpstate
+#elif defined(__linux__)
 #define _scp_gs     (scp->gs)
 #define _scp_fs     (scp->fs)
 #ifdef __x86_64__
@@ -112,6 +152,7 @@ typedef struct sigcontext sigcontext_t;
 #define _scp_rsp _scp_esp
 #define _scp_rax _scp_eax
 #endif
+#endif  // __linux__
 
 extern void SIGNAL_save( void (*signal_call)(void *), void *arg, size_t size,
 	const char *name );

--- a/src/include/sig.h
+++ b/src/include/sig.h
@@ -48,7 +48,70 @@ extern void SIG_close(void);
 #define SIG_ACQUIRE     SIGUSR2
 #define SIG_THREAD_NOTIFY (SIGRTMIN + 0)
 
-typedef mcontext_t sigcontext_t;
+typedef struct sigcontext sigcontext_t;
+
+#define _scp_gs     (scp->gs)
+#define _scp_fs     (scp->fs)
+#ifdef __x86_64__
+#define _scp_es     HI_WORD(scp->trapno)
+#define _scp_ds     (((union g_reg *)&(scp->trapno))->w[2])
+#define _scp_rdi    (scp->rdi)
+#define _scp_rsi    (scp->rsi)
+#define _scp_rbp    (scp->rbp)
+#define _scp_rsp    (scp->rsp)
+#define _scp_rbx    (scp->rbx)
+#define _scp_rdx    (scp->rdx)
+#define _scp_rcx    (scp->rcx)
+#define _scp_rax    (scp->rax)
+#define _scp_rip    (scp->rip)
+#define _scp_ss     (scp->__pad0)
+#define _scp_edi    DWORD_(_scp_rdi)
+#define _scp_esi    DWORD_(_scp_rsi)
+#define _scp_ebp    DWORD_(_scp_rbp)
+#define _scp_esp    DWORD_(_scp_rsp)
+#define _scp_ebx    DWORD_(_scp_rbx)
+#define _scp_edx    DWORD_(_scp_rdx)
+#define _scp_ecx    DWORD_(_scp_rcx)
+#define _scp_eax    DWORD_(_scp_rax)
+#define _scp_eip    DWORD_(_scp_rip)
+#define _scp_eax    DWORD_(_scp_rax)
+#define _scp_eip    DWORD_(_scp_rip)
+#define _scp_err    LO_WORD(scp->err)
+#define _scp_lerr   (unsigned long)LO_WORD(scp->err)
+#define _scp_trapno LO_WORD(scp->trapno)
+#define _scp_ltrapno (unsigned long)LO_WORD(scp->trapno)
+#define _scp_cs     LO_WORD(scp->cs)
+#define _scp_eflags LO_WORD(scp->eflags)
+#define _scp_lflags (unsigned long)LO_WORD(scp->eflags)
+#define _scp_cr2    (scp->cr2)
+#define _scp_fpstate (scp->fpstate)
+#else
+#define _scp_es     (scp->es)
+#define _scp_ds     (scp->ds)
+#define _scp_edi    (scp->edi)
+#define _scp_esi    (scp->esi)
+#define _scp_ebp    (scp->ebp)
+#define _scp_esp    (scp->esp)
+#define _scp_ebx    (scp->ebx)
+#define _scp_edx    (scp->edx)
+#define _scp_ecx    (scp->ecx)
+#define _scp_eax    (scp->eax)
+#define _scp_eip    (scp->eip)
+#define _scp_ss     (scp->ss)
+#define _scp_err    (scp->err)
+#define _scp_lerr   (scp->err)
+#define _scp_trapno (scp->trapno)
+#define _scp_ltrapno (scp->trapno)
+#define _scp_cs     (scp->cs)
+#define _scp_eflags (scp->eflags)
+#define _scp_lflags (scp->eflags)
+#define _scp_cr2    (scp->cr2)
+#define _scp_fpstate (scp->fpstate)
+/* some compat */
+#define _scp_rip _scp_eip
+#define _scp_rsp _scp_esp
+#define _scp_rax _scp_eax
+#endif
 
 extern void SIGNAL_save( void (*signal_call)(void *), void *arg, size_t size,
 	const char *name );
@@ -68,7 +131,6 @@ extern void init_handler(sigcontext_t *scp, unsigned long uc_flags);
 extern void deinit_handler(sigcontext_t *scp, unsigned long *uc_flags);
 
 extern void dosemu_fault(int, siginfo_t *, void *);
-extern void print_exception_info(sigcontext_t *scp);
 void signal_block_async_nosig(sigset_t *old_mask);
 
 extern pthread_t dosemu_pthread_self;

--- a/src/include/vgaemu.h
+++ b/src/include/vgaemu.h
@@ -475,7 +475,7 @@ int VGA_emulate_outb(ioport_t, Bit8u);
 int VGA_emulate_outw(ioport_t, Bit16u);
 Bit8u VGA_emulate_inb(ioport_t);
 Bit16u VGA_emulate_inw(ioport_t);
-int vga_emu_fault(dosaddr_t, unsigned, sigcontext_t *);
+int vga_emu_fault(dosaddr_t, unsigned, cpuctx_t *);
 int vga_emu_pre_init(void);
 int vga_emu_init(int src_modes, struct ColorSpaceDesc *);
 void vga_emu_done(void);

--- a/src/include/vm86_compat.h
+++ b/src/include/vm86_compat.h
@@ -1,9 +1,6 @@
 #ifndef _VM86_COMPAT_H
 #define _VM86_COMPAT_H
 
-#ifdef __i386__
-#include <asm/vm86.h>
-#else
 #include <Asm/processor-flags.h>
 
 /*
@@ -64,22 +61,22 @@ struct vm86_regs {
 /*
  * normal regs, with special meaning for the segment descriptors..
  */
-	int ebx;
-	int ecx;
-	int edx;
-	int esi;
-	int edi;
-	int ebp;
-	int eax;
-	int __null_ds;
-	int __null_es;
-	int __null_fs;
-	int __null_gs;
-	int orig_eax;
-	int eip;
+	unsigned ebx;
+	unsigned ecx;
+	unsigned edx;
+	unsigned esi;
+	unsigned edi;
+	unsigned ebp;
+	unsigned eax;
+	unsigned __null_ds;
+	unsigned __null_es;
+	unsigned __null_fs;
+	unsigned __null_gs;
+	unsigned orig_eax;
+	unsigned eip;
 	unsigned short cs, __csh;
-	int eflags;
-	int esp;
+	unsigned eflags;
+	unsigned esp;
 	unsigned short ss, __ssh;
 /*
  * these are specific to v86 mode:
@@ -139,6 +136,4 @@ struct vm86plus_struct {
 #define VIF_MASK	0x00080000	/* virtual interrupt flag */
 #define VIP_MASK	0x00100000	/* virtual interrupt pending */
 #define ID_MASK		0x00200000
-#endif
-
 #endif


### PR DESCRIPTION
First pass.

With this, the dosemu2 core should no longer depend on a sigcontext type, which should make it finally portable.