### PR TITLE
mapping: alloc_mapping_huge_page_aligned for SHM

### DIFF
--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -653,9 +653,7 @@ void *alloc_mapping(int cap, size_t mapsize)
   void *addr;
 
   Q__printf("MAPPING: alloc, cap=%s size=%#zx\n", cap, mapsize);
-  addr = mmap(NULL, mapsize, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
-  if (addr != MAP_FAILED)
-    addr = mappingdriver->alloc(cap, mapsize, addr);
+  addr = mappingdriver->alloc(cap, mapsize, (void *)-1);
   if (addr == MAP_FAILED) {
     error("failed to alloc %zx\n", mapsize);
     leavedos(2);

--- a/src/arch/linux/mapping/mapshm.c
+++ b/src/arch/linux/mapping/mapshm.c
@@ -139,9 +139,15 @@ static void close_mapping_shm(int cap)
 
 static void *alloc_mapping_shm(int cap, size_t mapsize, void *target)
 {
+  int fixed = 0;
+
   Q__printf("MAPPING: alloc, cap=%s, mapsize=%zx\n", cap, mapsize);
+  if (target != (void *)-1)
+    fixed = MAP_FIXED;
+  else
+    target = NULL;
   return mmap(target, mapsize, PROT_READ | PROT_WRITE,
-    MAP_SHARED | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
+    MAP_SHARED | MAP_ANONYMOUS | fixed, -1, 0);
 }
 
 static void free_mapping_shm(int cap, void *addr, size_t mapsize)

--- a/src/base/dev/vga/vgaemu.c
+++ b/src/base/dev/vga/vgaemu.c
@@ -1675,15 +1675,12 @@ int vga_emu_pre_init(void)
   vga.mem.size = (vga.mem.size + ((1 << 18) - 1)) & ~((1 << 18) - 1);
   vga.mem.pages = vga.mem.size >> 12;
 
-  vga.mem.base = alloc_mapping(MAPPING_VGAEMU, vga.mem.size + PAGE_SIZE);
+  vga.mem.base = alloc_mapping_huge_page_aligned(MAPPING_VGAEMU, vga.mem.size);
   if(vga.mem.base == MAP_FAILED) {
     error("vga_emu_init: not enough memory (%u k)\n", vga.mem.size >> 10);
     config.exitearly = 1;
     return 1;
   }
-  /* create guard page to trap bad things */
-  mprotect(vga.mem.base, PAGE_SIZE, PROT_NONE);
-  vga.mem.base += PAGE_SIZE;
 
   /* alloc more pages because vgaemu_dirty_page() does weird things */
   if((vga.mem.dirty_map = (unsigned char *) malloc(vga.mem.pages | 0xff)) == NULL) {

--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -362,7 +362,7 @@ void low_mem_init(void)
 
   open_mapping(MAPPING_INIT_LOWRAM);
   g_printf ("DOS+HMA memory area being mapped in\n");
-  lowmem = alloc_mapping(MAPPING_INIT_LOWRAM, LOWMEM_SIZE + HMASIZE +
+  lowmem = alloc_mapping_huge_page_aligned(MAPPING_INIT_LOWRAM, LOWMEM_SIZE + HMASIZE +
 	EXTMEM_SIZE);
   if (lowmem == MAP_FAILED) {
     perror("LOWRAM alloc");

--- a/src/include/mapping.h
+++ b/src/include/mapping.h
@@ -74,6 +74,7 @@ void close_mapping(int cap);
 
 typedef void *alloc_mapping_type(int cap, size_t mapsize, void *target);
 void *alloc_mapping (int cap, size_t mapsize);
+void *alloc_mapping_huge_page_aligned (int cap, size_t mapsize);
 
 typedef void free_mapping_type(int cap, void *addr, size_t mapsize);
 void free_mapping (int cap, void *addr, size_t mapsize);
@@ -87,7 +88,6 @@ void *mmap_mapping(int cap, void *target, size_t mapsize, int protect);
 typedef void *alias_mapping_type(int cap, void *target, size_t mapsize, int protect, void *source);
 int alias_mapping(int cap, dosaddr_t targ, size_t mapsize, int protect, void *source);
 int alias_mapping_pa(int cap, unsigned addr, size_t mapsize, int protect, void *source);
-void *alias_mapping_huge_page_aligned(int cap, size_t mapsize, int protect, void *source);
 int unalias_mapping_pa(int cap, unsigned addr, size_t mapsize);
 void *alias_mapping_ux(int cap, size_t mapsize, int protect, void *source);
 


### PR DESCRIPTION
This change introduces alloc_mapping_huge_page_aligned and removes the now redundant alias_mapping_huge_page_aligned. It's used for lowmem_base and vga.mem.base, and hence the intermediate mapping for the VGAEMU LFB is no longer needed for KVM.

The guard page logic that was used for vga.mem.base in vgaemu.c has been moved into the mapping functions, so that there's always a PROT_NOTE page in front of a huge page aligned mmap and SHM alloc, and one after a huge page aligned SHM alloc as well.

See also #1922