### PR TITLE
boot: pass boot drive in DL to BS [fixes #2068]

### DIFF
--- a/src/base/bios/setup.c
+++ b/src/base/bios/setup.c
@@ -214,14 +214,6 @@ static void bios_setup(void)
    */
   install_int_10_handler();
 
-  {
-    /* update boot drive in Banner-code */
-    unsigned ptr;
-
-    ptr = SEGOFF2LINEAR(BIOSSEG, bios_f000_bootdrive);
-    WRITE_BYTE(ptr, (config.hdiskboot >= 2 || config.hdiskboot == -1) ? 0x80 : 0);
-  }
-
   bios_mem_setup();		/* setup values in BIOS area */
 }
 

--- a/src/base/bios/x86/bios.S
+++ b/src/base/bios/x86/bios.S
@@ -81,8 +81,6 @@ no_vbios_post:
 video_init_done:
 	movb	$DOS_HELPER_SHOW_BANNER,%al
 	int	$DOS_HELPER_INT
-	movb	%cs:bios_f000_bootdrive,%dl
-
 	movb	$DOS_HELPER_READ_MBR,%al
 	int	$DOS_HELPER_INT
 	ljmp	$0x0, $0x7c00		/* Some boot sectors require cs=0 */
@@ -452,10 +450,6 @@ bios_f000_int10_old:
 
 	.globl	bios_in_int10_callback
 bios_in_int10_callback:
-	.byte	0
-
-	.globl	bios_f000_bootdrive
-bios_f000_bootdrive:
 	.byte	0
 
 	/* this is the paramblock, we told DOS to use for INT21 AX=4B01 */

--- a/src/base/bios/x86/bios_offsets.h
+++ b/src/base/bios/x86/bios_offsets.h
@@ -13,7 +13,6 @@ extern const unsigned HD_parameter_table1;
 extern const unsigned bios_f000_int10ptr;
 extern const unsigned bios_f000_int10_old;
 extern const unsigned bios_in_int10_callback;
-extern const unsigned bios_f000_bootdrive;
 extern const unsigned DBGload_parblock;
 extern const unsigned DBGload_CSIP;
 extern const unsigned PKTDRV_param;

--- a/src/base/core/emu.c
+++ b/src/base/core/emu.c
@@ -144,7 +144,7 @@ static int find_boot_drive(void)
 void boot(void)
 {
     unsigned buffer;
-    struct disk    *dp = NULL;
+    struct disk *dp = NULL;
 
     if (config.try_freedos && config.hdiskboot == -1 &&
 	    config.hdisks > 0 && !disk_is_bootable(&hdisktab[0])) {
@@ -246,6 +246,9 @@ mbr:
 	}
     }
     disk_close();
+
+    /* put boot drive to dl */
+    _DX = dp->drive_num;
 }
 
 static int c_chk(void)

--- a/src/base/misc/fatfs.c
+++ b/src/base/misc/fatfs.c
@@ -1616,7 +1616,7 @@ void mimic_boot_blk(void)
   uint16_t seg;
   uint16_t ofs;
 
-  fatfs_t *f = get_fat_fs_by_drive(HI(ax));
+  fatfs_t *f = get_fat_fs_by_drive(LO(dx));
 
   if (!f || (idx = sys_file_idx(f->obj[1].name, f)) == -1) {
     error("BOOT-helper requested, but no systemfile available\n");
@@ -1909,7 +1909,7 @@ void build_boot_blk(fatfs_t *f, unsigned char *b)
   /* boot loading is done by DOSEMU-HELPER with mimic_boot_blk() function */
   b[0x40] = 0xb8;	/* mov ax,0fdh */
   b[0x41] = DOS_HELPER_BOOTSECT;
-  b[0x42] = f->drive_num;
+  b[0x42] = 0;
   b[0x43] = 0xcd;	/* int 0e6h */
   b[0x44] = DOS_HELPER_INT;
 


### PR DESCRIPTION
DL was passed to MBR, not to BS.
But MBR itself finds the bootable drive, so the wrong drive was passed. It was later overridden by passing the boot drive in AH...

This patch untangles the mess and removes the wrong code.