### PR TITLE
debug: move crash info from dnative/sigsegv.c to debug.c (#1953)

### DIFF
--- a/src/arch/linux/async/debug.h
+++ b/src/arch/linux/async/debug.h
@@ -1,6 +1,7 @@
 #ifndef __DEBUG_H
 #define __DEBUG_H
 
+void siginfo_debug(const siginfo_t *si);
 void gdb_debug(void);
 
 #endif

--- a/src/arch/linux/async/signal.c
+++ b/src/arch/linux/async/signal.c
@@ -475,7 +475,7 @@ static void leavedos_emerg(int sig, siginfo_t *si, void *uc)
 SIG_PROTO_PFX
 static void abort_signal(int sig, siginfo_t *si, void *uc)
 {
-  gdb_debug();
+  siginfo_debug(si);
   _exit(sig);
 }
 
@@ -496,7 +496,7 @@ static void minfault(int sig, siginfo_t *si, void *uc)
     return;
 #endif
 #endif
-  gdb_debug();
+  siginfo_debug(si);
   _exit(sig);
 }
 


### PR DESCRIPTION
Instead of being silent (except for dnative), a crash now causes output using portable siginfo_t information, like this:

```
ERROR: cpu exception in dosemu code outside of VM86()!
Segmentation fault (Address not mapped to object [0xd4000000])

ERROR: Please install gdb, update dosemu from git, compile it with debug
info and make a bug report with the content of ~/.dosemu/boot.log at
https://github.com/dosemu2/dosemu2/issues
Please provide any additional info you can, like the test-cases,
URLs and all the rest that fits.
```