### PR TITLE
mapping: allow $_dpmi=(0).

### DIFF
--- a/src/arch/linux/mapping/mapfile.c
+++ b/src/arch/linux/mapping/mapfile.c
@@ -103,7 +103,7 @@ static int open_mapping_f(int cap)
     /* first estimate the needed size of the mapfile */
     mapsize  = HMASIZE >> 10;	/* HMA */
  				/* VGAEMU */
-    mapsize += config.vgaemu_memsize ? config.vgaemu_memsize : 1024;
+    mapsize += config.vgaemu_memsize;
     mapsize += config.ems_size;	/* EMS */
     mapsize += config.xms_size;	/* XMS */
     mapsize += LOWMEM_SIZE >> 10; /* Low Mem */

--- a/src/base/dev/vga/vgaemu.c
+++ b/src/base/dev/vga/vgaemu.c
@@ -1664,10 +1664,7 @@ int vga_emu_pre_init(void)
 
   open_mapping(MAPPING_VGAEMU);
 
-  if(config.vgaemu_memsize)
-    vga.mem.size = config.vgaemu_memsize << 10;
-  else
-    vga.mem.size = 1024 << 10;
+  vga.mem.size = config.vgaemu_memsize << 10;
 
   /* force 256k granularity to prevent possible problems
    * (with 4-plane-modes, to be precise)

--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -263,14 +263,17 @@ void device_init(void)
  *
  * description:
  *  reserves address space seen by DOS and DPMI apps
- *   There are three possibilities:
- *  1) 0-based mapping: one map at 0 of 1088k, the rest below 1G
+ *   There are two possibilities:
+ *  1) 0-based mapping: one map at 0 of 1088k, and the combined map
+ *     below.
  *     This is only used for i386 + vm86() (not KVM/CPUEMU)
- *  2) non-zero-based mapping: one combined mmap, everything below 4G
+ *  2) non-zero-based mapping: one combined mmap.
+ *     Everything needs to be below 4G for native DPMI
+ *     (intrinsically) and JIT CPUEMU (for now)
  *
  * DANG_END_FUNCTION
  */
-static void *mem_reserve(uint32_t memsize, uint32_t dpmi_size)
+static void *mem_reserve(uint32_t memsize)
 {
   void *result;
   int cap = MAPPING_INIT_LOWRAM | MAPPING_SCRATCH | MAPPING_DPMI;
@@ -279,7 +282,7 @@ static void *mem_reserve(uint32_t memsize, uint32_t dpmi_size)
 #ifdef __i386__
   if (config.cpu_vm == CPUVM_VM86) {
     result = mmap_mapping(MAPPING_NULL | MAPPING_SCRATCH,
-			  NULL, memsize, PROT_NONE);
+			  NULL, LOWMEM_SIZE + HMASIZE, PROT_NONE);
     if (result == MAP_FAILED) {
       const char *msg =
 	"You can most likely avoid this problem by running\n"
@@ -306,14 +309,15 @@ static void *mem_reserve(uint32_t memsize, uint32_t dpmi_size)
   }
 #endif
 
-  result = mmap_mapping(cap, (void *)-1, memsize + dpmi_size, prot);
+  result = mmap_mapping(cap, (void *)-1, memsize, prot);
   if (result == MAP_FAILED) {
     perror ("LOWRAM mmap");
     exit(EXIT_FAILURE);
   }
   if (config.cpu_vm_dpmi == CPUVM_KVM)
-    /* map only DPMI here, rest is done with KVM_BASE in alias_mapping */
-    mmap_kvm(cap, (unsigned char *)result + memsize, dpmi_size, prot, memsize);
+    /* map only high memory here, rest is done with KVM_BASE in alias_mapping */
+    mmap_kvm(cap, (unsigned char *)result + LOWMEM_SIZE + HMASIZE,
+	     memsize - (LOWMEM_SIZE + HMASIZE), prot, LOWMEM_SIZE + HMASIZE);
   return result;
 }
 
@@ -329,8 +333,7 @@ void low_mem_init(void)
 {
   void *lowmem, *ptr;
   int result;
-  uint32_t memsize = LOWMEM_SIZE + HMASIZE;
-  uint32_t dpmi_size = config.dpmi ? dpmi_lin_mem_rsv() : config.dpmi_base - memsize;
+  uint32_t memsize = config.dpmi ? LOWMEM_SIZE + HMASIZE + dpmi_lin_mem_rsv() : config.dpmi_base;
   int32_t dpmi_rsv_low, phys_rsv;
   const uint32_t mem_1M = 1024 * 1024;
   /* 16Mb limit is for being in reach of DMAc */
@@ -339,19 +342,19 @@ void low_mem_init(void)
   open_mapping(MAPPING_INIT_LOWRAM);
   g_printf ("DOS+HMA memory area being mapped in\n");
   /* reserve 1Mb for XMS mappings */
-  if (memsize + EXTMEM_SIZE > mem_16M - mem_1M) {
+  if (LOWMEM_SIZE + HMASIZE + EXTMEM_SIZE > mem_16M - mem_1M) {
     error("$_ext_mem too large\n");
     leavedos(98);
     return;
   }
-  lowmem = alloc_mapping(MAPPING_INIT_LOWRAM, memsize);
+  lowmem = alloc_mapping(MAPPING_INIT_LOWRAM, LOWMEM_SIZE + HMASIZE);
   if (lowmem == MAP_FAILED) {
     perror("LOWRAM alloc");
     leavedos(98);
   }
 
-  mem_base = mem_reserve(memsize, dpmi_size);
-  result = alias_mapping(MAPPING_INIT_LOWRAM, 0, memsize,
+  mem_base = mem_reserve(memsize);
+  result = alias_mapping(MAPPING_INIT_LOWRAM, 0, LOWMEM_SIZE + HMASIZE,
 			 PROT_READ | PROT_WRITE | PROT_EXEC, lowmem);
   if (result == -1) {
     perror ("LOWRAM mmap");
@@ -360,22 +363,22 @@ void low_mem_init(void)
   c_printf("Conventional memory mapped from %p to %p\n", lowmem, mem_base);
 
   if (config.xms_size)
-    config.xms_map_size = (mem_16M - (memsize + EXTMEM_SIZE)) & PAGE_MASK;
+    config.xms_map_size = (mem_16M - (LOWMEM_SIZE + HMASIZE + EXTMEM_SIZE)) & PAGE_MASK;
 
-  sminit_comu(&main_pool, mem_base, memsize + dpmi_size, mcommit, muncommit);
-  ptr = smalloc(&main_pool, memsize);
+  sminit_comu(&main_pool, mem_base, memsize, mcommit, muncommit);
+  ptr = smalloc(&main_pool, LOWMEM_SIZE + HMASIZE);
   assert(ptr == mem_base);
   /* smalloc uses PROT_READ | PROT_WRITE, needs to add PROT_EXEC here */
-  mprotect_mapping(MAPPING_LOWMEM, 0, memsize, PROT_READ | PROT_WRITE |
+  mprotect_mapping(MAPPING_LOWMEM, 0, LOWMEM_SIZE + HMASIZE, PROT_READ | PROT_WRITE |
       PROT_EXEC);
   phys_rsv = EXTMEM_SIZE + config.xms_map_size;
-  if (config.dpmi_base < memsize + phys_rsv +
+  if (config.dpmi_base < LOWMEM_SIZE + HMASIZE + phys_rsv +
 			 (config.dpmi ? 0 : config.vgaemu_memsize * 1024)) {
     error("$_dpmi_base is too small\n");
     config.exitearly = 1;
     return;
   }
-  dpmi_rsv_low = config.dpmi ? (config.dpmi_base - (memsize + phys_rsv)) : 0;
+  dpmi_rsv_low = config.dpmi ? (config.dpmi_base - (LOWMEM_SIZE + HMASIZE + phys_rsv)) : 0;
   ptr = smalloc(&main_pool, phys_rsv + dpmi_rsv_low + dpmi_mem_size());
   assert(ptr);
   if (config.dpmi) {
@@ -383,11 +386,11 @@ void low_mem_init(void)
   }
 
   if (config.ext_mem) {
-    /* memsize == base
+    /* LOWMEM_SIZE + HMASIZE == base
      * Use dpmi_rsv_low as ext_mem. */
-    register_hardware_ram_virtual('m', memsize, EXTMEM_SIZE,
-	    MEM_BASE32(memsize), memsize);
-    x_printf("Ext.Mem of size 0x%x at %#x\n", EXTMEM_SIZE, result + memsize);
+    register_hardware_ram_virtual('m', LOWMEM_SIZE + HMASIZE, EXTMEM_SIZE,
+	    MEM_BASE32(LOWMEM_SIZE + HMASIZE), LOWMEM_SIZE + HMASIZE);
+    x_printf("Ext.Mem of size 0x%x at %#x\n", EXTMEM_SIZE, result + LOWMEM_SIZE + HMASIZE);
   }
 
   /* R/O protect 0xf0000-0xf4000 */

--- a/src/base/init/parser.y
+++ b/src/base/init/parser.y
@@ -1096,7 +1096,7 @@ x_flag		: L_DISPLAY string_expr	{ free(config.X_display); config.X_display = $2;
 		| X_FULLSCREEN bool   { config.X_fullscreen = $2; }
 		| X_NOCLOSE bool      { config.X_noclose = ($2!=0); }
 		| X_NORESIZE bool     { config.X_noresize = ($2!=0); }
-		| VGAEMU_MEMSIZE expression	{ config.vgaemu_memsize = $2; }
+		| VGAEMU_MEMSIZE expression	{ config.vgaemu_memsize = ($2 ? $2 : 1024); }
 		| VESAMODE INTEGER INTEGER { set_vesamodes($2,$3,0);}
 		| VESAMODE INTEGER INTEGER INTEGER { set_vesamodes($2,$3,$4);}
 		| VESAMODE expression ',' expression { set_vesamodes($2,$4,0);}

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -3764,6 +3764,8 @@ err2:
 
 void dpmi_reset(void)
 {
+    if (!config.dpmi) return;
+
     RSP_num = 0;
     if (config.pm_dos_api)
 	msdos_reset();
@@ -5842,6 +5844,8 @@ int dpmi_active(void)
 void dpmi_done(void)
 {
   int i;
+
+  if (!config.dpmi) return;
 
   D_printf("DPMI: finalizing\n");
   current_client = in_dpmi - 1;


### PR DESCRIPTION
This is related to VCPI (#1880) but this should work no matter what. Allocate enough memory to allow for EXTMEM, XMS, and VGAEMU LFB mappings independent of DPMI settings.

Relatedly this cleans up config.vgaemu_memsize a bit so it doesn't need to be checked for 0 (which means 1MB for historical reasons) every time.