### PR TITLE
mapping: reintroduce static aliasmap for lowmem only

### DIFF
--- a/src/arch/linux/mapping/mapping.c
+++ b/src/arch/linux/mapping/mapping.c
@@ -112,7 +112,7 @@ static void update_aliasmap(dosaddr_t dosaddr, size_t mapsize,
 
 void *dosaddr_to_unixaddr(dosaddr_t addr)
 {
-  if (addr < ALIAS_SIZE && lowmem_aliasmap[addr >> PAGE_SHIFT])
+  if (addr < ALIAS_SIZE)
     return lowmem_aliasmap[addr >> PAGE_SHIFT] + (addr & (PAGE_SIZE - 1));
   return MEM_BASE32(addr);
 }
@@ -865,6 +865,8 @@ static void hwram_update_aliasmap(struct hardware_ram *hw, unsigned addr,
   int off = addr - hw->base;
   assert(!(off & (PAGE_SIZE - 1))); // page-aligned
   assert(!(size & (PAGE_SIZE - 1))); // page-aligned
+  // lowmem needs permanent aliasing
+  assert(!(src == NULL && (hw->base + hw->size <= ALIAS_SIZE)));
   populate_aliasmap(&hw->aliasmap[off >> PAGE_SHIFT], src, size);
 }
 

--- a/src/base/emu-i386/simx86/cpatch.c
+++ b/src/base/emu-i386/simx86/cpatch.c
@@ -53,7 +53,7 @@ void m_munprotect(unsigned int addr, unsigned int len, unsigned char *eip)
 			e_printf("CODE %08x hit in DATA %p patch\n",addr,eip);
 	}
 	/* if only data in aliased low memory is hit, nothing to do */
-	if (LINEAR2UNIX(addr) != MEM_BASE32(addr)) {
+	if (addr < LOWMEM_SIZE + HMASIZE) {
 		if (e_querymark(addr, len))
 			// no need to invalidate the whole page here,
 			// as the page does not need to be unprotected

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -1289,7 +1289,7 @@ void e_invalidate(unsigned data, int cnt)
 	if (!e_querymprotrange(data, cnt))
 		return;
 	/* for low mappings only invalidate if code, not if data */
-	if (LINEAR2UNIX(data) != MEM_BASE32(data)) {
+	if (data < LOWMEM_SIZE + HMASIZE) {
 #ifdef HOST_ARCH_X86
 		if (!CONFIG_CPUSIM && e_querymark(data, cnt)) {
 			// no need to invalidate the whole page here,

--- a/src/include/mapping.h
+++ b/src/include/mapping.h
@@ -118,8 +118,6 @@ void mapping_init(void);
 void mapping_close(void);
 
 void init_hardware_ram(void);
-int map_hardware_ram(char type);
-int unmap_hardware_ram(char type);
 int register_hardware_ram(int type, dosaddr_t base, unsigned size);
 void register_hardware_ram_virtual(int type, unsigned base, unsigned size,
 	dosaddr_t va);


### PR DESCRIPTION
As mentioned in commit 0c983365, commit 705dab48 made dosaddr_to_unixaddr much slower. While sim is fast again, JIT was still slow in cpatch code. This patches reintroduces a static lowmem_aliasmap, shared by all lowmem hardware RAM registrations; for high memory it goes via the malloc'ed per-mapping aliasmaps.

The test in 0c983365 (which spends almost all its time in the cpatch) went from 6.5 to 4.5 seconds for JIT. It's harder to make the cpatch use the page cache since it needs to check for code at the subpage level, and the test writes to data in the same page as the code.