### PR TITLE
Cleanup mapping

### DIFF
--- a/src/arch/linux/async/signal.c
+++ b/src/arch/linux/async/signal.c
@@ -132,9 +132,8 @@ static void iret_frame_alloc(void)
         for (j = 0; j < 0x10000; j += PAGE_SIZE) {
             addr = (void *) (i * 0x100000000UL + j);
             iret_frame =
-                mmap_mapping_ux(MAPPING_SCRATCH | MAPPING_NOOVERLAP,
-                                addr, PAGE_SIZE,
-                                    PROT_READ | PROT_WRITE);
+                mmap_mapping(MAPPING_SCRATCH | MAPPING_NOOVERLAP,
+                             addr, PAGE_SIZE, PROT_READ | PROT_WRITE);
             if (iret_frame != MAP_FAILED)
                 goto out;
         }

--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -463,18 +463,6 @@ void *mmap_mapping_ux(int cap, void *target, size_t mapsize, int protect)
 		MAP_PRIVATE | flags | MAP_ANONYMOUS, -1, 0);
 }
 
-void *mmap_file_ux(int cap, void *target, size_t mapsize, int protect,
-    int flags, int fd)
-{
-  void *addr = mmap(target, mapsize, protect, flags, fd, 0);
-  if (addr == MAP_FAILED)
-    return MAP_FAILED;
-  if (is_kvm_map(cap))
-    /* Map guest memory in KVM */
-    mmap_kvm(cap, addr, mapsize, protect);
-  return addr;
-}
-
 /* Restore mapping previously broken by direct mmap() call. */
 int restore_mapping(int cap, dosaddr_t targ, size_t mapsize)
 {
@@ -500,44 +488,6 @@ int unalias_mapping_high(int cap, dosaddr_t targ, size_t mapsize)
   }
   ret |= smfree(&main_pool, target);
   return ret;
-}
-
-static void *do_mremap_grow(int cap, dosaddr_t from, size_t old_size,
-    size_t new_size)
-{
-#ifdef __linux__
-  void *old_ptr = MEM_BASE32(from);
-  void *ptr = mremap(old_ptr, old_size, new_size, MREMAP_MAYMOVE);
-  Q__printf("MAPPING: remap(grow), cap=%s, from=%x, old=%zx, new=%zx, %p\n",
-	cap, from, old_size, new_size, ptr);
-  if (ptr == MAP_FAILED)
-    return MAP_FAILED;
-  if (is_kvm_map(cap)) {
-    munmap_kvm(cap | MAPPING_IMMEDIATE, from, old_size);
-    mmap_kvm(cap | MAPPING_IMMEDIATE, ptr, new_size,
-        PROT_READ | PROT_WRITE | PROT_EXEC);
-  }
-  return ptr;
-#else
-  return MAP_FAILED;
-#endif
-}
-
-void *mremap_mapping(int cap, dosaddr_t from, size_t old_size, size_t new_size)
-{
-  dosaddr_t unm;
-  assert(new_size != old_size && !(from & (PAGE_SIZE - 1)) &&
-      !(old_size & (PAGE_SIZE - 1)) && !(new_size & (PAGE_SIZE - 1)));
-  if (new_size > old_size)
-    return do_mremap_grow(cap, from, old_size, new_size);
-  /* shrink is simple */
-  Q__printf("MAPPING: remap(shrink), cap=%s, from=%x, old=%zx, new=%zx\n",
-	cap, from, old_size, new_size);
-  unm = from + new_size;
-  munmap(MEM_BASE32(unm), old_size - new_size);
-  if (is_kvm_map(cap))
-    munmap_kvm(cap | MAPPING_IMMEDIATE, unm, old_size - new_size);
-  return MEM_BASE32(from);
 }
 
 int mprotect_mapping(int cap, dosaddr_t targ, size_t mapsize, int protect)
@@ -770,17 +720,6 @@ void *realloc_mapping(int cap, void *addr, size_t oldsize, size_t newsize)
   if (!oldsize)
     dosemu_error("realloc_mapping() addr=%p, oldsize=0\n", addr);
   return mappingdriver->realloc(cap, addr, oldsize, newsize);
-}
-
-int munmap_mapping(int cap, dosaddr_t targ, size_t mapsize)
-{
-#ifdef __linux__
-  assert(kmem_mapped(targ, mapsize) == 0);
-#endif
-  munmap(MEM_BASE32(targ), mapsize);
-  if (is_kvm_map(cap))
-    munmap_kvm(cap, targ, mapsize);
-  return 0;
 }
 
 struct hardware_ram {

--- a/src/base/emu-i386/kvm.c
+++ b/src/base/emu-i386/kvm.c
@@ -219,8 +219,8 @@ void init_kvm_monitor(dosaddr_t monitor_dosaddr)
     return;
 
   /* create monitor structure in memory */
-  monitor = mmap_mapping_ux(MAPPING_SCRATCH|MAPPING_KVM, (void *)-1,
-			    sizeof(*monitor), PROT_READ | PROT_WRITE);
+  monitor = mmap_mapping(MAPPING_SCRATCH|MAPPING_KVM, (void *)-1,
+			 sizeof(*monitor), PROT_READ | PROT_WRITE);
   /* exclude special regions for KVM-internal TSS and identity page */
   mmap_kvm(MAPPING_SCRATCH|MAPPING_KVM, monitor,
 	offsetof(struct monitor, kvm_tss),

--- a/src/base/emu-i386/kvm.c
+++ b/src/base/emu-i386/kvm.c
@@ -361,6 +361,11 @@ static int init_kvm_vcpu(void)
      this is only really needed if the vcpu is started in real mode and
      the kernel needs to emulate that using V86 mode, as is necessary
      on Nehalem and earlier Intel CPUs */
+  ret = ioctl(kvmfd, KVM_CHECK_EXTENSION, KVM_CAP_SET_TSS_ADDR);
+  if (ret <= 0) {
+    error("KVM: SET_TSS_ADDR unsupported %x\n", ret);
+    return 0;
+  }
   ret = ioctl(vmfd, KVM_SET_TSS_ADDR,
 	      sregs.tr.base + offsetof(struct monitor, kvm_tss));
   if (ret == -1) {
@@ -368,6 +373,11 @@ static int init_kvm_vcpu(void)
     return 0;
   }
 
+  ret = ioctl(kvmfd, KVM_CHECK_EXTENSION, KVM_CAP_SET_IDENTITY_MAP_ADDR);
+  if (ret <= 0) {
+    error("KVM: SET_IDENTITY_MAP_ADDR unsupported %x\n", ret);
+    return 0;
+  }
   uint64_t addr = sregs.tr.base + offsetof(struct monitor, kvm_identity_map);
   ret = ioctl(vmfd, KVM_SET_IDENTITY_MAP_ADDR, &addr);
   if (ret == -1) {

--- a/src/base/emu-i386/kvm.c
+++ b/src/base/emu-i386/kvm.c
@@ -554,14 +554,6 @@ static void do_munmap_kvm(dosaddr_t targ, size_t mapsize)
   }
 }
 
-void munmap_kvm(int cap, dosaddr_t targ, size_t mapsize)
-{
-  if (cap & MAPPING_IMMEDIATE)
-    do_munmap_kvm(targ, mapsize);
-  else
-    check_overlap_kvm(targ, mapsize);
-}
-
 void mmap_kvm(int cap, void *addr, size_t mapsize, int protect)
 {
   dosaddr_t targ;

--- a/src/base/emu-i386/kvm.c
+++ b/src/base/emu-i386/kvm.c
@@ -561,8 +561,6 @@ void mmap_kvm(int cap, void *addr, size_t mapsize, int protect, dosaddr_t targ)
   int slot;
 
   assert(cap & (MAPPING_INIT_LOWRAM|MAPPING_KVM));
-  if (cap & MAPPING_KMEM)
-    cap |= MAPPING_KVM_UC;
   /* with KVM we need to manually remove/shrink existing mappings */
   if (cap & MAPPING_IMMEDIATE)
     do_munmap_kvm(targ, mapsize);
@@ -602,8 +600,6 @@ void mprotect_kvm(int cap, dosaddr_t targ, size_t mapsize, int protect)
       monitor->pte[page] |= PG_PRESENT | PG_USER;
     if (cap & MAPPING_KVM)
       monitor->pte[page] &= ~PG_USER;
-    if (cap & MAPPING_KVM_UC)
-      monitor->pte[page] |= PG_DC;
   }
 
   mprotected_kvm = 1;

--- a/src/base/emu-i386/kvm.c
+++ b/src/base/emu-i386/kvm.c
@@ -560,9 +560,7 @@ void mmap_kvm(int cap, void *addr, size_t mapsize, int protect, dosaddr_t targ)
 {
   int slot;
 
-  if (!(cap & (MAPPING_INIT_LOWRAM|MAPPING_VGAEMU|MAPPING_KMEM|MAPPING_KVM|
-      MAPPING_IMMEDIATE)))
-    return;
+  assert(cap & (MAPPING_INIT_LOWRAM|MAPPING_KVM));
   if (cap & MAPPING_KMEM)
     cap |= MAPPING_KVM_UC;
   /* with KVM we need to manually remove/shrink existing mappings */

--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -278,8 +278,8 @@ static void *mem_reserve(uint32_t memsize, uint32_t dpmi_size)
 
 #ifdef __i386__
   if (config.cpu_vm == CPUVM_VM86) {
-    result = mmap_mapping_ux(MAPPING_NULL | MAPPING_SCRATCH,
-			     NULL, memsize, PROT_NONE);
+    result = mmap_mapping(MAPPING_NULL | MAPPING_SCRATCH,
+			  NULL, memsize, PROT_NONE);
     if (result == MAP_FAILED) {
       const char *msg =
 	"You can most likely avoid this problem by running\n"
@@ -306,7 +306,7 @@ static void *mem_reserve(uint32_t memsize, uint32_t dpmi_size)
   }
 #endif
 
-  result = mmap_mapping_ux(cap, (void *)-1, memsize + dpmi_size, prot);
+  result = mmap_mapping(cap, (void *)-1, memsize + dpmi_size, prot);
   if (result == MAP_FAILED) {
     perror ("LOWRAM mmap");
     exit(EXIT_FAILURE);

--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -351,7 +351,7 @@ void low_mem_init(void)
   if (config.cpu_vm == CPUVM_KVM || config.cpu_vm_dpmi == CPUVM_KVM) {
     init_kvm_monitor();
     mmap_kvm(MAPPING_INIT_LOWRAM, mem_base, memsize + dpmi_size,
-	    PROT_READ | PROT_WRITE);
+	    PROT_READ | PROT_WRITE, 0);
   }
   result = alias_mapping(MAPPING_INIT_LOWRAM, 0, memsize,
 			 PROT_READ | PROT_WRITE | PROT_EXEC, lowmem);

--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -349,7 +349,7 @@ void low_mem_init(void)
 
   mem_base = mem_reserve(memsize, dpmi_size);
   if (config.cpu_vm == CPUVM_KVM || config.cpu_vm_dpmi == CPUVM_KVM) {
-    init_kvm_monitor();
+    init_kvm_monitor(memsize + dpmi_size);
     mmap_kvm(MAPPING_INIT_LOWRAM, mem_base, memsize + dpmi_size,
 	    PROT_READ | PROT_WRITE, 0);
   }

--- a/src/dosext/dpmi/dmemory.h
+++ b/src/dosext/dpmi/dmemory.h
@@ -51,6 +51,5 @@ int DPMI_GetPageAttributes(dpmi_pm_block_root *root, unsigned long handle, int o
 int dpmi_lin_mem_rsv(void);
 int dpmi_lin_mem_free(void);
 int dpmi_free_memory(void);
-void dpmi_set_map_flags(int cap);
 
 #endif

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -3656,8 +3656,6 @@ void dpmi_setup(void)
 
     if (!config.dpmi) return;
 
-    dpmi_set_map_flags(0);
-
     get_ldt(ldt_buffer);
     memset(Segments, 0, sizeof(Segments));
     for (i = 0; i < MAX_SELECTORS; i++) {
@@ -3756,7 +3754,6 @@ void dpmi_setup(void)
       break;
     }
 
-    dpmi_set_map_flags(MAPPING_IMMEDIATE);
     return;
 
 err:

--- a/src/include/kvm.h
+++ b/src/include/kvm.h
@@ -22,7 +22,7 @@
 #ifdef USE_KVM
 /* kvm functions */
 int init_kvm_cpu(void);
-void init_kvm_monitor(void);
+void init_kvm_monitor(dosaddr_t monitor_dosaddr);
 int kvm_vm86(struct vm86_struct *info);
 int kvm_dpmi(cpuctx_t *scp);
 void mprotect_kvm(int cap, dosaddr_t targ, size_t mapsize, int protect);
@@ -40,7 +40,7 @@ void kvm_done(void);
 
 #else
 static inline int init_kvm_cpu(void) { return -1; }
-static inline void init_kvm_monitor(void) {}
+static inline void init_kvm_monitor(dosaddr_t monitor_dosaddr) {}
 static inline int kvm_vm86(struct vm86_struct *info) { return -1; }
 static inline int kvm_dpmi(cpuctx_t *scp) { return -1; }
 static inline void mprotect_kvm(int cap, dosaddr_t targ, size_t mapsize, int protect) {}

--- a/src/include/kvm.h
+++ b/src/include/kvm.h
@@ -26,7 +26,7 @@ void init_kvm_monitor(void);
 int kvm_vm86(struct vm86_struct *info);
 int kvm_dpmi(cpuctx_t *scp);
 void mprotect_kvm(int cap, dosaddr_t targ, size_t mapsize, int protect);
-void mmap_kvm(int cap, void *addr, size_t mapsize, int protect);
+void mmap_kvm(int cap, void *addr, size_t mapsize, int protect, dosaddr_t targ);
 void set_kvm_memory_regions(void);
 
 void kvm_set_idt_default(int i);
@@ -44,7 +44,7 @@ static inline void init_kvm_monitor(void) {}
 static inline int kvm_vm86(struct vm86_struct *info) { return -1; }
 static inline int kvm_dpmi(cpuctx_t *scp) { return -1; }
 static inline void mprotect_kvm(int cap, dosaddr_t targ, size_t mapsize, int protect) {}
-static inline void mmap_kvm(int cap, void *addr, size_t mapsize, int protect) {}
+static inline void mmap_kvm(int cap, void *addr, size_t mapsize, int protect, dosaddr_t targ) {}
 static inline void munmap_kvm(int cap, dosaddr_t targ, size_t mapsize) {}
 static inline void set_kvm_memory_regions(void) {}
 static inline void kvm_set_idt_default(int i) {}

--- a/src/include/kvm.h
+++ b/src/include/kvm.h
@@ -27,7 +27,6 @@ int kvm_vm86(struct vm86_struct *info);
 int kvm_dpmi(cpuctx_t *scp);
 void mprotect_kvm(int cap, dosaddr_t targ, size_t mapsize, int protect);
 void mmap_kvm(int cap, void *addr, size_t mapsize, int protect);
-void munmap_kvm(int cap, dosaddr_t targ, size_t mapsize);
 void set_kvm_memory_regions(void);
 
 void kvm_set_idt_default(int i);

--- a/src/include/mapping.h
+++ b/src/include/mapping.h
@@ -79,11 +79,7 @@ void free_mapping (int cap, void *addr, size_t mapsize);
 typedef void *realloc_mapping_type(int cap, void *addr, size_t oldsize, size_t newsize);
 void *realloc_mapping (int cap, void *addr, size_t oldsize, size_t newsize);
 
-void *mremap_mapping(int cap, dosaddr_t from, size_t old_size,
-    size_t new_size);
 void *mmap_mapping_ux(int cap, void *target, size_t mapsize, int protect);
-void *mmap_file_ux(int cap, void *target, size_t mapsize, int protect,
-    int flags, int fd);
 
 typedef void *alias_mapping_type(int cap, void *target, size_t mapsize, int protect, void *source);
 int alias_mapping(int cap, dosaddr_t targ, size_t mapsize, int protect, void *source);

--- a/src/include/mapping.h
+++ b/src/include/mapping.h
@@ -78,7 +78,7 @@ void free_mapping (int cap, void *addr, size_t mapsize);
 typedef void *realloc_mapping_type(int cap, void *addr, size_t oldsize, size_t newsize);
 void *realloc_mapping (int cap, void *addr, size_t oldsize, size_t newsize);
 
-void *mmap_mapping_ux(int cap, void *target, size_t mapsize, int protect);
+void *mmap_mapping(int cap, void *target, size_t mapsize, int protect);
 
 typedef void *alias_mapping_type(int cap, void *target, size_t mapsize, int protect, void *source);
 int alias_mapping(int cap, dosaddr_t targ, size_t mapsize, int protect, void *source);

--- a/src/include/mapping.h
+++ b/src/include/mapping.h
@@ -46,7 +46,6 @@
 #define MAPPING_KVM		0x000800
 #define MAPPING_IMMEDIATE	0x001000
 #define MAPPING_CPUEMU		0x002000
-#define MAPPING_KVM_UC		0x004000
 
 /* usage as: (kind of mapping required) */
 #define MAPPING_KMEM		0x010000


### PR DESCRIPTION
This mostly removes unused code, so it's clearer where mmap_kvm is used (only two places left), which will be needed for dirty page logging.

There are two changes though:
1. MAPPING_NOOVERLAP now applies to mmap_mapping_ux because it is called that way for the (legacy) native DPMI iret trampoline (only for SIGRETURN_WA), the relevant code was in the wrong function.
2. For KVM the monitor's guest address is now at a defined value immediately behind the main pool, instead of DOSADDR_REL(monitor), which was a bit dodgy since monitor is a general 64-bit allocation.