### PR TITLE
Mapmem

### DIFF
--- a/etc/dosemu.conf
+++ b/etc/dosemu.conf
@@ -316,10 +316,10 @@
 
 # $_dpmi = (0x20000)
 
-# Size of reserved linear address space for DPMI.
-# Default: 0x80000 (reserve 512Mb)
+# DPMI base address
+# Default: 0x20000000 (at 512Mb)
 
-# $_dpmi_lin_rsv_size = (0x80000)
+# $_dpmi_base = (0x20000000)
 
 # Some DJGPP-compiled programs have the NULL pointer dereference bugs.
 # They may work under Windows or QDPMI as these unfortunately do not

--- a/etc/global.conf
+++ b/etc/global.conf
@@ -134,7 +134,7 @@ else
   hma $_hma
   dos_up $_dos_up
   dpmi $_dpmi
-  dpmi_lin_rsv_size $_dpmi_lin_rsv_size
+  dpmi_base $_dpmi_base
   pm_dos_api 1
   ignore_djgpp_null_derefs $_ignore_djgpp_null_derefs
   dosmem $_dosmem

--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -315,7 +315,7 @@ static void *mmap_mapping_kmem(int cap, dosaddr_t targ, size_t mapsize,
   }
 
   if (targ == (dosaddr_t)-1) {
-    target = smalloc(&main_pool, mapsize);
+    target = smalloc_aligned_topdown(&main_pool, NULL, PAGE_SIZE, mapsize);
     if (!target) {
       error("OOM for mmap_mapping_kmem, %s\n", strerror(errno));
       return MAP_FAILED;
@@ -747,6 +747,8 @@ static int do_map_hwram(struct hardware_ram *hw)
   int cap = MAPPING_KMEM;
   if (hw->default_vbase != (dosaddr_t)-1)
     cap |= MAPPING_LOWMEM;
+  else if (!config.dpmi)
+    return 0;
   p = mmap_mapping_kmem(cap, hw->default_vbase, hw->size, hw->base);
   if (p == MAP_FAILED) {
     error("mmap error in map_hardware_ram %s\n", strerror (errno));

--- a/src/base/dev/vga/vgaemu.c
+++ b/src/base/dev/vga/vgaemu.c
@@ -1733,7 +1733,7 @@ int vga_emu_pre_init(void)
 
   vga.mem.lfb_base = 0;
   if (config.X_lfb && config.dpmi) {
-    void *addr = smalloc(&main_pool, vga.mem.size);
+    void *addr = smalloc_aligned_topdown(&main_pool, NULL, PAGE_SIZE, vga.mem.size);
     if (addr) {
       vga.mem.lfb_base = DOSADDR_REL(addr);
       memcheck_addtype('e', "VGAEMU LFB");

--- a/src/base/emu-i386/kvm.c
+++ b/src/base/emu-i386/kvm.c
@@ -613,7 +613,7 @@ void mprotect_kvm(int cap, dosaddr_t targ, size_t mapsize, int protect)
 	       MAPPING_DPMI|MAPPING_VGAEMU|MAPPING_KVM|MAPPING_CPUEMU|
 	       MAPPING_EXTMEM))) return;
 
-  p = kvm_get_memory_region(monitor->pte[start] & PAGE_MASK, mapsize);
+  p = kvm_get_memory_region(monitor->pte[start] & PAGE_MASK, PAGE_SIZE);
   if (!p) return;
 
   /* never apply write-protect to regions with dirty logging */

--- a/src/base/init/config.c
+++ b/src/base/init/config.c
@@ -183,8 +183,8 @@ void dump_config_status(void (*printfunc)(const char *, ...))
         config.ems_size, config.ems_frame);
     (*print)("umb_a0 %i\numb_b0 %i\numb_f0 %i\ndos_up %i\n",
         config.umb_a0, config.umb_b0, config.umb_f0, config.dos_up);
-    (*print)("dpmi 0x%x\ndpmi_lin_rsv_size 0x%x\npm_dos_api %i\nignore_djgpp_null_derefs %i\n",
-        config.dpmi, config.dpmi_lin_rsv_size, config.pm_dos_api, config.no_null_checks);
+    (*print)("dpmi 0x%x\ndpmi_base 0x%x\npm_dos_api %i\nignore_djgpp_null_derefs %i\n",
+        config.dpmi, config.dpmi_base, config.pm_dos_api, config.no_null_checks);
     (*print)("mapped_bios %d\nvbios_file %s\n",
         config.mapped_bios, (config.vbios_file ? config.vbios_file :""));
     (*print)("vbios_copy %d\nvbios_seg 0x%x\nvbios_size 0x%x\n",
@@ -831,8 +831,6 @@ static void config_post_process(void)
           "adjust $_cpu_vm_dpmi\n");
     c_printf("CONF: V86 cpu vm set to %d\n", config.cpu_vm);
     c_printf("CONF: DPMI cpu vm set to %d\n", config.cpu_vm_dpmi);
-    if (!config.dpmi)
-	config.dpmi_lin_rsv_size = 0;
 
     /* console scrub */
     if (!Video && getenv("DISPLAY") && !config.X && !config.term &&

--- a/src/base/init/lexer.l
+++ b/src/base/init/lexer.l
@@ -329,7 +329,7 @@ hma			RETURN(HMA);
 dos_up			RETURN(DOS_UP);
 ems			RETURN(L_EMS);
 dpmi			RETURN(L_DPMI);
-dpmi_lin_rsv_size	RETURN(DPMI_LIN_RSV_SIZE);
+dpmi_base		RETURN(DPMI_BASE);
 pm_dos_api		RETURN(PM_DOS_API);
 ignore_djgpp_null_derefs RETURN(NO_NULL_CHECKS);
 dosmem			RETURN(DOSMEM);

--- a/src/base/init/parser.y
+++ b/src/base/init/parser.y
@@ -234,7 +234,7 @@ enum {
 %token ETHDEV TAPDEV VDESWITCH SLIRPARGS VNET
 %token DEBUG MOUSE SERIAL COM KEYBOARD TERMINAL VIDEO EMURETRACE TIMER
 %token MATHCO CPU CPUSPEED BOOTDRIVE SWAP_BOOTDRIVE
-%token L_XMS L_DPMI DPMI_LIN_RSV_SIZE PM_DOS_API NO_NULL_CHECKS
+%token L_XMS L_DPMI DPMI_BASE PM_DOS_API NO_NULL_CHECKS
 %token PORTS DISK DOSMEM EXT_MEM
 %token L_EMS UMB_A0 UMB_B0 UMB_F0 HMA DOS_UP
 %token EMS_SIZE EMS_FRAME EMS_UMA_PAGES EMS_CONV_PAGES
@@ -621,10 +621,10 @@ line:		CHARSET '{' charset_flags '}' {}
 		    if ($2>=0) config.dpmi = $2;
 		    c_printf("CONF: DPMI-Server %s (%#x)\n", ($2) ? "on" : "off", ($2));
 		    }
-		| DPMI_LIN_RSV_SIZE int_bool
+		| DPMI_BASE int_bool
 		    {
-		    config.dpmi_lin_rsv_size = $2;
-		    c_printf("CONF: DPMI linear reserve size = %#x\n", $2);
+		    config.dpmi_base = $2;
+		    c_printf("CONF: DPMI base addr = %#x\n", $2);
 		    }
 		| PM_DOS_API bool
 		    {

--- a/src/dosext/dpmi/emudpmi.h
+++ b/src/dosext/dpmi/emudpmi.h
@@ -240,7 +240,7 @@ extern unsigned short dpmi_sel(void);
 extern unsigned short dpmi_sel16(void);
 extern unsigned short dpmi_sel32(void);
 unsigned long dpmi_mem_size(void);
-void dpmi_set_mem_base(void *base);
+void dpmi_set_mem_base(void);
 void dump_maps(void);
 
 int DPMIValidSelector(unsigned short selector);
@@ -344,7 +344,7 @@ static inline int get_ldt(void *buffer)
     return -1;
 }
 
-static inline void dpmi_set_mem_base(void *base)
+static inline void dpmi_set_mem_base(void)
 {
 }
 

--- a/src/dosext/dpmi/memory.c
+++ b/src/dosext/dpmi/memory.c
@@ -60,11 +60,11 @@ static int in_dpmi_pool(dosaddr_t base, unsigned int size)
     return 0;
 }
 
-void dpmi_set_mem_base(void *base)
+void dpmi_set_mem_base(void)
 {
     dpmi_lin_rsv_base = MEM_BASE32(LOWMEM_SIZE + HMASIZE);
-    dpmi_base = base;
-    c_printf("DPMI memory mapped to %p\n", base);
+    dpmi_base = MEM_BASE32(config.dpmi_base);
+    c_printf("DPMI memory mapped to %p\n", dpmi_base);
 }
 
 /* utility routines */
@@ -215,7 +215,7 @@ int dpmi_lin_mem_rsv(void)
 {
     if (!config.dpmi)
 	return 0;
-    return PAGE_ALIGN(config.dpmi_lin_rsv_size * 1024);
+    return PAGE_ALIGN(config.dpmi - (LOWMEM_SIZE + HMASIZE));
 }
 
 int dpmi_lin_mem_free(void)
@@ -229,7 +229,7 @@ int dpmi_alloc_pool(void)
 {
     uint32_t memsize = dpmi_mem_size();
 
-    if (dpmi_base < dpmi_lin_rsv_base || dpmi_base + memsize >
+    if (dpmi_base < dpmi_lin_rsv_base || dpmi_base <
 	    dpmi_lin_rsv_base + dpmi_lin_mem_rsv()) {
         error("$_dpmi or $_dpmi_base setting out of range\n");
         return -1;

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -270,7 +270,7 @@ typedef struct config_info {
        unsigned int ems_frame;
        int ems_uma_pages, ems_cnv_pages;
        int dpmi, pm_dos_api, no_null_checks;
-       uint32_t dpmi_lin_rsv_size;
+       uint32_t dpmi_base;
        int dos_up;
 
        int sillyint;            /* IRQ numbers for Silly Interrupt Generator


### PR DESCRIPTION
Place dpmi_base past all linear address mappings, use the old meaning for the fixed linear region.

We now have the following memory layout:
```
phys: low hma extmem xms dpmi_low_lin_rsv high_lin_rsv dpmi_base
virt: low hma dpmi_low_lin_rsv extmem xms high_lin_rsv dpmi_base
```

This build upon #1944 moving a few things around, realizing that the addition of all low things is always the same, so we can identity map after that. For the fixed linear region this reverts the meaning to what it was before 9322392 (but tasm32.exe still works).