### PR TITLE
mapping: cleanup mmap_mapping.

### DIFF
--- a/src/base/emu-i386/kvm.c
+++ b/src/base/emu-i386/kvm.c
@@ -223,7 +223,7 @@ static void init_kvm_monitor(void)
     return;
 
   /* create monitor structure in memory */
-  monitor = mmap_mapping(MAPPING_SCRATCH|MAPPING_KVM, (void *)-1,
+  monitor = mmap_mapping_huge_page_aligned(MAPPING_SCRATCH|MAPPING_KVM,
 			 sizeof(*monitor), PROT_READ | PROT_WRITE);
   /* exclude special regions for KVM-internal TSS and identity page */
   mmap_kvm(MAPPING_SCRATCH|MAPPING_KVM, monitor,
@@ -585,7 +585,7 @@ static void do_munmap_kvm(dosaddr_t targ, size_t mapsize)
 
 void mmap_kvm(int cap, void *addr, size_t mapsize, int protect, dosaddr_t targ)
 {
-  assert(cap & (MAPPING_INIT_LOWRAM|MAPPING_KVM));
+  assert(cap & (MAPPING_INIT_LOWRAM|MAPPING_LOWMEM|MAPPING_KVM));
   /* with KVM we need to manually remove/shrink existing mappings */
   do_munmap_kvm(targ, mapsize);
   mmap_kvm_no_overlap(targ, addr, mapsize, 0);

--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -309,7 +309,7 @@ static void *mem_reserve(uint32_t memsize)
   }
 #endif
 
-  result = mmap_mapping(cap, (void *)-1, memsize, prot);
+  result = mmap_mapping_huge_page_aligned(cap, memsize, prot);
   if (result == MAP_FAILED) {
     perror ("LOWRAM mmap");
     exit(EXIT_FAILURE);
@@ -354,7 +354,7 @@ void low_mem_init(void)
   }
 
   mem_base = mem_reserve(memsize);
-  result = alias_mapping(MAPPING_INIT_LOWRAM, 0, LOWMEM_SIZE + HMASIZE,
+  result = alias_mapping(MAPPING_LOWMEM, 0, LOWMEM_SIZE + HMASIZE,
 			 PROT_READ | PROT_WRITE | PROT_EXEC, lowmem);
   if (result == -1) {
     perror ("LOWRAM mmap");

--- a/src/include/mapping.h
+++ b/src/include/mapping.h
@@ -81,6 +81,7 @@ void free_mapping (int cap, void *addr, size_t mapsize);
 typedef void *realloc_mapping_type(int cap, void *addr, size_t oldsize, size_t newsize);
 void *realloc_mapping (int cap, void *addr, size_t oldsize, size_t newsize);
 
+void *mmap_mapping_huge_page_aligned(int cap, size_t mapsize, int protect);
 void *mmap_mapping(int cap, void *target, size_t mapsize, int protect);
 
 typedef void *alias_mapping_type(int cap, void *target, size_t mapsize, int protect, void *source);


### PR DESCRIPTION
Non-fixed mapping always want alignment; for those we call mmap_mapping_huge_page_aligned(), which uses _MAP_32BIT only for MAPPING_INIT_LOWRAM (mem_base mapping), and also sets up VM86_BASE and KVM_BASE.

mmap_mapping then only uses fixed mappings, which can either be truely fixed or with a hint.