### PR TITLE
Xms

### DIFF
--- a/etc/dosemu.conf
+++ b/etc/dosemu.conf
@@ -236,9 +236,9 @@
 
 # Extended Memory size. This memory is accessible via int15h and can be
 # used by himem.sys.
-# Default: 6144 (6Mb)
+# Default: 8192 (8Mb)
 
-# $_ext_mem = (6144)
+# $_ext_mem = (8192)
 
 # XMS (internal driver) is only needed if you do not load
 # himem.sys or another external XMS driver. Size in Kbytes.

--- a/src/base/core/int.c
+++ b/src/base/core/int.c
@@ -958,7 +958,7 @@ static int int15(void)
 	}
 
     case 0x88:
-	LWORD(eax) = (EXTMEM_SIZE + HMASIZE) >> 10;
+	LWORD(eax) = xms_intdrv() ? 0 : (EXTMEM_SIZE + HMASIZE) >> 10;
 	NOCARRY;
 	break;
 
@@ -1040,7 +1040,7 @@ static int int15(void)
 		-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
 #endif
 	    if (LO(ax) == 1) {
-	    Bit32u mem = (EXTMEM_SIZE + HMASIZE) >> 10;
+	    Bit32u mem = xms_intdrv() ? 0 : (EXTMEM_SIZE + HMASIZE) >> 10;
 	    if (mem < 0x3c00) {
 		LWORD(eax) = mem;
 		LWORD(ebx) = 0;

--- a/src/dosext/misc/xms.c
+++ b/src/dosext/misc/xms.c
@@ -361,6 +361,12 @@ static int xms_helper_init(void)
 
   if (!config.xms_size)
     return 0;
+  if (config.ext_mem) {
+    /* remove the mapping for external himem.sys */
+    int err = unregister_hardware_ram_virtual(LOWMEM_SIZE + HMASIZE);
+    if (err)
+      error("error unregistering ext_mem\n");
+  }
   intdrv = 1;
   return 1;
 }
@@ -459,7 +465,7 @@ void xms_helper(void)
 
 void xms_init(void)
 {
-  pgapool = pgainit(config.xms_map_size >> PAGE_SHIFT);
+  pgapool = pgainit(xms_map_size >> PAGE_SHIFT);
 }
 
 void xms_done(void)

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -265,7 +265,7 @@ typedef struct config_info {
 
        int hogthreshold;
 
-       int mem_size, ext_mem, xms_size, xms_map_size, ems_size;
+       int mem_size, ext_mem, xms_size, ems_size;
        int umb_a0, umb_b0, umb_f0, hma;
        unsigned int ems_frame;
        int ems_uma_pages, ems_cnv_pages;

--- a/src/include/memory.h
+++ b/src/include/memory.h
@@ -139,7 +139,8 @@
 #define HMASIZE (64*1024)
 #define LOWMEM_SIZE 0x100000
 #define EXTMEM_SIZE ((unsigned)(config.ext_mem << 10))
-#define xms_base (LOWMEM_SIZE + HMASIZE + EXTMEM_SIZE)
+#define xms_base (LOWMEM_SIZE + HMASIZE)
+#define xms_map_size (1024 * 1024 * 16 - xms_base)
 
 #ifndef __ASSEMBLER__
 


### PR DESCRIPTION
Hopefully the final part of xms rewrite.
ext_mem moved away from any known
pools and is unregistered on loading of
a native xms driver.
That allows to set $_ext_mem back to
8Mb w/o limiting xms or dpmi or whatever
else.