### PR TITLE
mapping: add TLB for dosaddr_to_unixaddr for unprotected pages

### DIFF
--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -106,6 +106,7 @@ static void update_aliasmap(dosaddr_t dosaddr, size_t mapsize,
   if (addr2 == (unsigned)-1)
     return;
   hwram_update_aliasmap(hw, addr2, mapsize, unixaddr);
+  invalidate_unprotected_page_cache(dosaddr, mapsize);
 }
 
 void *dosaddr_to_unixaddr(dosaddr_t addr)
@@ -477,6 +478,7 @@ int mprotect_mapping(int cap, dosaddr_t targ, size_t mapsize, int protect)
 
   Q__printf("MAPPING: mprotect, cap=%s, targ=%x, size=%zx, protect=%x\n",
 	cap, targ, mapsize, protect);
+  invalidate_unprotected_page_cache(targ, mapsize);
   if (is_kvm_map(cap))
     mprotect_kvm(cap, targ, mapsize, protect);
   if (!(cap & MAPPING_LOWMEM)) {
@@ -1103,6 +1105,7 @@ int alias_mapping_pa(int cap, unsigned addr, size_t mapsize, int protect,
     return 0;
   assert(addr2 == MEM_BASE32(va));
   hwram_update_aliasmap(hw, addr, mapsize, source);
+  invalidate_unprotected_page_cache(va, mapsize);
   if (is_kvm_map(cap))
     mprotect_kvm(cap, va, mapsize, protect);
   return 1;
@@ -1117,5 +1120,6 @@ int unalias_mapping_pa(int cap, unsigned addr, size_t mapsize)
   assert(addr >= LOWMEM_SIZE + HMASIZE);
   restore_mapping(cap, va, mapsize);
   hwram_update_aliasmap(hw, addr, mapsize, NULL);
+  invalidate_unprotected_page_cache(va, mapsize);
   return 1;
 }

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -1279,7 +1279,6 @@ static void do_invalidate(unsigned data, int cnt)
 	if (!CONFIG_CPUSIM)
 		InvalidateNodeRange(data, cnt, 0);
 #endif
-	invalidate_unprotected_page_cache(data, cnt);
 }
 
 void e_invalidate(unsigned data, int cnt)

--- a/src/base/misc/dos2linux.c
+++ b/src/base/misc/dos2linux.c
@@ -645,6 +645,7 @@ void do_write_word(dosaddr_t addr, uint16_t word, sim_pagefault_handler_t handle
     if (((addr+1) & (PAGE_SIZE-1)) == 0) {
       do_write_byte(addr, word & 0xff, handler);
       do_write_byte(addr+1, word >> 8, handler);
+      return;
     }
     if (vga_write_access(addr)) {
       vga_write_word(addr, word);
@@ -664,6 +665,7 @@ void do_write_dword(dosaddr_t addr, uint32_t dword, sim_pagefault_handler_t hand
     if (((addr+3) & (PAGE_SIZE-1)) < 3) {
       do_write_word(addr, dword & 0xffff, handler);
       do_write_word(addr+2, dword >> 16, handler);
+      return;
     }
     if (vga_write_access(addr)) {
       vga_write_dword(addr, dword);

--- a/src/base/misc/dos2linux.c
+++ b/src/base/misc/dos2linux.c
@@ -633,6 +633,7 @@ void do_write_byte(dosaddr_t addr, uint8_t byte, sim_pagefault_handler_t handler
     }
     if (config.mmio_tracing && mmio_check(addr))
       mmio_trace_byte(addr, byte, MMIO_WRITE);
+    e_invalidate(addr, 1);
     if (check_write_pagefault(addr, byte, 1, handler))
       return;
   }
@@ -653,6 +654,7 @@ void do_write_word(dosaddr_t addr, uint16_t word, sim_pagefault_handler_t handle
     }
     if (config.mmio_tracing && mmio_check(addr))
       mmio_trace_word(addr, word, MMIO_WRITE);
+    e_invalidate(addr, 2);
     if (check_write_pagefault(addr, word, 2, handler))
       return;
   }
@@ -673,6 +675,7 @@ void do_write_dword(dosaddr_t addr, uint32_t dword, sim_pagefault_handler_t hand
     }
     if (config.mmio_tracing && mmio_check(addr))
       mmio_trace_dword(addr, dword, MMIO_WRITE);
+    e_invalidate(addr, 4);
     if (check_write_pagefault(addr, dword, 4, handler))
       return;
   }


### PR DESCRIPTION
commit 705dab48 made dosaddr_to_unixaddr much slower. It's on the hot path for cpusim (read_byte etc.), so this slowed it down by almost 50% for code running from low memory.

I could make dosaddr_to_unixaddr faster again using a small hack:
```
diff --git a/src/arch/linux/mapping/mapping.c b/src/arch/linux/mapping/mapping.c
index ed40a6b11..708384308 100644
--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -108,13 +108,11 @@ static void update_aliasmap(dosaddr_t dosaddr, size_t mapsize,
   hwram_update_aliasmap(hw, addr2, mapsize, unixaddr);
 }

+static unsigned char **lowmem_aliasmap;
 void *dosaddr_to_unixaddr(dosaddr_t addr)
 {
-  if (addr < ALIAS_SIZE) {
-    void *ret = get_hardware_uaddr(addr);
-    if (ret != MAP_FAILED)
-      return ret;
-  }
+  if (addr < ALIAS_SIZE && lowmem_aliasmap[addr >> PAGE_SHIFT])
+    return lowmem_aliasmap[addr >> PAGE_SHIFT] + (addr & (PAGE_SIZE - 1));
   return MEM_BASE32(addr);
 }

@@ -854,6 +852,8 @@ static int do_register_hwram(int type, unsigned base, unsigned size,
   hw->size = size;
   hw->type = type;
   hw->aliasmap = alloc_aliasmap(uaddr, size);
+  if (type == 'L')
+    lowmem_aliasmap = hw->aliasmap;
   hw->next = hardware_ram;
   hardware_ram = hw;
   if (!uaddr && (base >= LOWMEM_SIZE || type == 'h'))
```

but even faster is to use a TLB, since we already have the infrastructure and invalidation logic to see if the page is special, and profiling then shows dosaddr_to_unixaddr is only used very rarely.

Here's my little testcase (nasm -fbin test.asm -o test.com), just writing the same byte 268 million times:

```
org 100h
mov bx, 800h
outer:
mov cx, 0ffffh
inner:
mov byte [test], 0
loop inner
dec bx
jnz outer
ret
test:
```

Test with cpusim:
Before: 22.7s (11.8 MIPS)
With quick and dirty patch above: 16.0s (16.8 MIPS) With TLB: 14.5s (18.5 MIPS)