### PR TITLE
simx86 JIT: eliminate use of -mno-red-zone and force_align_arg_pointer (#1844)

### DIFF
--- a/src/base/emu-i386/simx86/Makefile
+++ b/src/base/emu-i386/simx86/Makefile
@@ -12,7 +12,6 @@ EM86DIR=$(REALTOPDIR)/src/emu-i386/simx86
 EM86FLG=-Dlinux -DDOSEMU
 ifeq ($(X86_JIT),1)
 JITFILES = codegen-x86.c fp87-x86.c sigsegv.c cpatch.c trees.c
-ALL_CPPFLAGS += -mno-red-zone
 endif
 CFILES = interp.c cpu-emu.c modrm-gen.c $(JITFILES) \
 	codegen-sim.c fp87-sim.c modrm-sim.c protmode.c \

--- a/src/base/emu-i386/simx86/cpatch.h
+++ b/src/base/emu-i386/simx86/cpatch.h
@@ -4,11 +4,9 @@
 #define EXTERN extern
 #endif
 #ifdef __i386__
-#define asmlinkage EXTERN __attribute__((cdecl)) \
-	__attribute__((force_align_arg_pointer))
+#define asmlinkage EXTERN __attribute__((cdecl))
 #else
-#define asmlinkage EXTERN \
-	__attribute__((force_align_arg_pointer))
+#define asmlinkage EXTERN
 #endif
 
 struct rep_stack;


### PR DESCRIPTION
We can decrease `%rsp` by 128 bytes skipping below the red zone and then align to a 16-byte boundary to make sure `cpatch.c` functions are always called with a 16-byte aligned stack.