### PR TITLE
i386: fix configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -245,7 +245,7 @@ AC_DEFINE_DIR([SYSTEM_XFONTS_PATH], [x11fontdir], [ Directory for x11 fonts ])
 CONFIG_HOST='linux'
 AC_SUBST(CONFIG_HOST)
 
-machine=`$CC -dumpmachine | cut -d- -f1`
+machine=`$CC -dumpmachine | cut -d- -f1 | sed 's/i.86/i386/'`
 
 DOSEMU_CPPFLAGS="$DOSEMU_CPPFLAGS -imacros config.hh"
 DOSEMU_CFLAGS="$DOSEMU_CFLAGS -Wall -Wstrict-prototypes -Wmissing-declarations \


### PR DESCRIPTION
gcc -dumpmachine can return i686-pc-linux-gnu, so sed to i386 if necessary.

For FPU, always better to memcpy and not adjust the pointer on the signal stack (see eb54cce), and allow for the fact that "struct _fpstate" may be bigger than "struct emu_fpstate".

Note: I'm a little surprised we are back to using `struct sigcontext`, as I thought `mcontext_t` is more modern and more standard, it's a bit of a revert from 4581e6bc5a (#506).