### PR TITLE
KVM: handle planar modes using MMIO region instead of page faults

### DIFF
--- a/src/base/dev/vga/vgaemu.c
+++ b/src/base/dev/vga/vgaemu.c
@@ -2861,6 +2861,7 @@ int changed_vga_colors(void (*upd_func)(DAC_entry *, int, void *), void *arg)
 static void vgaemu_adjust_instremu(int value)
 {
   int i;
+  vga_mapping_type *vmt = &vga.mem.map[VGAEMU_MAP_BANK_MODE];
 
   if (value == EMU_ALL_INST) {
     if (vga.inst_emu != EMU_ALL_INST) {
@@ -2876,6 +2877,10 @@ static void vgaemu_adjust_instremu(int value)
       dirty_all_video_pages();
     }
   }
+  if (vga.inst_emu != value &&
+      (config.cpu_vm == CPUVM_KVM || config.cpu_vm_dpmi == CPUVM_KVM))
+    kvm_set_mmio(vmt->base_page << PAGE_SHIFT, vmt->pages << PAGE_SHIFT,
+		 value != 0);
   vga.inst_emu = value;
 }
 

--- a/src/base/dev/vga/vgaemu.c
+++ b/src/base/dev/vga/vgaemu.c
@@ -305,6 +305,7 @@ static void print_prot_map(void);
 #endif
 static int vga_emu_setup_mode(vga_mode_info *, int, unsigned, unsigned, unsigned);
 static void vga_emu_setup_mode_table(void);
+static void vgaemu_adjust_instremu(int value);
 
 static Bit32u rasterop(Bit32u value);
 static pthread_mutex_t prot_mtx = PTHREAD_MUTEX_INITIALIZER;
@@ -2403,7 +2404,8 @@ static int __vga_emu_setmode(int mode, int width, int height)
     vga.pixel_size = (vga.pixel_size + 7) & ~7;		/* assume byte alignment for these modes */
     vga.scan_len *= vga.pixel_size >> 3;
   }
-  vga.inst_emu = ((vga.mode_type==PL4 || vga.mode_type==PL2) ? EMU_ALL_INST : 0);
+  vgaemu_adjust_instremu((vga.mode_type==PL4 || vga.mode_type==PL2)
+			 ? EMU_ALL_INST : 0);
 
   vga_msg("vga_emu_setmode: scan_len = %d\n", vga.scan_len);
   i = vga.scan_len;
@@ -2856,28 +2858,25 @@ int changed_vga_colors(void (*upd_func)(DAC_entry *, int, void *), void *arg)
   return j;
 }
 
-static void vgaemu_adjust_instremu(void)
+static void vgaemu_adjust_instremu(int value)
 {
   int i;
 
-  if (vga.mem.planes > 1) {
+  if (value == EMU_ALL_INST) {
     if (vga.inst_emu != EMU_ALL_INST) {
       v_printf("Seq_write_value: instemu on\n");
       pthread_mutex_lock(&prot_mtx);
-      for (i = 0; i < vga.mem.pages; i++) {
-        if (vga.mem.dirty_map[i])
-          _vga_emu_adjust_protection(i, 0, NONE, 1);
-      }
+      for (i = 0; i < vga.mem.pages; i++)
+	_vga_emu_adjust_protection(i, 0, NONE, 1);
       pthread_mutex_unlock(&prot_mtx);
-      vga.inst_emu = EMU_ALL_INST;
     }
   } else {
     if (vga.inst_emu != 0) {
       v_printf("Seq_write_value: instemu off\n");
       dirty_all_video_pages();
-      vga.inst_emu = 0;
     }
   }
+  vga.inst_emu = value;
 }
 
 /*
@@ -2909,7 +2908,7 @@ void vgaemu_adj_cfg(unsigned what, unsigned msg)
         vga_msg("vgaemu_adj_cfg: mem reconfig (%u planes)\n", u1);
         vgaemu_map_bank();	// update page protection
       }
-      vgaemu_adjust_instremu();
+      vgaemu_adjust_instremu(vga.mem.planes > 1 ? EMU_ALL_INST : 0);
       if(msg || u != u0) vga_msg("vgaemu_adj_cfg: seq.addr_mode = %s\n", txt1[u]);
       if (vga.mode_class == TEXT && vga.width < 2048) {
         int horizontal_display_end = vga.crtc.data[0x1] + 1;
@@ -3133,9 +3132,9 @@ void vgaemu_adj_cfg(unsigned what, unsigned msg)
       }
       old_color_bits = vga.color_bits;
       vga.color_bits = vga.pixel_size;
-      vga.inst_emu = (vga.mode_type==PL4 || vga.mode_type==PL2)
-	? EMU_ALL_INST : 0;
       vgaemu_map_bank();      // update page protection
+      vgaemu_adjust_instremu((vga.mode_type==PL4 || vga.mode_type==PL2)
+			     ? EMU_ALL_INST : 0);
       if (oldclass != vga.mode_class) {
 	vgaemu_adj_cfg(CFG_SEQ_ADDR_MODE, 0);
 	vgaemu_adj_cfg(CFG_CRTC_WIDTH, 0);

--- a/src/include/kvm.h
+++ b/src/include/kvm.h
@@ -27,6 +27,7 @@ int kvm_dpmi(cpuctx_t *scp);
 void mprotect_kvm(int cap, dosaddr_t targ, size_t mapsize, int protect);
 void mmap_kvm(int cap, unsigned phys_addr, size_t mapsize, void *addr, dosaddr_t targ, int protect);
 void set_kvm_memory_regions(void);
+void kvm_set_mmio(dosaddr_t base, dosaddr_t size, int on);
 void kvm_set_readonly(dosaddr_t base, dosaddr_t size);
 void kvm_set_dirty_log(dosaddr_t base, dosaddr_t size);
 void kvm_get_dirty_map(dosaddr_t base, unsigned char *bitmap);
@@ -48,6 +49,7 @@ static inline void mprotect_kvm(int cap, dosaddr_t targ, size_t mapsize, int pro
 static inline void mmap_kvm(int cap, unsigned phys_addr, size_t mapsize, void *addr, dosaddr_t targ, int protect) {}
 static inline void munmap_kvm(int cap, dosaddr_t targ, size_t mapsize) {}
 static inline void set_kvm_memory_regions(void) {}
+static inline void kvm_set_mmio(dosaddr_t base, dosaddr_t size, int on) {}
 static inline void kvm_set_readonly(dosaddr_t base, dosaddr_t size) {}
 static inline void kvm_set_dirty_log(dosaddr_t base, dosaddr_t size) {}
 static inline void kvm_get_dirty_map(dosaddr_t base, unsigned char *bitmap) {}


### PR DESCRIPTION
So now the only remaining in-KVM page protections are for DPMI, where it's necessary, and the low 1MB is all treated like physical RAM, for future compatibility with VCPI (and perhaps real mode as well).

The KVM MMIO interface is a little complex to exit from, as one needs to re-enter KVM to finish the operation, and sometimes twice, for read-modify-write.

With older kernels it's even more complex, as immediate exits from KVM need to be programmed using a signal (with a dummy signal handler that is never actually called) that is masked outside KVM but unmasked inside KVM_RUN.
