### PR TITLE
CI: Some CI updates

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -6,8 +6,6 @@ on:
   pull_request:
     types:
       - opened
-      - edited
-      - ready_for_review
       - reopened
       - synchronize
   push:

--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -114,6 +114,8 @@ def get_test_binaries():
 
 class BaseTestCase(object):
 
+    attrs = []
+
     @classmethod
     def setUpClass(cls):
         cls.topdir = Path('.').resolve()

--- a/test/func_libi86_testsuite.py
+++ b/test/func_libi86_testsuite.py
@@ -37,6 +37,8 @@ def libi86_create_items(testcase):
         name = 'test_libi86_item_%03d' % int(test[0])
         setattr(testcase, name, create_test(test))
 
+    testcase.attrs += ['libi86test',]
+
 
 def libi86_test_item(self, test):
     self.mkfile("dosemu.conf", """\

--- a/test/test_dos.py
+++ b/test/test_dos.py
@@ -66,6 +66,7 @@ PRGFIL_LFN = "Program Files"
 
 class OurTestCase(BaseTestCase):
 
+    attrs = ['cputest', 'dpmitest', 'hmatest', 'nettest', 'umatest', 'xmstest']
     pname = "test_dos"
 
     # Tests using assembler
@@ -5275,6 +5276,8 @@ if __name__ == '__main__':
             inspect.getmembers(modules[__name__], predicate=inspect.isclass)
             if issubclass(c[1], OurTestCase) and c[0] != "OurTestCase"]
 
+    attrs = sorted(OurTestCase.attrs)
+
     def explode(n, attr=None):
         if n in tests:
             return [c + "." + n for c in cases]
@@ -5294,10 +5297,17 @@ if __name__ == '__main__':
 
     if len(argv) > 1:
         if argv[1] == "--help":
-            print("Usage: %s [--help | --get-test-binaries | --list-cases | --list-tests] | [--require-attr=STRING TestCase ...] | [TestCase[.testname] ...]" % argv[0])
+            print(("Usage: %s [--help | --get-test-binaries | " +
+                   "--list-attrs | --list-cases | --list-tests] | " +
+                   "[--require-attr=STRING TestCase ...] | " +
+                   "[TestCase[.testname] ...]") % argv[0])
             exit(0)
         elif argv[1] == "--get-test-binaries":
             get_test_binaries()
+            exit(0)
+        elif argv[1] == "--list-attrs":
+            for a in attrs:
+                print(str(a))
             exit(0)
         elif argv[1] == "--list-cases":
             for m in cases:


### PR DESCRIPTION
1/ In the case that pexpect gets a timeout, check if GDB has been attached, wait a while for any backtrace to complete, then stop the test run early.
2/ Reduce the number of unnecessary test runs, due to PR edit and draft/ready change.
3/ Add option to list the test group attributes