### PR TITLE
mapping: don't add readonly pages to the unprotected page cache

### DIFF
--- a/src/base/emu-i386/simx86/memory.c
+++ b/src/base/emu-i386/simx86/memory.c
@@ -123,7 +123,7 @@ static int AddMpMap(unsigned int addr, unsigned int aend, int onoff)
 }
 
 
-static inline int e_querymprot(unsigned int addr)
+int e_querymprot(dosaddr_t addr)
 {
 	register int a2 = addr >> PAGE_SHIFT;
 	tMpMap *M = FindM(addr);

--- a/src/base/misc/dos2linux.c
+++ b/src/base/misc/dos2linux.c
@@ -569,7 +569,8 @@ static void check_read_pagefault(dosaddr_t addr, void *uaddr,
     if (!dpmi_write_access(addr))
       return;
   }
-  set_unprotected_page(addr, uaddr);
+  if (!e_querymprot(addr) && !memcheck_is_rom(addr))
+    set_unprotected_page(addr, uaddr);
 }
 
 uint8_t do_read_byte(dosaddr_t addr, sim_pagefault_handler_t handler)
@@ -636,7 +637,8 @@ static int check_write_pagefault(dosaddr_t addr, void *uaddr, uint32_t op, int l
     handler(addr, 6 + dpmi_read_access(addr), op, len);
     return 1;
   }
-  set_unprotected_page(addr, uaddr);
+  if (!e_querymprot(addr) && !memcheck_is_rom(addr))
+    set_unprotected_page(addr, uaddr);
   return 0;
 }
 

--- a/src/include/cpu-emu.h
+++ b/src/include/cpu-emu.h
@@ -125,4 +125,7 @@ void e_gen_sigalrm(void);
 #define e_in_compiled_code() 0
 #endif
 
+/* called from dos2linux.c */
+int e_querymprot(dosaddr_t addr);
+
 #endif	/*DOSEMU_CPUEMU_H*/


### PR DESCRIPTION
This showed up when attempting to use write_byte() etc. from cpatch.c, (that's for another PR) which would sometimes attempt to write to protected pages and cause a page fault.