### PR TITLE
cpuctx_t: make cr2 of type dosaddr_t

### DIFF
--- a/src/base/emu-i386/kvm.c
+++ b/src/base/emu-i386/kvm.c
@@ -1158,7 +1158,7 @@ int kvm_dpmi(cpuctx_t *scp)
     if (exit_reason == KVM_EXIT_HLT) {
       /* orig_eax >> 16 = exception number */
       /* orig_eax & 0xffff = error code */
-      _cr2 = (uintptr_t)MEM_BASE32(monitor->cr2);
+      _cr2 = monitor->cr2;
       _trapno = (regs->orig_eax >> 16) & 0xff;
       _err = regs->orig_eax & 0xffff;
       if (_trapno > 0x10) {

--- a/src/base/emu-i386/simx86/cpatch.c
+++ b/src/base/emu-i386/simx86/cpatch.c
@@ -255,7 +255,7 @@ asmlinkage void wri_8(unsigned char *paddr, Bit8u value, unsigned char *eip)
 	addr = DOSADDR_REL(paddr);
 	m_munprotect(addr, 1, eip);
 	InCompiledCode++;
-	if (!emu_ldt_write(paddr, value, 1)) {
+	if (!emu_ldt_write(addr, value, 1)) {
 		if (vga_write_access(addr))
 			vga_write(addr, value);
 		else
@@ -274,7 +274,7 @@ asmlinkage void wri_16(unsigned char *paddr, Bit16u value, unsigned char *eip)
 	addr = DOSADDR_REL(paddr);
 	m_munprotect(addr, 2, eip);
 	InCompiledCode++;
-	if (!emu_ldt_write(paddr, value, 2)) {
+	if (!emu_ldt_write(addr, value, 2)) {
 		if (vga_write_access(addr))
 			vga_write_word(addr, value);
 		else
@@ -293,7 +293,7 @@ asmlinkage void wri_32(unsigned char *paddr, Bit32u value, unsigned char *eip)
 	addr = DOSADDR_REL(paddr);
 	m_munprotect(addr, 4, eip);
 	InCompiledCode++;
-	if (!emu_ldt_write(paddr, value, 4)) {
+	if (!emu_ldt_write(addr, value, 4)) {
 		if (vga_write_access(addr))
 			vga_write_dword(addr, value);
 		else

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -1045,7 +1045,7 @@ int e_vm86(void)
 	      }
 	    default: {
 		/* FAULT, handled via signal callback */
-		vm86_fault(xval-1, TheCPU.scp_err, DOSADDR_REL(LINP(TheCPU.cr2)));
+		vm86_fault(xval-1, TheCPU.scp_err, TheCPU.cr2);
 		retval = VM86_SIGNAL;
 		break;
 	    }
@@ -1130,7 +1130,7 @@ int e_dpmi(cpuctx_t *scp)
     else if (xval==EXCP_GOBACK) {
         retval = DPMI_RET_DOSEMU;
     }
-    else if (xval == EXCP0E_PAGE && vga_emu_fault(DOSADDR_REL(LINP(_cr2)),_err,scp)==True) {
+    else if (xval == EXCP0E_PAGE && vga_emu_fault(_cr2,_err,scp)==True) {
 	retval = DPMI_RET_CLIENT;
     } else {
 	retval = DPMI_RET_FAULT;

--- a/src/base/emu-i386/simx86/memory.c
+++ b/src/base/emu-i386/simx86/memory.c
@@ -469,7 +469,7 @@ int e_handle_fault(sigcontext_t *scp)
 	TheCPU.err = EXCP00_DIVZ + _scp_trapno;
 	_scp_eax = TheCPU.cr2;
 	_scp_edx = _scp_eflags;
-	TheCPU.cr2 = _scp_cr2;
+	TheCPU.cr2 = DOSADDR_REL(LINP(_scp_cr2));
 	_scp_rip = *(long *)_scp_rsp;
 	_scp_rsp += sizeof(long);
 	return 1;

--- a/src/base/emu-i386/simx86/protmode.c
+++ b/src/base/emu-i386/simx86/protmode.c
@@ -369,20 +369,20 @@ void emu_mhp_SetTypebyte (unsigned short selector, int typebyte)
 
 /* ======================================================================= */
 
-int emu_ldt_write(unsigned char *paddr, uint32_t op, int len)
+int emu_ldt_write(dosaddr_t addr, uint32_t op, int len)
 {
 	static cpuctx_t sc = {0};
 	cpuctx_t *scp = &sc;
 
-	if (!(msdos_ldt_access(paddr)))
+	if (!(msdos_ldt_access(addr)))
 		return 0;
 
-	_cr2 = (uintptr_t)paddr;
+	_cr2 = addr;
 	_ds = TheCPU.ds;
 	_es = TheCPU.es;
 	_fs = TheCPU.fs;
 	_gs = TheCPU.gs;
-	msdos_ldt_write(scp, op, len, (unsigned char *)_cr2);
+	msdos_ldt_write(scp, op, len, _cr2);
 	if (_ds == 0) { TheCPU.ds = 0; SetSegProt(0,Ofs_DS,NULL,0); }
 	if (_es == 0) { TheCPU.es = 0; SetSegProt(0,Ofs_ES,NULL,0); }
 	if (_fs == 0) { TheCPU.fs = 0; SetSegProt(0,Ofs_FS,NULL,0); }
@@ -396,7 +396,7 @@ void emu_pagefault_handler(dosaddr_t addr, int err, uint32_t op, int len)
 		default_sim_pagefault_handler(addr, err, op, len);
 		return;
 	}
-	if ((err & 2) && emu_ldt_write(MEM_BASE32(addr), op, len))
+	if ((err & 2) && emu_ldt_write(addr, op, len))
 		return;
 	/* trigger an exception in DPMI */
 	TheCPU.err = EXCP0E_PAGE;

--- a/src/base/emu-i386/simx86/protmode.h
+++ b/src/base/emu-i386/simx86/protmode.h
@@ -230,7 +230,7 @@ int SetSegReal(unsigned short sel, int ofs);
 int e_larlsl(int mode, unsigned short sel);
 int hsw_verr(unsigned short sel);
 int hsw_verw(unsigned short sel);
-int emu_ldt_write(unsigned char *paddr, uint32_t op, int len);
+int emu_ldt_write(dosaddr_t addr, uint32_t op, int len);
 void emu_pagefault_handler(dosaddr_t addr, int err, uint32_t op, int len);
 //
 

--- a/src/base/emu-i386/simx86/sigsegv.c
+++ b/src/base/emu-i386/simx86/sigsegv.c
@@ -241,7 +241,7 @@ int e_emu_pagefault(sigcontext_t *scp, int pmode)
 	    return 1;
 #endif
 	/* use CPatch for LDT page faults, which should not fail */
-	if (msdos_ldt_access((unsigned char *)_scp_cr2) && Cpatch(scp))
+	if (msdos_ldt_access(cr2) && Cpatch(scp))
 	    return 1;
 	TheCPU.scp_err = _scp_err;
 	/* save eip, eflags, and do a "ret" out of compiled code */
@@ -250,7 +250,7 @@ int e_emu_pagefault(sigcontext_t *scp, int pmode)
 	e_printf("FindPC: found %x\n",_scp_eax);
 	_scp_edx = *(long *)_scp_rsp; // flags
 	_scp_rsp += sizeof(long);
-	TheCPU.cr2 = _scp_cr2;
+	TheCPU.cr2 = cr2;
 	_scp_rip = *(long *)_scp_rsp;
 	_scp_rsp += sizeof(long);
 	return 1;

--- a/src/dosext/dpmi/dnative/dnative.c
+++ b/src/dosext/dpmi/dnative/dnative.c
@@ -102,7 +102,7 @@ static void copy_to_dpmi(sigcontext_t *scp, cpuctx_t *s)
   _C(eflags);
   _C(trapno);
   _C(err);
-  _C(cr2);
+  _scp_cr2 = (uintptr_t)MEM_BASE32(get_cr2(s));
 
   if (scp->fpregs) {
     void *fpregs = scp->fpregs;
@@ -141,7 +141,7 @@ static void copy_to_emu(cpuctx_t *d, sigcontext_t *scp)
   _D(eflags);
   _D(trapno);
   _D(err);
-  _D(cr2);
+  get_cr2(d) = DOSADDR_REL(LINP(_scp_cr2));
   if (scp->fpregs) {
     void *fpregs = scp->fpregs;
 #ifdef __x86_64__
@@ -164,7 +164,7 @@ static void dpmi_thr(void *arg);
 static int handle_pf(cpuctx_t *scp)
 {
     int rc;
-    dosaddr_t cr2 = DOSADDR_REL(LINP(_cr2));
+    dosaddr_t cr2 = _cr2;
 #ifdef X86_EMULATOR
 #ifdef HOST_ARCH_X86
     /* DPMI code touches cpuemu prot */

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -4204,7 +4204,7 @@ static void do_pm_cpu_exception(cpuctx_t *scp, INTDESC entry)
 
   /* Extended exception stack frame - DPMI 1.0 */
   *--ssp = 0;	/* PTE */
-  *--ssp = DOSADDR_REL(LINP(_cr2));
+  *--ssp = _cr2;
   *--ssp = _gs;
   *--ssp = _fs;
   *--ssp = _ds;
@@ -4357,7 +4357,7 @@ static void do_legacy_cpu_exception(cpuctx_t *scp, INTDESC entry)
 
 static void do_cpu_exception(cpuctx_t *scp)
 {
-  D_printf("DPMI: do_cpu_exception(0x%02x) at %#x:%#x, ss:esp=%x:%x, cr2=%#lx, err=%#x\n",
+  D_printf("DPMI: do_cpu_exception(0x%02x) at %#x:%#x, ss:esp=%x:%x, cr2=%#x, err=%#x\n",
 	_trapno, _cs, _eip, _ss, _esp, _cr2, _err);
   if (debug_level('M') > 5)
     D_printf("DPMI: %s\n", DPMI_show_state(scp));
@@ -5908,7 +5908,7 @@ char *DPMI_show_state(cpuctx_t *scp)
     unsigned char *csp2, *ssp2;
     dosaddr_t daddr, saddr;
     pos += sprintf(buf + pos, "eip: 0x%08x  esp: 0x%08x  eflags: 0x%08x\n"
-	     "\ttrapno: 0x%02x  errorcode: 0x%08x  cr2: 0x%08lx\n"
+	     "\ttrapno: 0x%02x  errorcode: 0x%08x  cr2: 0x%08x\n"
 	     "\tcs: 0x%04x  ds: 0x%04x  es: 0x%04x  ss: 0x%04x  fs: 0x%04x  gs: 0x%04x\n",
 	     _eip, _esp, _eflags, _trapno, _err, _cr2, _cs, _ds, _es, _ss, _fs, _gs);
     pos += sprintf(buf + pos, "EAX: %08x  EBX: %08x  ECX: %08x  EDX: %08x\n",

--- a/src/dosext/dpmi/msdos/instr_dec.h
+++ b/src/dosext/dpmi/msdos/instr_dec.h
@@ -3,6 +3,6 @@
 
 int decode_segreg(cpuctx_t *scp);
 uint16_t decode_selector(cpuctx_t *scp);
-int decode_memop(cpuctx_t *scp, uint32_t *op, unsigned char *cr2);
+int decode_memop(cpuctx_t *scp, uint32_t *op, dosaddr_t cr2);
 
 #endif

--- a/src/dosext/dpmi/msdos/msdos_ldt.c
+++ b/src/dosext/dpmi/msdos/msdos_ldt.c
@@ -35,7 +35,7 @@
 #define LDT_UPDATE_LIM 1
 
 static unsigned char *ldt_backbuf;
-static unsigned char *ldt_alias;
+static dosaddr_t ldt_alias;
 static uint32_t ldt_h;
 static uint32_t ldt_alias_h;
 static unsigned short dpmi_ldt_alias;
@@ -90,7 +90,7 @@ unsigned short msdos_ldt_init(void)
     ldt_alias_h = shm.handle;
     if (ldt_h == ldt_alias_h)
 	error("DPMI: problems allocating shm\n");
-    ldt_alias = MEM_BASE32(shm.addr);
+    ldt_alias = shm.addr;
     msdos_free(name);
     FreeDescriptor(name_sel);
     for (i = 0; i < npages; i++)
@@ -259,7 +259,7 @@ out:
   dpmi_ext_ldt_monitor_enable(1);
 }
 
-int msdos_ldt_access(unsigned char *cr2)
+int msdos_ldt_access(dosaddr_t cr2)
 {
     if (!ldt_alias)
         return 0;
@@ -267,7 +267,7 @@ int msdos_ldt_access(unsigned char *cr2)
 }
 
 void msdos_ldt_write(cpuctx_t *scp, uint32_t op, int len,
-    unsigned char *cr2)
+    dosaddr_t cr2)
 {
     if (!len) {
 	/* 0-len shouldn't fault, so can't be here */
@@ -281,7 +281,7 @@ int msdos_ldt_pagefault(cpuctx_t *scp)
 {
     uint32_t op;
     int len;
-    unsigned char *cr2 = MEM_BASE32(_cr2);
+    dosaddr_t cr2 = _cr2;
 
     if (!msdos_ldt_access(cr2))
 	return 0;

--- a/src/dosext/dpmi/msdos/msdos_ldt.h
+++ b/src/dosext/dpmi/msdos/msdos_ldt.h
@@ -4,9 +4,9 @@
 unsigned short msdos_ldt_init(void);
 void msdos_ldt_done(void);
 int msdos_ldt_fault(cpuctx_t *scp, uint16_t sel);
-int msdos_ldt_access(unsigned char *cr2);
+int msdos_ldt_access(dosaddr_t cr2);
 void msdos_ldt_write(cpuctx_t *scp, uint32_t op, int len,
-    unsigned char *cr2);
+    dosaddr_t cr2);
 int msdos_ldt_pagefault(cpuctx_t *scp);
 int msdos_ldt_is32(unsigned short selector);
 

--- a/src/include/cpu.h
+++ b/src/include/cpu.h
@@ -468,7 +468,7 @@ struct pm_regs {
 
 	unsigned trapno;
 	unsigned err;
-	unsigned long cr2;
+	dosaddr_t cr2;
 };
 typedef struct pm_regs cpuctx_t;
 #define REGS_SIZE offsetof(struct pm_regs, trapno)


### PR DESCRIPTION
To avoid conversion bugs, and unnecessary MEM_BASE32 then DOSADDR_REL conversions when coming from KVM, use dosaddr_t for cr2 throughout, except for _scp_cr2, where it's actually used (JIT and dnative only).

So the only place where it's still a Unix address is in sigcontext_t.
