### PR TITLE
KVM: reload cr3 to flush TLB after mprotect_kvm()

### DIFF
--- a/src/base/emu-i386/kvm.c
+++ b/src/base/emu-i386/kvm.c
@@ -120,8 +120,9 @@ static struct monitor {
 	-sizeof(struct emu_fpxstate)
 	-sizeof(struct vm86_regs)];          /* 2308 */
     unsigned int cr2;         /* Fault stack at 2DA0 */
+    unsigned int cr3;  /* cr3 in (no TLB flush if 0) */
     struct vm86_regs regs;
-    unsigned padding[2];
+    unsigned padding[1];
     struct emu_fpxstate fpstate;             /* 2e00 */
     /* 3000: page directory, 4000: page table */
     unsigned int pde[PAGE_SIZE/sizeof(unsigned int)];
@@ -634,6 +635,7 @@ void mprotect_kvm(int cap, dosaddr_t targ, size_t mapsize, int protect)
     if (cap & MAPPING_KVM)
       monitor->pte[page] &= ~PG_USER;
   }
+  monitor->cr3 = sregs.cr3; /* Force TLB flush */
 }
 
 /* Enable dirty logging from base to base+size.

--- a/src/base/emu-i386/kvmmon.S
+++ b/src/base/emu-i386/kvmmon.S
@@ -57,6 +57,8 @@ kvm_mon_main:
         push %edx
         push %ecx
         push %ebx
+        /* cr3: mark as 0 to not reload by default */
+        pushl $0
         mov %cr2,%eax
         push %eax
 #if 0
@@ -71,6 +73,12 @@ kvm_mon_hlt:
         addl $0x200,%esp
 #endif
         pop %eax
+        pop %eax
+        or %eax,%eax
+        jz skip_cr3
+        /* flush TLB by reloading cr3 if nonzero (set by mprotect_kvm()) */
+        mov %eax,%cr3
+skip_cr3:
         pop %ebx
         pop %ecx
         pop %edx


### PR DESCRIPTION
This avoids page faults on pages that are no longer protected. Fixes #1965