### PR TITLE
vgaemu: allocate LFB via smalloc() from main_pool.

### DIFF
--- a/src/arch/linux/async/signal.c
+++ b/src/arch/linux/async/signal.c
@@ -911,7 +911,7 @@ static void sigstack_init(void)
       config.exitearly = 1;
       return;
     }
-    backup_stack = alias_mapping_high(MAPPING_OTHER, SIGSTACK_SIZE,
+    backup_stack = alias_mapping_high(MAPPING_OTHER, (void *)-1, SIGSTACK_SIZE,
 	PROT_READ | PROT_WRITE, cstack);
     if (backup_stack == MAP_FAILED) {
       error("Unable to allocate stack\n");

--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -30,7 +30,6 @@
 #include "dos2linux.h"
 #include "kvm.h"
 #include "mapping.h"
-#include "smalloc.h"
 #include <string.h>
 #include <errno.h>
 #include <unistd.h>
@@ -252,18 +251,8 @@ static int is_kvm_map(int cap)
   return (!(cap & MAPPING_DPMI));
 }
 
-void *alias_mapping_high(int cap, size_t mapsize, int protect, void *source)
+void *alias_mapping_high(int cap, void *target, size_t mapsize, int protect, void *source)
 {
-  void *target = (void *)-1;
-
-  if (cap & (MAPPING_DPMI|MAPPING_VGAEMU|MAPPING_INIT_LOWRAM)) {
-    target = smalloc(&main_pool, mapsize);
-    if (!target) {
-      error("OOM for alias_mapping_high, %s\n", strerror(errno));
-      return MAP_FAILED;
-    }
-  }
-
   target = mappingdriver->alias(cap, target, mapsize, protect, source);
   if (target == MAP_FAILED)
     return target;

--- a/src/base/dev/vga/vesa.c
+++ b/src/base/dev/vga/vesa.c
@@ -568,7 +568,7 @@ static int vbe_mode_info(unsigned mode, unsigned int vbemodeinfo)
 
     vbemi.DirectColor = 0;
     if(vmi->color_bits >= 8 && vga.mem.lfb_base_page)
-      vbemi.PhysBasePtr = (uintptr_t)vga.mem.lfb_base;	/* LFB support */
+      vbemi.PhysBasePtr = vga.mem.lfb_base;	/* LFB support */
 
     vbemi.OffScreenOfs = 0;
     vbemi.OffScreenMem = 0;

--- a/src/include/mapping.h
+++ b/src/include/mapping.h
@@ -120,7 +120,7 @@ void init_hardware_ram(void);
 int map_hardware_ram(char type);
 int map_hardware_ram_manual(size_t base, dosaddr_t vbase);
 int unmap_hardware_ram(char type);
-int register_hardware_ram(int type, unsigned base, unsigned size);
+int register_hardware_ram(int type, dosaddr_t base, unsigned size);
 unsigned get_hardware_ram(unsigned addr, uint32_t size);
 void list_hardware_ram(void (*print)(const char *, ...));
 void *mapping_find_hole(unsigned long start, unsigned long stop,

--- a/src/include/mapping.h
+++ b/src/include/mapping.h
@@ -88,7 +88,7 @@ void *mmap_file_ux(int cap, void *target, size_t mapsize, int protect,
 
 typedef void *alias_mapping_type(int cap, void *target, size_t mapsize, int protect, void *source);
 int alias_mapping(int cap, dosaddr_t targ, size_t mapsize, int protect, void *source);
-void *alias_mapping_high(int cap, size_t mapsize, int protect, void *source);
+void *alias_mapping_high(int cap, void *target, size_t mapsize, int protect, void *source);
 
 int munmap_mapping(int cap, dosaddr_t targ, size_t mapsize);
 int mprotect_mapping(int cap, dosaddr_t targ, size_t mapsize, int protect);

--- a/src/include/vgaemu.h
+++ b/src/include/vgaemu.h
@@ -262,7 +262,7 @@ typedef struct {
   unsigned bank_len;			/* banked length in bytes */
   unsigned graph_base;                  /* graphics base, normally 0xa0000 */
   unsigned graph_size;                  /* graphics size, normally 0x20000 */
-  unsigned char *lfb_base;		/* base address for lfb, NULL if no lfb */
+  dosaddr_t lfb_base;			/* base address for lfb, 0 if no lfb */
   unsigned lfb_base_page;		/* lfb base page, 0 -> no lfb support */
   vga_mapping_type map[VGAEMU_MAX_MAPPINGS];	/* all the mappings */
   unsigned bank_pages;			/* size of a bank in pages */


### PR DESCRIPTION
This way vga.mem.lfb_base can be of dosaddr_t and will be allocated above mem_base (just above the mem_pool main DPMI area). This fixes LFB users for 64-bit mem_base where lfb_base was mmap'ed below it.