### PR TITLE
FPU fixes for the simulator

### DIFF
--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -275,6 +275,7 @@ extern int  (*Fp87_op)(int exop, int reg);
 extern unsigned int (*CloseAndExec)(unsigned int PC, int mode, int ln);
 void EndGen(void);
 extern void fp87_set_rounding(void);
+extern void fp87_save_except(void);
 //
 extern unsigned char InterOps[];
 extern char RmIsReg[];

--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -274,6 +274,7 @@ extern void (*AddrGen)(int op, int mode, ...);
 extern int  (*Fp87_op)(int exop, int reg);
 extern unsigned int (*CloseAndExec)(unsigned int PC, int mode, int ln);
 void EndGen(void);
+extern void fp87_set_rounding(void);
 //
 extern unsigned char InterOps[];
 extern char RmIsReg[];

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -572,6 +572,8 @@ void Cpu2Reg (void)
   if (TheCPU.fpstate == NULL) {
     if (!CONFIG_CPUSIM)
       savefpstate(vm86_fpu_state);
+    else
+      fp87_save_except();
     fesetenv(&dosemu_fenv);
   }
 
@@ -650,6 +652,8 @@ static void Cpu2Scp (cpuctx_t *scp, int trapno)
   if (TheCPU.fpstate == NULL) {
     if (!CONFIG_CPUSIM)
       savefpstate(vm86_fpu_state);
+    else
+      fp87_save_except();
     /* there is no real need to save and restore the FPU state of the
        emulator itself: savefpstate (fnsave) also resets the current FPU
        state using fninit; fesetenv then restores trapping of division by

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -572,9 +572,7 @@ void Cpu2Reg (void)
   if (TheCPU.fpstate == NULL) {
     if (!CONFIG_CPUSIM)
       savefpstate(vm86_fpu_state);
-#ifdef HOST_ARCH_X86
     fesetenv(&dosemu_fenv);
-#endif
   }
 
   if (debug_level('e')>1) e_printf("Cpu2Reg< vm86=%08x dpm=%08x emu=%08x\n",
@@ -658,9 +656,7 @@ static void Cpu2Scp (cpuctx_t *scp, int trapno)
        zero and overflow which is good enough for calling FPU-using
        routines.
     */
-#ifdef HOST_ARCH_X86
     fesetenv(&dosemu_fenv);
-#endif
   }
 
   /* push running flags - same as eflags, RF is cosmetic */

--- a/src/base/emu-i386/simx86/fp87-sim.c
+++ b/src/base/emu-i386/simx86/fp87-sim.c
@@ -135,7 +135,7 @@ static void fxam(long double d)
 		break;
 	}
 	if (signbit(d)) fps |= 0x200;
-	TheCPU.fpus = (fps&0xc7df)|(TheCPU.fpstt<<11);
+	TheCPU.fpus = (fps&0xc7ff)|(TheCPU.fpstt<<11);
 }
 
 static void ftest(void)
@@ -147,7 +147,7 @@ static void ftest(void)
 	if (exceptions & FE_OVERFLOW) fps |= 0x8;
 	if (exceptions & FE_UNDERFLOW) fps |= 0x10;
 	if (exceptions & FE_INEXACT) fps |= 0x20;
-	TheCPU.fpus = (fps&0xc7df)|(TheCPU.fpstt<<11);
+	TheCPU.fpus = (fps&0xc7ff)|(TheCPU.fpstt<<11);
 }
 
 /* round long double to integer depending on rounding mode */

--- a/src/base/emu-i386/simx86/fp87-sim.c
+++ b/src/base/emu-i386/simx86/fp87-sim.c
@@ -96,6 +96,16 @@ void init_emu_npu (void)
 	WFR0 = WFR1 = 0.0;
 }
 
+void fp87_set_rounding(void)
+{
+	switch (TheCPU.fpuc & 0xc00) {
+	case 0x000: fesetround(FE_TONEAREST); break;
+	case 0x400: fesetround(FE_DOWNWARD); break;
+	case 0x800: fesetround(FE_UPWARD); break;
+	default:    fesetround(FE_TOWARDZERO); break;
+	}
+}
+
 static void fxam(long double d)
 {
 	unsigned short fps = TheCPU.fpus & ~0x4700;
@@ -443,6 +453,7 @@ fcom00:			TheCPU.fpus &= (~0x4500);	/* (C3,C2,C0) <-- 000 */
 /*29*/	case 0x29:
 //*	29	D9 xx101nnn	FLDCW	2b
 		TheCPU.fpuc = read_word(AR1.d) | 0x40;
+		fp87_set_rounding();
 		break;
 /*39*/	case 0x39:
 //*	39	D9 xx111nnn	FSTCW	2b
@@ -685,6 +696,7 @@ fcom00:			TheCPU.fpus &= (~0x4500);	/* (C3,C2,C0) <-- 000 */
 			TheCPU.fpstt = 0;
 			TheCPU.fpuc  = 0x37f;
 			TheCPU.fptag = 0xffff;
+			fp87_set_rounding();
 			feclearexcept(FE_ALL_EXCEPT);
 			WFR0 = WFR1 = 0.0;
 			break;
@@ -942,6 +954,7 @@ fcom00:			TheCPU.fpus &= (~0x4500);	/* (C3,C2,C0) <-- 000 */
 //	25	DD xx100nnn	FRSTOR	94/108byte
 		    dosaddr_t p = TheCPU.mem_ref, q;
 		    TheCPU.fpuc = read_word(p) | 0x40;
+		    fp87_set_rounding();
 		    if (reg&DATA16) {
 			TheCPU.fpus = read_word(p+2); TheCPU.fptag = read_word(p+4);
 			q = p+14;
@@ -1055,6 +1068,7 @@ fcom00:			TheCPU.fpus &= (~0x4500);	/* (C3,C2,C0) <-- 000 */
 			TheCPU.fpstt = 0;
 			TheCPU.fpuc  = 0x37f;
 			TheCPU.fptag = 0xffff;
+			fp87_set_rounding();
 			feclearexcept(FE_ALL_EXCEPT);
 			WFR0 = WFR1 = 0.0;
 		    }

--- a/src/base/emu-i386/simx86/fp87-sim.c
+++ b/src/base/emu-i386/simx86/fp87-sim.c
@@ -40,6 +40,20 @@
 #include "codegen.h"
 #include "codegen-sim.h"
 
+// These are GNU extensions, so define them here if not already
+#ifndef M_PIl
+#define M_PIl 3.141592653589793238462643383279502884L
+#endif
+#ifndef M_LN2l
+#define M_LN2l 0.693147180559945309417232121458176568L
+#endif
+#ifndef M_LN10l
+#define M_LN10l 2.302585092994045684017991454684364208L
+#endif
+#ifndef M_LOG2El
+#define M_LOG2El 1.442695040888963407359924681001892137L
+#endif
+
 int (*Fp87_op)(int exop, int reg);
 static int Fp87_op_sim(int exop, int reg);
 
@@ -689,11 +703,11 @@ fcom00:			TheCPU.fpus &= (~0x4500);	/* (C3,C2,C0) <-- 000 */
 			DECFSPP;
 			switch (reg) {
 			case 0: WFR0 = 1.0; break;
-			case 1: WFR0 = M_LN10/M_LN2; break;
-			case 2: WFR0 = M_LOG2E; break;
-			case 3: WFR0 = M_PI; break;
-			case 4: WFR0 = M_LN2/M_LN10; break;
-			case 5: WFR0 = M_LN2; break;
+			case 1: WFR0 = M_LN10l/M_LN2l; break;
+			case 2: WFR0 = M_LOG2El; break;
+			case 3: WFR0 = M_PIl; break;
+			case 4: WFR0 = M_LN2l/M_LN10l; break;
+			case 5: WFR0 = M_LN2l; break;
 			case 6: WFR0 = 0.0; break;
 			default: goto fp_notok;
 			}

--- a/src/base/emu-i386/simx86/fp87-sim.c
+++ b/src/base/emu-i386/simx86/fp87-sim.c
@@ -88,7 +88,9 @@ static void fxam(long double d)
 
 	// https://www.felixcloutier.com/x86/fxam
 	// bits in status word: c0:8, c1:9, c2:10, c3:14
-	switch(fpclassify(d)) {
+	if (!iscanonical(d))
+		fps |= isnan(d) ? 0x0 : 0x4400; // pseudo normal/denormal
+	else switch(fpclassify(d)) {
 	case FP_NAN:
 		fps |= 0x100;
 		break;

--- a/src/base/emu-i386/simx86/fp87-sim.c
+++ b/src/base/emu-i386/simx86/fp87-sim.c
@@ -770,7 +770,7 @@ fcom00:			TheCPU.fpus &= ~(FPUS_C0 | FPUS_C2 | FPUS_C3);
 //	71.7	D9 11110111	FINCSTP
 		   case 0:		/* F2XM1 */
 	   		WFR0 = *ST0;
-			WFR0 = exp2l(WFR0) - 1.0;
+			WFR0 = expm1l(WFR0*M_LN2l);
 			*ST0 = WFR0;
 			break;
 		   case 1:		/* FYL2X */
@@ -780,7 +780,7 @@ fcom00:			TheCPU.fpus &= ~(FPUS_C0 | FPUS_C2 | FPUS_C3);
 				WFR0 = -NAN;
 				TheCPU.fpus |= FPUS_IE;
 			} else if (WFR0 == 0.0) {
-				WFR0 = -INFINITY;
+				WFR0 = signbit(WFR1) ? INFINITY : -INFINITY;
 				TheCPU.fpus |= FPUS_ZE;
 			} else {
 				WFR0 = WFR1 * log2l(WFR0);
@@ -912,7 +912,7 @@ fcom00:			TheCPU.fpus &= ~(FPUS_C0 | FPUS_C2 | FPUS_C3);
 	   		WFR0 = *ST0;
 			WFR1 = *ST1;
 			if (WFR0 > -1.0)
-				WFR0 = WFR1 * log2l(WFR0 + 1.0);
+				WFR0 = (WFR1 / M_LN2l) * log1pl(WFR0);
 			INCFSPP;
 			*ST0 = WFR0;
 			break;

--- a/src/base/emu-i386/simx86/fp87-sim.c
+++ b/src/base/emu-i386/simx86/fp87-sim.c
@@ -418,9 +418,16 @@ fcom00:			TheCPU.fpus &= (~0x4500);	/* (C3,C2,C0) <-- 000 */
 		int i;
 		WFR0 = *ST0;
 		round_double();
-		b = WFR0;
-		write_byte(p+9, b < 0 ? 0x80 : 0);
-		b = llabs(b);
+		if (isnan(WFR0) || fabsl(WFR0) >= 1000000000000000000.0L) {
+			/* store packed BCD indefinite value */
+			write_dword(p, 0);
+			write_word(p+4, 0);
+			write_dword(p+6, 0xffffc000u);
+			INCFSPP;
+			break;
+		}
+		write_byte(p+9, signbit(WFR0) ? 0x80 : 0);
+		b = llabs(WFR0);
 		for (i=0; i < 9; i++) {
 			uint8_t u = b % 10;
 			b /= 10;

--- a/src/base/emu-i386/simx86/fp87-sim.c
+++ b/src/base/emu-i386/simx86/fp87-sim.c
@@ -853,7 +853,20 @@ fcom00:			TheCPU.fpus &= (~0x4500);	/* (C3,C2,C0) <-- 000 */
 		   case 5:		/* FSCALE */
 	   		WFR0 = *ST0;
 			WFR1 = *ST1;
-			WFR0 = ldexpl(WFR0, truncl(WFR1));
+			if (isnan(WFR1) ||
+			    (WFR0 == 0.0 && isinf(WFR1) == 1) ||
+			    (isinf(WFR0) && isinf(WFR1) == -1))
+				WFR0 = WFR1 = NAN;
+			else if (isfinite(WFR0)) {
+				int inf = isinf(WFR1);
+				if (inf == 1)
+					WFR0 = WFR0 > 0 ? INFINITY : -INFINITY;
+				else if (inf == -1)
+					WFR0 = WFR0 > 0 ? 0.0 : -0.0;
+			}
+			if (WFR1 >= INT_MAX) WFR1 = INT_MAX;
+			if (WFR1 <= INT_MIN) WFR1 = INT_MIN;
+			WFR0 = ldexpl(WFR0, WFR1);
 			ftest();
 			*ST0 = WFR0;
 			break;

--- a/src/base/emu-i386/simx86/fp87-sim.c
+++ b/src/base/emu-i386/simx86/fp87-sim.c
@@ -150,17 +150,6 @@ static void ftest(void)
 	TheCPU.fpus = (fps&0xc7ff)|(TheCPU.fpstt<<11);
 }
 
-/* round long double to integer depending on rounding mode */
-static inline void round_double(void)
-{
-	switch (TheCPU.fpuc & 0xc00) {
-	case 0x000: WFR0 = rintl(WFR0); break;
-	case 0x400: WFR0 = floorl(WFR0); break;
-	case 0x800: WFR0 = ceill(WFR0); break;
-	default:    WFR0 = truncl(WFR0); break;
-	}
-}
-
 static float read_float(dosaddr_t addr)
 {
 	union { uint32_t u32; float f; } x = {.u32 = read_dword(addr)};
@@ -390,7 +379,7 @@ fcom00:			TheCPU.fpus &= (~0x4500);	/* (C3,C2,C0) <-- 000 */
 		case 0x1b:
 		case 0x17:
 		case 0x1f: {
-			round_double();
+			WFR0 = rintl(WFR0);
 			if (exop & 4) {
 			    if (isnan(WFR0) || isinf(WFR0) ||
 				WFR0 < (long double)-0x8000 ||
@@ -417,7 +406,7 @@ fcom00:			TheCPU.fpus &= (~0x4500);	/* (C3,C2,C0) <-- 000 */
 		long long b;
 		int i;
 		WFR0 = *ST0;
-		round_double();
+		WFR0 = rintl(WFR0);
 		if (isnan(WFR0) || fabsl(WFR0) >= 1000000000000000000.0L) {
 			/* store packed BCD indefinite value */
 			write_dword(p, 0);
@@ -446,7 +435,7 @@ fcom00:			TheCPU.fpus &= (~0x4500);	/* (C3,C2,C0) <-- 000 */
 /*3f*/	case 0x3f: {
 //	3F	DF xx111nnn	FISTP	qw
 		WFR0 = *ST0;
-		round_double();
+		WFR0 = rintl(WFR0);
 		if (isnan(WFR0) || isinf(WFR0) ||
 		    WFR0 < (long double)(long long)0x8000000000000000ULL ||
 		    WFR0 > (long double)(long long)0x7fffffffffffffffULL) {
@@ -915,7 +904,7 @@ fcom00:			TheCPU.fpus &= (~0x4500);	/* (C3,C2,C0) <-- 000 */
 			break;
 		   case 4:		/* FRNDINT */
 	   		WFR0 = *ST0;
-			round_double();
+			WFR0 = rintl(WFR0);
 			ftest();
 			*ST0 = WFR0;
 			break;

--- a/src/base/emu-i386/simx86/fp87-sim.c
+++ b/src/base/emu-i386/simx86/fp87-sim.c
@@ -102,7 +102,9 @@ static void fxam(long double d)
 
 	// https://www.felixcloutier.com/x86/fxam
 	// bits in status word: c0:8, c1:9, c2:10, c3:14
-	if (!iscanonical(d))
+	if (((TheCPU.fptag >> 2*S_reg(TheCPU.fpstt,0)) & 3) == 3)
+		fps |= 0x4100; // empty
+	else if (!iscanonical(d))
 		fps |= isnan(d) ? 0x0 : 0x4400; // pseudo normal/denormal
 	else switch(fpclassify(d)) {
 	case FP_NAN:

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -2728,11 +2728,13 @@ repag0:
 #ifdef HOST_ARCH_X86
 			if (TheCPU.fpstate) {
 				/* For simulator, only need to mask all
-				   exceptions; for JIT, load emulated FPU state
+				   exceptions, and set rounding properly;
+				   for JIT, load emulated FPU state
 				   into real FPU */
-				if (CONFIG_CPUSIM)
+				if (CONFIG_CPUSIM) {
 					fesetenv(FE_DFL_ENV);
-				else
+					fp87_set_rounding();
+				} else
 					loadfpstate(*TheCPU.fpstate);
 				TheCPU.fpstate = NULL;
 			}


### PR DESCRIPTION
This is a collection of various fixes to fp87-sim.c. It's not perfect yet but getting there.
There are a few more standalone tests from QEMU that were helpful (compiled with DJGPP out of the box), in
https://gitlab.com/qemu-project/qemu/-/tree/master/tests/tcg/i386
@andrewbird you may find them useful, haven't gone through all of them yet though (see commit msgs for which ones I used)