### PR TITLE
Add some 386 instructions to instremu to help DOOM

### DIFF
--- a/src/base/video/instremu.c
+++ b/src/base/video/instremu.c
@@ -2215,9 +2215,12 @@ static inline int instr_sim(x86_regs *x86, int pmode)
     mem = x86->modrm(MEM_BASE32(cs + eip), x86, &inst_len);
     switch (*(unsigned char *)MEM_BASE32(cs + eip + 1)&0x38) {
     case 0x00: /* test mem word, imm */
-      if (x86->operand_size == 4) return 0;
-      instr_flags(instr_read_word(mem) & R_WORD(*(unsigned char *)MEM_BASE32(cs + eip + 2+inst_len)), 0x8000, &EFLAGS);
-      eip += inst_len + 4; break;
+      und = x86->instr_read(mem);
+      if (x86->operand_size == 4)
+	instr_flags(und & R_DWORD(*(unsigned char *)MEM_BASE32(cs + eip + 2+inst_len)), 0x80000000, &EFLAGS);
+      else
+	instr_flags(und & R_WORD(*(unsigned char *)MEM_BASE32(cs + eip + 2+inst_len)), 0x8000, &EFLAGS);
+      eip += inst_len + x86->operand_size + 2; break;
     case 0x08: return 0;
     case 0x10: /*not word*/
       x86->instr_write(mem, ~x86->instr_read(mem));

--- a/src/base/video/instremu.c
+++ b/src/base/video/instremu.c
@@ -1034,16 +1034,14 @@ static inline int instr_sim(x86_regs *x86, int pmode)
   unsigned eip = x86->eip;
   unsigned cs = x86->cs_base;
 
-#if DEBUG_INSTR >= 2
-  {
-    int refseg, rc;
-    unsigned char frmtbuf[256];
+  if (debug_level('v') >= 9) {
+    unsigned int refseg;
+    char frmtbuf[256];
     refseg = x86->cs;
     dump_x86_regs(x86);
-    rc = dis_8086(MEM_BASE32(cs+eip), frmtbuf, x86->_32bit, &refseg, MEM_BASE32(cs));
+    dis_8086(cs+eip, frmtbuf, x86->_32bit ? 3 : 0, &refseg, cs);
     instr_deb("vga_emu_fault: about to simulate %d: %s\n", count, frmtbuf);
   }
-#endif
 
   if (x86->prefixes) {
     prepare_x86(x86);
@@ -2503,7 +2501,7 @@ int instr_emu(cpuctx_t *scp, int pmode, int cnt)
     if (!instr_sim(&x86, pmode)) {
       if (debug_level('v')) {
 #ifdef USE_MHPDBG
-        dosaddr_t cp = SEGOFF2LINEAR(x86.cs, x86.eip);
+        dosaddr_t cp = x86.cs_base + x86.eip;
         unsigned int ref;
         char frmtbuf[256];
         dis_8086(cp, frmtbuf, x86._32bit ? 3 : 0, &ref, x86.cs_base);


### PR DESCRIPTION
While working on converting the planar VGA PROT_NONE buffer into an MMIO region for KVM I noticed DOOM was even slower and exiting instremu really quickly.

So I added some more instructions to reduce the number of page faults.

Bench: start DOOM let the demo run, wait until it's outside the first time.
before:
real    0m30.732s
user    0m21.878s
sys     0m9.000s
number of calls to vga_emu_fault: 6120000

after:
real    0m28.120s
user    0m23.927s
sys     0m3.727s
number of calls to vga_emu_fault 370000

the real time hasn't changed all that much but it feels much more responsive.

(yes I know, should really use simx86 instead, but that's a bigger project)