### PR TITLE
Introduce KVM base

### DIFF
--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -583,7 +583,6 @@ char *decode_mapping_cap(int cap)
     if (cap & MAPPING_HGC) p += sprintf(p, " HGC");
     if (cap & MAPPING_HMA) p += sprintf(p, " HMA");
     if (cap & MAPPING_SHARED) p += sprintf(p, " SHARED");
-    if (cap & MAPPING_IMMEDIATE) p += sprintf(p, " IMMEDIATE");
     if (cap & MAPPING_INIT_HWRAM) p += sprintf(p, " INIT_HWRAM");
     if (cap & MAPPING_INIT_LOWRAM) p += sprintf(p, " INIT_LOWRAM");
     if (cap & MAPPING_EXTMEM) p += sprintf(p, " EXTMEM");

--- a/src/include/mapping.h
+++ b/src/include/mapping.h
@@ -44,8 +44,7 @@
 #define MAPPING_INIT_LOWRAM	0x000200
 #define MAPPING_EXTMEM		0x000400
 #define MAPPING_KVM		0x000800
-#define MAPPING_IMMEDIATE	0x001000
-#define MAPPING_CPUEMU		0x002000
+#define MAPPING_CPUEMU		0x001000
 
 /* usage as: (kind of mapping required) */
 #define MAPPING_KMEM		0x010000


### PR DESCRIPTION
This is quite the minimal change introducing KVM_BASE. See #198 for details.

For now it's identical to MEM_BASE for low memory but the memory protections can be permanently unprotected for it once dirty logging is in.