### PR TITLE
Fix GCC warnings

### DIFF
--- a/src/base/misc/utilities.c
+++ b/src/base/misc/utilities.c
@@ -20,6 +20,9 @@
 #include <dlfcn.h>
 #include <pthread.h>
 #include <wordexp.h>
+#ifdef HAVE_LIBBSD
+#include <bsd/unistd.h>
+#endif
 
 #include "bios.h"
 #include "timers.h"

--- a/src/plugin/sdl/sdl.c
+++ b/src/plugin/sdl/sdl.c
@@ -169,6 +169,7 @@ static SDL_Keycode mgrab_key = SDLK_HOME;
 
 #define CONFIG_SDL_SELECTION 1
 
+#if defined(HAVE_SDL2_TTF) && defined(HAVE_FONTCONFIG)
 static void SDL_draw_string(void *opaque, int x, int y, const char *text,
     int len, Bit8u attr);
 static void SDL_draw_line(void *opaque, int x, int y, float ul, int len,
@@ -189,6 +190,7 @@ static struct text_system Text_SDL =
   NULL,
   "sdl",
 };
+#endif
 
 /* separate done call-back for video-unrelated things (eg audio) */
 static void SDL_done(void)


### PR DESCRIPTION
I kept running into a few warnings so fixed them.

There is one left due to
```
#include <signal.h>
#include <linux/signal.h>
```
not compiling, as you noted in https://github.com/dosemu2/dosemu2/discussions/1778, which causes `Not disabling SIGALTSTACK_WA, update your kernel` unless I don't use `./default_configure -d` or explicitly add `--enable-system-wa`
Not sure what to do with that?