### PR TITLE
KVM: allow nonidentical phys<->virt maps (#1922)

### DIFF
--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -434,7 +434,7 @@ void *mmap_mapping_huge_page_aligned(int cap, size_t mapsize, int protect)
       void *kvm_base = mmap_mapping_huge_page_aligned(cap, mapsize, protect);
       if (kvm_base == MAP_FAILED)
 	return kvm_base;
-      mmap_kvm(cap, kvm_base, mapsize, protect, 0);
+      mmap_kvm(cap, 0, mapsize, kvm_base, 0, protect);
       mem_bases[KVM_BASE] = kvm_base;
     }
 #ifdef __i386__

--- a/src/base/dev/vga/vgaemu.c
+++ b/src/base/dev/vga/vgaemu.c
@@ -1696,7 +1696,7 @@ int vga_emu_pre_init(void)
       p = (dosaddr_t)-1;
       if (addr != MAP_FAILED) {
 	p = VGAEMU_PHYS_LFB_BASE;
-	mmap_kvm(MAPPING_VGAEMU, addr, vga.mem.size, VGA_EMU_RW_PROT, p);
+	mmap_kvm(MAPPING_VGAEMU, p, vga.mem.size, addr, p, VGA_EMU_RW_PROT);
       }
     } else if (config.dpmi) {
       p = alias_mapping_high(MAPPING_VGAEMU,

--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -316,8 +316,9 @@ static void *mem_reserve(uint32_t memsize)
   }
   if (config.cpu_vm_dpmi == CPUVM_KVM)
     /* map only high memory here, rest is done with KVM_BASE in alias_mapping */
-    mmap_kvm(cap, (unsigned char *)result + LOWMEM_SIZE + HMASIZE,
-	     memsize - (LOWMEM_SIZE + HMASIZE), prot, LOWMEM_SIZE + HMASIZE);
+    mmap_kvm(cap, LOWMEM_SIZE + HMASIZE, memsize - (LOWMEM_SIZE + HMASIZE),
+	     (unsigned char *)result + LOWMEM_SIZE + HMASIZE,
+	     LOWMEM_SIZE + HMASIZE, prot);
   return result;
 }
 

--- a/src/include/kvm.h
+++ b/src/include/kvm.h
@@ -25,7 +25,7 @@ int init_kvm_cpu(void);
 int kvm_vm86(struct vm86_struct *info);
 int kvm_dpmi(cpuctx_t *scp);
 void mprotect_kvm(int cap, dosaddr_t targ, size_t mapsize, int protect);
-void mmap_kvm(int cap, void *addr, size_t mapsize, int protect, dosaddr_t targ);
+void mmap_kvm(int cap, unsigned phys_addr, size_t mapsize, void *addr, dosaddr_t targ, int protect);
 void set_kvm_memory_regions(void);
 void kvm_set_dirty_log(dosaddr_t base, dosaddr_t size);
 void kvm_get_dirty_map(dosaddr_t base, unsigned char *bitmap);
@@ -44,7 +44,7 @@ static inline int init_kvm_cpu(void) { return -1; }
 static inline int kvm_vm86(struct vm86_struct *info) { return -1; }
 static inline int kvm_dpmi(cpuctx_t *scp) { return -1; }
 static inline void mprotect_kvm(int cap, dosaddr_t targ, size_t mapsize, int protect) {}
-static inline void mmap_kvm(int cap, void *addr, size_t mapsize, int protect, dosaddr_t targ) {}
+static inline void mmap_kvm(int cap, unsigned phys_addr, size_t mapsize, void *addr, dosaddr_t targ, int protect) {}
 static inline void munmap_kvm(int cap, dosaddr_t targ, size_t mapsize) {}
 static inline void set_kvm_memory_regions(void) {}
 static inline void kvm_set_dirty_log(dosaddr_t base, dosaddr_t size) {}


### PR DESCRIPTION
mmap_kvm() now takes an extra phys_addr parameter, has the same parameter order as register_hardware_ram_virtual(), and sets up the page table mappings.

mprotect_kvm() now only adjusts the protection on the page tables.