### PR TITLE
ports: add opaque pointer arg to handlers

### DIFF
--- a/src/base/core/emu.c
+++ b/src/base/core/emu.c
@@ -498,7 +498,7 @@ static void __leavedos_main(int code, int sig)
 	* My port logic is actually stolen from kd_nosound in the kernel.
 	* 		--EB 21 September 1997
 	*/
-        port_safe_outb(0x61, port_safe_inb(0x61)&0xFC); /* turn off any sound */
+        port_outb(0x61, port_inb(0x61)&0xFC); /* turn off any sound */
     }
 
     free(vm86_hlt_state);

--- a/src/base/dev/dma/dma.c
+++ b/src/base/dev/dma/dma.c
@@ -257,7 +257,7 @@ int dma_pulse_DRQ(int ch, Bit8u * buf)
     HANDLE_##n(2, 2); \
     HANDLE_##n(2, 3); \
     HANDLE_##n(2, 4)
-static Bit8u dma_io_read(ioport_t port)
+static Bit8u dma_io_read(ioport_t port, void *arg)
 {
     Bit8u r = 0xff;
     switch (port) {
@@ -319,7 +319,7 @@ static Bit8u dma_io_read(ioport_t port)
     return r;
 }
 
-static void dma_io_write(ioport_t port, Bit8u value)
+static void dma_io_write(ioport_t port, Bit8u value, void *arg)
 {
     switch (port) {
 

--- a/src/base/dev/misc/8042.c
+++ b/src/base/dev/misc/8042.c
@@ -343,7 +343,7 @@ static Bit8u read_port60(void)
 }
 
 
-Bit8u keyb_io_read(ioport_t port)
+Bit8u keyb_io_read(ioport_t port, void *arg)
 {
   Bit8u r = 0;
 
@@ -368,7 +368,7 @@ Bit8u keyb_io_read(ioport_t port)
   return r;
 }
 
-void keyb_io_write(ioport_t port, Bit8u value)
+void keyb_io_write(ioport_t port, Bit8u value, void *arg)
 {
   switch (port) {
   case 0x60:

--- a/src/base/dev/misc/chipset.c
+++ b/src/base/dev/misc/chipset.c
@@ -13,7 +13,7 @@
 #define CONTROL_A20GATE_MASK 2
 
 
-static Bit8u port92h_io_read(ioport_t port)
+static Bit8u port92h_io_read(ioport_t port, void *arg)
 {
   Bit8u ret = 0;
   if (a20)
@@ -21,14 +21,14 @@ static Bit8u port92h_io_read(ioport_t port)
   return ret;
 }
 
-static void port92h_io_write(ioport_t port, Bit8u val)
+static void port92h_io_write(ioport_t port, Bit8u val, void *arg)
 {
   int enA20 = (val & CONTROL_A20GATE_MASK) ? 1 : 0;
   if (val & CONTROL_RESET_MASK) cpu_reset();
   set_a20(enA20);
 }
 
-static Bit8u picext_io_read(ioport_t port)
+static Bit8u picext_io_read(ioport_t port, void *arg)
 {
   Bit8u val = 0xff;
 

--- a/src/base/dev/misc/cmos.c
+++ b/src/base/dev/misc/cmos.c
@@ -37,7 +37,7 @@ cmos_chksum(void)
   return sum;
 }
 
-Bit8u cmos_read(ioport_t port)
+Bit8u cmos_read(ioport_t port, void *arg)
 {
   unsigned char holder = 0;
 
@@ -67,7 +67,7 @@ Bit8u cmos_read(ioport_t port)
   return holder;
 }
 
-void cmos_write(ioport_t port, Bit8u byte)
+void cmos_write(ioport_t port, Bit8u byte, void *arg)
 {
   if (port == 0x70)
     cmos.address = byte & ~0xc0;/* get true address */

--- a/src/base/dev/misc/joystick.c
+++ b/src/base/dev/misc/joystick.c
@@ -151,8 +151,8 @@ static void joy_emu_axis_set (const int joynum, const int axis, const int value)
 static int joy_emu_axis_conv (const int linux_val, const int invalid_val);
 
 /* port emulation */
-Bit8u joy_port_inb (ioport_t port);
-void joy_port_outb (ioport_t port, Bit8u value);
+Bit8u joy_port_inb (ioport_t port, void *arg);
+void joy_port_outb (ioport_t port, Bit8u value, void *arg);
 
 
 /*
@@ -1281,7 +1281,7 @@ int joy_bios_read (void)
  *
  * DANG_END_FUNCTION
  */
-Bit8u joy_port_inb (ioport_t port)
+Bit8u joy_port_inb (ioport_t port, void *arg)
 {
 	Bit8u ret = 0;
 	int joynum;
@@ -1347,7 +1347,7 @@ Bit8u joy_port_inb (ioport_t port)
 	return ret;
 }
 
-void joy_port_outb (ioport_t port, Bit8u value)
+void joy_port_outb (ioport_t port, Bit8u value, void *arg)
 {
 #ifdef JOY_PORT_DEBUG
 	joy_port_printf ("port 0x%X: outb()\n", port);

--- a/src/base/dev/misc/lpt.c
+++ b/src/base/dev/misc/lpt.c
@@ -69,7 +69,7 @@ static int get_printer(ioport_t port)
   return -1;
 }
 
-static Bit8u printer_io_read(ioport_t port)
+static Bit8u printer_io_read(ioport_t port, void *arg)
 {
   int i = get_printer(port);
   Bit8u val;
@@ -104,7 +104,7 @@ static Bit8u printer_io_read(ioport_t port)
   return val;
 }
 
-static void printer_io_write(ioport_t port, Bit8u value)
+static void printer_io_write(ioport_t port, Bit8u value, void *arg)
 {
   int i = get_printer(port);
   if (i == -1)

--- a/src/base/dev/misc/timers.c
+++ b/src/base/dev/misc/timers.c
@@ -302,14 +302,14 @@ static void pit_latch(int latch)
 /* This is called also by port 0x61 - some programs can use timer #2
  * as a GP timer and read bit 5 of port 0x61 (e.g. Matrox BIOS)
  */
-Bit8u pit_inp(ioport_t port)
+Bit8u pit_inp(ioport_t port, void *arg)
 {
   int ret = 0;
   port -= 0x40;
 
   if ((port == 2) && (config.speaker == SPKR_NATIVE)) {
 	error ("pit_inp() - how could we come here if we defined PORT_FAST?\n");
-	return safe_port_in_byte(0x42);
+	return port_inb(0x42);
   }
   else if (port == 1)
     i_printf("PIT:  someone is reading the CMOS refresh time?!?");
@@ -344,7 +344,7 @@ Bit8u pit_inp(ioport_t port)
   return ret;
 }
 
-void pit_outp(ioport_t port, Bit8u val)
+void pit_outp(ioport_t port, Bit8u val, void *arg)
 {
 
   port -= 0x40;
@@ -352,7 +352,7 @@ void pit_outp(ioport_t port, Bit8u val)
     i_printf("PORT: someone is writing the CMOS refresh time?!?");
   else if (port == 2 && config.speaker == SPKR_NATIVE) {
     error ("pit_outp() - how could we come here if we defined PORT_FAST?\n");
-    safe_port_out_byte(0x42, val);
+    port_outb(0x42, val);
     return;
   }
 
@@ -403,12 +403,12 @@ void pit_outp(ioport_t port, Bit8u val)
   }
 }
 
-Bit8u pit_control_inp(ioport_t port)
+Bit8u pit_control_inp(ioport_t port, void *arg)
 {
   return 0;
 }
 
-void pit_control_outp(ioport_t port, Bit8u val)
+void pit_control_outp(ioport_t port, Bit8u val, void *arg)
 {
   int latch = (val >> 6) & 0x03;
 
@@ -439,7 +439,7 @@ void pit_control_outp(ioport_t port, Bit8u val)
   switch (latch) {
     case 2:
       if (config.speaker == SPKR_NATIVE) {
-        safe_port_out_byte(0x43, val);
+        port_outb(0x43, val);
 	break;
       }
       /* nobreak; */
@@ -546,7 +546,7 @@ static int timer_irq_ack(int masked)
 Bit8u spkr_io_read(ioport_t port) {
    if (port==0x61)  {
       if (config.speaker == SPKR_NATIVE)
-         return port_safe_inb(0x61);
+         return port_inb(0x61);
       else {
 	 /* keep the connection between port 0x61 and PIT timer#2 */
 	 pit_latch(2);
@@ -562,7 +562,7 @@ void spkr_io_write(ioport_t port, Bit8u value) {
    if (port==0x61) {
       switch (config.speaker) {
        case SPKR_NATIVE:
-          port_safe_outb(0x61, value & 0x03);
+          port_outb(0x61, value & 0x03);
           break;
 
        case SPKR_EMULATED:

--- a/src/base/dev/misc/virq.c
+++ b/src/base/dev/misc/virq.c
@@ -53,7 +53,7 @@ struct vhandler_s vhandlers[VIRQ_MAX];
 
 static void virq_lower(int virq_num);
 
-static Bit16u virq_irr_read(ioport_t port)
+static Bit16u virq_irr_read(ioport_t port, void *arg)
 {
     uint16_t irr;
 
@@ -63,7 +63,7 @@ static Bit16u virq_irr_read(ioport_t port)
     return irr;
 }
 
-static void virq_hwc_write(ioport_t port, Bit8u value)
+static void virq_hwc_write(ioport_t port, Bit8u value, void *arg)
 {
     struct vhandler_s *vh;
     enum VirqHwRet rc = VIRQ_HWRET_DONE;

--- a/src/base/dev/misc/vtmr.c
+++ b/src/base/dev/misc/vtmr.c
@@ -88,12 +88,12 @@ static struct vint_presets vip[VTMR_MAX] = {
 
 static int do_vtmr_raise(int timer);
 
-static Bit8u vtmr_irr_read(ioport_t port)
+static Bit8u vtmr_irr_read(ioport_t port, void *arg)
 {
     return vtmr_irr;
 }
 
-static Bit16u vtmr_vpend_read(ioport_t port)
+static Bit16u vtmr_vpend_read(ioport_t port, void *arg)
 {
     /* clang has __atomic_swap() */
     return __atomic_exchange_n(&vtmr_pirr, 0, __ATOMIC_ACQ_REL);
@@ -109,7 +109,7 @@ static void post_req(int timer)
     h_printf("vtmr: post-REQ on %i, irr=%x\n", timer, vtmr_irr);
 }
 
-static void vtmr_io_write(ioport_t port, Bit8u value)
+static void vtmr_io_write(ioport_t port, Bit8u value, void *arg)
 {
     int masked = (value >> 7) & 1;
     int timer = value & 0x7f;

--- a/src/base/dev/ne2k/ne2000.c
+++ b/src/base/dev/ne2k/ne2000.c
@@ -170,10 +170,10 @@ typedef struct NE2000State {
 static NE2000State ne2000state;
 
 // For io_device
-Bit16u ne2000_io_read16(ioport_t port);
-void ne2000_io_write16(ioport_t port, Bit16u value);
-Bit8u ne2000_io_read8(ioport_t port);
-void ne2000_io_write8(ioport_t port, Bit8u value);
+Bit16u ne2000_io_read16(ioport_t port, void *arg);
+void ne2000_io_write16(ioport_t port, Bit16u value, void *arg);
+Bit8u ne2000_io_read8(ioport_t port, void *arg);
+void ne2000_io_write8(ioport_t port, Bit8u value, void *arg);
 static void ne2000_irq_activate(int);
 
 static void ne2000_receive_req_async(int fd, void *arg);
@@ -869,7 +869,7 @@ static void ne2000_write(NE2000State *s, uint32_t addr, uint64_t data, unsigned 
 /* --------------------------------- */
 /* 16 bit io functions - only on data port */
 
-Bit16u ne2000_io_read16(ioport_t port)
+Bit16u ne2000_io_read16(ioport_t port, void *arg)
 {
     NE2000State *s = &ne2000state;
     ioport_t addr = port - NE2000_IOBASE;
@@ -882,7 +882,7 @@ Bit16u ne2000_io_read16(ioport_t port)
         return ne2000_read(s, addr, 1);
 }
 
-void ne2000_io_write16(ioport_t port, Bit16u value)
+void ne2000_io_write16(ioport_t port, Bit16u value, void *arg)
 {
     NE2000State *s = &ne2000state;
     ioport_t addr = port - NE2000_IOBASE;
@@ -899,7 +899,7 @@ void ne2000_io_write16(ioport_t port, Bit16u value)
 
 /* handle io reads from ne2000 */
 
-Bit8u ne2000_io_read8(ioport_t port)
+Bit8u ne2000_io_read8(ioport_t port, void *arg)
 {
     NE2000State *s = &ne2000state;
     ioport_t addr = port - NE2000_IOBASE;
@@ -912,7 +912,7 @@ Bit8u ne2000_io_read8(ioport_t port)
 
 /* handle io writes to ne2000 */
 
-void ne2000_io_write8(ioport_t port, Bit8u value)
+void ne2000_io_write8(ioport_t port, Bit8u value, void *arg)
 {
     NE2000State *s = &ne2000state;
     ioport_t addr = port - NE2000_IOBASE;

--- a/src/base/dev/pic/pic.c
+++ b/src/base/dev/pic/pic.c
@@ -32,7 +32,7 @@ static PICCommonState pic[2];
 PICCommonState *slave_pic;
 static pthread_mutex_t pic_mtx = PTHREAD_MUTEX_INITIALIZER;
 
-static void write_pic0(ioport_t port, Bit8u value)
+static void write_pic0(ioport_t port, Bit8u value, void *arg)
 {
     r_printf("PIC0: write 0x%x --> 0x%x\n", value, port);
     pthread_mutex_lock(&pic_mtx);
@@ -42,7 +42,7 @@ static void write_pic0(ioport_t port, Bit8u value)
             pic[0].isr, pic[0].imr, pic[0].irr);
 }
 
-static void write_pic1(ioport_t port, Bit8u value)
+static void write_pic1(ioport_t port, Bit8u value, void *arg)
 {
     r_printf("PIC1: write 0x%x --> 0x%x\n", value, port);
     pthread_mutex_lock(&pic_mtx);
@@ -52,7 +52,7 @@ static void write_pic1(ioport_t port, Bit8u value)
             pic[1].isr, pic[1].imr, pic[1].irr);
 }
 
-static Bit8u read_pic0(ioport_t port)
+static Bit8u read_pic0(ioport_t port, void *arg)
 {
     Bit8u ret;
 
@@ -63,7 +63,7 @@ static Bit8u read_pic0(ioport_t port)
     return ret;
 }
 
-static Bit8u read_pic1(ioport_t port)
+static Bit8u read_pic1(ioport_t port, void *arg)
 {
     Bit8u ret;
 
@@ -74,7 +74,7 @@ static Bit8u read_pic1(ioport_t port)
     return ret;
 }
 
-static Bit8u read_elcr(ioport_t port)
+static Bit8u read_elcr(ioport_t port, void *arg)
 {
     Bit8u ret;
 
@@ -84,14 +84,14 @@ static Bit8u read_elcr(ioport_t port)
     return ret;
 }
 
-static void write_elcr(ioport_t port, Bit8u value)
+static void write_elcr(ioport_t port, Bit8u value, void *arg)
 {
     pthread_mutex_lock(&pic_mtx);
     elcr_ioport_write(&pic[port & 1], port & 1, value, 1);
     pthread_mutex_unlock(&pic_mtx);
 }
 
-static Bit8u read_firr(ioport_t port)
+static Bit8u read_firr(ioport_t port, void *arg)
 {
     Bit8u ret;
 
@@ -101,7 +101,7 @@ static Bit8u read_firr(ioport_t port)
     return ret;
 }
 
-static void write_firr(ioport_t port, Bit8u value)
+static void write_firr(ioport_t port, Bit8u value, void *arg)
 {
     pthread_mutex_lock(&pic_mtx);
     pic[port & 1].fake_irr = value;

--- a/src/base/dev/sb16/adlib.c
+++ b/src/base/dev/sb16/adlib.c
@@ -83,7 +83,7 @@ Bit8u adlib_io_read_base(ioport_t port)
     return ret;
 }
 
-static Bit8u adlib_io_read(ioport_t port)
+static Bit8u adlib_io_read(ioport_t port, void *arg)
 {
     return adlib_io_read_base(port - ADLIB_BASE);
 }
@@ -103,7 +103,7 @@ void adlib_io_write_base(ioport_t port, Bit8u value)
     pthread_mutex_unlock(&synth_mtx);
 }
 
-static void adlib_io_write(ioport_t port, Bit8u value)
+static void adlib_io_write(ioport_t port, Bit8u value, void *arg)
 {
     adlib_io_write_base(port - ADLIB_BASE, value);
 }

--- a/src/base/dev/sb16/sb16.c
+++ b/src/base/dev/sb16/sb16.c
@@ -1642,7 +1642,7 @@ int sb_mixer_get_chan_num(enum MixChan ch)
  * DANG_END_FUNCTION
  */
 
-static void sb_io_write(ioport_t port, Bit8u value)
+static void sb_io_write(ioport_t port, Bit8u value, void *arg)
 {
     ioport_t addr;
     addr = port - config.sb_base;
@@ -1715,7 +1715,7 @@ static void sb_io_write(ioport_t port, Bit8u value)
  * DANG_END_FUNCTION
  */
 
-static Bit8u sb_io_read(ioport_t port)
+static Bit8u sb_io_read(ioport_t port, void *arg)
 {
     ioport_t addr;
     Bit8u result = 0;
@@ -1845,7 +1845,7 @@ int sb_get_dma_data(void *ptr, int is16bit)
     return 0;
 }
 
-static Bit8u mpu401_io_read(ioport_t port)
+static Bit8u mpu401_io_read(ioport_t port, void *arg)
 {
     ioport_t addr;
     Bit8u r = 0xff;
@@ -1877,7 +1877,7 @@ static Bit8u mpu401_io_read(ioport_t port)
     return r;
 }
 
-static void mpu401_io_write(ioport_t port, Bit8u value)
+static void mpu401_io_write(ioport_t port, Bit8u value, void *arg)
 {
     uint32_t addr;
     addr = port - config.mpu401_base;

--- a/src/base/dev/vga/vgaemu.c
+++ b/src/base/dev/vga/vgaemu.c
@@ -340,7 +340,7 @@ vgaemu_bios_type vgaemu_bios;
  *
  */
 
-int VGA_emulate_outb(ioport_t port, Bit8u value)
+int VGA_emulate_outb(ioport_t port, Bit8u value, void *arg)
 {
   vga_deb2_io("VGA_emulate_outb: port[0x%03x] = 0x%02x\n", (unsigned) port, (unsigned) value);
 
@@ -443,16 +443,16 @@ int VGA_emulate_outb(ioport_t port, Bit8u value)
 }
 
 
-static void VGA_emulate_outb_handler(ioport_t port, Bit8u value)
+static void VGA_emulate_outb_handler(ioport_t port, Bit8u value, void *arg)
 {
-    int ret = VGA_emulate_outb(port, value);
+    int ret = VGA_emulate_outb(port, value, arg);
     assert(ret!=-1);
 }
 
-static void VGA_emulate_outw_handler(ioport_t port, Bit16u value)
+static void VGA_emulate_outw_handler(ioport_t port, Bit16u value, void *arg)
 {
-    VGA_emulate_outb_handler(port,value);
-    VGA_emulate_outb_handler(port+1,value>>8);
+    VGA_emulate_outb_handler(port, value, arg);
+    VGA_emulate_outb_handler(port+1, value>>8, arg);
 }
 
 /*
@@ -469,7 +469,7 @@ static void VGA_emulate_outw_handler(ioport_t port, Bit16u value)
  *
  */
 
-int VGA_emulate_inb(ioport_t port)
+int VGA_emulate_inb(ioport_t port, void *arg)
 {
   Bit8u uc = 0xff;
 
@@ -567,17 +567,17 @@ int VGA_emulate_inb(ioport_t port)
   return uc;
 }
 
-static Bit8u VGA_emulate_inb_handler(ioport_t port)
+static Bit8u VGA_emulate_inb_handler(ioport_t port, void *arg)
 {
-    int ret = VGA_emulate_inb(port);
+    int ret = VGA_emulate_inb(port, arg);
     assert(ret != -1);
     return ret;
 }
 
-static Bit16u VGA_emulate_inw_handler(ioport_t port)
+static Bit16u VGA_emulate_inw_handler(ioport_t port, void *arg)
 {
-    Bit16u v = VGA_emulate_inb_handler(port);
-    return v | (VGA_emulate_inb_handler(port+1)<<8);
+    Bit16u v = VGA_emulate_inb_handler(port, arg);
+    return v | (VGA_emulate_inb_handler(port+1, arg)<<8);
 }
 
 

--- a/src/base/emu-i386/cpu.c
+++ b/src/base/emu-i386/cpu.c
@@ -248,12 +248,12 @@ static void fpu_reset(void)
     kvm_update_fpu();
 }
 
-static Bit8u fpu_io_read(ioport_t port)
+static Bit8u fpu_io_read(ioport_t port, void *arg)
 {
   return 0xff;
 }
 
-static void fpu_io_write(ioport_t port, Bit8u val)
+static void fpu_io_write(ioport_t port, Bit8u val, void *arg)
 {
   switch (port) {
   case 0xf0:

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -2543,7 +2543,7 @@ repag0:
 			CODE_FLUSH();
 			a = rDX;
 			if ((CEmuStat & CeS_INSTREMU) &&
-			    (uc=VGA_emulate_inb(a)) != -1) {
+			    (uc=VGA_emulate_inb(a, NULL)) != -1) {
 				rAL = uc;
 				PC++;
 				break;
@@ -2672,7 +2672,7 @@ repag0:
 			a = rDX;
 			/* Note that we short circuit for vgaemu planar */
 			if ((CEmuStat & CeS_INSTREMU) &&
-			    VGA_emulate_outb(a, rAL) != -1) {
+			    VGA_emulate_outb(a, rAL, NULL) != -1) {
 				PC++;
 				break;
 			}
@@ -2701,8 +2701,8 @@ repag0:
 			CODE_FLUSH();
 			a = rDX;
 			if ((CEmuStat & CeS_INSTREMU) &&
-			    VGA_emulate_outb(a, rAL) != -1 &&
-			    VGA_emulate_outb(a+1, rAH) != -1) {
+			    VGA_emulate_outb(a, rAL, NULL) != -1 &&
+			    VGA_emulate_outb(a+1, rAH, NULL) != -1) {
 				PC++;
 				break;
 			}

--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -1163,14 +1163,14 @@ disk_close_all(void)
 
 static Bit8u floppy_DOR = 0xc;
 
-static Bit8u floppy_io_read(ioport_t port)
+static Bit8u floppy_io_read(ioport_t port, void *arg)
 {
   if (port == 0x3f2)
     return floppy_DOR;
   return 0xff;
 }
 
-static void floppy_io_write(ioport_t port, Bit8u value)
+static void floppy_io_write(ioport_t port, Bit8u value, void *arg)
 {
   if (port == 0x3f2) {
     floppy_DOR = value;

--- a/src/base/serial/ser_init.c
+++ b/src/base/serial/ser_init.c
@@ -84,7 +84,7 @@ static void add_dmx(ioport_t port, int val)
   sprintf(dmxs[i].name, "ser_dmx_%hhi", (uint8_t)i);
 }
 
-static Bit8u dmx_readb(ioport_t port)
+static Bit8u dmx_readb(ioport_t port, void *arg)
 {
   int num, i;
   Bit8u val;
@@ -107,7 +107,7 @@ static Bit8u dmx_readb(ioport_t port)
   return val;
 }
 
-static void dmx_writeb(ioport_t port, Bit8u value)
+static void dmx_writeb(ioport_t port, Bit8u value, void *arg)
 {
   s_printf("SER: write to readonly port %#x, val=%#x\n", port, value);
 }
@@ -183,7 +183,8 @@ static void ser_setup_custom(int num)
   }
 }
 
-static Bit8u com_readb(ioport_t port) {
+static Bit8u com_readb(ioport_t port, void *arg)
+{
   int tmp;
   for (tmp = 0; tmp < config.num_ser; tmp++) {
     if (((u_short)(port & ~7)) == com_cfg[tmp].base_port) {
@@ -193,7 +194,8 @@ static Bit8u com_readb(ioport_t port) {
   return 0;
 }
 
-static void com_writeb(ioport_t port, Bit8u value) {
+static void com_writeb(ioport_t port, Bit8u value, void *arg)
+{
   int tmp;
   for (tmp = 0; tmp < config.num_ser; tmp++) {
     if (((u_short)(port & ~7)) == com_cfg[tmp].base_port) {

--- a/src/base/speaker/speaker.c
+++ b/src/base/speaker/speaker.c
@@ -159,8 +159,8 @@ void speaker_pause (void)
 	switch (config.speaker)
 	{
 	case SPKR_NATIVE:
-		saved_port_val = port_safe_inb (0x61);
-	 	port_safe_outb (0x61, saved_port_val & 0xFC);	/* clear timer & speaker bits */
+		saved_port_val = port_inb (0x61);
+	 	port_outb (0x61, saved_port_val & 0xFC);	/* clear timer & speaker bits */
 		break;
 	case SPKR_EMULATED:
 		speaker_off ();
@@ -175,7 +175,7 @@ void speaker_resume (void)
 	switch (config.speaker)
 	{
 	case SPKR_NATIVE:
-		port_safe_outb (0x61, saved_port_val);	/* restore timer & speaker bits */
+		port_outb (0x61, saved_port_val);	/* restore timer & speaker bits */
 		break;
 	case SPKR_EMULATED:
 //		do_sound(pit[2].write_latch & 0xffff);

--- a/src/include/cmos.h
+++ b/src/include/cmos.h
@@ -43,8 +43,10 @@
 #define CMOS_INFO	0x33
 #define CMOS_RESV4	0x34	/* 12 bytes reserved */
 
-void cmos_write(ioport_t, Bit8u), cmos_init(void), cmos_reset(void);
-Bit8u cmos_read(ioport_t);
+void cmos_write(ioport_t reg, Bit8u val, void *arg);
+void cmos_init(void);
+void cmos_reset(void);
+Bit8u cmos_read(ioport_t, void *arg);
 Bit8u rtc_read(Bit8u reg);
 void rtc_write(Bit8u reg, Bit8u val);
 void rtc_run(void);

--- a/src/include/keyboard/keyb_server.h
+++ b/src/include/keyboard/keyb_server.h
@@ -18,8 +18,8 @@
  * these are needed in some other modules, e.g. ports.c
  */
 
-Bit8u keyb_io_read(ioport_t port);
-void keyb_io_write(ioport_t port, Bit8u value);
+Bit8u keyb_io_read(ioport_t port, void *arg);
+void keyb_io_write(ioport_t port, Bit8u value, void *arg);
 void keyb_8042_init(void);
 void keyb_8042_reset(void);
 

--- a/src/include/port.h
+++ b/src/include/port.h
@@ -19,26 +19,17 @@
 
 /* Hey, stranger, there is one too many of us in this town! */
 typedef struct {
-  Bit8u         (* read_portb)(ioport_t port);
-  void          (* write_portb)(ioport_t port, Bit8u byte);
-  Bit16u        (* read_portw)(ioport_t port);
-  void          (* write_portw)(ioport_t port, Bit16u word);
-  Bit32u        (* read_portd)(ioport_t port);
-  void          (* write_portd)(ioport_t port, Bit32u word);
-  const char    *handler_name;
+  Bit8u         (* read_portb)(ioport_t port, void *arg);
+  void          (* write_portb)(ioport_t port, Bit8u byte, void *arg);
+  Bit16u        (* read_portw)(ioport_t port, void *arg);
+  void          (* write_portw)(ioport_t port, Bit16u word, void *arg);
+  Bit32u        (* read_portd)(ioport_t port, void *arg);
+  void          (* write_portd)(ioport_t port, Bit32u word, void *arg);
+  const char   *handler_name;
   ioport_t      start_addr;
   ioport_t      end_addr;
-} emu_iodev_t;
-
-typedef struct {
-  Bit8u  (*read_portb)  (ioport_t port_addr);
-  void   (*write_portb) (ioport_t port_addr, Bit8u byte);
-  Bit16u (*read_portw) (ioport_t port_addr);
-  void   (*write_portw) (ioport_t port_addr, Bit16u word);
-  Bit32u (*read_portd) (ioport_t port_addr);
-  void   (*write_portd) (ioport_t port_addr, Bit32u dword);
-  const char *handler_name;
-} _port_handler;
+  void         *arg;
+} emu_iodev_t, _port_handler;
 
 extern int in_crit_section;
 
@@ -107,12 +98,12 @@ extern void    port_outb(ioport_t port, Bit8u byte);
 extern void    port_outw(ioport_t port, Bit16u word);
 extern void    port_outd(ioport_t port, Bit32u word);
 
-extern Bit8u  std_port_inb(ioport_t port);
-extern void   std_port_outb(ioport_t port, Bit8u byte);
-extern Bit16u std_port_inw(ioport_t port);
-extern void   std_port_outw(ioport_t port, Bit16u word);
-extern Bit32u std_port_ind(ioport_t port);
-extern void   std_port_outd(ioport_t port, Bit32u word);
+extern Bit8u  std_port_inb(ioport_t port, void *arg);
+extern void   std_port_outb(ioport_t port, Bit8u byte, void *arg);
+extern Bit16u std_port_inw(ioport_t port, void *arg);
+extern void   std_port_outw(ioport_t port, Bit16u word, void *arg);
+extern Bit32u std_port_ind(ioport_t port, void *arg);
+extern void   std_port_outd(ioport_t port, Bit32u word, void *arg);
 extern void   pci_port_outd(ioport_t port, Bit32u word);
 
 extern int port_rep_inb(ioport_t port, Bit8u *dest, int df, Bit32u count);
@@ -125,13 +116,6 @@ extern int port_rep_outd(ioport_t port, Bit32u *dest, int df, Bit32u count);
 extern void port_exit(void);
 
 extern unsigned char emu_io_bitmap[];
-
-#define safe_port_in_byte	std_port_inb
-#define safe_port_out_byte	std_port_outb
-#define port_safe_inb		std_port_inb
-#define port_safe_outb		std_port_outb
-#define port_safe_inw		std_port_inw
-#define port_safe_outw		std_port_outw
 
 extern int extra_port_init(void);
 extern void release_ports(void);

--- a/src/include/timers.h
+++ b/src/include/timers.h
@@ -10,8 +10,8 @@
 #define TIMER_DIVISOR   6
 
 extern void timer_tick(void);
-extern Bit8u pit_inp(ioport_t);
-extern void pit_outp(ioport_t, Bit8u);
+extern Bit8u pit_inp(ioport_t, void *);
+extern void pit_outp(ioport_t, Bit8u, void *);
 
 /* The divisor used to time faster-than-1sec activities (floppy,printer,
  * IPX) - see signal.c
@@ -123,8 +123,8 @@ extern hitimer_t pic_sys_time;
 
 /* --------------------------------------------------------------------- */
 
-extern Bit8u pit_control_inp(ioport_t);
-extern void pit_control_outp(ioport_t port, Bit8u val);
+extern Bit8u pit_control_inp(ioport_t, void *);
+extern void pit_control_outp(ioport_t port, Bit8u val, void *);
 extern void get_time_init(void);
 extern void cputime_late_init(void);
 extern void do_sound(Bit16u period);

--- a/src/include/vgaemu.h
+++ b/src/include/vgaemu.h
@@ -478,8 +478,8 @@ struct ColorSpaceDesc;
  * Functions defined in env/video/vgaemu.c.
  */
 
-int VGA_emulate_outb(ioport_t, Bit8u);
-int VGA_emulate_inb(ioport_t);
+int VGA_emulate_outb(ioport_t, Bit8u, void *arg);
+int VGA_emulate_inb(ioport_t, void *arg);
 int vga_emu_fault(dosaddr_t, unsigned, cpuctx_t *);
 int vga_emu_pre_init(void);
 int vga_emu_init(int src_modes, struct ColorSpaceDesc *);


### PR DESCRIPTION
Replace the direct calls of std_port_xxx with port_xxx funcs.