### PR TITLE
mfs: in FindFirst/Next return large file's size as 0xFFFFffff

### DIFF
--- a/src/dosext/mfs/mfs.c
+++ b/src/dosext/mfs/mfs.c
@@ -1753,6 +1753,14 @@ static int exists(const char *name, const char *filename,
   return find_file(fullname, st, drives[drive].root_len, NULL);
 }
 
+static void set_32bit_size_or_position(uint32_t* sftfield, uint64_t fullvalue) {
+  if (fullvalue < 0x100000000) {
+    *sftfield = fullvalue;
+  } else {
+    *sftfield = 0xFFFFffff;
+  }
+}
+
 static void fill_entry(struct dir_ent *entry, const char *name, int drive)
 {
   char buf[PATH_MAX];
@@ -1773,7 +1781,7 @@ static void fill_entry(struct dir_ent *entry, const char *name, int drive)
     entry->attr = REGULAR_FILE;
   } else {
     entry->mode = sbuf.st_mode;
-    entry->size = sbuf.st_size;
+    set_32bit_size_or_position(&entry->size, sbuf.st_size);
     entry->time = sbuf.st_mtime;
     entry->attr = get_dos_attr(buf, entry->mode);
   }
@@ -1873,7 +1881,7 @@ static struct dir_list *get_dir_ff(char *name, char *mname, char *mext,
       memcpy(entry->ext, mext, 3);
       strcpy(entry->d_name, buf);
       entry->mode = sbuf.st_mode;
-      entry->size = sbuf.st_size;
+      set_32bit_size_or_position(&entry->size, sbuf.st_size);
       entry->time = sbuf.st_mtime;
       entry->attr = get_dos_attr(buf, entry->mode);
     }
@@ -3832,14 +3840,6 @@ static u_short unix_access_mode(struct stat *st, int drive, u_short dos_mode)
     unix_mode = O_RDONLY;
   }
   return unix_mode;
-}
-
-static void set_32bit_size_or_position(uint32_t* sftfield, uint64_t fullvalue) {
-  if (fullvalue < 0x100000000) {
-    *sftfield = fullvalue;
-  } else {
-    *sftfield = 0xFFFFffff;
-  }
 }
 
 static void do_update_sft(struct file_fd *f, char *fname, char *fext,

--- a/src/dosext/mfs/mfs.h
+++ b/src/dosext/mfs/mfs.h
@@ -241,7 +241,7 @@ struct dir_ent {
   char d_name[256];             /* unix name as in readdir */
   u_short mode;			/* unix st_mode value */
   u_short long_path;            /* directory has long path */
-  int size;			/* size of file */
+  uint32_t size;		/* size of file */
   time_t time;			/* st_mtime */
   int attr;
 };


### PR DESCRIPTION
Prior to this the size would be returned as modulo 4 GiB. Fix to use the `set_32bit_size_or_position` function which will clamp the size to the maximum value instead.

Test: Create a file like so:
`dd if=/dev/urandom bs=1024 seek=4194304 count=2 of=big1.dat`

(This creates a sparse file that is just over 4 GiB.)

Prior to this commit FreeCOM shows the file size as 2048 bytes. With this commit this improves to show the size as 4,294,967,295 bytes.