### PR TITLE
SDL: add configuration item SDL_clip_native to enable native clipboard [#2088]

### DIFF
--- a/etc/dosemu.conf
+++ b/etc/dosemu.conf
@@ -933,6 +933,12 @@
 
 # $_SDL_wcontrols = (on)
 
+# Enable native clipboard access.
+# Can be toggled at run-time by pressing Ctrl-Alt-c.
+# Default: off
+
+# $_SDL_clip_native = (off)
+
 ##############################################################################
 ## Common video driver settings
 

--- a/etc/global.conf
+++ b/etc/global.conf
@@ -192,7 +192,7 @@ else
     }
 
   ## SDL settings
-  SDL { sdl_hwrend $_SDL_hwrend sdl_fonts $_SDL_fonts sdl_wcontrols $_SDL_wcontrols }
+  SDL { sdl_hwrend $_SDL_hwrend sdl_fonts $_SDL_fonts sdl_wcontrols $_SDL_wcontrols sdl_clip_native $_SDL_clip_native }
 
   # video settings
   vga_fonts $$_force_vga_fonts

--- a/src/base/init/config.c
+++ b/src/base/init/config.c
@@ -213,6 +213,8 @@ void dump_config_status(void (*printfunc)(const char *, ...))
 	     config.vgaemu_memsize);
     (*print)("SDL_hwrend %d\nSDL_fonts \"%s\"\n",
         config.sdl_hwrend, config.sdl_fonts);
+    (*print)("SDL_clip_native %d\n",
+        config.sdl_clip_native);
     (*print)("vesamode_list %p\nX_lfb %d\nX_pm_interface %d\n",
         config.vesamode_list, config.X_lfb, config.X_pm_interface);
     (*print)("X_font \"%s\"\n", config.X_font);

--- a/src/base/init/lexer.l
+++ b/src/base/init/lexer.l
@@ -541,6 +541,7 @@ noresize		RETURN(X_NORESIZE);
 sdl_hwrend		RETURN(SDL_HWREND);
 sdl_fonts		RETURN(SDL_FONTS);
 sdl_wcontrols		RETURN(SDL_WCONTROLS);
+sdl_clip_native		RETURN(SDL_CLIP_NATIVE);
 
         /* Sound stuff */
 

--- a/src/base/init/parser.y
+++ b/src/base/init/parser.y
@@ -268,7 +268,7 @@ enum {
 %token X_WINSIZE X_NOCLOSE X_NORESIZE
 %token X_GAMMA X_FULLSCREEN VGAEMU_MEMSIZE VESAMODE X_LFB X_PM_INTERFACE X_MGRAB_KEY X_BACKGROUND_PAUSE
 	/* sdl */
-%token SDL_HWREND SDL_FONTS SDL_WCONTROLS
+%token SDL_HWREND SDL_FONTS SDL_WCONTROLS SDL_CLIP_NATIVE
 	/* video */
 %token VGA MGA CGA EGA NONE CONSOLE GRAPHICS CHIPSET FULLREST PARTREST
 %token MEMSIZE VBIOS_SIZE_TOK VBIOS_SEG VGAEMUBIOS_FILE VBIOS_FILE 
@@ -1112,6 +1112,7 @@ sdl_flags	: sdl_flag
 sdl_flag	: SDL_HWREND expression	{ config.sdl_hwrend = ($2!=0); }
 		| SDL_FONTS string_expr	{ free(config.sdl_fonts); config.sdl_fonts = $2; }
 		| SDL_WCONTROLS expression	{ config.sdl_wcontrols = ($2!=0); }
+		| SDL_CLIP_NATIVE bool		{ config.sdl_clip_native = ($2!=0); }
 		;
 
 	/* sb emulation */

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -209,6 +209,7 @@ typedef struct config_info {
        boolean sdl_hwrend;		/* accelerate SDL with OpenGL */
        boolean sdl_wcontrols;		/* enable window controls */
        char    *sdl_fonts;		/* TTF font used in SDL2 */
+       boolean sdl_clip_native;		/* enable native clipboard */
        boolean fullrestore;
        boolean force_vt_switch;         /* in case of console_video force switch to emu VT at start */
        int     dualmon;

--- a/src/plugin/sdl/sdl.c
+++ b/src/plugin/sdl/sdl.c
@@ -464,6 +464,12 @@ static int SDL_init(void)
 #endif
 #endif
 
+  if (config.sdl_clip_native) {
+    sdlclip_mode = 1;
+    sdlclip_setnative(sdlclip_mode);
+    SDL_change_config(CHG_TITLE, NULL);
+  }
+
   c_printf("VID: SDL plugin initialization completed\n");
 
   return 0;


### PR DESCRIPTION
As requested in https://github.com/dosemu2/dosemu2/pull/2088#issuecomment-1714274854

Command line switch `-I "sdl { SDL_clip_native 1 }"` or the .dosemurc line like `$_SDL_clip_native = (on)` will enable the native clipboard by default.