### PR TITLE
Use smalloc for non-fixed linear DPMI allocations.

### DIFF
--- a/etc/dosemu.conf
+++ b/etc/dosemu.conf
@@ -319,9 +319,9 @@
 # $_dpmi_lin_rsv_base = (auto)
 
 # Size of reserved linear address space for DPMI.
-# Default: 0x8000 (reserve 32Mb)
+# Default: 0x80000 (reserve 512Mb)
 
-# $_dpmi_lin_rsv_size = (0x8000)
+# $_dpmi_lin_rsv_size = (0x80000)
 
 # Some DJGPP-compiled programs have the NULL pointer dereference bugs.
 # They may work under Windows or QDPMI as these unfortunately do not

--- a/src/dosext/dpmi/memory.c
+++ b/src/dosext/dpmi/memory.c
@@ -491,8 +491,9 @@ dpmi_pm_block * DPMI_mallocLinear(dpmi_pm_block_root *root,
     if ((block = alloc_pm_block(root, size)) == NULL)
 	return NULL;
 
-    if (inp) {
-	realbase = smalloc_fixed(&lin_pool, MEM_BASE32(base), size);
+    if (inp || base == -1) {
+	realbase = inp ? smalloc_fixed(&lin_pool, MEM_BASE32(base), size) :
+	    smalloc(&lin_pool, size);
 	if (realbase == NULL) {
 	    free_pm_block(root, block);
 	    return NULL;


### PR DESCRIPTION
To work with tasm32, increase linear address space to allocate by default from 32M to 512M.

Alternative to #1845 