### PR TITLE
Enable FAT32 support for MS-DOS 7.10

### DIFF
--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -371,7 +371,7 @@ class BaseTestCase(object):
         elif fat == "16b":
             bcount = 900 * 15 * 17  # type 9
         elif fat == "32":
-            bcount = 524288         # 256 MiB
+            bcount = 1048576        # 1 GiB
         else:
             raise ValueError
         name = "fat%s.img" % fat

--- a/test/test_dos.py
+++ b/test/test_dos.py
@@ -5202,9 +5202,6 @@ class MSDOS710TestCase(OurTestCase, unittest.TestCase):
         ]
 
         cls.actions = {
-            "test_fat32_img_d_writable": UNSUPPORTED,
-            "test_lfn_volume_info_fat32": UNSUPPORTED,
-            "test_lfs_disk_info_fat32": UNSUPPORTED,
         }
 
         cls.setUpClassPost()


### PR DESCRIPTION
It seems MS-DOS 7.10 (a.k.a WIN95 SE) needs the correct partition type to recognise FAT32 format. Bare VBR images and partitions were marked in the generated MBR as FAT12/16/16B based on size.