### PR TITLE
native DPMI: only copy vm86 FPU state in sigcontext, fix i386 SSE

### DIFF
--- a/src/base/init/config.c
+++ b/src/base/init/config.c
@@ -727,8 +727,7 @@ static void read_cpu_info(void)
         }
 #endif
 #ifdef __i386__
-        if (cpuflags && (strstr(cpuflags, "fxsr")) &&
-	    sizeof(vm86_fpu_state) == (112+512)) {
+        if (cpuflags && (strstr(cpuflags, "fxsr"))) {
           config.cpufxsr = 1;
 	  if (cpuflags && strstr(cpuflags, "sse"))
 	    config.cpusse = 1;

--- a/src/dosext/dpmi/dnative/dnative.c
+++ b/src/dosext/dpmi/dnative/dnative.c
@@ -34,6 +34,7 @@
 #include "dpmisel.h"
 #include "dnative.h"
 
+#define EMU_X86_FXSR_MAGIC	0x0000
 static coroutine_t dpmi_tid;
 static cohandle_t co_handle;
 static int dpmi_ret_val;
@@ -46,16 +47,53 @@ static int dpmi_thr_running;
 static void copy_context(sigcontext_t *d, sigcontext_t *s)
 {
 #ifdef __linux__
+  /* keep pointer to FPU state the same */
   fpregset_t fptr = d->fpregs;
 #endif
   *d = *s;
 #ifdef __linux__
-  if (fptr == s->fpregs)
-    dosemu_error("Copy FPU context between the same locations?\n");
-  *fptr = *s->fpregs;
   d->fpregs = fptr;
 #endif
 }
+
+#ifdef __i386__
+/* On i386 only, if SSE is available (i.e. since the Pentium III),
+   the kernel will use FXSAVE to save FPU state, then put the following
+   on the signal stack:
+   * FXSAVE format converted to FSAVE format (108 bytes)
+   * status and magic field where magic == X86_FXSR_MAGIC (4 bytes)
+   * FXSAVE format (512 bytes), which can be used directly by our loadfpstate
+   However, when restoring FPU state it will only use the mxcsr and xmm
+   fields from the FXSAVE format, and take everything else from the FSAVE
+   format, so we must "undo" the kernel logic and put those fields into the
+   FSAVE region.
+   see also arch/x86/kernel/fpu/regset.c in Linux kernel */
+static void convert_from_fxsr(fpregset_t fptr,
+			      const struct emu_fpxstate *fxsave)
+{
+  unsigned int tmp;
+  int i;
+
+  fptr->cw = fxsave->cwd | 0xffff0000u;
+  fptr->sw = fxsave->swd | 0xffff0000u;
+  /* Expand the valid bits */
+  tmp = fxsave->ftw;			/* 00000000VVVVVVVV */
+  tmp = (tmp | (tmp << 4)) & 0x0f0f;	/* 0000VVVV0000VVVV */
+  tmp = (tmp | (tmp << 2)) & 0x3333;	/* 00VV00VV00VV00VV */
+  tmp = (tmp | (tmp << 1)) & 0x5555;	/* 0V0V0V0V0V0V0V0V */
+  /* Transform each bit from 1 to 00 (valid) or 0 to 11 (empty).
+     The kernel will convert it back, so no need to worry about zero
+     and special states 01 and 10. */
+  tmp = ~(tmp | (tmp << 1));
+  fptr->tag = tmp | 0xffff0000u;
+  fptr->ipoff = fxsave->fip;
+  fptr->cssel = (uint16_t)fxsave->fcs | ((uint32_t)fxsave->fop << 16);
+  fptr->dataoff = fxsave->fdp;
+  fptr->datasel = fxsave->fds;
+  for (i = 0; i < 8; i++)
+    memcpy(&fptr->_st[i], &fxsave->st[i], sizeof(fptr->_st[i]));
+}
+#endif
 
 static void copy_to_dpmi(sigcontext_t *scp, cpuctx_t *s)
 {
@@ -85,9 +123,23 @@ static void copy_to_dpmi(sigcontext_t *scp, cpuctx_t *s)
   _C(trapno);
   _C(err);
   _C(cr2);
-  static_assert(sizeof(*scp->fpregs) == sizeof(vm86_fpu_state),
-		"size mismatch");
-  scp->fpregs = (fpregset_t)&vm86_fpu_state;
+
+  if (scp->fpregs) {
+    void *fpregs = scp->fpregs;
+#ifdef __x86_64__
+    static_assert(sizeof(*scp->fpregs) == sizeof(vm86_fpu_state.fxsave),
+		  "size mismatch");
+#else
+    /* i386: convert fxsave state (if available) to fsave state */
+    if (emu_fpstate_get_type(&vm86_fpu_state) == EMU_FPSTATE_FXSAVE) {
+      convert_from_fxsr(scp->fpregs, &vm86_fpu_state.fxsave);
+      if ((scp->fpregs->status >> 16) != EMU_X86_FXSR_MAGIC)
+	return;
+      fpregs = &scp->fpregs->status + 1;
+    }
+#endif
+    memcpy(fpregs, &vm86_fpu_state, vm86_fpu_state.size);
+  }
 }
 
 static void copy_to_emu(cpuctx_t *d, sigcontext_t *scp)
@@ -112,10 +164,19 @@ static void copy_to_emu(cpuctx_t *d, sigcontext_t *scp)
   _D(trapno);
   _D(err);
   _D(cr2);
-  if (scp->fpregs && scp->fpregs != (fpregset_t)&vm86_fpu_state) {
-    static_assert(sizeof(*scp->fpregs) == sizeof(vm86_fpu_state),
+  if (scp->fpregs) {
+    void *fpregs = scp->fpregs;
+#ifdef __x86_64__
+    static_assert(sizeof(*scp->fpregs) == sizeof(vm86_fpu_state.fxsave),
 		"size mismatch");
-    memcpy(&vm86_fpu_state, scp->fpregs, sizeof(*scp->fpregs));
+#else
+    emu_fpstate_set_type(&vm86_fpu_state, EMU_FPSTATE_FSAVE);
+    if ((scp->fpregs->status >> 16) == EMU_X86_FXSR_MAGIC) {
+      emu_fpstate_set_type(&vm86_fpu_state, EMU_FPSTATE_FXSAVE);
+      fpregs = &scp->fpregs->status + 1;
+    }
+#endif
+    memcpy(&vm86_fpu_state, fpregs, vm86_fpu_state.size);
   }
 }
 
@@ -200,15 +261,18 @@ void dpmi_return(sigcontext_t *scp, int retcode)
     }
     dpmi_ret_val = retcode;
     if (retcode == DPMI_RET_EXIT) {
-        *scp = emu_stack_frame;
+        copy_context(scp, &emu_stack_frame);
         return;
     }
     copy_to_emu(dpmi_get_scp(), scp);
+    /* signal handlers start with clean FPU state, but we unmask
+       overflow/division by zero in main code */
+    fesetenv(&dosemu_fenv);
     signal_return_to_dosemu();
     co_resume(co_handle);
     signal_return_to_dpmi();
     if (dpmi_ret_val == DPMI_RET_EXIT)
-        *scp = emu_stack_frame;
+        copy_context(scp, &emu_stack_frame);
     else
         copy_to_dpmi(scp, dpmi_get_scp());
 }
@@ -217,9 +281,6 @@ static void dpmi_switch_sa(int sig, siginfo_t * inf, void *uc)
 {
     ucontext_t *uct = uc;
     sigcontext_t *scp = &uct->uc_mcontext;
-#ifdef __linux__
-    emu_stack_frame.fpregs = aligned_alloc(16, sizeof(*_scp_fpstate));
-#endif
     copy_context(&emu_stack_frame, scp);
     copy_to_dpmi(scp, dpmi_get_scp());
     sigaction(DPMI_TMP_SIG, &emu_tmp_act, NULL);
@@ -242,9 +303,8 @@ static void indirect_dpmi_transfer(void)
     pthread_kill(pthread_self(), DPMI_TMP_SIG);
     /* and we are back */
     signal_set_altstack(0);
-#ifdef __linux__
-    free(emu_stack_frame.fpregs);
-#endif
+    /* we inherited FPU state from DPMI, so put back to DOSEMU state */
+    fesetenv(&dosemu_fenv);
 }
 
 static void dpmi_thr(void *arg)

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -3321,6 +3321,8 @@ static void quit_dpmi(cpuctx_t *scp, unsigned short errcode,
   if (!in_dpmi_pm())
     dpmi_soft_cleanup();
 
+  port_outb(0xf1, 0); /* reset FPU */
+
   if (dos_exit) {
     if (!have_tsr || !tsr_para) {
       HI(ax) = 0x4c;


### PR DESCRIPTION
When entering DPMI, inherit a clean FPU environment from emulator. Signal handlers from DPMI simply save and restore the DPMI FPU environment without any intervention.
Finally, after leaving DPMI, and in signal handlers just before co_resume, dosemu restores its normal FPU environment.

This roughly corresponds to case 4 in #572, just not cooked but inherited, so there is no more attempt to copy to and from the VM86 FPU environment.

Fixes #572