### PR TITLE
mapping: start adding non-identity map support

### DIFF
--- a/src/arch/linux/mapping/mapfile.c
+++ b/src/arch/linux/mapping/mapfile.c
@@ -93,7 +93,8 @@ static int commit(void *ptr, size_t size)
 
 static int open_mapping_f(int cap)
 {
-    int mapsize, estsize, padsize;
+    int mapsize = 0;
+    int estsize, padsize;
 
     if (cap) Q_printf("MAPPING: open, cap=%s\n",
 	  decode_mapping_cap(cap));
@@ -101,12 +102,11 @@ static int open_mapping_f(int cap)
     padsize = 4*1024;
 
     /* first estimate the needed size of the mapfile */
-    mapsize  = HMASIZE >> 10;	/* HMA */
- 				/* VGAEMU */
     mapsize += config.vgaemu_memsize;
     mapsize += config.ems_size;	/* EMS */
     mapsize += config.xms_size;	/* XMS */
-    mapsize += LOWMEM_SIZE >> 10; /* Low Mem */
+    mapsize += config.ext_mem;	/* extended mem */
+    mapsize += (LOWMEM_SIZE + HMASIZE) >> 10; /* Low Mem */
     estsize = mapsize;
 				/* keep heap fragmentation in mind */
     mapsize += (mapsize/4 < padsize ? padsize : mapsize/4);

--- a/src/base/dev/vga/vgaemu.c
+++ b/src/base/dev/vga/vgaemu.c
@@ -1740,24 +1740,14 @@ int vga_emu_pre_init(void)
     if (addr) {
       vga.mem.lfb_base = DOSADDR_REL(addr);
       memcheck_addtype('e', "VGAEMU LFB");
-      register_hardware_ram_virtual('e', VGAEMU_PHYS_LFB_BASE, vga.mem.size,
-				    vga.mem.base, vga.mem.lfb_base);
+      register_hardware_ram_virtual2('e', VGAEMU_PHYS_LFB_BASE, vga.mem.size,
+				     vga.mem.base, vga.mem.lfb_base);
       if (!alias_mapping_pa(MAPPING_VGAEMU, VGAEMU_PHYS_LFB_BASE,
 			    vga.mem.size, VGA_EMU_RW_PROT, vga.mem.base))
 	addr = NULL;
     }
-    if (addr && config.cpu_vm_dpmi == CPUVM_KVM) {
-      /* create mapping:
-	 Linear vga.mem.lfb_base -> phys VGAEMU_PHYS_LFB_BASE=0xe0000000 ->
-	 addr (hugepage aligned) -> vga.mem.base */
-      addr = alias_mapping_huge_page_aligned(MAPPING_VGAEMU, vga.mem.size,
-					     VGA_EMU_RW_PROT, vga.mem.base);
-      if (addr != MAP_FAILED) {
-	mmap_kvm(MAPPING_VGAEMU, VGAEMU_PHYS_LFB_BASE, vga.mem.size, addr,
-		 vga.mem.lfb_base, VGA_EMU_RW_PROT);
+    if (addr && config.cpu_vm_dpmi == CPUVM_KVM)
 	kvm_set_dirty_log(VGAEMU_PHYS_LFB_BASE, vga.mem.size);
-      }
-    }
     if(addr == NULL || addr == MAP_FAILED) {
       error("vga_emu_init: not enough memory (%u k)\n", vga.mem.size >> 10);
       config.exitearly = 1;

--- a/src/base/emu-i386/kvm.c
+++ b/src/base/emu-i386/kvm.c
@@ -609,7 +609,7 @@ void mprotect_kvm(int cap, dosaddr_t targ, size_t mapsize, int protect)
   unsigned int page;
   struct kvm_userspace_memory_region *p;
 
-  if (!(cap & (MAPPING_INIT_LOWRAM|MAPPING_LOWMEM|MAPPING_EMS|MAPPING_HMA|
+  if (!(cap & (MAPPING_LOWMEM|MAPPING_EMS|MAPPING_HMA|
 	       MAPPING_DPMI|MAPPING_VGAEMU|MAPPING_KVM|MAPPING_CPUEMU|
 	       MAPPING_EXTMEM))) return;
 

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -1312,6 +1312,14 @@ void e_invalidate_pa(unsigned pa, int cnt)
     e_invalidate(addr, cnt);
 }
 
+void e_invalidate_full_pa(unsigned pa, int cnt)
+{
+    dosaddr_t addr = physaddr_to_dosaddr(pa, cnt);
+    if (addr == (dosaddr_t)-1)
+	return;
+    e_invalidate_full(addr, cnt);
+}
+
 /* invalidate and unprotect even if we hit only data.
  * Needed if we are about to destroy the page protection by other means.
  * Otherwise use e_invalidate() */

--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -314,11 +314,6 @@ static void *mem_reserve(uint32_t memsize)
     perror ("LOWRAM mmap");
     exit(EXIT_FAILURE);
   }
-  if (config.cpu_vm_dpmi == CPUVM_KVM)
-    /* map only high memory here, rest is done with KVM_BASE in alias_mapping */
-    mmap_kvm(cap, LOWMEM_SIZE + HMASIZE, memsize - (LOWMEM_SIZE + HMASIZE),
-	     (unsigned char *)result + LOWMEM_SIZE + HMASIZE,
-	     LOWMEM_SIZE + HMASIZE, prot);
   return result;
 }
 
@@ -360,14 +355,15 @@ static void low_mem_init_config_scrub(void)
  */
 void low_mem_init(void)
 {
-  void *lowmem, *ptr;
+  unsigned char *lowmem, *ptr, *ptr2;
   int result;
   uint32_t memsize = config.dpmi ? LOWMEM_SIZE + HMASIZE + dpmi_lin_mem_rsv() : config.dpmi_base;
   int32_t dpmi_rsv_low, phys_rsv;
 
   open_mapping(MAPPING_INIT_LOWRAM);
   g_printf ("DOS+HMA memory area being mapped in\n");
-  lowmem = alloc_mapping(MAPPING_INIT_LOWRAM, LOWMEM_SIZE + HMASIZE);
+  lowmem = alloc_mapping(MAPPING_INIT_LOWRAM, LOWMEM_SIZE + HMASIZE +
+	EXTMEM_SIZE);
   if (lowmem == MAP_FAILED) {
     perror("LOWRAM alloc");
     leavedos(98);
@@ -378,6 +374,7 @@ void low_mem_init(void)
 #ifdef __x86_64__
   if (_MAP_32BIT) mem_base_mask = 0xffffffffu;
 #endif
+  register_hardware_ram_virtual('L', 0, LOWMEM_SIZE + HMASIZE, 0);
   result = alias_mapping(MAPPING_LOWMEM, 0, LOWMEM_SIZE + HMASIZE,
 			 PROT_READ | PROT_WRITE | PROT_EXEC, lowmem);
   if (result == -1) {
@@ -405,14 +402,34 @@ void low_mem_init(void)
   }
 
   if (config.ext_mem) {
-    /* LOWMEM_SIZE + HMASIZE == base
-     * Use dpmi_rsv_low as ext_mem. */
-    register_hardware_ram_virtual('X', LOWMEM_SIZE + HMASIZE, EXTMEM_SIZE,
-	    MEM_BASE32(LOWMEM_SIZE + HMASIZE), LOWMEM_SIZE + HMASIZE);
+    /* LOWMEM_SIZE + HMASIZE == base */
     memcheck_addtype('X', "EXT MEM");
     memcheck_reserve('X', LOWMEM_SIZE + HMASIZE, EXTMEM_SIZE);
     x_printf("Ext.Mem of size 0x%x at %#x\n", EXTMEM_SIZE, result + LOWMEM_SIZE + HMASIZE);
   }
+
+  ptr += phys_rsv + dpmi_rsv_low;
+  /* create non-identity mapping up to dpmi_base */
+  phys_rsv = config.dpmi_base - (LOWMEM_SIZE + HMASIZE);
+  ptr2 = smalloc_aligned_topdown(&main_pool, MEM_BASE32(memsize),
+	PAGE_SIZE, phys_rsv);
+  assert(ptr2);
+  /* establish alias access for int15 */
+  register_hardware_ram_virtual('X', LOWMEM_SIZE + HMASIZE, phys_rsv,
+	    DOSADDR_REL(ptr2));
+  register_hardware_ram_virtual('U',  DOSADDR_REL(ptr2), phys_rsv,
+	    LOWMEM_SIZE + HMASIZE);
+  /* map dpmi+uncommitted space to kvm */
+  if (config.cpu_vm_dpmi == CPUVM_KVM) {
+    int prot = PROT_READ | PROT_WRITE | PROT_EXEC;
+    mmap_kvm(MAPPING_INIT_LOWRAM, config.dpmi_base, ptr2 - ptr, ptr,
+	config.dpmi_base, prot);
+  }
+  /* create alias for dpmi */
+  result = alias_mapping(MAPPING_EXTMEM, DOSADDR_REL(ptr2), EXTMEM_SIZE,
+			 PROT_READ | PROT_WRITE,
+			 lowmem + LOWMEM_SIZE + HMASIZE);
+  assert(result != -1);
 
   /* R/O protect 0xf0000-0xf4000 */
   if (!config.umb_f0)

--- a/src/dosext/dpmi/memory.c
+++ b/src/dosext/dpmi/memory.c
@@ -267,7 +267,6 @@ int dpmi_alloc_pool(void)
 
 void dpmi_free_pool(void)
 {
-    uint32_t memsize = dpmi_mem_size() + low_rsv;
     int leak = smdestroy(&mem_pool);
     if (leak)
 	error("DPMI: leaked %i bytes (main pool)\n", leak);
@@ -275,7 +274,7 @@ void dpmi_free_pool(void)
     if (leak)
 	error("DPMI: leaked %i bytes (lin pool)\n", leak);
     mprotect_mapping(MAPPING_DPMI, DOSADDR_REL(dpmi_lin_rsv_base),
-                memsize, PROT_READ | PROT_WRITE);
+                low_rsv, PROT_READ | PROT_WRITE);
 }
 
 static int SetAttribsForPage(unsigned int ptr, us attr, us *old_attr_p)

--- a/src/include/cpu-emu.h
+++ b/src/include/cpu-emu.h
@@ -80,11 +80,13 @@ char *e_scp_disasm(cpuctx_t *scp, int pmode);
 #ifdef X86_JIT
 void e_invalidate(unsigned data, int cnt);
 void e_invalidate_full(unsigned data, int cnt);
+void e_invalidate_full_pa(unsigned data, int cnt);
 int e_invalidate_page_full(unsigned data);
 void e_invalidate_pa(unsigned data, int cnt);
 #else
 #define e_invalidate(x,y)
 #define e_invalidate_full(x,y)
+#define e_invalidate_full_pa(x,y)
 #define e_invalidate_page_full(x) 0
 #define e_invalidate_pa(x,y)
 #endif

--- a/src/include/mapping.h
+++ b/src/include/mapping.h
@@ -121,8 +121,10 @@ void init_hardware_ram(void);
 int map_hardware_ram(char type);
 int unmap_hardware_ram(char type);
 int register_hardware_ram(int type, dosaddr_t base, unsigned size);
-int register_hardware_ram_virtual(int type, unsigned base, unsigned size,
-    void *uaddr, dosaddr_t va);
+void register_hardware_ram_virtual(int type, unsigned base, unsigned size,
+	dosaddr_t va);
+void register_hardware_ram_virtual2(int type, unsigned base, unsigned size,
+	void *uaddr, dosaddr_t va);
 int unregister_hardware_ram_virtual(dosaddr_t base);
 dosaddr_t get_hardware_ram(unsigned addr, uint32_t size);
 void *get_hardware_uaddr(unsigned addr);


### PR DESCRIPTION
This patch adds alias_mapping_pa() and unalias_mapping_pa() funcs that take pa as an argument.

init: create non-identity mapping for region from hma end to dpmi_base.
xms: use new API that allows to get rid of va.