### PR TITLE
FPU save-restore hooks for vm86/native/cpuemu

### DIFF
--- a/src/base/bios/x86/bios.S
+++ b/src/base/bios/x86/bios.S
@@ -902,7 +902,12 @@ INT75_OFF:
 	outb %al, $0xa0
 	outb %al, $0x20
 	int $2		/* Bochs does this; RBIL says: redirected to INT 02 */
-        iret		/* by the BIOS, for compatibility with the PC */
+			/* by the BIOS, for compatibility with the PC */
+	fnclex		/* Clear FP exceptions just in case a hooked
+			   handler hasn't already done so, so we won't
+			   get stuck (in real mode IGNNE would prevent
+			   further exceptions but we don't emulate that) */
+	iret
 
 /* ----------------------------------------------------------------- */
 	.globl INT08_OFF

--- a/src/base/bios/x86/bios.S
+++ b/src/base/bios/x86/bios.S
@@ -896,17 +896,17 @@ bios_text_font:
 	_ORG(0xfea6)
 	.globl INT75_OFF
 INT75_OFF:
-	xorb %al, %al
-	outb %al, $0xf0
-	movb $0x20, %al
-	outb %al, $0xa0
-	outb %al, $0x20
 	int $2		/* Bochs does this; RBIL says: redirected to INT 02 */
 			/* by the BIOS, for compatibility with the PC */
 	fnclex		/* Clear FP exceptions just in case a hooked
 			   handler hasn't already done so, so we won't
 			   get stuck (in real mode IGNNE would prevent
 			   further exceptions but we don't emulate that) */
+	xorb %al, %al
+	outb %al, $0xf0
+	movb $0x20, %al
+	outb %al, $0xa0
+	outb %al, $0x20
 	iret
 
 /* ----------------------------------------------------------------- */

--- a/src/base/core/emu.c
+++ b/src/base/core/emu.c
@@ -383,6 +383,11 @@ int main(int argc, char **argv, char * const *envp)
     case CPUVM_EMU:
       e_enter();
       break;
+#ifdef __i386__
+    case CPUVM_VM86:
+      true_vm86_enter();
+      break;
+#endif
     }
     can_leavedos = 1;
 

--- a/src/base/core/emu.c
+++ b/src/base/core/emu.c
@@ -376,8 +376,14 @@ int main(int argc, char **argv, char * const *envp)
       set_kvm_memory_regions();
 
     cpu_reset();
-    if (config.cpu_vm == CPUVM_KVM)
+    switch(config.cpu_vm) {
+    case CPUVM_KVM:
       kvm_enter(0);
+      break;
+    case CPUVM_EMU:
+      e_enter();
+      break;
+    }
     can_leavedos = 1;
 
     while (!fatalerr && !config.exitearly) {

--- a/src/base/core/emu.c
+++ b/src/base/core/emu.c
@@ -376,19 +376,6 @@ int main(int argc, char **argv, char * const *envp)
       set_kvm_memory_regions();
 
     cpu_reset();
-    switch(config.cpu_vm) {
-    case CPUVM_KVM:
-      kvm_enter(0);
-      break;
-    case CPUVM_EMU:
-      e_enter();
-      break;
-#ifdef __i386__
-    case CPUVM_VM86:
-      true_vm86_enter();
-      break;
-#endif
-    }
     can_leavedos = 1;
 
     while (!fatalerr && !config.exitearly) {

--- a/src/base/emu-i386/cpu.c
+++ b/src/base/emu-i386/cpu.c
@@ -413,7 +413,7 @@ void cpu_setup(void)
 #define FP_EXP_TAG_SPECIAL	2
 #define FP_EXP_TAG_EMPTY	3
 
-static inline uint32_t twd_fxsr_to_i387(const struct emu_fpxstate *fxsave)
+static inline uint32_t twd_fxsr_to_i387(const struct emu_fpstate *fxsave)
 {
 	const struct emu_fpxreg *st;
 	uint32_t tos = (fxsave->swd >> 11) & 7;
@@ -454,7 +454,7 @@ static inline uint32_t twd_fxsr_to_i387(const struct emu_fpxstate *fxsave)
 	return ret;
 }
 
-void fxsave_to_fsave(const struct emu_fpxstate *fxsave, struct emu_fsave *fptr)
+void fxsave_to_fsave(const struct emu_fpstate *fxsave, struct emu_fsave *fptr)
 {
   int i;
 
@@ -489,7 +489,7 @@ static unsigned short twd_i387_to_fxsr(unsigned short twd)
 
 /* NOTE: this function does NOT memset the "unused" fxsave fields.
  * We preserve the previous fxsave context. */
-void fsave_to_fxsave(const struct emu_fsave *fptr, struct emu_fpxstate *fxsave)
+void fsave_to_fxsave(const struct emu_fsave *fptr, struct emu_fpstate *fxsave)
 
 {
 	int i;

--- a/src/base/emu-i386/cpu.c
+++ b/src/base/emu-i386/cpu.c
@@ -257,8 +257,7 @@ static void fpu_io_write(ioport_t port, Bit8u val)
 {
   switch (port) {
   case 0xf0:
-    /* not sure about this */
-    vm86_fpu_state.swd &= ~0x8000;
+    pic_untrigger(13); /* done by default via int75 handler in bios.S */
     break;
   case 0xf1:
     fpu_reset();

--- a/src/base/emu-i386/do_vm86.c
+++ b/src/base/emu-i386/do_vm86.c
@@ -74,7 +74,6 @@ int vm86_fault(unsigned trapno, unsigned err, dosaddr_t cr2)
     return 0;
 
   case 0x10: /* coprocessor error */
-    pic_untrigger(13);
     pic_request(13); /* this is the 386 way of signalling this */
     return 0;
 

--- a/src/base/emu-i386/do_vm86.c
+++ b/src/base/emu-i386/do_vm86.c
@@ -487,17 +487,15 @@ again:
 
 void true_vm86_set_fpu_state(const emu_fpstate *fpstate)
 {
-    if (config.cpufxsr)
-        true_vm86_fxsave = *fpstate;
-    else
+    true_vm86_fxsave = *fpstate;
+    if (!config.cpufxsr)
         fxsave_to_fsave(fpstate, &true_vm86_fsave);
 }
 
 void true_vm86_get_fpu_state(emu_fpstate *fpstate)
 {
-    if (config.cpufxsr)
-        *fpstate = true_vm86_fxsave;
-    else
+    *fpstate = true_vm86_fxsave;
+    if (!config.cpufxsr)
         fsave_to_fxsave(&true_vm86_fsave, fpstate);
 }
 #endif

--- a/src/base/emu-i386/do_vm86.c
+++ b/src/base/emu-i386/do_vm86.c
@@ -485,7 +485,7 @@ again:
     return ret;
 }
 
-void true_vm86_update_fpu(const emu_fpstate *fpstate)
+void true_vm86_set_fpu_state(const emu_fpstate *fpstate)
 {
     if (config.cpufxsr)
         true_vm86_fxsave = *fpstate;
@@ -493,12 +493,7 @@ void true_vm86_update_fpu(const emu_fpstate *fpstate)
         fxsave_to_fsave(fpstate, &true_vm86_fsave);
 }
 
-void true_vm86_enter(const emu_fpstate *fpstate)
-{
-    true_vm86_update_fpu(fpstate);
-}
-
-void true_vm86_leave(emu_fpstate *fpstate)
+void true_vm86_get_fpu_state(emu_fpstate *fpstate)
 {
     if (config.cpufxsr)
         *fpstate = true_vm86_fxsave;

--- a/src/base/emu-i386/do_vm86.c
+++ b/src/base/emu-i386/do_vm86.c
@@ -487,14 +487,14 @@ again:
 
 void true_vm86_set_fpu_state(const emu_fpstate *fpstate)
 {
-    true_vm86_fxsave = *fpstate;
+    true_vm86_fxsave.emu_fpstate = *fpstate;
     if (!config.cpufxsr)
         fxsave_to_fsave(fpstate, &true_vm86_fsave);
 }
 
 void true_vm86_get_fpu_state(emu_fpstate *fpstate)
 {
-    *fpstate = true_vm86_fxsave;
+    *fpstate = true_vm86_fxsave.emu_fpstate;
     if (!config.cpufxsr)
         fsave_to_fxsave(&true_vm86_fsave, fpstate);
 }

--- a/src/base/emu-i386/kvm.c
+++ b/src/base/emu-i386/kvm.c
@@ -1166,7 +1166,6 @@ int kvm_dpmi(cpuctx_t *scp)
         print_exception_info(scp);
 #endif
         dbug_printf("coprocessor exception, calling IRQ13\n");
-        pic_untrigger(13);
         pic_request(13);
         ret = DPMI_RET_DOSEMU;
       } else if (_trapno == 0x0e &&

--- a/src/base/emu-i386/kvm.c
+++ b/src/base/emu-i386/kvm.c
@@ -783,7 +783,7 @@ static void set_ldt_seg(struct kvm_segment *seg, unsigned selector)
   seg->unusable = !desc->present;
 }
 
-void kvm_update_fpu(const emu_fpstate *fpstate)
+void kvm_set_fpu_state(const emu_fpstate *fpstate)
 {
   struct kvm_xsave fpu = {};
   int ret;
@@ -796,12 +796,7 @@ void kvm_update_fpu(const emu_fpstate *fpstate)
   }
 }
 
-void kvm_enter(int pm, const emu_fpstate *fpstate)
-{
-  kvm_update_fpu(fpstate);
-}
-
-void kvm_leave(int pm, emu_fpstate *fpstate)
+void kvm_get_fpu_state(emu_fpstate *fpstate)
 {
   struct kvm_xsave fpu;
   int ret = ioctl(vcpufd, KVM_GET_XSAVE, &fpu);

--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -276,6 +276,8 @@ extern unsigned int (*CloseAndExec)(unsigned int PC, int mode);
 void EndGen(void);
 extern void fp87_set_rounding(void);
 extern void fp87_save_except(void);
+extern void fp87_save_fpstate(emu_fpstate *);
+extern void fp87_load_fpstate(const emu_fpstate *);
 //
 extern unsigned char InterOps[];
 extern char RmIsReg[];

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -583,24 +583,23 @@ void Cpu2Reg (void)
 
 void e_set_fpu_state(const emu_fpstate *fpstate)
 {
+  TheCPU._fpstate = *fpstate;
   if (CONFIG_CPUSIM)
     fp87_load_fpstate(fpstate);
   else {
     // unmasked exception settings are emulated
     TheCPU.fpuc = fpstate->cwd;
-    TheCPU._fpstate = *fpstate;
     TheCPU._fpstate.cwd |= 0x3f;
   }
 }
 
 void e_get_fpu_state(emu_fpstate *fpstate)
 {
+  *fpstate = TheCPU._fpstate;
   if (CONFIG_CPUSIM)
     fp87_save_fpstate(fpstate);
-  else {
-    *fpstate = TheCPU._fpstate;
+  else
     fpstate->cwd = (fpstate->cwd & ~0x3f) | (TheCPU.fpuc & 0x3f);
-  }
 }
 
 /* ======================================================================= */

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -581,6 +581,24 @@ void Cpu2Reg (void)
 	REG(eflags),get_FLAGS(TheCPU.eflags),TheCPU.eflags);
 }
 
+void e_enter(void)
+{
+  if (CONFIG_CPUSIM)
+    fp87_load_fpstate(&vm86_fpu_state);
+  else {
+    // unmasked exception settings are emulated
+    TheCPU.fpuc = vm86_fpu_state.cwd;
+    vm86_fpu_state.cwd |= 0x3f;
+  }
+}
+
+void e_leave(void)
+{
+  if (CONFIG_CPUSIM)
+    fp87_save_fpstate(&vm86_fpu_state);
+  else
+    vm86_fpu_state.cwd = (vm86_fpu_state.cwd & ~0x3f) | (TheCPU.fpuc & 0x3f);
+}
 
 /* ======================================================================= */
 

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -581,7 +581,7 @@ void Cpu2Reg (void)
 	REG(eflags),get_FLAGS(TheCPU.eflags),TheCPU.eflags);
 }
 
-void e_update_fpu(const emu_fpstate *fpstate)
+void e_set_fpu_state(const emu_fpstate *fpstate)
 {
   if (CONFIG_CPUSIM)
     fp87_load_fpstate(fpstate);
@@ -593,12 +593,7 @@ void e_update_fpu(const emu_fpstate *fpstate)
   }
 }
 
-void e_enter(const emu_fpstate *fpstate)
-{
-  e_update_fpu(fpstate);
-}
-
-void e_leave(emu_fpstate *fpstate)
+void e_get_fpu_state(emu_fpstate *fpstate)
 {
   if (CONFIG_CPUSIM)
     fp87_save_fpstate(fpstate);

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -583,19 +583,19 @@ void Cpu2Reg (void)
 
 void e_set_fpu_state(const emu_fpstate *fpstate)
 {
-  TheCPU._fpstate = *fpstate;
+  TheCPU._fpstate.emu_fpstate = *fpstate;
   if (CONFIG_CPUSIM)
     fp87_load_fpstate(fpstate);
   else {
     // unmasked exception settings are emulated
     TheCPU.fpuc = fpstate->cwd;
-    TheCPU._fpstate.cwd |= 0x3f;
+    TheCPU._fpstate.emu_fpstate.cwd |= 0x3f;
   }
 }
 
 void e_get_fpu_state(emu_fpstate *fpstate)
 {
-  *fpstate = TheCPU._fpstate;
+  *fpstate = TheCPU._fpstate.emu_fpstate;
   if (CONFIG_CPUSIM)
     fp87_save_fpstate(fpstate);
   else

--- a/src/base/emu-i386/simx86/fp87-sim.c
+++ b/src/base/emu-i386/simx86/fp87-sim.c
@@ -177,6 +177,36 @@ void fp87_save_except(void)
 	TheCPU.fpus = (fps&~FPUS_TOP)|(TheCPU.fpstt<<FPUS_TOP_BIT);
 }
 
+void fp87_save_fpstate(emu_fpstate *fpstate)
+{
+	int i;
+	struct emu_fsave fsave;
+
+	fsave.cw = TheCPU.fpuc;
+	fsave.sw = TheCPU.fpus;
+	fsave.tag = TheCPU.fptag;
+	fsave.ipoff = 0;
+	fsave.cssel = 0;
+	fsave.dataoff = 0;
+	fsave.datasel = 0;
+	for (i=0; i<8; i++)
+		memcpy(&fsave.st[i], &TheCPU.fpregs[i], sizeof TheCPU.fpregs[i]);
+	fsave_to_fxsave(&fsave, fpstate);
+}
+
+void fp87_load_fpstate(const emu_fpstate *fpstate)
+{
+	int i;
+	struct emu_fsave fsave;
+
+	fxsave_to_fsave(fpstate, &fsave);
+	TheCPU.fpuc = fsave.cw;
+	TheCPU.fpus = fsave.sw;
+	TheCPU.fptag = fsave.tag;
+	for (i=0; i<8; i++)
+		memcpy(&TheCPU.fpregs[i], &fsave.st[i], sizeof TheCPU.fpregs[i]);
+}
+
 static float read_float(dosaddr_t addr)
 {
 	union { uint32_t u32; float f; } x = {.u32 = read_dword(addr)};

--- a/src/base/emu-i386/simx86/syncpu.h
+++ b/src/base/emu-i386/simx86/syncpu.h
@@ -157,8 +157,8 @@ typedef struct {
 	/* if not NULL, points to emulated FPU state
 	   if NULL, emulator uses FPU instructions, so flags that
 	   dosemu needs to restore its own FPU environment. */
-	emu_fpregset_t fpstate;
-	emu_fpstate _fpstate __attribute__((aligned(16)));
+	struct emu_fpxstate *fpstate;
+	struct emu_fpxstate _fpstate __attribute__((aligned(16)));
 } SynCPU;
 
 union _SynCPU {

--- a/src/base/emu-i386/simx86/syncpu.h
+++ b/src/base/emu-i386/simx86/syncpu.h
@@ -158,6 +158,7 @@ typedef struct {
 	   if NULL, emulator uses FPU instructions, so flags that
 	   dosemu needs to restore its own FPU environment. */
 	emu_fpregset_t fpstate;
+	emu_fpstate _fpstate __attribute__((aligned(16)));
 } SynCPU;
 
 union _SynCPU {

--- a/src/dosext/dpmi/dnative/dnative.c
+++ b/src/dosext/dpmi/dnative/dnative.c
@@ -70,7 +70,7 @@ static void copy_context(sigcontext_t *d, sigcontext_t *s)
    FSAVE region.
    see also arch/x86/kernel/fpu/regset.c in Linux kernel */
 static void convert_from_fxsr(fpregset_t fptr,
-			      const struct emu_fpxstate *fxsave)
+			      const struct emu_fpstate *fxsave)
 {
   static_assert(sizeof(*fptr) == sizeof(struct emu_fsave),
 		  "size mismatch");
@@ -78,7 +78,7 @@ static void convert_from_fxsr(fpregset_t fptr,
 }
 
 /* since the kernel may not be able to keep SSE state, keep it here */
-static struct emu_fpxstate fxsave_state_holder_i386;
+static struct emu_fpstate fxsave_state_holder_i386;
 #endif
 
 static void copy_to_dpmi(sigcontext_t *scp, cpuctx_t *s)
@@ -117,7 +117,7 @@ void native_dpmi_set_fpu_state(const emu_fpstate *fpstate)
   if (scp_fpregs) {
     void *fpregs = scp_fpregs;
 #ifdef __x86_64__
-    static_assert(sizeof(*scp_fpregs) == sizeof(*fpstate),
+    static_assert(offsetof(struct _fpstate, _xmm[8]) == sizeof(*fpstate),
 		  "size mismatch");
 #else
     /* i386: convert fxsave state to fsave state */
@@ -161,7 +161,7 @@ void native_dpmi_get_fpu_state(emu_fpstate *fpstate)
   if (scp_fpregs) {
     void *fpregs = scp_fpregs;
 #ifdef __x86_64__
-    static_assert(sizeof(*scp_fpregs) == sizeof(*fpstate),
+    static_assert(offsetof(struct _fpstate, _xmm[8]) == sizeof(*fpstate),
 		"size mismatch");
 #else
     if ((scp_fpregs->status >> 16) == EMU_X86_FXSR_MAGIC)

--- a/src/dosext/dpmi/dnative/dnative.c
+++ b/src/dosext/dpmi/dnative/dnative.c
@@ -109,7 +109,7 @@ static void copy_to_dpmi(sigcontext_t *scp, cpuctx_t *s)
   scp_fpregs = NULL;
 }
 
-void native_dpmi_update_fpu(const emu_fpstate *fpstate)
+void native_dpmi_set_fpu_state(const emu_fpstate *fpstate)
 {
   if (scp_fpregs) {
     void *fpregs = scp_fpregs;
@@ -125,11 +125,6 @@ void native_dpmi_update_fpu(const emu_fpstate *fpstate)
 #endif
     memcpy(fpregs, fpstate, sizeof(*fpstate));
   }
-}
-
-void native_dpmi_enter_from_vm86(const emu_fpstate *fpstate)
-{
-  native_dpmi_update_fpu(fpstate);
 }
 
 static void copy_to_emu(cpuctx_t *d, sigcontext_t *scp)
@@ -157,7 +152,7 @@ static void copy_to_emu(cpuctx_t *d, sigcontext_t *scp)
   scp_fpregs = scp->fpregs;
 }
 
-void native_dpmi_leave_to_vm86(emu_fpstate *fpstate)
+void native_dpmi_get_fpu_state(emu_fpstate *fpstate)
 {
   if (scp_fpregs) {
     void *fpregs = scp_fpregs;

--- a/src/dosext/dpmi/dnative/dnative.h
+++ b/src/dosext/dpmi/dnative/dnative.h
@@ -9,8 +9,9 @@ int native_dpmi_control(cpuctx_t *scp);
 int native_dpmi_exit(cpuctx_t *scp);
 void native_dpmi_enter(void);
 void native_dpmi_leave(void);
-void native_dpmi_enter_from_vm86(void);
-void native_dpmi_leave_to_vm86(void);
+void native_dpmi_enter_from_vm86(const emu_fpstate *fpstate);
+void native_dpmi_leave_to_vm86(emu_fpstate *fpstate);
+void native_dpmi_update_fpu(const emu_fpstate *fpstate);
 void dpmi_return(sigcontext_t *scp, int retcode);
 
 #else
@@ -43,11 +44,15 @@ static inline void native_dpmi_leave(void)
 {
 }
 
-static inline void native_dpmi_enter_from_vm86(void)
+static inline void native_dpmi_enter_from_vm86(const emu_fpstate *fpstate)
 {
 }
 
-static inline void native_dpmi_leave_to_vm86(void)
+static inline void native_dpmi_leave_to_vm86(emu_fpstate *fpstate)
+{
+}
+
+static inline void native_dpmi_update_fpu(const emu_fpstate *fpstate)
 {
 }
 

--- a/src/dosext/dpmi/dnative/dnative.h
+++ b/src/dosext/dpmi/dnative/dnative.h
@@ -9,9 +9,8 @@ int native_dpmi_control(cpuctx_t *scp);
 int native_dpmi_exit(cpuctx_t *scp);
 void native_dpmi_enter(void);
 void native_dpmi_leave(void);
-void native_dpmi_enter_from_vm86(const emu_fpstate *fpstate);
-void native_dpmi_leave_to_vm86(emu_fpstate *fpstate);
-void native_dpmi_update_fpu(const emu_fpstate *fpstate);
+void native_dpmi_get_fpu_state(emu_fpstate *fpstate);
+void native_dpmi_set_fpu_state(const emu_fpstate *fpstate);
 void dpmi_return(sigcontext_t *scp, int retcode);
 
 #else
@@ -44,15 +43,11 @@ static inline void native_dpmi_leave(void)
 {
 }
 
-static inline void native_dpmi_enter_from_vm86(const emu_fpstate *fpstate)
+static inline void native_dpmi_set_fpu_state(const emu_fpstate *fpstate)
 {
 }
 
-static inline void native_dpmi_leave_to_vm86(emu_fpstate *fpstate)
-{
-}
-
-static inline void native_dpmi_update_fpu(const emu_fpstate *fpstate)
+static inline void native_dpmi_get_fpu_state(emu_fpstate *fpstate)
 {
 }
 

--- a/src/dosext/dpmi/dnative/dnative.h
+++ b/src/dosext/dpmi/dnative/dnative.h
@@ -9,6 +9,8 @@ int native_dpmi_control(cpuctx_t *scp);
 int native_dpmi_exit(cpuctx_t *scp);
 void native_dpmi_enter(void);
 void native_dpmi_leave(void);
+void native_dpmi_enter_from_vm86(void);
+void native_dpmi_leave_to_vm86(void);
 void dpmi_return(sigcontext_t *scp, int retcode);
 
 #else
@@ -38,6 +40,14 @@ static inline void native_dpmi_enter(void)
 }
 
 static inline void native_dpmi_leave(void)
+{
+}
+
+static inline void native_dpmi_enter_from_vm86(void)
+{
+}
+
+static inline void native_dpmi_leave_to_vm86(void)
 {
 }
 

--- a/src/dosext/dpmi/dnative/sigsegv.c
+++ b/src/dosext/dpmi/dnative/sigsegv.c
@@ -122,7 +122,6 @@ static void dosemu_fault1(int signum, sigcontext_t *scp)
     if (_scp_trapno == 0x10) {
       dbug_printf("coprocessor exception, calling IRQ13\n");
       print_exception_info(scp);
-      pic_untrigger(13);
       pic_request(13);
       dpmi_return(scp, DPMI_RET_DOSEMU);
       return;

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -427,6 +427,9 @@ static void leave_backend(int be, int pm)
   case CPUVM_NATIVE:
     native_dpmi_leave_to_vm86();
     break;
+  case CPUVM_EMU:
+    e_leave();
+    break;
   }
 }
 
@@ -438,6 +441,9 @@ static void enter_backend(int be, int pm)
     break;
   case CPUVM_NATIVE:
     native_dpmi_enter_from_vm86();
+    break;
+  case CPUVM_EMU:
+    e_enter();
     break;
   }
 }

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -468,7 +468,7 @@ static void dpmi_set_pm(int pm)
   }
   dpmi_pm = pm;
   if (config.cpu_vm != config.cpu_vm_dpmi) {
-    emu_fpstate fpstate;
+    static emu_fpstate fpstate;
     leave_backend(pm ? config.cpu_vm : config.cpu_vm_dpmi, !pm, &fpstate);
     enter_backend(!pm ? config.cpu_vm : config.cpu_vm_dpmi, pm, &fpstate);
   }

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -420,7 +420,7 @@ static void print_ldt(void)
 
 static void dpmi_set_pm(int pm)
 {
-  static emu_fpstate fpstate;
+  emu_fpstate fpstate;
   assert(pm <= 1);
   if (pm == dpmi_pm) {
     if (!pm)

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -420,14 +420,26 @@ static void print_ldt(void)
 
 static void leave_backend(int be, int pm)
 {
-  if (be == CPUVM_KVM)
+  switch(be) {
+  case CPUVM_KVM:
     kvm_leave(pm);
+    break;
+  case CPUVM_NATIVE:
+    native_dpmi_leave_to_vm86();
+    break;
+  }
 }
 
 static void enter_backend(int be, int pm)
 {
-  if (be == CPUVM_KVM)
+  switch(be) {
+  case CPUVM_KVM:
     kvm_enter(pm);
+    break;
+  case CPUVM_NATIVE:
+    native_dpmi_enter_from_vm86();
+    break;
+  }
 }
 
 static void dpmi_set_pm(int pm)

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -430,6 +430,11 @@ static void leave_backend(int be, int pm)
   case CPUVM_EMU:
     e_leave();
     break;
+#ifdef __i386__
+  case CPUVM_VM86:
+    true_vm86_leave();
+    break;
+#endif
   }
 }
 
@@ -445,6 +450,11 @@ static void enter_backend(int be, int pm)
   case CPUVM_EMU:
     e_enter();
     break;
+#ifdef __i386__
+  case CPUVM_VM86:
+    true_vm86_enter();
+    break;
+#endif
   }
 }
 

--- a/src/include/cpu-emu.h
+++ b/src/include/cpu-emu.h
@@ -97,8 +97,9 @@ void reset_emu_cpu (void);
 int e_dpmi(cpuctx_t *scp);
 void e_dpmi_b0x(int op,cpuctx_t *scp);
 extern int in_dpmi_emu;
-void e_enter(void);
-void e_leave(void);
+void e_enter(const emu_fpstate *fpstate);
+void e_leave(emu_fpstate *fpstate);
+void e_update_fpu(const emu_fpstate *fpstate);
 
 /* called from emu-ldt.c */
 void InvalidateSegs(void);

--- a/src/include/cpu-emu.h
+++ b/src/include/cpu-emu.h
@@ -97,9 +97,8 @@ void reset_emu_cpu (void);
 int e_dpmi(cpuctx_t *scp);
 void e_dpmi_b0x(int op,cpuctx_t *scp);
 extern int in_dpmi_emu;
-void e_enter(const emu_fpstate *fpstate);
-void e_leave(emu_fpstate *fpstate);
-void e_update_fpu(const emu_fpstate *fpstate);
+void e_get_fpu_state(emu_fpstate *fpstate);
+void e_set_fpu_state(const emu_fpstate *fpstate);
 
 /* called from emu-ldt.c */
 void InvalidateSegs(void);

--- a/src/include/cpu-emu.h
+++ b/src/include/cpu-emu.h
@@ -97,6 +97,8 @@ void reset_emu_cpu (void);
 int e_dpmi(cpuctx_t *scp);
 void e_dpmi_b0x(int op,cpuctx_t *scp);
 extern int in_dpmi_emu;
+void e_enter(void);
+void e_leave(void);
 
 /* called from emu-ldt.c */
 void InvalidateSegs(void);

--- a/src/include/cpu.h
+++ b/src/include/cpu.h
@@ -73,6 +73,12 @@ struct emu_fsave {
   uint32_t		status;
 };
 
+struct emu_fpxreg {
+  uint16_t		significand[4];
+  uint16_t		exponent;
+  uint16_t		reserved[3];
+};
+
 struct emu_fpxstate {
   /* 32-bit FXSAVE format in 64bit mode (same as in 32bit mode but more xmms) */
   uint16_t		cwd;
@@ -85,7 +91,7 @@ struct emu_fpxstate {
   uint32_t		fds;
   uint32_t		mxcsr;
   uint32_t		mxcr_mask;
-  struct { uint32_t element[4]; } st[8];
+  struct emu_fpxreg	st[8];
   struct { uint32_t element[4]; } xmm[16];
   struct { uint32_t element[4]; } reserved[3];
   struct { uint32_t element[4]; } scratch[3];

--- a/src/include/cpu.h
+++ b/src/include/cpu.h
@@ -232,7 +232,6 @@ static inline dosaddr_t FAR2ADDR(far_t ptr) {
 
 #define peek(seg, off)	(READ_WORD(SEGOFF2LINEAR(seg, off)))
 
-extern emu_fpstate vm86_fpu_state;
 extern fenv_t dosemu_fenv;
 
 /*

--- a/src/include/cpu.h
+++ b/src/include/cpu.h
@@ -108,6 +108,9 @@ void fsave_to_fxsave(const struct emu_fsave *fptr,
 typedef struct emu_fpxstate emu_fpstate;
 typedef emu_fpstate *emu_fpregset_t;
 
+void get_fpu_state(emu_fpstate *);
+void set_fpu_state(const emu_fpstate *);
+
 union g_reg {
   greg_t reg;
 #ifdef __x86_64__

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -104,6 +104,8 @@ extern FILE *real_stderr;
 void dos_ctrl_alt_del(void);	/* disabled */
 
 extern void vm86_helper(void);
+extern void true_vm86_enter(void);
+extern void true_vm86_leave(void);
 extern void run_vm86(void);
 extern void loopstep_run_vm86(void);
 extern int do_call_back(Bit16u cs, Bit16u ip);

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -104,9 +104,8 @@ extern FILE *real_stderr;
 void dos_ctrl_alt_del(void);	/* disabled */
 
 extern void vm86_helper(void);
-extern void true_vm86_enter(const emu_fpstate *fpstate);
-extern void true_vm86_leave(emu_fpstate *fpstate);
-extern void true_vm86_update_fpu(const emu_fpstate *fpstate);
+extern void true_vm86_get_fpu_state(emu_fpstate *fpstate);
+extern void true_vm86_set_fpu_state(const emu_fpstate *fpstate);
 extern void run_vm86(void);
 extern void loopstep_run_vm86(void);
 extern int do_call_back(Bit16u cs, Bit16u ip);

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -104,8 +104,9 @@ extern FILE *real_stderr;
 void dos_ctrl_alt_del(void);	/* disabled */
 
 extern void vm86_helper(void);
-extern void true_vm86_enter(void);
-extern void true_vm86_leave(void);
+extern void true_vm86_enter(const emu_fpstate *fpstate);
+extern void true_vm86_leave(emu_fpstate *fpstate);
+extern void true_vm86_update_fpu(const emu_fpstate *fpstate);
 extern void run_vm86(void);
 extern void loopstep_run_vm86(void);
 extern int do_call_back(Bit16u cs, Bit16u ip);

--- a/src/include/kvm.h
+++ b/src/include/kvm.h
@@ -33,9 +33,9 @@ void set_kvm_memory_regions(void);
 void kvm_set_idt_default(int i);
 void kvm_set_idt(int i, uint16_t sel, uint32_t offs, int is_32, int tg);
 
-void kvm_enter(int pm);
-void kvm_leave(int pm);
-void kvm_update_fpu(void);
+void kvm_enter(int pm, const emu_fpstate *fpstate);
+void kvm_leave(int pm, emu_fpstate *fpstate);
+void kvm_update_fpu(const emu_fpstate *fpstate);
 
 void kvm_done(void);
 
@@ -51,9 +51,9 @@ static inline void set_kvm_memory_regions(void) {}
 static inline void kvm_set_idt_default(int i) {}
 static inline void kvm_set_idt(int i, uint16_t sel, uint32_t offs, int is_32,
     int tg) {}
-static inline void kvm_enter(int pm) {}
-static inline void kvm_leave(int pm) {}
-static inline void kvm_update_fpu(void) {}
+static inline void kvm_enter(int pm, const emu_fpstate *fpstate) {}
+static inline void kvm_leave(int pm, emu_fpstate *fpstate) {}
+static inline void kvm_update_fpu(const emu_fpstate *fpstate) {}
 static inline void kvm_done(void) {}
 #endif
 

--- a/src/include/kvm.h
+++ b/src/include/kvm.h
@@ -33,9 +33,8 @@ void set_kvm_memory_regions(void);
 void kvm_set_idt_default(int i);
 void kvm_set_idt(int i, uint16_t sel, uint32_t offs, int is_32, int tg);
 
-void kvm_enter(int pm, const emu_fpstate *fpstate);
-void kvm_leave(int pm, emu_fpstate *fpstate);
-void kvm_update_fpu(const emu_fpstate *fpstate);
+void kvm_get_fpu_state(emu_fpstate *fpstate);
+void kvm_set_fpu_state(const emu_fpstate *fpstate);
 
 void kvm_done(void);
 
@@ -51,9 +50,8 @@ static inline void set_kvm_memory_regions(void) {}
 static inline void kvm_set_idt_default(int i) {}
 static inline void kvm_set_idt(int i, uint16_t sel, uint32_t offs, int is_32,
     int tg) {}
-static inline void kvm_enter(int pm, const emu_fpstate *fpstate) {}
-static inline void kvm_leave(int pm, emu_fpstate *fpstate) {}
-static inline void kvm_update_fpu(const emu_fpstate *fpstate) {}
+static inline void kvm_set_fpu_state(const emu_fpstate *fpstate) {}
+static inline void kvm_get_fpu_state(emu_fpstate *fpstate) {}
 static inline void kvm_done(void) {}
 #endif
 


### PR DESCRIPTION
This avoids copying FPU state when it's not necessary, similar to how its done for KVM.

I tested with real vm86 to make sure it all works!