### PR TITLE
Xms rv

### DIFF
--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -179,7 +179,8 @@ static unsigned char *MEM_BASE32x(dosaddr_t a, int base)
   uintptr_t baddr = (uintptr_t)mem_bases[base];
   if (mem_bases[base] == MAP_FAILED)
     return MAP_FAILED;
-  assert(a < LOWMEM_SIZE + HMASIZE || base == MEM_BASE);
+  if (a >= LOWMEM_SIZE + HMASIZE && base != MEM_BASE)
+    return MAP_FAILED;
   off = baddr + a;
   if (config.cpu_vm_dpmi == CPUVM_NATIVE)
     off &= 0xffffffff;
@@ -292,7 +293,6 @@ dosaddr_t alias_mapping_high(int cap, size_t mapsize, int protect, void *source)
 
 int alias_mapping(int cap, dosaddr_t targ, size_t mapsize, int protect, void *source)
 {
-  void *target, *addr;
   int i;
 
   assert(targ != (dosaddr_t)-1);
@@ -308,7 +308,9 @@ int alias_mapping(int cap, dosaddr_t targ, size_t mapsize, int protect, void *so
       mem_bases[VM86_BASE] = 0;
 #endif
   }
+
   for (i = 0; i < MAX_BASES; i++) {
+    void *target, *addr;
     target = MEM_BASE32x(targ, i);
     if (target == MAP_FAILED)
       continue;
@@ -317,8 +319,7 @@ int alias_mapping(int cap, dosaddr_t targ, size_t mapsize, int protect, void *so
       return -1;
     Q__printf("MAPPING: %s alias created at %p\n", cap, addr);
   }
-  if (targ != (dosaddr_t)-1)
-    update_aliasmap(targ, mapsize, source);
+  update_aliasmap(targ, mapsize, source);
   if (is_kvm_map(cap))
     mprotect_kvm(cap, targ, mapsize, protect);
 

--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -1046,3 +1046,21 @@ void *mapping_find_hole(unsigned long start, unsigned long stop,
 	return MAP_FAILED;
     return (void *)pend;
 }
+
+int mcommit(void *ptr, size_t size)
+{
+  dosaddr_t targ = DOSADDR_REL(ptr);
+  int cap = (targ >= LOWMEM_SIZE + HMASIZE ? MAPPING_DPMI : MAPPING_LOWMEM);
+  if (mprotect_mapping(cap, targ, size, PROT_READ | PROT_WRITE) == -1)
+    return 0;
+  return 1;
+}
+
+int muncommit(void *ptr, size_t size)
+{
+  dosaddr_t targ = DOSADDR_REL(ptr);
+  int cap = (targ >= LOWMEM_SIZE + HMASIZE ? MAPPING_DPMI : MAPPING_LOWMEM);
+  if (mprotect_mapping(cap, targ, size, PROT_NONE) == -1)
+    return 0;
+  return 1;
+}

--- a/src/base/core/int.c
+++ b/src/base/core/int.c
@@ -959,7 +959,7 @@ static int int15(void)
 	}
 
     case 0x88:
-	LWORD(eax) = xms_intdrv() ? 0 : (EXTMEM_SIZE + HMASIZE) >> 10;
+	LWORD(eax) = (EXTMEM_SIZE + HMASIZE) >> 10;
 	NOCARRY;
 	break;
 
@@ -1041,7 +1041,7 @@ static int int15(void)
 		-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
 #endif
 	    if (LO(ax) == 1) {
-	    Bit32u mem = xms_intdrv() ? 0 : (EXTMEM_SIZE + HMASIZE) >> 10;
+	    Bit32u mem = (EXTMEM_SIZE + HMASIZE) >> 10;
 	    if (mem < 0x3c00) {
 		LWORD(eax) = mem;
 		LWORD(ebx) = 0;

--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -330,6 +330,7 @@ void low_mem_init(void)
   uint32_t dpmi_size = dpmi_lin_mem_rsv();
   int32_t dpmi_rsv_low = config.dpmi_base;
   const uint32_t mem_1M = 1024 * 1024;
+  /* 16Mb limit is for being in reach of DMAc */
   const uint32_t mem_16M = mem_1M * 16;
 
   open_mapping(MAPPING_INIT_LOWRAM);
@@ -367,7 +368,7 @@ void low_mem_init(void)
   ptr = smalloc(&main_pool, memsize);
   assert(ptr == mem_base);
   dpmi_rsv_low -= memsize;
-  if (dpmi_rsv_low < EXTMEM_SIZE) {
+  if (dpmi_rsv_low < EXTMEM_SIZE + config.xms_map_size) {
     error("$_dpmi_base is too small\n");
     config.exitearly = 1;
     return;

--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -330,10 +330,18 @@ void low_mem_init(void)
   uint32_t memsize = LOWMEM_SIZE + HMASIZE;
   uint32_t dpmi_size = dpmi_lin_mem_rsv();
   int32_t dpmi_rsv_low = config.dpmi_base;
+  const uint32_t mem_1M = 1024 * 1024;
+  const uint32_t mem_16M = mem_1M * 16;
 
   open_mapping(MAPPING_INIT_LOWRAM);
   g_printf ("DOS+HMA memory area being mapped in\n");
-  lowmem = alloc_mapping(MAPPING_INIT_LOWRAM, memsize);
+  /* reserve 1Mb for XMS mappings */
+  if (memsize + EXTMEM_SIZE > mem_16M - mem_1M) {
+    error("$_ext_mem too large\n");
+    leavedos(98);
+    return;
+  }
+  lowmem = alloc_mapping(MAPPING_INIT_LOWRAM, memsize + EXTMEM_SIZE);
   if (lowmem == MAP_FAILED) {
     perror("LOWRAM alloc");
     leavedos(98);
@@ -354,6 +362,9 @@ void low_mem_init(void)
   }
   c_printf("Conventional memory mapped from %p to %p\n", lowmem, mem_base);
 
+  if (config.xms_size)
+    config.xms_map_size = (mem_16M - (memsize + EXTMEM_SIZE)) & PAGE_MASK;
+
   ptr = smalloc(&main_pool, memsize);
   assert(ptr == mem_base);
   dpmi_rsv_low -= memsize;
@@ -369,20 +380,16 @@ void low_mem_init(void)
   }
 
   if (config.ext_mem) {
-    ptr = alloc_mapping(MAPPING_EXTMEM, EXTMEM_SIZE);
-    if (ptr == MAP_FAILED) {
-      perror("ext_mem alloc");
-      leavedos(98);
-    }
     addr = alias_mapping_high(MAPPING_EXTMEM, EXTMEM_SIZE,
-		 PROT_READ | PROT_WRITE, ptr);
+		 PROT_READ | PROT_WRITE, lowmem + memsize);
     if (addr == (dosaddr_t)-1) {
       error("failure to allocate ext mem\n");
       config.exitearly = 1;
       return;
     }
     /* memsize == base */
-    register_hardware_ram_virtual('m', memsize, EXTMEM_SIZE, ptr, addr);
+    register_hardware_ram_virtual('m', memsize, EXTMEM_SIZE, lowmem + memsize,
+	    addr);
     x_printf("Ext.Mem of size 0x%x at %#x\n", EXTMEM_SIZE, addr);
   }
 

--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -45,8 +45,6 @@
 #define GFX_CHARS       0xffa6e
 
 smpool main_pool;
-unsigned char *extmem_base;
-dosaddr_t extmem_vbase;
 
 #if 0
 static inline void dbug_dumpivec(void)
@@ -383,9 +381,9 @@ void low_mem_init(void)
       config.exitearly = 1;
       return;
     }
+    /* memsize == base */
+    register_hardware_ram_virtual('m', memsize, EXTMEM_SIZE, ptr, addr);
     x_printf("Ext.Mem of size 0x%x at %#x\n", EXTMEM_SIZE, addr);
-    extmem_base = ptr;
-    extmem_vbase = addr;
   }
 
   /* R/O protect 0xf0000-0xf4000 */

--- a/src/dosext/misc/xms.c
+++ b/src/dosext/misc/xms.c
@@ -309,7 +309,8 @@ static void do_free_EMB(int h)
     handles[h].addr = NULL;
 }
 
-void xms_reset(void)
+void
+xms_reset(void)
 {
   int i;
 
@@ -326,11 +327,6 @@ void xms_reset(void)
   freeHMA = 0;
   ext_hooked_hma = 0;
   pgareset(pgapool);
-  if (config.ext_mem) {
-    /* Register mem for himem.sys. Unregister later if internal driver loaded. */
-    register_hardware_ram_virtual('m', LOWMEM_SIZE + HMASIZE, EXTMEM_SIZE,
-	extmem_base, extmem_vbase);
-  }
 }
 
 static void xms_local_reset(void)

--- a/src/dosext/misc/xms.c
+++ b/src/dosext/misc/xms.c
@@ -360,12 +360,6 @@ static int xms_helper_init(void)
 
   if (!config.xms_size)
     return 0;
-  if (config.ext_mem) {
-    /* remove the mapping for external himem.sys */
-    int err = unregister_hardware_ram_virtual(LOWMEM_SIZE + HMASIZE);
-    if (err)
-      error("error unregistering ext_mem\n");
-  }
   intdrv = 1;
   return 1;
 }
@@ -464,7 +458,7 @@ void xms_helper(void)
 
 void xms_init(void)
 {
-  pgapool = pgainit(xms_map_size >> PAGE_SHIFT);
+  pgapool = pgainit(config.xms_map_size >> PAGE_SHIFT);
 }
 
 void xms_done(void)

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -265,7 +265,7 @@ typedef struct config_info {
 
        int hogthreshold;
 
-       int mem_size, ext_mem, xms_size, ems_size;
+       int mem_size, ext_mem, xms_size, xms_map_size, ems_size;
        int umb_a0, umb_b0, umb_f0, hma;
        unsigned int ems_frame;
        int ems_uma_pages, ems_cnv_pages;

--- a/src/include/mapping.h
+++ b/src/include/mapping.h
@@ -130,4 +130,7 @@ void list_hardware_ram(void (*print)(const char *, ...));
 void *mapping_find_hole(unsigned long start, unsigned long stop,
 	unsigned long size);
 
+int mcommit(void *ptr, size_t size);
+int muncommit(void *ptr, size_t size);
+
 #endif /* _MAPPING_H_ */

--- a/src/include/memory.h
+++ b/src/include/memory.h
@@ -139,8 +139,7 @@
 #define HMASIZE (64*1024)
 #define LOWMEM_SIZE 0x100000
 #define EXTMEM_SIZE ((unsigned)(config.ext_mem << 10))
-#define xms_base (LOWMEM_SIZE + HMASIZE)
-#define xms_map_size (1024 * 1024 * 16 - xms_base)
+#define xms_base (LOWMEM_SIZE + HMASIZE + EXTMEM_SIZE)
 
 #ifndef __ASSEMBLER__
 

--- a/src/include/memory.h
+++ b/src/include/memory.h
@@ -210,8 +210,6 @@ static inline dosaddr_t DOSADDR_REL(const unsigned char *a)
    once, at startup
 */
 extern uint8_t *lowmem_base;
-extern uint8_t *extmem_base;
-extern dosaddr_t extmem_vbase;
 
 #define UNIX_READ_BYTE(addr)		(*(Bit8u *) (addr))
 #define UNIX_WRITE_BYTE(addr, val)	(*(Bit8u *) (addr) = (val) )


### PR DESCRIPTION
Revert XMS optimizations about moving
away ext_mem.
ext_mem is needed for vcpi, see #1880 