### PR TITLE
semaphores: use Mach semaphores on macOS

### DIFF
--- a/src/base/misc/utilities.c
+++ b/src/base/misc/utilities.c
@@ -1024,8 +1024,6 @@ static int pts_open(int pty_fd)
     return pts_fd;
 }
 
-typedef sem_t *pshared_sem_t;
-
 static int pshared_sem_init(pshared_sem_t *sem, unsigned int value)
 {
     char sem_name[] = "/dosemu2_psem_%PXXXXXX";
@@ -1086,7 +1084,7 @@ pid_t run_external_command(const char *path, int argc, const char **argv,
 	pts_fd = pts_open(pty_fd);
 	/* Reading master side before slave opened, results in EOF.
 	 * Notify user that reads are now safe. */
-	sem_post(pty_sem);
+	pshared_sem_post(pty_sem);
 	pshared_sem_destroy(&pty_sem);
 	if (pts_fd == -1) {
 	    error("run_unix_command(): open pts failed %s\n", strerror(errno));
@@ -1140,7 +1138,7 @@ pid_t run_external_command(const char *path, int argc, const char **argv,
     }
     sigprocmask(SIG_SETMASK, &oset, NULL);
     /* wait until its safe to read from pty_fd */
-    sem_wait(pty_sem);
+    pshared_sem_wait(pty_sem);
     pshared_sem_destroy(&pty_sem);
     return pid;
 }

--- a/src/plugin/fluidsynth/mid_o_flus.c
+++ b/src/plugin/fluidsynth/mid_o_flus.c
@@ -31,8 +31,12 @@
 #include <string.h>
 #include <unistd.h>
 #include <pthread.h>
-#include <semaphore.h>
 #include <fluidsynth.h>
+#ifdef __APPLE__ /* to redefine sem_init() and related functions */
+#include "utilities.h"
+#else
+#include <semaphore.h>
+#endif
 #include "seqbind.h"
 #include "emu.h"
 #include "init.h"

--- a/src/plugin/libao/snd_o_ao.c
+++ b/src/plugin/libao/snd_o_ao.c
@@ -40,7 +40,11 @@
 #include <unistd.h>
 #include <ao/ao.h>
 #include <pthread.h>
+#ifdef __APPLE__ /* to redefine sem_init() and related functions */
+#include "utilities.h"
+#else
 #include <semaphore.h>
+#endif
 
 #define aosnd_name "ao"
 #define aosnd_longname "Sound Output: libao"

--- a/src/plugin/munt/munt.c
+++ b/src/plugin/munt/munt.c
@@ -22,10 +22,14 @@
  */
 
 #include <pthread.h>
-#include <semaphore.h>
 #include <string.h>
 #include <limits.h>
 #include <mt32emu/c_interface/c_interface.h>
+#ifdef __APPLE__ /* to redefine sem_init() and related functions */
+#include "utilities.h"
+#else
+#include <semaphore.h>
+#endif
 #include "emu.h"
 #include "init.h"
 #include "timers.h"


### PR DESCRIPTION
As macOS doesn't support unnamed semaphores via sem_init, work around those via named semaphores using wrapper functions which call sem_open/sem_close on macOS and sem_init/sem_destroy on other OSes.