### PR TITLE
vgaemu: don't call unalias_mapping_high for KVM

### DIFF
--- a/src/base/dev/vga/vgaemu.c
+++ b/src/base/dev/vga/vgaemu.c
@@ -1810,7 +1810,7 @@ static int vga_emu_post_init(void)
 
 void vga_emu_done()
 {
-  if (vga.mem.lfb_base && config.dpmi)
+  if (vga.mem.lfb_base && config.dpmi && config.cpu_vm_dpmi != CPUVM_KVM)
     unalias_mapping_high(MAPPING_VGAEMU, vga.mem.lfb_base, vga.mem.size);
 }
 


### PR DESCRIPTION
Since the map is no longer done via main_pool then, we can't use that any more. Fixes #1915