### PR TITLE
bios: set dl to 1 when -B switch is specified

### DIFF
--- a/src/base/bios/setup.c
+++ b/src/base/bios/setup.c
@@ -219,7 +219,8 @@ static void bios_setup(void)
     unsigned ptr;
 
     ptr = SEGOFF2LINEAR(BIOSSEG, bios_f000_bootdrive);
-    WRITE_BYTE(ptr, (config.hdiskboot >= 2 || config.hdiskboot == -1) ? 0x80 : 0);
+    WRITE_BYTE(ptr, (config.hdiskboot >= 2 || config.hdiskboot == -1) ? 0x80 :
+      config.hdiskboot);
   }
 
   bios_mem_setup();		/* setup values in BIOS area */


### PR DESCRIPTION
Running the following commands, with repos from https://hg.pushbx.org/ecm/

```
nasm ../ldosboot/boot.asm -I ../lmacros/ -D_LOAD_NAME="'LDEBUG'" -o boot12.bin
nasm ../bootimg/bootimg.asm -I ../lmacros/ -I ../ldebug/bin/ -D_BOOTPATCHFILE="'boot12.bin'" -D_PAYLOADFILE=ldebug.com -o diskette.img
nasm ../bootimg/bootimg.asm -I ../lmacros/ -D_PAYLOADFILE=::empty -o diska.img
dosemu -I "floppy { device diska.img }" -I "floppy { device diskette.img }" -B
```

Without this commit I get an "F" error (File not found). It appears that the boot loader is read from `diskette.img` (the second diskette drive) but it is passed unit 00h in `dl`. With this commit, the debugger boots as expected.