### PR TITLE
cpuemu: don't also check TheCPU.sigalrm_pending in CeS_INSTREMU check

### DIFF
--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -965,6 +965,7 @@ int e_vm86(void)
   int errcode;
 
   if (iniflag==0) enter_cpu_emu();
+  TheCPU.sigalrm_pending = 0;
 
 #ifdef PROFILE
   if (debug_level('e')) tt0 = GETTSC();
@@ -1074,6 +1075,7 @@ int e_dpmi(cpuctx_t *scp)
   int xval,retval,mode;
 
   if (iniflag==0) enter_cpu_emu();
+  TheCPU.sigalrm_pending = 0;
 
   e_sigpa_count = 0;
   /* make clear we are in PM now */

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -3427,7 +3427,7 @@ repag0:
 				if (debug_level('e')>1)
 					dbug_printf("CeS_INSTREMU, count=%d\n",
 						    interp_inst_emu_count);
-				if (interp_inst_emu_count-- == 0 || TheCPU.sigalrm_pending) {
+				if (interp_inst_emu_count-- == 0) {
 					TheCPU.err = EXCP_GOBACK;
 					return PC;
 				}


### PR DESCRIPTION
Fixes performance regression from #1975 / e056787b

It checked for it but didn't reset which caused performance issues (DOOM ran much more slowly). It's better to just let the existing sim/interp logic check for it and exit the interpreter loop that way when an async signal arrives.