### PR TITLE
Map DPMI using a flexible KVM-internal location in guest physical memory, eliminate xms_map_size

### DIFF
--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -747,6 +747,8 @@ static int do_map_hwram(struct hardware_ram *hw)
   int cap = MAPPING_KMEM;
   if (hw->default_vbase != (dosaddr_t)-1)
     cap |= MAPPING_LOWMEM;
+  else if (!config.dpmi)
+    return 0;
   p = mmap_mapping_kmem(cap, hw->default_vbase, hw->size, hw->base);
   if (p == MAP_FAILED) {
     error("mmap error in map_hardware_ram %s\n", strerror (errno));

--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -408,7 +408,6 @@ void low_mem_init(void)
     x_printf("Ext.Mem of size 0x%x at %#x\n", EXTMEM_SIZE, result + LOWMEM_SIZE + HMASIZE);
   }
 
-  ptr += phys_rsv + dpmi_rsv_low;
   /* create non-identity mapping up to dpmi_base */
   phys_rsv = config.dpmi_base - (LOWMEM_SIZE + HMASIZE);
   ptr2 = smalloc_aligned_topdown(&main_pool, MEM_BASE32(memsize),
@@ -417,13 +416,11 @@ void low_mem_init(void)
   /* establish alias access for int15 */
   register_hardware_ram_virtual('X', LOWMEM_SIZE + HMASIZE, phys_rsv,
 	    DOSADDR_REL(ptr2));
-  register_hardware_ram_virtual('U',  DOSADDR_REL(ptr2), phys_rsv,
-	    LOWMEM_SIZE + HMASIZE);
   /* map dpmi+uncommitted space to kvm */
-  if (config.cpu_vm_dpmi == CPUVM_KVM) {
+  if (config.dpmi && config.cpu_vm_dpmi == CPUVM_KVM) {
     int prot = PROT_READ | PROT_WRITE | PROT_EXEC;
     mmap_kvm(MAPPING_INIT_LOWRAM, (unsigned)-1, ptr2 - ptr, ptr,
-	config.dpmi_base, prot);
+	LOWMEM_SIZE + HMASIZE, prot);
   }
   /* create alias for dpmi */
   result = alias_mapping(MAPPING_EXTMEM, DOSADDR_REL(ptr2), EXTMEM_SIZE,

--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -422,7 +422,7 @@ void low_mem_init(void)
   /* map dpmi+uncommitted space to kvm */
   if (config.cpu_vm_dpmi == CPUVM_KVM) {
     int prot = PROT_READ | PROT_WRITE | PROT_EXEC;
-    mmap_kvm(MAPPING_INIT_LOWRAM, config.dpmi_base, ptr2 - ptr, ptr,
+    mmap_kvm(MAPPING_INIT_LOWRAM, (unsigned)-1, ptr2 - ptr, ptr,
 	config.dpmi_base, prot);
   }
   /* create alias for dpmi */

--- a/src/dosext/misc/xms.c
+++ b/src/dosext/misc/xms.c
@@ -280,7 +280,7 @@ static void unmap_EMB(unsigned base, unsigned size)
 void *xms_resolve_physaddr(unsigned addr)
 {
   struct pgrm m;
-  assert(addr >= xms_base && addr < xms_base + config.xms_map_size);
+  assert(addr >= xms_base && addr < xms_base + config.xms_size*1024);
   m = pgarmap(pgapool, (addr - xms_base) >> PAGE_SHIFT);
   if (m.pgoff == -1)
     return MAP_FAILED;
@@ -455,7 +455,7 @@ void xms_helper(void)
 
 void xms_init(void)
 {
-  pgapool = pgainit(config.xms_map_size >> PAGE_SHIFT);
+  pgapool = pgainit((config.xms_size*1024) >> PAGE_SHIFT);
 }
 
 void xms_done(void)

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -265,7 +265,7 @@ typedef struct config_info {
 
        int hogthreshold;
 
-       int mem_size, ext_mem, xms_size, xms_map_size, ems_size;
+       int mem_size, ext_mem, xms_size, ems_size;
        int umb_a0, umb_b0, umb_f0, hma;
        unsigned int ems_frame;
        int ems_uma_pages, ems_cnv_pages;


### PR DESCRIPTION
This ports much of my patch on top of #1922 to current devel.

There is one somewhat awkward line left in init.c:
```
   uint32_t memsize = LOWMEM_SIZE + HMASIZE +
    (config.dpmi ? dpmi_lin_mem_rsv() : phys_rsv + PAGE_SIZE);
```
if I remove the PAGE_SIZE and set $_dpmi=(0), then smalloc complains, even though there should be exactly enough space in main_pool with
```
dosemu.bin: smalloc.c:90: do_smerror: Assertion `prio != -1' failed.
```

But in any case I intend to change that line to simply:
```
   uint32_t memsize = LOWMEM_SIZE + HMASIZE + (config.dpmi ? dpmi_lin_mem_rsv() : 0);
```
in a follow-up PR by adding the physical memory to kvm_base instead, and having the XMS alias mappings for DPMI done and undone on demand in dpmi/memory.c for ax=0x0800 and ax=0x0801, ie.:
* xms.c `map_EMB()` will allocate physical memory, and calls `register_hardware_ram()`; without KVM it simply does the page alloc for accounting, with KVM, it can also alias the corresponding location in kvm_base to SHM.
* memory.c `DPMI_mapHWRam()` can then `smalloc` some virtual memory from `main_pool`, exactly what is asked for, and alias map that to the SHM registered in xms.c (or init.c for extmem with himem.sys).
I had that approach working yesterday but it needs some more cleanups before publishing.