### PR TITLE
Handle low KVM readonly memory at KVM API (physical) level, fix JIT/VGAEMU ROM

### DIFF
--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -873,7 +873,10 @@ void register_hardware_ram_virtual2(int type, unsigned base, unsigned int size,
   if (config.cpu_vm_dpmi == CPUVM_KVM ||
       (config.cpu_vm == CPUVM_KVM && base + size <= LOWMEM_SIZE + HMASIZE)) {
     int prot = PROT_READ | PROT_WRITE | PROT_EXEC;
-    mmap_kvm(MAPPING_INIT_LOWRAM, base, size, uaddr, va, prot);
+    int cap = MAPPING_INIT_LOWRAM;
+    if (type == 'L')
+      cap |= MAPPING_LOWMEM;
+    mmap_kvm(cap, base, size, uaddr, va, prot);
   }
 }
 

--- a/src/base/init/memcheck.c
+++ b/src/base/init/memcheck.c
@@ -141,8 +141,11 @@ void memcheck_reserve(unsigned char map_char, dosaddr_t addr_start,
       !(map_char == 'd' || map_char == 'U' || map_char == 'X' ||
         map_char == 'H' || map_char == 'r'));
 
-  if (memcheck_is_rom(addr_start))
+  if (memcheck_is_rom(addr_start)) {
     mprotect_mapping(MAPPING_LOWMEM, addr_start, size, PROT_READ);
+    if (config.cpu_vm == CPUVM_KVM || config.cpu_vm_dpmi == CPUVM_KVM)
+      kvm_set_readonly(addr_start, size);
+  }
 }
 
 void memcheck_map_free(unsigned char map_char)

--- a/src/include/kvm.h
+++ b/src/include/kvm.h
@@ -27,6 +27,7 @@ int kvm_dpmi(cpuctx_t *scp);
 void mprotect_kvm(int cap, dosaddr_t targ, size_t mapsize, int protect);
 void mmap_kvm(int cap, unsigned phys_addr, size_t mapsize, void *addr, dosaddr_t targ, int protect);
 void set_kvm_memory_regions(void);
+void kvm_set_readonly(dosaddr_t base, dosaddr_t size);
 void kvm_set_dirty_log(dosaddr_t base, dosaddr_t size);
 void kvm_get_dirty_map(dosaddr_t base, unsigned char *bitmap);
 
@@ -47,6 +48,7 @@ static inline void mprotect_kvm(int cap, dosaddr_t targ, size_t mapsize, int pro
 static inline void mmap_kvm(int cap, unsigned phys_addr, size_t mapsize, void *addr, dosaddr_t targ, int protect) {}
 static inline void munmap_kvm(int cap, dosaddr_t targ, size_t mapsize) {}
 static inline void set_kvm_memory_regions(void) {}
+static inline void kvm_set_readonly(dosaddr_t base, dosaddr_t size) {}
 static inline void kvm_set_dirty_log(dosaddr_t base, dosaddr_t size) {}
 static inline void kvm_get_dirty_map(dosaddr_t base, unsigned char *bitmap) {}
 static inline void kvm_set_idt_default(int i) {}


### PR DESCRIPTION
KVM now uses dirty logging if used in combination with the JIT; all pages it touched are invalidated.
ROM areas are marked with flags = KVM_MEM_READONLY, so writes will exit KVM with KVM_EXIT_MMIO.

This way there is no more need to write protect pages via the page tables, which will be important for VCPI since there page faults can't be trapped by the monitor.

The only protection still left is PROT_NONE for planar VGA modes, which will be for a later PR (it can be unmapped by KVM, so then all accesses produce KVM_EXIT_MMIO).

Two related bugs are fixed:
1. the ROM at 0xc0000 wasn't readonly (wrong order in vgaemu.c)
2. JIT would crash on writes to 0xf0000 if $_umb_f0 = (off).