### PR TITLE
cpuemu: invalidate segment cache for instremu

### DIFF
--- a/src/dosext/dpmi/emu-ldt.c
+++ b/src/dosext/dpmi/emu-ldt.c
@@ -55,10 +55,8 @@ static int emu_update_LDT (struct user_desc *ldt_info, int oldmode)
 	Descriptor *lp;
 	int bSelType;
 
-#ifdef X86_EMULATOR
-	if (config.cpu_vm_dpmi == CPUVM_EMU)
-		InvalidateSegs();
-#endif
+	/* invalidate segment base cache in cpuemu */
+	InvalidateSegs();
 
 	/* Install the new entry ...  */
 	lp = &((Descriptor *)dpmi_get_ldt_buffer())[ldt_info->entry_number];


### PR DESCRIPTION
For regular cpuemu the segment base cache is invalidated via emu_modify_ldt, but not with KVM/native DPMI backends, so we must invalidate it entering cpuemu for a VGA fault.

Fixes #2007