### PR TITLE
LFN: VFAT searches were always root based

### DIFF
--- a/src/dosext/mfs/lfn.c
+++ b/src/dosext/mfs/lfn.c
@@ -100,39 +100,28 @@ void close_dirhandles(unsigned psp)
 	}
 }
 
-static int vfat_search(char *dest, const char *src, const char *_path, int alias)
+static int vfat_search(char *dest, const char *src, const char *path, int alias)
 {
   struct mfs_dir *dir;
   struct mfs_dirent *de;
-  char *path, *slash;
   int ret = 0;
 
-  d_printf("LFN: vfat_search src=%s path=%s alias=%d\n", src, _path, alias);
-
-  path = strdup(_path);
-  if (!path)
-    return 0;
-
-  slash = strrchr(path, '/');
-  if (!slash) {
-    free(path);
-    return 0;
-  }
-  *slash = '\0';
+  d_printf("LFN: vfat_search src=%s path=%s alias=%d\n", src, path, alias);
 
   dir = dos_opendir(path);
-  free(path);
   if (dir == NULL)
     return 0;
 
   if (dir->dir == NULL)
     while ((de = dos_readdir(dir)) != NULL) {
-      d_printf("LFN: vfat_search %s %s\n", de->d_name, de->d_long_name);
+      d_printf("LFN: vfat_search (short='%s', long='%s')", de->d_name, de->d_long_name);
       if ((strcasecmp(de->d_long_name, src) == 0) || (strcasecmp(de->d_name, src) == 0)) {
         strlcpy(dest, alias ? de->d_name : de->d_long_name, 260);
         ret = 1;
+        d_printf(" matched\n");
         break;
       }
+      d_printf("\n");
     }
   else
     d_printf("LFN: vfat_search (not VFAT)\n");

--- a/src/dosext/mfs/lfn.c
+++ b/src/dosext/mfs/lfn.c
@@ -152,8 +152,13 @@ static int make_unmake_dos_mangled_path(char *dest, const char *fpath,
 	char *src;
 	char *fpath2;
 	char root[MAX_RESOURCE_LENGTH_EXT];
-	int root_len = get_redirection_root1(current_drive, root, sizeof(root));
+	int root_len;
+
+	d_printf("LFN: make_unmake_dos_mangled_path fpath='%s', drive='%c', alias='%d'\n",
+			fpath, current_drive + 'A', alias);
+
 	/* root ends with / and fpath may not, so -1 */
+	root_len = get_redirection_root1(current_drive, root, sizeof(root));
 	if (root_len <= 0 || strncmp(fpath, root, root_len - 1) != 0)
 		return -1;
 	*dest++ = current_drive + 'A';
@@ -166,10 +171,11 @@ static int make_unmake_dos_mangled_path(char *dest, const char *fpath,
 	fpath2 = strdup(fpath);
 	src = fpath2 + root_len;
 	if (*src == '/') src++;
+
 	while (src != NULL && *src != '\0') {
 		char *src2 = strchr(src, '/');
 		if (src2 == src) break;
-		if (src - 1 > fpath)
+		if (src - 1 > fpath2)
 			src[-1] = '\0';
 		if (src2 != NULL)
 			*src2++ = '\0';
@@ -185,7 +191,7 @@ static int make_unmake_dos_mangled_path(char *dest, const char *fpath,
 		}
 		dest += strlen(dest);
 		*dest = '\\';
-		if (src - 1 > fpath)
+		if (src - 1 > fpath2)
 			src[-1] = '/';
 		src = src2;
 	}

--- a/test/func_mfs_truename.py
+++ b/test/func_mfs_truename.py
@@ -1,5 +1,4 @@
-from os import makedirs
-from os.path import join
+from pathlib import Path
 
 from common_framework import (VFAT_MNTPNT,
                               setup_vfat_mounted_image, teardown_vfat_mounted_image)
@@ -9,8 +8,8 @@ def mfs_truename(self, fstype, tocreate, nametype, instring, expected):
     ename = "mfstruen"
 
     if fstype == "UFS":
-        testdir = "test-imagedir/dXXXXs/d"
-        makedirs(testdir, exist_ok=True)
+        testdir = Path("test-imagedir/dXXXXs/d")
+        testdir.mkdir(parents=True, exist_ok=True)
 
         batchfile = """\
 %s
@@ -23,7 +22,7 @@ $_floppy_a = ""
 """
 
     elif fstype == "VFAT":
-        testdir = VFAT_MNTPNT
+        testdir = Path(VFAT_MNTPNT)
         setup_vfat_mounted_image(self)
 
         batchfile = """\
@@ -45,11 +44,12 @@ $_lredir_paths = "/mnt/dosemu"
 
 # Make test files and directory names
     for i in tocreate:
+        p = testdir / i[1]
         if i[0] == "FILE":
-            with open(join(testdir, i[1]), "w") as f:
-                f.write("Some data")
+            p.parents[0].mkdir(parents=True, exist_ok=True)
+            p.write_text("Some data")
         elif i[0] == "DIR":
-            makedirs(join(testdir, i[1]), exist_ok=True)
+            p.mkdir(parents=True, exist_ok=True)
 
     if nametype == "LFN0":
         intnum = "0x7160"

--- a/test/test_dos.py
+++ b/test/test_dos.py
@@ -3558,21 +3558,33 @@ $_floppy_a = ""
             ("FILE", "verylongfilename2.txt"),
             ("FILE", "space embedded filename.txt"),
             ("FILE", "MixedCaseFilename.ext"),
+            ("DIR", "test/1234567890987654321"),
+            ("DIR", "abcdefgfedcba/1234567890987654321"),
+            ("FILE", "1234567890987654321/abcdefgfedcba.txt"),
+            ("FILE", "1234567890987654321/abcdefclash.txt"),
         )
         tests = (
-            ("LFN1", "X:\\verylongfilename.txt",        "X:\\VERYLO~1.TXT"),
-            ("LFN1", "X:\\verylongfilename2.txt",       "X:\\VERYLO~2.TXT"),
-            ("LFN1", "X:\\space embedded filename.txt", "X:\\SPACEE~1.TXT"),
-            ("LFN1", "X:\\MixedCaseFilename.ext",       "X:\\MIXEDC~1.EXT"),
+            ("LFN1", r"X:\verylongfilename.txt",                  r"X:\VERYLO~1.TXT"),
+            ("LFN1", r"X:\verylongfilename2.txt",                 r"X:\VERYLO~2.TXT"),
+            ("LFN1", r"X:\space embedded filename.txt",           r"X:\SPACEE~1.TXT"),
+            ("LFN1", r"X:\MixedCaseFilename.ext",                 r"X:\MIXEDC~1.EXT"),
+            ("LFN1", r"X:\test\1234567890987654321",              r"X:\TEST\123456~1"),
+            ("LFN1", r"X:\abcdefgfedcba\1234567890987654321",     r"X:\ABCDEF~1\123456~1"),
+            ("LFN1", r"X:\1234567890987654321\abcdefgfedcba.txt", r"X:\123456~1\ABCDEF~1.TXT"),
+            ("LFN1", r"X:\1234567890987654321\abcdefclash.txt",   r"X:\123456~1\ABCDEF~2.TXT"),
 
-            ("LFN2", "X:\\VERYLO~1.TXT", "X:\\verylongfilename.txt"),
-            ("LFN2", "X:\\VERYLO~2.TXT", "X:\\verylongfilename2.txt"),
-            ("LFN2", "X:\\SPACEE~1.TXT", "X:\\space embedded filename.txt"),
-            ("LFN2", "X:\\MIXEDC~1.EXT", "X:\\MixedCaseFilename.ext"),
+            ("LFN2", r"X:\VERYLO~1.TXT",          r"X:\verylongfilename.txt"),
+            ("LFN2", r"X:\VERYLO~2.TXT",          r"X:\verylongfilename2.txt"),
+            ("LFN2", r"X:\SPACEE~1.TXT",          r"X:\space embedded filename.txt"),
+            ("LFN2", r"X:\MIXEDC~1.EXT",          r"X:\MixedCaseFilename.ext"),
+            ("LFN2", r"X:\TEST\123456~1",         r"X:\test\1234567890987654321"),
+            ("LFN2", r"X:\ABCDEF~1\123456~1",     r"X:\abcdefgfedcba\1234567890987654321"),
+            ("LFN2", r"X:\123456~1\ABCDEF~1.TXT", r"X:\1234567890987654321\abcdefgfedcba.txt"),
+            ("LFN2", r"X:\123456~1\ABCDEF~2.TXT", r"X:\1234567890987654321\abcdefclash.txt"),
 
-            ("LFN0", "X:\\progra~1",      "X:\\PROGRA~1"),
-            ("LFN1", "X:\\Program Files", "X:\\PROGRA~1"),
-            ("LFN2", "X:\\PROGRA~1",      "X:\\Program Files"),
+            ("LFN0", r"X:\progra~1",      r"X:\PROGRA~1"),
+            ("LFN1", r"X:\Program Files", r"X:\PROGRA~1"),
+            ("LFN2", r"X:\PROGRA~1",      r"X:\Program Files"),
         )
         for t in tests:
             with self.subTest(t=t):
@@ -3587,14 +3599,22 @@ $_floppy_a = ""
             ("FILE", "verylongfilename2.txt"),
             ("FILE", "space embedded filename.txt"),
             ("FILE", "MixedCaseFilename.ext"),
+            ("DIR", "test/1234567890987654321"),
+            ("DIR", "abcdefgfedcba/1234567890987654321"),
+            ("FILE", "654321fedcba/abcdef123456.txt"),
+            ("FILE", "654321fedcba/abcdefclash.txt"),
         )
         tests = (
-            ("SFN", "X:\\testname", "X:\\TESTNAME"),
-            ("SFN", "d:\\shrtname.txt", "D:\\SHRTNAME.TXT"),
-            ("SFN", "X:\\verylo~1.txt", "X:\\VERYLO~1.TXT"),
-            ("SFN", "X:\\verylo~2.txt", "X:\\VERYLO~2.TXT"),
-            ("SFN", "X:\\spacee~1.txt", "X:\\SPACEE~1.TXT"),
-            ("SFN", "X:\\mixedc~1.ext", "X:\\MIXEDC~1.EXT"),
+            ("SFN", r"X:\testname",          r"X:\TESTNAME"),
+            ("SFN", r"d:\shrtname.txt",      r"D:\SHRTNAME.TXT"),
+            ("SFN", r"X:\verylo~1.txt",      r"X:\VERYLO~1.TXT"),
+            ("SFN", r"X:\verylo~2.txt",      r"X:\VERYLO~2.TXT"),
+            ("SFN", r"X:\spacee~1.txt",      r"X:\SPACEE~1.TXT"),
+            ("SFN", r"X:\mixedc~1.ext",      r"X:\MIXEDC~1.EXT"),
+            ("SFN", r"X:\test\123456~1",     r"X:\TEST\123456~1"),
+            ("SFN", r"X:\abcdef~1\123456~1", r"X:\ABCDEF~1\123456~1"),
+            ("SFN", r"X:\654321~1\abcdef~1", r"X:\654321~1\ABCDEF~1"),
+            ("SFN", r"X:\654321~1\abcdef~2", r"X:\654321~1\ABCDEF~2"),
         )
         for t in tests:
             with self.subTest(t=t):


### PR DESCRIPTION
1/ In a previous patch (~2bc0ea8f69~) some pointers were forgotten to be changed, so some length calculations were being done between different strings.

2/ A previous fix (7b50ae495d) for (1) missed the root cause and so only worked around the issue in the root directory.

3/ Enhance test to cover searches in a non root directory.