### PR TITLE
mapping: optimize MEM_BASE32

### DIFF
--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -63,6 +63,7 @@ static struct mem_map_struct kmem_map[MAX_KMEM_MAPPINGS];
 
 static int init_done = 0;
 unsigned char *mem_base;
+uintptr_t mem_base_mask;
 static unsigned char *mem_bases[MAX_BASES];
 uint8_t *lowmem_base;
 
@@ -175,21 +176,13 @@ static int map_find(struct mem_map_struct *map, int max,
 
 static unsigned char *MEM_BASE32x(dosaddr_t a, int base)
 {
-  uintptr_t off;
-  uintptr_t baddr = (uintptr_t)mem_bases[base];
   if (mem_bases[base] == MAP_FAILED)
     return MAP_FAILED;
-  if (a >= LOWMEM_SIZE + HMASIZE && base != MEM_BASE)
+  if (base == MEM_BASE)
+    return MEM_BASE32(a);
+  if (a >= LOWMEM_SIZE + HMASIZE)
     return MAP_FAILED;
-  off = baddr + a;
-  if (config.cpu_vm_dpmi == CPUVM_NATIVE && base == MEM_BASE)
-    off &= 0xffffffff;
-  return LINP(off);
-}
-
-unsigned char *MEM_BASE32(dosaddr_t a)
-{
-    return MEM_BASE32x(a, MEM_BASE);
+  return &mem_bases[base][a];
 }
 
 #ifdef __linux__

--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -354,6 +354,10 @@ void low_mem_init(void)
   }
 
   mem_base = mem_reserve(memsize);
+  mem_base_mask = ~(uintptr_t)0;
+#ifdef __x86_64__
+  if (_MAP_32BIT) mem_base_mask = 0xffffffffu;
+#endif
   result = alias_mapping(MAPPING_LOWMEM, 0, LOWMEM_SIZE + HMASIZE,
 			 PROT_READ | PROT_WRITE | PROT_EXEC, lowmem);
   if (result == -1) {

--- a/src/include/memory.h
+++ b/src/include/memory.h
@@ -190,9 +190,19 @@ dosaddr_t physaddr_to_dosaddr(unsigned addr, int len);
    give NULL pointer protection.
 */
 extern unsigned char *mem_base;
+extern uintptr_t mem_base_mask;
 
 #define LINP(a) ((unsigned char *)(uintptr_t)(a))
-unsigned char *MEM_BASE32(dosaddr_t a);
+static inline unsigned char *MEM_BASE32(dosaddr_t a) {
+#if defined(__i386__)
+  /* we want to wrap around 4G; &mem_base[a] may cause issues with UBSAN */
+  return LINP((uintptr_t)mem_base + a);
+#elif defined(__x86_64__)
+  return LINP(((uintptr_t)mem_base + a) & mem_base_mask);
+#else
+  return &mem_base[a];
+#endif
+}
 static inline dosaddr_t DOSADDR_REL(const unsigned char *a)
 {
     return (a - mem_base);


### PR DESCRIPTION
MEM_BASE32 took up 13% of the time in perf in the simulator. Optimize and inline it (on x86-64 we can do that with a mask that depends on the DPMI backend).