### PR TITLE
Align KVM mappings at 2MB and print slot info.

### DIFF
--- a/src/base/emu-i386/kvm.c
+++ b/src/base/emu-i386/kvm.c
@@ -487,7 +487,11 @@ kvm_get_memory_region(dosaddr_t dosaddr, dosaddr_t size)
 
 static void set_kvm_memory_region(struct kvm_userspace_memory_region *region)
 {
-  int ret = ioctl(vmfd, KVM_SET_USER_MEMORY_REGION, region);
+  int ret;
+  Q_printf("KVM: map slot=%d flags=%d dosaddr=0x%08llx size=0x%08llx unixaddr=0x%llx\n",
+	   region->slot, region->flags, region->guest_phys_addr,
+	   region->memory_size, region->userspace_addr);
+  ret = ioctl(vmfd, KVM_SET_USER_MEMORY_REGION, region);
   if (ret == -1) {
     perror("KVM: KVM_SET_USER_MEMORY_REGION");
     leavedos_main(99);

--- a/src/base/emu-i386/kvm.c
+++ b/src/base/emu-i386/kvm.c
@@ -218,6 +218,9 @@ void init_kvm_monitor(dosaddr_t monitor_dosaddr)
   if (!cpuid)
     return;
 
+  /* align monitor to 2MB boundary */
+  monitor_dosaddr = HUGE_PAGE_ALIGN(monitor_dosaddr);
+
   /* create monitor structure in memory */
   monitor = mmap_mapping(MAPPING_SCRATCH|MAPPING_KVM, (void *)-1,
 			 sizeof(*monitor), PROT_READ | PROT_WRITE);

--- a/src/include/mapping.h
+++ b/src/include/mapping.h
@@ -24,6 +24,10 @@
 #endif
 #define EMM_PAGE_SIZE	(16*1024)
 
+#define HUGE_PAGE_SIZE ((uintptr_t)(2*1024*1024))
+#define HUGE_PAGE_MASK	(~(HUGE_PAGE_SIZE-1))
+#define HUGE_PAGE_ALIGN(addr)	(((addr)+HUGE_PAGE_SIZE-1)&HUGE_PAGE_MASK)
+
 #define Q__printf(f,cap,a...) ({\
   Q_printf(f,decode_mapping_cap(cap),##a); \
 })


### PR DESCRIPTION
KVM api.txt (https://docs.kernel.org/virt/kvm/api.html#kvm-set-user-memory-region) recommends that the lower 21 bits of guest_phys_addr and userspace_addr be identical. This also helps debugging, since subtracting hex numbers is much easier that way for a human being, so always have mem_base aligned that way even without KVM.
