### PR TITLE
Eliminate use of DPMI memory when $_dpmi=(0).

### DIFF
--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -87,8 +87,8 @@ static struct mappingdrivers *mappingdriver;
 
 #define ALIAS_SIZE (LOWMEM_SIZE + HMASIZE)
 struct hardware_ram;
-static dosaddr_t do_get_hardware_ram(unsigned addr, uint32_t size,
-	struct hardware_ram **r_hw);
+static struct hardware_ram *do_get_hardware_ram(unsigned addr, uint32_t size,
+	dosaddr_t *pva);
 static void hwram_update_aliasmap(struct hardware_ram *hw, unsigned addr,
 	int size, unsigned char *src);
 
@@ -101,8 +101,8 @@ static void update_aliasmap(dosaddr_t dosaddr, size_t mapsize,
   if (dosaddr >= ALIAS_SIZE)
     return;
   /* identity map below ALIAS_SIZE */
-  addr2 = do_get_hardware_ram(dosaddr, mapsize, &hw);
-  assert(addr2 == dosaddr);
+  hw = do_get_hardware_ram(dosaddr, mapsize, &addr2);
+  assert(hw && addr2 == dosaddr);
   hwram_update_aliasmap(hw, dosaddr, mapsize, unixaddr);
 }
 
@@ -787,7 +787,7 @@ void init_hardware_ram(void)
 
   for (hw = hardware_ram; hw != NULL; hw = hw->next) {
     int cap = MAPPING_KMEM;
-    if (hw->vbase != (dosaddr_t)-1)  /* virtual hardware ram mapped later */
+    if (hw->type != 'h' && hw->type != 'v')  /* virtualized hardware ram mapped later */
       continue;
     if (hw->default_vbase != (dosaddr_t)-1)
       cap |= MAPPING_LOWMEM;
@@ -839,10 +839,6 @@ static int do_register_hwram(int type, unsigned base, unsigned size,
 {
   struct hardware_ram *hw;
 
-  if (!can_do_root_stuff && !uaddr) {
-    dosemu_error("can't use hardware ram in low feature (non-suid root) DOSEMU\n");
-    return 0;
-  }
   c_printf("Registering HWRAM, type=%c base=%#x size=%#x\n", type, base, size);
   hw = malloc(sizeof(*hw));
   hw->base = base;
@@ -863,13 +859,18 @@ static int do_register_hwram(int type, unsigned base, unsigned size,
 
 int register_hardware_ram(int type, unsigned base, unsigned int size)
 {
+  if (!can_do_root_stuff) {
+    dosemu_error("can't use hardware ram in low feature (non-suid root) DOSEMU\n");
+    return 0;
+  }
   return do_register_hwram(type, base, size, NULL, -1);
 }
 
 void register_hardware_ram_virtual2(int type, unsigned base, unsigned int size,
 	void *uaddr, dosaddr_t va)
 {
-  do_register_hwram(type, base, size, MEM_BASE32(va), va);
+  do_register_hwram(type, base, size,
+		    (va == (dosaddr_t)-1) ? NULL : MEM_BASE32(va), va);
   if (config.cpu_vm_dpmi == CPUVM_KVM ||
       (config.cpu_vm == CPUVM_KVM && base + size <= LOWMEM_SIZE + HMASIZE)) {
     int prot = PROT_READ | PROT_WRITE | PROT_EXEC;
@@ -903,26 +904,33 @@ int unregister_hardware_ram_virtual(dosaddr_t base)
   return -1;
 }
 
-/* given physical address addr, gives the corresponding vbase or -1 */
-static dosaddr_t do_get_hardware_ram(unsigned addr, uint32_t size,
-	struct hardware_ram **r_hw)
+/* given physical address addr, gives a pointer to the corresponding
+   hardware_ram struct, and if it exists sets the corresponding vbase
+   (or -1 if there is no vbase) in *pva, if pva != NULL.
+*/
+static struct hardware_ram *do_get_hardware_ram(unsigned addr, uint32_t size,
+	dosaddr_t *pva)
 {
   struct hardware_ram *hw;
+  dosaddr_t va = (dosaddr_t)-1;
 
   for (hw = hardware_ram; hw != NULL; hw = hw->next) {
-    if (hw->vbase != -1 &&
-	hw->base <= addr && addr + size <= hw->base + hw->size) {
-	if (r_hw)
-	  *r_hw = hw;
-      return hw->vbase + addr - hw->base;
+    if (hw->base <= addr && addr + size <= hw->base + hw->size) {
+      if (hw->vbase != (dosaddr_t)-1)
+	va = hw->vbase + addr - hw->base;
+      break;
     }
   }
-  return -1;
+  if (hw && pva)
+    *pva = va;
+  return hw;
 }
 
 dosaddr_t get_hardware_ram(unsigned addr, uint32_t size)
 {
-  return do_get_hardware_ram(addr, size, NULL);
+  dosaddr_t va = (dosaddr_t)-1;
+  do_get_hardware_ram(addr, size, &va);
+  return va;
 }
 
 static void hwram_update_aliasmap(struct hardware_ram *hw, unsigned addr,
@@ -936,12 +944,11 @@ static void hwram_update_aliasmap(struct hardware_ram *hw, unsigned addr,
 
 void *get_hardware_uaddr(unsigned addr)
 {
-  struct hardware_ram *hw;
+  struct hardware_ram *hw = do_get_hardware_ram(addr, 1, NULL);
 
-  for (hw = hardware_ram; hw != NULL; hw = hw->next) {
-    if (hw->vbase != -1 &&
-	hw->base <= addr && addr < hw->base + hw->size) {
-      int off = addr - hw->base;
+  if (hw) {
+    int off = addr - hw->base;
+    if (hw->aliasmap[off >> PAGE_SHIFT]) {
       return hw->aliasmap[off >> PAGE_SHIFT] + (off & (PAGE_SIZE - 1));
     }
   }
@@ -1073,9 +1080,9 @@ int alias_mapping_pa(int cap, unsigned addr, size_t mapsize, int protect,
        void *source)
 {
   void *addr2;
-  struct hardware_ram *hw;
-  dosaddr_t va = do_get_hardware_ram(addr, mapsize, &hw);
-  if (va == (dosaddr_t)-1)
+  dosaddr_t va;
+  struct hardware_ram *hw = do_get_hardware_ram(addr, mapsize, &va);
+  if (hw == NULL)
     return 0;
   assert(addr >= LOWMEM_SIZE + HMASIZE);
   if (is_kvm_map(cap)) {
@@ -1087,11 +1094,13 @@ int alias_mapping_pa(int cap, unsigned addr, size_t mapsize, int protect,
       assert(addr2 == MEM_BASE32x(addr, KVM_BASE));
     }
   }
+  hwram_update_aliasmap(hw, addr, mapsize, source);
+  if (va == (dosaddr_t)-1)
+    return 1;
   addr2 = mappingdriver->alias(cap, MEM_BASE32(va), mapsize, protect, source);
   if (addr2 == MAP_FAILED)
     return 0;
   assert(addr2 == MEM_BASE32(va));
-  hwram_update_aliasmap(hw, addr, mapsize, source);
   if (is_kvm_map(cap))
     mprotect_kvm(cap, va, mapsize, protect);
   return 1;
@@ -1099,17 +1108,18 @@ int alias_mapping_pa(int cap, unsigned addr, size_t mapsize, int protect,
 
 int unalias_mapping_pa(int cap, unsigned addr, size_t mapsize)
 {
-  struct hardware_ram *hw;
-  dosaddr_t va = do_get_hardware_ram(addr, mapsize, &hw);
-  if (va == (dosaddr_t)-1)
+  dosaddr_t va;
+  struct hardware_ram *hw = do_get_hardware_ram(addr, mapsize, &va);
+  if (hw == NULL)
     return 0;
   assert(addr >= LOWMEM_SIZE + HMASIZE);
-  restore_mapping(cap, va, mapsize);
   hwram_update_aliasmap(hw, addr, mapsize, NULL);
   if (is_kvm_map(cap)) {
     void *target = MEM_BASE32x(addr,KVM_BASE);
     if (target != MAP_FAILED)
       mmap_mapping(cap, target, mapsize, PROT_READ | PROT_WRITE);
   }
+  if (va != (dosaddr_t)-1)
+    restore_mapping(cap, va, mapsize);
   return 1;
 }

--- a/src/base/emu-i386/kvm.c
+++ b/src/base/emu-i386/kvm.c
@@ -534,6 +534,19 @@ static void mmap_kvm_no_overlap(unsigned targ, void *addr, size_t mapsize, int f
       return;
   }
 
+  for (slot = 0; slot < MAXSLOT; slot++) {
+    region = &maps[slot];
+    if (region->guest_phys_addr + region->memory_size == targ &&
+	region->userspace_addr + region->memory_size == (uintptr_t)addr &&
+	region->flags == flags) {
+      /* merge slots */
+      region->memory_size += mapsize;
+      Q_printf("KVM: merged mapped guest %#x to host addr %p, size=%zx, LOG_DIRTY=%d\n",
+	   targ, addr, mapsize, flags == KVM_MEM_LOG_DIRTY_PAGES ? 1 : 0);
+      return;
+    }
+  }
+
   for (slot = 0; slot < MAXSLOT; slot++)
     if (maps[slot].memory_size == 0) break;
 

--- a/src/base/emu-i386/kvm.c
+++ b/src/base/emu-i386/kvm.c
@@ -605,6 +605,9 @@ void mmap_kvm(int cap, unsigned phys_addr, size_t mapsize, void *addr, dosaddr_t
   /* with KVM we need to manually remove/shrink existing mappings */
   do_munmap_kvm(phys_addr, mapsize);
   mmap_kvm_no_overlap(phys_addr, addr, mapsize, 0);
+  /* physical-only mapping, used when $_dpmi=(0) */
+  if (targ == (dosaddr_t)-1)
+    return;
   for (page = start; page < end; page++, phys_addr += pagesize) {
     int pde_entry = page >> 10;
     if (monitor->pde[pde_entry] == 0)

--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -429,11 +429,11 @@ void low_mem_init(void)
     register_hardware_ram_virtual('U', DOSADDR_REL(ptr2), phys_rsv,
 	    LOWMEM_SIZE + HMASIZE);
     /* create ext_mem alias for dpmi */
-    result = alias_mapping(MAPPING_EXTMEM, DOSADDR_REL(ptr2),
+    result = alias_mapping_pa(MAPPING_EXTMEM, LOWMEM_SIZE + HMASIZE,
 			 EXTMEM_SIZE - HMASIZE,
 			 PROT_READ | PROT_WRITE,
 			 lowmem + LOWMEM_SIZE + HMASIZE);
-    assert(result != -1);
+    assert(result == 1);
   }
 
   /* R/O protect 0xf0000-0xf4000 */

--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -388,6 +388,12 @@ void low_mem_init(void)
   }
   c_printf("Conventional memory mapped from %p to %p\n", lowmem, mem_base);
 
+  /* LOWMEM_SIZE + HMASIZE == base */
+  memcheck_addtype('X', "EXT MEM");
+  memcheck_reserve('X', LOWMEM_SIZE + HMASIZE, EXTMEM_SIZE - HMASIZE);
+  x_printf("Ext.Mem of size 0x%x at %#x\n", EXTMEM_SIZE - HMASIZE,
+      LOWMEM_SIZE + HMASIZE);
+
   if (config.xms_size)
     memcheck_reserve('x', LOWMEM_SIZE + EXTMEM_SIZE, XMS_SIZE);
 
@@ -414,22 +420,12 @@ void low_mem_init(void)
     }
     /* unused hole for alignment */
     ptr2 += LOWMEM_SIZE + HMASIZE;
-  }
-
-  /* LOWMEM_SIZE + HMASIZE == base */
-  memcheck_addtype('X', "EXT MEM");
-  memcheck_reserve('X', LOWMEM_SIZE + HMASIZE, EXTMEM_SIZE - HMASIZE);
-  x_printf("Ext.Mem of size 0x%x at %#x\n", EXTMEM_SIZE - HMASIZE,
-      LOWMEM_SIZE + HMASIZE);
-
-  /* establish ext_mem alias access for int15 */
-  register_hardware_ram_virtual('X', LOWMEM_SIZE + HMASIZE, phys_rsv,
-	    DOSADDR_REL(ptr2));
-  if (config.dpmi) {
     register_hardware_ram_virtual('U', DOSADDR_REL(ptr2), phys_rsv,
 	    LOWMEM_SIZE + HMASIZE);
   }
   /* create ext_mem alias for int15/dpmi */
+  register_hardware_ram_virtual('X', LOWMEM_SIZE + HMASIZE, phys_rsv,
+	    DOSADDR_REL(ptr2));
   result = alias_mapping_pa(MAPPING_EXTMEM, LOWMEM_SIZE + HMASIZE,
 			 EXTMEM_SIZE - HMASIZE,
 			 PROT_READ | PROT_WRITE,

--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -428,13 +428,13 @@ void low_mem_init(void)
   if (config.dpmi) {
     register_hardware_ram_virtual('U', DOSADDR_REL(ptr2), phys_rsv,
 	    LOWMEM_SIZE + HMASIZE);
-    /* create ext_mem alias for dpmi */
-    result = alias_mapping_pa(MAPPING_EXTMEM, LOWMEM_SIZE + HMASIZE,
+  }
+  /* create ext_mem alias for int15/dpmi */
+  result = alias_mapping_pa(MAPPING_EXTMEM, LOWMEM_SIZE + HMASIZE,
 			 EXTMEM_SIZE - HMASIZE,
 			 PROT_READ | PROT_WRITE,
 			 lowmem + LOWMEM_SIZE + HMASIZE);
-    assert(result == 1);
-  }
+  assert(result == 1);
 
   /* R/O protect 0xf0000-0xf4000 */
   if (!config.umb_f0)


### PR DESCRIPTION
Up so far we've always had a vbase for virtual hardware, but with extmem/XMS the vbase is only needed for DPMI, whereas the physical RAM always exists.

With the LFB it's similar, except it's convenient to keep the LFB vbase constant; XMS mappings are temporary, and we've already disabled the LFB completely with config.dpmi==0, and that cannot be done with XMS.

Allowing register_hardware_ram without a vbase makes it possible to use a minimal main_pool of just 0x110000 if $_dpmi=(0).
    
My goal is to only alias map and unmap that extmem/XMS virtual hardware ram on demand in DPMI fn 0800/0801 in a followup PR.

With VCPI extmem/XMS will need to be mapped into KVM again, but that should be just physical memory (where we don't know the virtual address unless we inspect the VCPI client's page tables), not something in mem_base with a specific dosaddr associated to it.
