### PR TITLE
mfs: in FindFirst/Next return large file's size as 0xFFFFffff (v2)

### DIFF
--- a/src/dosext/mfs/mfs.c
+++ b/src/dosext/mfs/mfs.c
@@ -3556,6 +3556,14 @@ static int dos_would_allow(char *fpath, const char *op, int equal)
   return TRUE;
 }
 
+static void set_32bit_size_or_position(uint32_t* sftfield, uint64_t fullvalue) {
+  if (fullvalue < 0x100000000) {
+    *sftfield = fullvalue;
+  } else {
+    *sftfield = 0xFFFFffff;
+  }
+}
+
 static int find_again(int firstfind, int drive, char *fpath,
 			    struct dir_list *hlist, struct vm86_regs *state, sdb_t sdb)
 {
@@ -3590,7 +3598,7 @@ static int find_again(int firstfind, int drive, char *fpath,
     time_to_dos(de->time,
 		&sdb_file_date(sdb),
 		&sdb_file_time(sdb));
-    sdb_file_size(sdb) = de->size;
+    set_32bit_size_or_position(&sdb_file_size(sdb), de->size);
     strncpy(sdb_file_name(sdb), de->name, 8);
     strncpy(sdb_file_ext(sdb), de->ext, 3);
 
@@ -3832,14 +3840,6 @@ static u_short unix_access_mode(struct stat *st, int drive, u_short dos_mode)
     unix_mode = O_RDONLY;
   }
   return unix_mode;
-}
-
-static void set_32bit_size_or_position(uint32_t* sftfield, uint64_t fullvalue) {
-  if (fullvalue < 0x100000000) {
-    *sftfield = fullvalue;
-  } else {
-    *sftfield = 0xFFFFffff;
-  }
 }
 
 static void do_update_sft(struct file_fd *f, char *fname, char *fext,

--- a/src/dosext/mfs/mfs.h
+++ b/src/dosext/mfs/mfs.h
@@ -241,7 +241,7 @@ struct dir_ent {
   char d_name[256];             /* unix name as in readdir */
   u_short mode;			/* unix st_mode value */
   u_short long_path;            /* directory has long path */
-  int size;			/* size of file */
+  uint64_t size;		/* size of file */
   time_t time;			/* st_mtime */
   int attr;
 };


### PR DESCRIPTION
Prior to this the size would be returned as modulo 4 GiB. Fix to use the `set_32bit_size_or_position` function which will clamp the size to the maximum value instead.

Test: Create a file like so:
`dd if=/dev/urandom bs=1024 seek=$((1024 * 1024 * 4)) count=2 of=big1.dat`

(This creates a sparse file that is just over 4 GiB.)

Prior to this commit FreeCOM shows the file size as 2048 bytes. With this commit this improves to show the size as 4,294,967,295 bytes.

----

Second revision of https://github.com/dosemu2/dosemu2/pull/1919