### PR TITLE
fp87-sim: remove asm phase2

### DIFF
--- a/src/base/emu-i386/simx86/fp87-sim.c
+++ b/src/base/emu-i386/simx86/fp87-sim.c
@@ -760,14 +760,13 @@ fcom00:			TheCPU.fpus &= (~0x4500);	/* (C3,C2,C0) <-- 000 */
 			break;
 		   case 4:		/* FXTRACT */
 	   		WFR0 = *ST0;
-			__asm__ __volatile__ (
-			"fldt	%3\n"
-			"fxtract\n"
-			"fnstsw	%2\n"
-			"fstpt	%1\n"
-			"fstpt	%0" : "=m"(WFR0),"=m"(WFR1),"=g"(WFRS) : "m"(WFR0) : "memory" );
+			{
+				int exp;
+				WFR1 = frexpl(WFR0, &exp) * 2;
+				WFR0 = logbl(WFR0);
+			}
 			*ST0 = WFR0; DECFSPP;
-			fssync();
+			ftest();
 			*ST0 = WFR1;
 			break;
 		   case 5:		/* FPREM1 */
@@ -815,14 +814,8 @@ fcom00:			TheCPU.fpus &= (~0x4500);	/* (C3,C2,C0) <-- 000 */
 		   case 5:		/* FSCALE */
 	   		WFR0 = *ST0;
 			WFR1 = *ST1;
-			__asm__ __volatile__ (
-			"fldt	%2\n"
-			"fldt	%3\n"
-			"fscale\n"
-			"fnstsw	%1\n"
-			"fstpt	%0\n"
-			"fstp	%%st(0)" : "=m"(WFR0),"=g"(WFRS) : "m"(WFR1),"m"(WFR0) : "memory" );
-			fssync();
+			WFR0 = ldexpl(WFR0, truncl(WFR1));
+			ftest();
 			*ST0 = WFR0;
 			break;
 		   case 1:		/* FYL2XP1 */

--- a/src/base/emu-i386/simx86/fp87-sim.c
+++ b/src/base/emu-i386/simx86/fp87-sim.c
@@ -112,7 +112,7 @@ static void fxam(long double d)
 
 static void ftest(void)
 {
-	unsigned short fps = TheCPU.fpus & ~0x3f;
+	unsigned short fps = TheCPU.fpus;
 	int exceptions = fetestexcept(FE_ALL_EXCEPT);
 	if (exceptions & FE_INVALID) fps |= 0x1;
 	if (exceptions & FE_DIVBYZERO) fps |= 0x4;

--- a/src/base/emu-i386/simx86/fp87-sim.c
+++ b/src/base/emu-i386/simx86/fp87-sim.c
@@ -840,12 +840,13 @@ fcom00:			TheCPU.fpus &= (~0x4500);	/* (C3,C2,C0) <-- 000 */
 			break;
 		   case 2:		/* FSQRT */
 	   		WFR0 = *ST0;
-			__asm__ __volatile__ (
-			"fldt	%2\n"
-			"fsqrt\n"
-			"fnstsw	%1\n"
-			"fstpt	%0" : "=m"(WFR0),"=g"(WFRS) : "m"(WFR0) : "memory" );
-			fssync();
+			if (signbit(WFR0) && WFR0 != -0.0) {
+				WFR0 = -NAN;
+				TheCPU.fpus |= 0x1;
+			} else {
+				WFR0 = sqrtl(WFR0);
+				ftest();
+			}
 			*ST0 = WFR0;
 			break;
 		   case 4:		/* FRNDINT */


### PR DESCRIPTION
I used a DOS program mcpdiag to check correctness, though it still detects issues (rounding via control word related I think).

It's just as correct as before the asm removal according to this program now.