### PR TITLE
simx86: mask FPU exceptions also for !HOST_ARCH_X86

### DIFF
--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -2753,7 +2753,6 @@ repag0:
 				}
 			}
 			b &= 7;
-#ifdef HOST_ARCH_X86
 			if (TheCPU.fpstate) {
 				/* For simulator, only need to mask all
 				   exceptions, and set rounding properly;
@@ -2766,7 +2765,6 @@ repag0:
 					loadfpstate(*TheCPU.fpstate);
 				TheCPU.fpstate = NULL;
 			}
-#endif
 			if (sim) {
 			    if (Fp87_op(exop,b)) { TheCPU.err = -96; return P0; }
 			}


### PR DESCRIPTION
This is needed since feenableexcept is called independently of it, and we don't want unmasked FP exceptions when simulating code.

The code here is portable as loadfpstate is just an empty define for !HOST_ARCH_X86. Should fix #1995 on Arm.