### PR TITLE
Use union instead of struct to avoid warning. Fixes #2057

### DIFF
--- a/src/base/emu-i386/kvm.c
+++ b/src/base/emu-i386/kvm.c
@@ -182,9 +182,9 @@ static void kvm_set_immediate_exit(int set)
       sigset_t sigset;
       /* KVM_SET_SIGNAL_MASK expects a kernel sigset_t which is
 	 smaller than a glibc one */
-      struct {
+      union {
 	struct kvm_signal_mask mask;
-	unsigned char buf[KERNEL_SIGSET_T_SIZE];
+	unsigned char buf[sizeof(struct kvm_signal_mask) + KERNEL_SIGSET_T_SIZE];
       } maskbuf;
 
       sa.sa_flags = 0;


### PR DESCRIPTION
Avoids:
```
kvm.c:186:25: warning: field 'mask' with variable sized type 'struct kvm_signal_mask' not at the end of a struct or class is a GNU extension [-Wgnu-variable-sized-type-not-at-end]
        struct kvm_signal_mask mask;
```