### PR TITLE
CI: Arguments need to strings not Paths [skip ci]

### DIFF
--- a/test/test_dos.py
+++ b/test/test_dos.py
@@ -4672,7 +4672,7 @@ $_ignore_djgpp_null_derefs = (off)
 
         # Compare DOS output to reference file
         if dosoutput != refoutput:
-            diff = unified_diff(refoutput, dosoutput, fromfile=reffile, tofile=dosfile)
+            diff = unified_diff(refoutput, dosoutput, fromfile=str(reffile), tofile=str(dosfile))
             self.fail('differences detected\n' + ''.join(list(diff)))
 
     def test_cpu_1_vm86native(self):


### PR DESCRIPTION
In the error path of cputests the filenames supplied to diff need to be strings as it's not yet Path aware.