### PR TITLE
share FPU state between virtualization back-ends

### DIFF
--- a/src/base/core/emu.c
+++ b/src/base/core/emu.c
@@ -377,7 +377,8 @@ int main(int argc, char **argv, char * const *envp)
       set_kvm_memory_regions();
 
     cpu_reset();
-
+    if (config.cpu_vm == CPUVM_KVM)
+      kvm_enter(0);
     can_leavedos = 1;
 
     while (!fatalerr && !config.exitearly) {

--- a/src/base/emu-i386/kvmmon.S
+++ b/src/base/emu-i386/kvmmon.S
@@ -59,9 +59,17 @@ kvm_mon_main:
         push %ebx
         mov %cr2,%eax
         push %eax
+#if 0
+        subl $0x200,%esp
+        fxsave (%esp)
+#endif
 	.globl kvm_mon_hlt
 kvm_mon_hlt:
         hlt
+#if 0
+        fxrstor (%esp)
+        addl $0x200,%esp
+#endif
         pop %eax
         pop %ebx
         pop %ecx

--- a/src/base/init/config.c
+++ b/src/base/init/config.c
@@ -727,8 +727,7 @@ static void read_cpu_info(void)
         }
 #endif
 #ifdef __i386__
-        if (cpuflags && (strstr(cpuflags, "fxsr")) &&
-	    sizeof(vm86_fpu_state) == (112+512)) {
+        if (cpuflags && (strstr(cpuflags, "fxsr"))) {
           config.cpufxsr = 1;
 	  if (cpuflags && strstr(cpuflags, "sse"))
 	    config.cpusse = 1;

--- a/src/include/kvm.h
+++ b/src/include/kvm.h
@@ -33,6 +33,10 @@ void set_kvm_memory_regions(void);
 void kvm_set_idt_default(int i);
 void kvm_set_idt(int i, uint16_t sel, uint32_t offs, int is_32, int tg);
 
+void kvm_enter(int pm);
+void kvm_leave(int pm);
+void kvm_update_fpu(void);
+
 void kvm_done(void);
 
 #else
@@ -47,6 +51,8 @@ static inline void set_kvm_memory_regions(void) {}
 static inline void kvm_set_idt_default(int i) {}
 static inline void kvm_set_idt(int i, uint16_t sel, uint32_t offs, int is_32,
     int tg) {}
+static inline void kvm_enter(int pm) {}
+static inline void kvm_leave(int pm) {}
 static inline void kvm_done(void) {}
 #endif
 


### PR DESCRIPTION
This patch adds an ability to save/restore FPU state to the fxsave-compatible storage. Added converters between fsave/fxsave formats.
Added FPU state handling for KVM, vm86 and native DPMI.

Based on initial work and suggestions by @bartoldeman, thanks!

Design note: FPU state is NOT treated as part of a CPU registers context. It is therefore not added as a member of CPU registers structure. Its handling rules are different from generic CPU registers, for example we avoid copying FPU state as long as possible, doing the state sync only on back-end switch. We avoid copying dosemu's FPU state when returning from signal handler, prefering to use fesetenv() for restoring dosemu context.