### PR TITLE
kvm: mapping fixes

### DIFF
--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -419,7 +419,16 @@ static void *do_mmap_mapping(int cap, void *target, size_t mapsize, int protect)
 
 void *mmap_mapping_ux(int cap, void *target, size_t mapsize, int protect)
 {
-  return do_mmap_mapping(cap, target, mapsize, protect);
+  int flags = (target != (void *)-1) ? MAP_FIXED : 0;
+  /* TODO: remove this once Bart's patches are merged */
+#ifdef __x86_64__
+  if (flags == 0 &&
+      (cap & (MAPPING_DPMI|MAPPING_VGAEMU|MAPPING_INIT_LOWRAM|MAPPING_KVM)))
+    flags = _MAP_32BIT;
+#endif
+  if (target == (void *)-1) target = NULL;
+  return mmap(target, mapsize, protect,
+		MAP_PRIVATE | flags | MAP_ANONYMOUS, -1, 0);
 }
 
 void *mmap_file_ux(int cap, void *target, size_t mapsize, int protect,

--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -340,10 +340,13 @@ void low_mem_init(void)
   }
 
   mem_base = mem_reserve(memsize, dpmi_size);
-  if (config.cpu_vm == CPUVM_KVM || config.cpu_vm_dpmi == CPUVM_KVM)
+  if (config.cpu_vm == CPUVM_KVM || config.cpu_vm_dpmi == CPUVM_KVM) {
     init_kvm_monitor();
+    mmap_kvm(MAPPING_INIT_LOWRAM, mem_base, memsize + dpmi_size,
+	    PROT_READ | PROT_WRITE);
+  }
   sminit(&main_pool, mem_base, memsize + dpmi_size);
-  result = alias_mapping(MAPPING_INIT_LOWRAM, 0, LOWMEM_SIZE + HMASIZE,
+  result = alias_mapping(MAPPING_INIT_LOWRAM, 0, memsize,
 			 PROT_READ | PROT_WRITE | PROT_EXEC, lowmem);
   if (result == -1) {
     perror ("LOWRAM mmap");

--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -342,6 +342,7 @@ void low_mem_init(void)
   mem_base = mem_reserve(memsize, dpmi_size);
   if (config.cpu_vm == CPUVM_KVM || config.cpu_vm_dpmi == CPUVM_KVM)
     init_kvm_monitor();
+  sminit(&main_pool, mem_base, memsize + dpmi_size);
   result = alias_mapping(MAPPING_INIT_LOWRAM, 0, LOWMEM_SIZE + HMASIZE,
 			 PROT_READ | PROT_WRITE | PROT_EXEC, lowmem);
   if (result == -1) {
@@ -350,7 +351,6 @@ void low_mem_init(void)
   }
   c_printf("Conventional memory mapped from %p to %p\n", lowmem, mem_base);
 
-  sminit(&main_pool, mem_base, memsize + dpmi_size);
   ptr = smalloc(&main_pool, memsize);
   assert(ptr == mem_base);
   dpmi_rsv_low -= memsize;


### PR DESCRIPTION
mmap_mapping_ux() should not update kvm.
It did so for INIT_LOWRAM which happens w/o mem_base, so the _ux() version is used. The bug was that kvm's monitor was not initialized, so the initial mprotect_kvm() was omitted, resulting in no page tables being built for an initial mapping. This was later worked around (hidden) with mprotect_kvm() calls in alias_mapping() and friends, but I observed that these calls are needed even if the protection never changed, which was the hint towards a bug.
This patch changes mmap_mapping_ux() to just use mmap() and adds an explicit mmap_kvm() call after monitor is initialized, in both init.c and kvm.c.
Surprisingly that didn't work. Even plain move of mmap_kvm() out of mmap_mapping_ux() broke the boot immediately. I was staring for the whole night into 2 lines of code:
+  monitor = mmap_mapping_ux(MAPPING_SCRATCH|MAPPING_KVM, (void *)-1, sizeof(*monitor), PROT_READ | PROT_WRITE);
+  mmap_kvm(MAPPING_SCRATCH|MAPPING_KVM, monitor, sizeof(*monitor),
+       PROT_READ | PROT_WRITE);

How can that didn't work, if moving mmap_kvm() inside mmap_mapping_ux() works perfectly? Impossible! Mis-compilation!
Well, at 6:00AM I've finally realized that "monitor =" is a culprit here. If any other var is used, then things work... So in that case mprotect_kvm() was omitted by calling it before assigning a monitor pointer...
Added a proper check:
+  if (!(cap & MAPPING_KVM))
+    mprotect_kvm(cap, targ, mapsize, protect);

Well, I've never seen the bugs being hidden that carefully! Making me to stare for the whole night at 2 lines of code, is something. Thanks Bart. :)