### PR TITLE
Create physical base for VGAEMU LFB at 0xe0000000

### DIFF
--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -271,6 +271,17 @@ void *alias_mapping_ux(int cap, size_t mapsize, int protect, void *source)
   return mappingdriver->alias(cap, target, mapsize, protect, source);
 }
 
+void *alias_mapping_huge_page_aligned(int cap, size_t mapsize, int protect, void *source)
+{
+  void *addr = mmap_mapping_huge_page_aligned(cap, mapsize, PROT_NONE);
+  if (addr == MAP_FAILED ||
+      mappingdriver->alias(cap, addr, mapsize, protect, source) != addr)
+    return MAP_FAILED;
+
+  Q__printf("MAPPING: %s alias created at %p\n", cap, addr);
+  return addr;
+}
+
 dosaddr_t alias_mapping_high(int cap, size_t mapsize, int protect, void *source)
 {
   dosaddr_t targ;

--- a/src/base/dev/vga/vesa.c
+++ b/src/base/dev/vga/vesa.c
@@ -570,7 +570,7 @@ static int vbe_mode_info(unsigned mode, unsigned int vbemodeinfo)
 
     vbemi.DirectColor = 0;
     if(vmi->color_bits >= 8 && vga.mem.lfb_base_page)
-      vbemi.PhysBasePtr = vga.mem.lfb_base;	/* LFB support */
+      vbemi.PhysBasePtr = VGAEMU_PHYS_LFB_BASE;	/* LFB support */
 
     vbemi.OffScreenOfs = 0;
     vbemi.OffScreenMem = 0;

--- a/src/base/dev/vga/vgaemu.c
+++ b/src/base/dev/vga/vgaemu.c
@@ -1747,10 +1747,9 @@ int vga_emu_pre_init(void)
       kvm_set_dirty_log(VGA_PHYS_TEXT_BASE, VGA_TEXT_SIZE);
     }
   }
-
   if(vga.mem.lfb_base != 0) {
     memcheck_addtype('e', "VGAEMU LFB");
-    register_hardware_ram_virtual('e', vga.mem.lfb_base, vga.mem.size,
+    register_hardware_ram_virtual('e', VGAEMU_PHYS_LFB_BASE, vga.mem.size,
 	    vga.mem.base, vga.mem.lfb_base);
     if (config.cpu_vm_dpmi == CPUVM_KVM)
       kvm_set_dirty_log(vga.mem.lfb_base, vga.mem.size);

--- a/src/base/emu-i386/kvm.c
+++ b/src/base/emu-i386/kvm.c
@@ -585,7 +585,7 @@ static void do_munmap_kvm(dosaddr_t targ, size_t mapsize)
 
 void mmap_kvm(int cap, void *addr, size_t mapsize, int protect, dosaddr_t targ)
 {
-  assert(cap & (MAPPING_INIT_LOWRAM|MAPPING_LOWMEM|MAPPING_KVM));
+  assert(cap & (MAPPING_INIT_LOWRAM|MAPPING_LOWMEM|MAPPING_KVM|MAPPING_VGAEMU));
   /* with KVM we need to manually remove/shrink existing mappings */
   do_munmap_kvm(targ, mapsize);
   mmap_kvm_no_overlap(targ, addr, mapsize, 0);

--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -372,8 +372,7 @@ void low_mem_init(void)
   mprotect_mapping(MAPPING_LOWMEM, 0, LOWMEM_SIZE + HMASIZE, PROT_READ | PROT_WRITE |
       PROT_EXEC);
   phys_rsv = EXTMEM_SIZE + config.xms_map_size;
-  if (config.dpmi_base < LOWMEM_SIZE + HMASIZE + phys_rsv +
-			 (config.dpmi ? 0 : config.vgaemu_memsize * 1024)) {
+  if (config.dpmi_base < LOWMEM_SIZE + HMASIZE + phys_rsv) {
     error("$_dpmi_base is too small\n");
     config.exitearly = 1;
     return;

--- a/src/include/mapping.h
+++ b/src/include/mapping.h
@@ -86,6 +86,7 @@ void *mmap_mapping(int cap, void *target, size_t mapsize, int protect);
 
 typedef void *alias_mapping_type(int cap, void *target, size_t mapsize, int protect, void *source);
 int alias_mapping(int cap, dosaddr_t targ, size_t mapsize, int protect, void *source);
+void *alias_mapping_huge_page_aligned(int cap, size_t mapsize, int protect, void *source);
 dosaddr_t alias_mapping_high(int cap, size_t mapsize, int protect, void *source);
 int unalias_mapping_high(int cap, dosaddr_t targ, size_t mapsize);
 void *alias_mapping_ux(int cap, size_t mapsize, int protect, void *source);

--- a/src/include/vgaemu.h
+++ b/src/include/vgaemu.h
@@ -243,6 +243,10 @@ typedef struct {
 #define VGAEMU_MAP_BANK_MODE	0
 #define VGAEMU_MAP_LFB_MODE	1
 
+/* Physical LFB base. With KVM this is actually used; without KVM this is
+   just a cookie, reported by the VESA VBE interface, that can be mapped using DPMI
+   int31/ax=0x0800 */
+#define VGAEMU_PHYS_LFB_BASE	0xe0000000
 
 typedef struct {
   unsigned base_page;			/* base address (in 4k) of mapping */


### PR DESCRIPTION
That value is just a commonly used value in hardware and other emulators, and acts as a cookie without KVM (VESA BIOS reports it, and it gets fed to DPMI ax=0x0800 to get the linear address).

With KVM, it's at the proper physical address, so that for VCPI it'll work and the VCPI client can set the page tables.
Then with VCPI even if $_dpmi=(0) there is no need to reserve LFB within main_pool.

We then have a mapping:
guest linear -> guest physical -> host linear -> host backend
0xe0000000 -> 0xe0000000 -> custom hugepage-aligned alias map -> backend storage
so the LFB is no longer visible from mem_base (MEM_BASE32(vga.mem.lfb_base) is not a valid pointer).

I think this is the simplest approach, however if you'd rather have LFB visible from main_pool as well then that can be done if you like, but we would then need two mappings
guest linear -> guest physical -> host linear -> host backend
vga.mem.lfb_base below 512M -(1)> 0xe0000000 -> custom hugepage-aligned alias map -> backend storage
plus
MEM_BASE32(vga.mem.lfb_base) -(2)> backend storage

(1) this page table mapping doesn't apply for VCPI, since it uses its own page tables; with VCPI we don't care what linear address it uses for the LFB.
(2) this is the general mapping we have without this PR, it should only be done if config.dpmi != 0.