### PR TITLE
smalloc: add sminit_comu() func [#1902]

### DIFF
--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -364,7 +364,7 @@ void low_mem_init(void)
   if (config.xms_size)
     config.xms_map_size = (mem_16M - (memsize + EXTMEM_SIZE)) & PAGE_MASK;
 
-  sminit_com(&main_pool, mem_base, memsize + dpmi_size, mcommit, muncommit);
+  sminit_comu(&main_pool, mem_base, memsize + dpmi_size, mcommit, muncommit);
   ptr = smalloc(&main_pool, memsize);
   assert(ptr == mem_base);
   /* smalloc uses PROT_READ | PROT_WRITE, needs to add PROT_EXEC here */

--- a/src/base/lib/misc/smalloc.c
+++ b/src/base/lib/misc/smalloc.c
@@ -583,16 +583,30 @@ int sminit(struct mempool *mp, void *start, size_t size)
   return 0;
 }
 
-int sminit_com(struct mempool *mp, void *start, size_t size,
+static int do_sminit_com(struct mempool *mp, void *start, size_t size,
     int (*commit)(void *area, size_t size),
-    int (*uncommit)(void *area, size_t size))
+    int (*uncommit)(void *area, size_t size), int do_uncommit)
 {
   sminit(mp, start, size);
   mp->commit = commit;
   mp->uncommit = uncommit;
-  if (uncommit)
+  if (uncommit && do_uncommit)
     uncommit(start, size);
   return 0;
+}
+
+int sminit_com(struct mempool *mp, void *start, size_t size,
+    int (*commit)(void *area, size_t size),
+    int (*uncommit)(void *area, size_t size))
+{
+  return do_sminit_com(mp, start, size, commit, uncommit, 1);
+}
+
+int sminit_comu(struct mempool *mp, void *start, size_t size,
+    int (*commit)(void *area, size_t size),
+    int (*uncommit)(void *area, size_t size))
+{
+  return do_sminit_com(mp, start, size, commit, uncommit, 0);
 }
 
 void smfree_all(struct mempool *mp)

--- a/src/include/smalloc.h
+++ b/src/include/smalloc.h
@@ -41,6 +41,9 @@ int sminit(struct mempool *mp, void *start, size_t size);
 int sminit_com(struct mempool *mp, void *start, size_t size,
     int (*commit)(void *area, size_t size),
     int (*uncommit)(void *area, size_t size));
+int sminit_comu(struct mempool *mp, void *start, size_t size,
+    int (*commit)(void *area, size_t size),
+    int (*uncommit)(void *area, size_t size));
 void smfree_all(struct mempool *mp);
 int smdestroy(struct mempool *mp);
 size_t smget_free_space(struct mempool *mp);


### PR DESCRIPTION
Same as sminit_com() but doesn't call the initial uncommit. mem_reserve() in init.c uses PROT_NONE as a mapping prot so we do not need to uncommit that.