### PR TITLE
mapping: Use pgalloc for file-based SHM, pass target (#1934)

### DIFF
--- a/src/base/lib/misc/pgalloc.c
+++ b/src/base/lib/misc/pgalloc.c
@@ -81,6 +81,32 @@ int pgaalloc(void *pool, unsigned npages, unsigned id)
     return idx - 1;
 }
 
+int pgaresize(void *pool, unsigned page, unsigned oldpages, unsigned newpages)
+{
+    int i;
+    int *p = pool;
+    page++;  // skip len
+    assert(page + oldpages < p[0]);
+    assert(page + newpages < p[0]);
+    assert(p[page] < 0);
+
+    if (newpages <= oldpages) { /* shrink */
+        for (i = newpages; i < oldpages; i++)
+             p[page+i] = 0;
+        return page;
+    }
+
+    /* check if we can expand */
+    for (i = oldpages; i < newpages; i++)
+         if (p[page+i])
+             return -1;
+
+    /* allocate the expansion */
+    for (i = oldpages; i < newpages; i++)
+         p[page+i] = i;
+    return page;
+}
+
 void pgafree(void *pool, unsigned page)
 {
     int *p = pool;

--- a/src/include/mapping.h
+++ b/src/include/mapping.h
@@ -72,13 +72,13 @@ int open_mapping (int cap);
 typedef void close_mapping_type(int cap);
 void close_mapping(int cap);
 
-typedef void *alloc_mapping_type(int cap, size_t mapsize);
+typedef void *alloc_mapping_type(int cap, size_t mapsize, void *target);
 void *alloc_mapping (int cap, size_t mapsize);
 
 typedef void free_mapping_type(int cap, void *addr, size_t mapsize);
 void free_mapping (int cap, void *addr, size_t mapsize);
 
-typedef void *realloc_mapping_type(int cap, void *addr, size_t oldsize, size_t newsize);
+typedef void *resize_mapping_type(int cap, void *addr, size_t oldsize, size_t newsize);
 void *realloc_mapping (int cap, void *addr, size_t oldsize, size_t newsize);
 
 void *mmap_mapping_huge_page_aligned(int cap, size_t mapsize, int protect);
@@ -102,7 +102,7 @@ struct mappingdrivers {
   close_mapping_type *close;
   alloc_mapping_type *alloc;
   free_mapping_type *free;
-  realloc_mapping_type *realloc;
+  resize_mapping_type *resize;
   alias_mapping_type *alias;
 };
 char *decode_mapping_cap(int cap);

--- a/src/include/pgalloc.h
+++ b/src/include/pgalloc.h
@@ -6,6 +6,7 @@ void pgadone(void *pool);
 void pgareset(void *pool);
 int pgaalloc(void *pool, unsigned npages, unsigned id);
 void pgafree(void *pool, unsigned page);
+int pgaresize(void *pool, unsigned page, unsigned oldpages, unsigned newpages);
 int pgaavail_largest(void *pool);
 struct pgrm {
     int id;


### PR DESCRIPTION
Using the page allocator instead of smalloc allows us to mmap memory on demand, but still keeping track of the file offsets that were used to map that memory.

The realloc method was renamed to resize, as we can keep both the mmap area and file area the same without copying then, but if resizing isn't possible, mapping.c code deals with it, using a new allocation and copying to it.

Passing target will makes it easier to align to huge pages.