### PR TITLE
mapping: use memcheck API to handle ROM areas (#1971)

### DIFF
--- a/src/base/emu-i386/simx86/sigsegv.c
+++ b/src/base/emu-i386/simx86/sigsegv.c
@@ -181,7 +181,7 @@ int e_vgaemu_fault(sigcontext_t *scp, unsigned page_fault)
       }
       return 1;
     }
-    else if (page_fault >= 0xc0 && page_fault < (0xc0 + vgaemu_bios.pages)) {	/* ROM area */
+    else if (memcheck_is_rom(page_fault << PAGE_SHIFT)) {	/* ROM area */
 #ifdef HOST_ARCH_X86
       if (!CONFIG_CPUSIM) {
 	u = jitx86_instr_len((unsigned char *)_scp_rip);

--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -437,8 +437,10 @@ void low_mem_init(void)
   }
 
   /* R/O protect 0xf0000-0xf4000 */
-  if (!config.umb_f0)
-    mprotect_mapping(MAPPING_LOWMEM, 0xf0000, 0x4000, PROT_READ);
+  if (!config.umb_f0) {
+    memcheck_addtype('R', "ROM at f000:0000 for $_umb_f0 = (off)");
+    memcheck_reserve('R', 0xF0000, DOSEMU_LMHEAP_OFF);
+  }
 }
 
 /*

--- a/src/include/memory.h
+++ b/src/include/memory.h
@@ -172,6 +172,9 @@ int  memcheck_findhole(dosaddr_t *start_addr, uint32_t min_size,
     uint32_t max_size);
 int memcheck_is_reserved(dosaddr_t addr_start, uint32_t size,
 	unsigned char map_char);
+int memcheck_is_rom(dosaddr_t addr);
+int memcheck_is_hardware_ram(dosaddr_t addr);
+int memcheck_is_system_ram(dosaddr_t addr);
 void memcheck_dump(void);
 void memcheck_type_init(void);
 extern struct system_memory_map *system_memory_map;


### PR DESCRIPTION
Introduce memcheck_is_{rom,hardware_ram,system_ram}(addr) and use memcheck_is_rom to check if the address is ROM to skip writes in signal handlers.

The mprotect calls for ROM areas are now done by memcheck_reserve().

A new letter ('R') was introduced for $_umb_f0=(off).

This fixes two issues with ROM:
* VGAEMU ROM wasn't protected due to initialization order being wrong
* JIT didn't take $_umb_f0=(off) into account and crashed on writes there.