### PR TITLE
mapping: strip PROT_EXEC when possible

### DIFF
--- a/src/base/init/memcheck.c
+++ b/src/base/init/memcheck.c
@@ -143,7 +143,7 @@ void memcheck_reserve(unsigned char map_char, dosaddr_t addr_start,
         map_char == 'H' || map_char == 'r'));
 
   if (memcheck_is_rom(addr_start)) {
-    mprotect_mapping(MAPPING_LOWMEM, addr_start, size, PROT_READ);
+    mprotect_mapping(MAPPING_LOWMEM, addr_start, size, PROT_READ|PROT_EXEC);
     if (config.cpu_vm == CPUVM_KVM || config.cpu_vm_dpmi == CPUVM_KVM)
       kvm_set_readonly(addr_start, size);
   }


### PR DESCRIPTION
macOS doesn't like PROT_EXEC on shared memory so to fix this properly, remove it anywhere where possible. We only need it for native and vm86. JIT sets PROT_EXEC on the codegen buffer via dlmalloc; KVM only needs it in the page tables inside the VM, not on the backend memory.

When double checking with native DPMI I found that ROM was marked noexec, so corrected that.