### PR TITLE
Remove CONFIG_CPUSIM everywhere except interp.c, cpu-emu.c, emu86.h (#1975)

### DIFF
--- a/src/arch/linux/async/debug.c
+++ b/src/arch/linux/async/debug.c
@@ -242,7 +242,7 @@ void siginfo_debug(const siginfo_t *si)
 
 #ifdef X86_EMULATOR
     /* gdb_debug() will crash in jit code doing backtrace() */
-    if (!(IS_EMU() && !CONFIG_CPUSIM && e_in_compiled_code()))
+    if (!IS_EMU_JIT() && e_in_compiled_code())
 #endif
     gdb_debug();
 }

--- a/src/arch/linux/async/signal.c
+++ b/src/arch/linux/async/signal.c
@@ -338,7 +338,7 @@ static void minfault(int sig, siginfo_t *si, void *uc)
   }
 #endif
 #ifdef X86_EMULATOR
-  if (IS_EMU() && e_emu_fault(scp, in_vm86))
+  if (IS_EMU_JIT() && e_emu_fault(scp, in_vm86))
     return;
 #endif
 #endif

--- a/src/base/emu-i386/kvm.c
+++ b/src/base/emu-i386/kvm.c
@@ -594,7 +594,7 @@ void mmap_kvm(int cap, unsigned phys_addr, size_t mapsize, void *addr, dosaddr_t
   do_munmap_kvm(phys_addr, mapsize);
   mmap_kvm_no_overlap(phys_addr, addr, mapsize, 0);
   /* monitor dirty pages on regular low ram for JIT */
-  if ((cap & MAPPING_LOWMEM) && IS_EMU() && !CONFIG_CPUSIM)
+  if ((cap & MAPPING_LOWMEM) && IS_EMU_JIT())
     kvm_set_dirty_log(phys_addr, mapsize);
   for (page = start; page < end; page++, phys_addr += pagesize) {
     int pde_entry = page >> 10;
@@ -865,7 +865,7 @@ void kvm_leave(int pm)
   memcpy(&vm86_fpu_state, fpu.region, sizeof(vm86_fpu_state));
 
   /* collect and invalidate all touched low dirty pages with JIT code */
-  if (IS_EMU() && !CONFIG_CPUSIM) {
+  if (IS_EMU_JIT()) {
     int slot;
     struct kvm_userspace_memory_region *p = &maps[0];
     for (slot = 0; slot < MAXSLOT; slot++, p++)

--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -268,7 +268,11 @@ static __inline__ void POP_ONLY(int m)
 }
 
 void InitGen(void);
+#ifdef X86_JIT
 int  NewIMeta(int npc, int *rc);
+#else
+static inline int NewIMeta(int npc, int *rc) {return 0;}
+#endif
 extern void (*Gen)(int op, int mode, ...);
 extern void (*AddrGen)(int op, int mode, ...);
 extern int  (*Fp87_op)(int exop, int reg);

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -825,7 +825,7 @@ void enter_cpu_emu(void)
 
 	/* The simulator uses dosaddr_t throughout, the JIT adds mem_base
 	   to the segment bases */
-	TheCPU.mem_base = CONFIG_CPUSIM ? 0 : (uintptr_t)mem_base;
+	TheCPU.mem_base = (uintptr_t)mem_base;
 
 	if (debug_level('e')) {
 		TotalTime = 0;

--- a/src/base/emu-i386/simx86/emu86.h
+++ b/src/base/emu-i386/simx86/emu86.h
@@ -50,6 +50,12 @@ extern hitimer_t AddTime, SearchTime, ExecTime, CleanupTime;
 extern hitimer_t GenTime, LinkTime;
 #endif
 
+#ifdef X86_JIT
+#define CONFIG_CPUSIM config.cpusim
+#else
+#define CONFIG_CPUSIM 1
+#endif
+
 /* octal digits in a byte: hhmm.mlll */
 #define D_HO(b)	(((b)>>6)&3)
 #define D_MO(b)	(((b)>>3)&7)

--- a/src/base/emu-i386/simx86/emu86.h
+++ b/src/base/emu-i386/simx86/emu86.h
@@ -742,12 +742,13 @@ void CollectStat(void);
 //
 /////////////////////////////////////////////////////////////////////////////
 #ifdef HOST_ARCH_X86
+int e_handle_pagefault(dosaddr_t addr, unsigned err, sigcontext_t *scp);
+int e_handle_fault(sigcontext_t *scp);
 void init_emu_npu_x86(void);
 #endif
 void init_emu_npu(void);
 
 void e_VgaMovs(unsigned char **rdi, unsigned char **rsi, unsigned int rep,
 	       int dp, unsigned int access);
-int e_vgaemu_fault(sigcontext_t *scp, unsigned page_fault);
 
 #endif // _EMU86_EMU86_H

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -374,7 +374,6 @@ static unsigned int _JumpGen(unsigned int P2, int mode, int opc,
 	_P1; \
 })
 
-
 /////////////////////////////////////////////////////////////////////////////
 
 #if !defined(SINGLESTEP)&&defined(HOST_ARCH_X86)
@@ -3353,6 +3352,7 @@ repag0:
 		}
 		if (TheCPU.err < 0)
 			return P0;
+#ifdef HOST_ARCH_X86
 		if (NewNode) {
 			int rc=0;
 			if (!CONFIG_CPUSIM && !(TheCPU.mode&SKIPOP)) {
@@ -3366,6 +3366,7 @@ repag0:
 				}
 			}
 		}
+#endif
 
 		/* check segment boundaries. TODO for prot mode */
 		if (REALADDR() && (PC - LONG_CS > 0xffff)) {

--- a/src/base/init/parser.y
+++ b/src/base/init/parser.y
@@ -483,7 +483,7 @@ line:		CHARSET '{' charset_flags '}' {}
 #ifdef X86_EMULATOR
 			config.cpusim = $2;
 			c_printf("CONF: CPUEMU set to %s\n",
-				CONFIG_CPUSIM ? "sim" : "jit");
+				config.cpusim ? "sim" : "jit");
 #endif
 			}
 		| CPUSPEED real_expression

--- a/src/dosext/dpmi/dnative/dnative.c
+++ b/src/dosext/dpmi/dnative/dnative.c
@@ -168,7 +168,7 @@ static int handle_pf(cpuctx_t *scp)
 #ifdef X86_EMULATOR
 #ifdef HOST_ARCH_X86
     /* DPMI code touches cpuemu prot */
-    if (IS_EMU() && !CONFIG_CPUSIM && e_invalidate_page_full(cr2))
+    if (IS_EMU_JIT() && e_invalidate_page_full(cr2))
         return DPMI_RET_CLIENT;
 #endif
 #endif

--- a/src/dosext/dpmi/dnative/sigsegv.c
+++ b/src/dosext/dpmi/dnative/sigsegv.c
@@ -267,7 +267,7 @@ static void dosemu_fault1(int signum, sigcontext_t *scp, const siginfo_t *si)
   if (_scp_trapno == 0x0e && _scp_cr2 > 0xffffffff)
   {
 #ifdef X86_EMULATOR
-    if (IS_EMU() && !CONFIG_CPUSIM && e_in_compiled_code()) {
+    if (IS_EMU_JIT() && e_in_compiled_code()) {
       int i;
       /* dosemu_error() will SIGSEGV in backtrace(). */
       error("JIT fault accessing invalid address 0x%08"PRI_RG", "

--- a/src/dosext/dpmi/dnative/sigsegv.c
+++ b/src/dosext/dpmi/dnative/sigsegv.c
@@ -320,7 +320,7 @@ static void dosemu_fault1(int signum, sigcontext_t *scp, const siginfo_t *si)
 
 #ifdef X86_EMULATOR
   /* case 3 */
-  if (IS_EMU() && e_emu_fault(scp, in_vm86))
+  if (IS_EMU_JIT() && e_emu_fault(scp, in_vm86))
     return;
 #endif
 

--- a/src/include/cpu-emu.h
+++ b/src/include/cpu-emu.h
@@ -45,9 +45,9 @@ extern void e_priv_iopl(int);
 
 #ifdef X86_JIT
 #define HOST_ARCH_X86
-#define CONFIG_CPUSIM config.cpusim
+#define IS_EMU_JIT() (IS_EMU() && !config.cpusim)
 #else
-#define CONFIG_CPUSIM 1
+#define IS_EMU_JIT() (0)
 #endif
 
 /* ----------------------------------------------------------------------- */

--- a/src/include/cpu-emu.h
+++ b/src/include/cpu-emu.h
@@ -105,14 +105,8 @@ void InvalidateSegs(void);
 
 #ifdef X86_JIT
 /* called from sigsegv.c */
-int e_emu_pagefault(sigcontext_t *scp, int pmode);
-int e_handle_pagefault(dosaddr_t addr, unsigned err, sigcontext_t *scp);
-int e_handle_fault(sigcontext_t *scp);
 int e_emu_fault(sigcontext_t *scp, int in_vm86);
 #else
-#define e_emu_pagefault(scp, pmode) 0
-#define e_handle_pagefault(addr, err, scp) 0
-#define e_handle_fault(scp) 0
 #define e_emu_fault(scp, in_vm86) 0
 #endif
 

--- a/src/include/mapping.h
+++ b/src/include/mapping.h
@@ -61,7 +61,7 @@
 #ifdef __x86_64__
 /* FIXME: JIT should support 64bit mem_base */
 #define _MAP_32BIT ((config.cpu_vm_dpmi == CPUVM_NATIVE || \
-    (IS_EMU() && !CONFIG_CPUSIM)) ? MAP_32BIT : 0)
+    IS_EMU_JIT()) ? MAP_32BIT : 0)
 #else
 #define _MAP_32BIT 0
 #endif


### PR DESCRIPTION
Related to the discussion in #1975.

CONFIG_CPUSIM outside simx86 can be replaced by IS_EMU_JIT().
invalidation code can just check page protections, which aren't set without JIT.

The remaining uses are all within e_vm86(), e_dpmi(), interp and functions called from there (where we want it to change dynamically for #1975).