### PR TITLE
Changes for macOS part 3 (#721)

### DIFF
--- a/src/arch/linux/Makefile.main
+++ b/src/arch/linux/Makefile.main
@@ -80,7 +80,7 @@ $(BINPATH)/bin/$(DOSBIN): $(LIBS_)
 ifeq ($(OS),Darwin)
 	$(LD) $(ALL_LDFLAGS) $(DOSBIN_LDFLAGS) -o $@ \
 	   -Wl,-all_load $(LIBS_) $(LIBS) \
-	   -Wl,-map,$(BINPATH)/bin/dosemu.map -Wl,-pagezero_size,0x10000
+	   -Wl,-map,$(BINPATH)/bin/dosemu.map
 else
 	$(LD) $(ALL_LDFLAGS) $(DOSBIN_LDFLAGS) -o $@ \
 	   -Wl,--whole-archive $(LIBS_) -Wl,--no-whole-archive $(LIBS) \

--- a/src/arch/linux/async/debug.c
+++ b/src/arch/linux/async/debug.c
@@ -35,7 +35,11 @@ static int start_gdb(pid_t dosemu_pid)
   printf("Debug info:\n");
   fflush(stdout);
 
+#ifdef __APPLE__
+  ret = asprintf(&buf, "lldb %s", dosemu_proc_self_exe);
+#else
   ret = asprintf(&buf, "gdb --readnow %s", dosemu_proc_self_exe);
+#endif
   assert(ret != -1);
 
   printf("%s", buf);
@@ -59,9 +63,15 @@ static int start_gdb(pid_t dosemu_pid)
 
 static void do_debug(void)
 {
+#ifdef __APPLE__
+  const char *cmd1 = "register read\n";
+//  const char *cmd2 = "bt\n";
+  const char *cmd3 = "thread backtrace all\n";
+#else
   const char *cmd1 = "info registers\n";
 //  const char *cmd2 = "backtrace\n";
   const char *cmd3 = "thread apply all backtrace full\n";
+#endif
 
   gdb_command(cmd1);
 //  gdb_command(cmd2);

--- a/src/arch/linux/async/signal.c
+++ b/src/arch/linux/async/signal.c
@@ -492,7 +492,11 @@ signal_pre_init(void)
 #else
   newsetsig(SIGILL, abort_signal);
   newsetsig(SIGTRAP, abort_signal);
+#ifdef __APPLE__
+  newsetsig(SIGBUS, minfault);
+#else
   newsetsig(SIGBUS, abort_signal);
+#endif
 #endif
   newsetsig(SIGFPE, minfault);
   newsetsig(SIGSEGV, minfault);

--- a/src/arch/linux/async/signal.c
+++ b/src/arch/linux/async/signal.c
@@ -550,7 +550,7 @@ void signal_done(void)
     if (setitimer(ITIMER_VIRTUAL, &itv, NULL) == -1)
 	g_printf("can't turn off vtimer at shutdown: %s\n", strerror(errno));
     sigprocmask(SIG_BLOCK, &nonfatal_q_mask, NULL);
-    for (i = 0; i < SIGMAX; i++) {
+    for (i = 1; i < SIGMAX; i++) {
 	if (sigismember(&q_mask, i))
 	    signal(i, SIG_DFL);
     }

--- a/src/arch/linux/async/signal.c
+++ b/src/arch/linux/async/signal.c
@@ -478,8 +478,10 @@ signal_pre_init(void)
   newsetqsig(SIGHUP, leavedos_signal);
 //  newsetqsig(SIGTERM, leavedos_emerg);
   /* below ones are initialized by other subsystems */
+#ifdef USE_CONSOLE_PLUGIN
   setup_nf_sig(SIG_ACQUIRE);
   setup_nf_sig(SIG_RELEASE);
+#endif
   setup_nf_sig(SIGWINCH);
   setup_nf_sig(SIGPROF);
   /* call that after all non-fatal sigs set up */

--- a/src/base/emu-i386/cputime.c
+++ b/src/base/emu-i386/cputime.c
@@ -94,7 +94,11 @@ static void idle_hlt_thr(void *arg);
 static hitimer_t do_gettime(void)
 {
   struct timespec tv;
+#ifdef CLOCK_MONOTONIC_COURSE
   int err = clock_gettime(CLOCK_MONOTONIC_COARSE, &tv);
+#else
+  int err = clock_gettime(CLOCK_MONOTONIC, &tv);
+#endif
   if (err) {
     error("Cannot get time!\n");
     leavedos(49);

--- a/src/dosext/dpmi/memory.c
+++ b/src/dosext/dpmi/memory.c
@@ -599,7 +599,7 @@ dpmi_pm_block *DPMI_mallocShared(dpmi_pm_block_root *root,
         return NULL;
     }
 
-    asprintf(&shmname, "/dosemu_dpmishm_%d_%s", getpid(), name);
+    asprintf(&shmname, "/dosemu_%s", name);
     if (init) {
         oflags |= O_CREAT;
         if (flags & SHM_EXCL)

--- a/src/dosext/mfs/xattr.c
+++ b/src/dosext/mfs/xattr.c
@@ -35,6 +35,13 @@
 #define XATTR_ATTRIBS_MASK (READ_ONLY_FILE | HIDDEN_FILE | SYSTEM_FILE | \
   ARCHIVE_NEEDED)
 
+#ifdef __APPLE__
+#define getxattr(path,name,value,size) getxattr(path,name,value,size,0,0)
+#define fgetxattr(fd,name,value,size) fgetxattr(fd,name,value,size,0,0)
+#define setxattr(path,name,value,size,flags) setxattr(path,name,value,size,0,flags)
+#define fsetxattr(fd,name,value,size,flags) fsetxattr(fd,name,value,size,0,flags)
+#endif
+
 static int do_extr_xattr(const char *xbuf, ssize_t size, const char *name)
 {
   if (size == -1 && errno == ENOTSUP) {

--- a/src/include/sig.h
+++ b/src/include/sig.h
@@ -43,10 +43,17 @@ extern void add_thread_callback(void (*cb)(void *), void *arg, const char *name)
 extern void SIG_init(void);
 extern void SIG_close(void);
 
-/* signals for Linux's process control of consoles */
+/* signals for Linux's process control of consoles
+   Note: on macOS, SIGRTMIN doesn't exist, but neither do Linux consoles, so
+   we can just use SIGUSR1 then for SIG_THREAD_NOTIFY
+ */
+#ifdef SIGRTMIN
 #define SIG_RELEASE     SIGUSR1
 #define SIG_ACQUIRE     SIGUSR2
 #define SIG_THREAD_NOTIFY (SIGRTMIN + 0)
+#else
+#define SIG_THREAD_NOTIFY SIGUSR1
+#endif
 
 typedef mcontext_t sigcontext_t;
 
@@ -208,9 +215,9 @@ static inline void signative_stop(void) {}
 static inline void unsetsig(int sig) {}
 #endif
 
-/* On glibc SIGRTMAX is not a constant but NSIG cpvers rt signals.
+/* On glibc SIGRTMAX is not a constant but NSIG covers rt signals.
  * On bsd its all the other way around. */
-#ifdef __GLIBC__
+#if defined(__GLIBC__) || !defined(SIGRTMAX)
 #define SIGMAX NSIG
 #else
 #define SIGMAX SIGRTMAX

--- a/src/include/sig.h
+++ b/src/include/sig.h
@@ -93,6 +93,17 @@ typedef mcontext_t sigcontext_t;
 #define _scp_trapno scp->mc_trapno
 #define _scp_err (*(unsigned *)&scp->mc_err)
 #define _scp_fpstate scp->mc_fpstate
+#elif defined(__APPLE__)
+#define _scp_eax    DWORD_((*scp)->__ss.__rax)
+#define _scp_edx    DWORD_((*scp)->__ss.__rdx)
+#define _scp_cs     ((*scp)->__ss.__cs)
+#define _scp_eflags ((*scp)->__ss.__rflags)
+#define _scp_rip    ((*scp)->__ss.__rip)
+#define _scp_rsp    ((*scp)->__ss.__rsp)
+#define _scp_cr2    ((*scp)->__es.__faultvaddr)
+#define _scp_trapno ((*scp)->__es.__trapno)
+#define _scp_err    ((*scp)->__es.__err)
+#define PRI_RG PRIx64
 #elif defined(__linux__)
 #define _scp_fpstate (scp->fpregs)
 #ifdef __x86_64__


### PR DESCRIPTION
This is another batch of misc small changes for Mac. Note that I could simply use another field for cr2, no need for si_addr for now.

What I still need to clean up is here:
https://gist.github.com/bartoldeman/f97d184e547eff2fbca355083f30db86

in there:

* sem_init doesn't work, but sem_open does... would it be better to also use sem_open on Linux, to keep the code identical, or use sem_init where possible? (Note that MacOS has unnamed semaphores, but it'll be either SYSV (portable but different) or Mach (Mac-specific) semaphores, we should probably avoid that).
* evtimer.c: better to use a seperate file for the Mac timers?
* asm("") stuff, I should convert that to macros, if I understand it well?
* Mac refuses rwx shared memory mappings, but perhaps better to just use rw everywhere with cpuemu as then nothing is executed directly in DOS mem?
* run_external_command: will need to study what is possible there... there's no easy workaround, no libbsd to the rescue
* There is a weird issue with SIGALRM interrupting threads even though it's blocked in those threads, and that only happens when using the JIT. I'm still debugging that.