### PR TITLE
XMS: already locked EMBs should not map more memory

### DIFF
--- a/src/dosext/misc/xms.c
+++ b/src/dosext/misc/xms.c
@@ -933,7 +933,10 @@ xms_lock_EMB(int flag)
       return 0;
     }
 
-    addr = map_EMB(handles[h].addr, handles[h].size, h);
+    if (handles[h].lockcount)
+      addr = handles[h].dst;
+    else
+      addr = map_EMB(handles[h].addr, handles[h].size, h);
     if (addr) {
       handles[h].lockcount++;
       x_printf("XMS lock EMB %d --> %#x\n", h, addr);


### PR DESCRIPTION
Win31 is locking the same EMB twice, which was failing the second time because it can't allocate twice the amount of SHM. Instead use the lock counter and simply return the address from the first lock if already locked. See discussion in #1963