### PR TITLE
config: dosbox style of prg-passing [closes #2045]

### DIFF
--- a/src/dosemu
+++ b/src/dosemu
@@ -187,7 +187,7 @@ fi
 
 exec 3>&1
 # in a non-bash case, $BASHPID won't work and we fail the cleanup - no problem
-DPID="$(echo "$BASHPID"; exec 1<&3; exec $COMMAND -L "Command line: `echo $COMMAND | tr -s ' '`" "$@")"
+DPID="$(echo "$BASHPID"; exec 1<&3; exec $COMMAND -L "Command line: `echo $COMMAND $* | tr -s ' '`" "$@")"
 EC=$?
 exec 3>&-
 if [ -f ~/.dosemu/stderr.log.$BASHPID ]; then


### PR DESCRIPTION
This adds the dosbox-alike syntax for passing DOS prog name for execution. Namely, you can now do:

dosemu ./my_prog.exe arg1 arg2

No -K or -E so a much simpler syntax.