### PR TITLE
mapping: fix XMS regression from 3476d32

### DIFF
--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -459,6 +459,8 @@ int restore_mapping(int cap, dosaddr_t targ, size_t mapsize)
   assert((cap & MAPPING_DPMI) && (targ != (dosaddr_t)-1));
   target = MEM_BASE32(targ);
   addr = mmap_mapping(cap, target, mapsize, PROT_READ | PROT_WRITE);
+  if (is_kvm_map(cap))
+    mprotect_kvm(cap, targ, mapsize, PROT_READ | PROT_WRITE);
   return (addr == target ? 0 : -1);
 }
 
@@ -1069,6 +1071,8 @@ int alias_mapping_pa(int cap, unsigned addr, size_t mapsize, int protect,
     return 0;
   assert(addr2 == MEM_BASE32(va));
   hwram_update_aliasmap(hw, addr, mapsize, source);
+  if (is_kvm_map(cap))
+    mprotect_kvm(cap, va, mapsize, protect);
   return 1;
 }
 


### PR DESCRIPTION
the test:
```
test/test_dos.py PPDOSGITTestCase.test_memory_xms
```
fails with KVM since commit 3476d32

`alias_mapping_pa()` (similar to `alias_mapping()`) needs to forward the new page protections to KVM's page tables, and similar for `unalias_mapping_pa()` via `restore_mapping()`.