### PR TITLE
Drop "pseudo" serial devices when fd is closed

### DIFF
--- a/src/base/serial/ser_defs.h
+++ b/src/base/serial/ser_defs.h
@@ -337,6 +337,7 @@ typedef struct {
   int opened;
   int wr_fd;
   boolean is_file;
+  boolean is_closed;
   boolean dev_locked;           /* Flag to indicate that device is locked */
   boolean fossil_active;	/* Flag: FOSSIL emulation active */
   fossil_info_t fossil_info;	/* FOSSIL driver info structure */

--- a/src/base/serial/ser_irq.c
+++ b/src/base/serial/ser_irq.c
@@ -199,10 +199,14 @@ void modstat_engine(int num)		/* Internal Modem Status processing */
   com[num].ms_timer += MS_MIN_FREQ;
 #endif
 
-  if(com_cfg[num].pseudo)
-    newmsr = UART_MSR_CTS | UART_MSR_DSR | UART_MSR_DCD;
-  else
+  if(com_cfg[num].pseudo) {
+    if (com[num].is_closed)
+      newmsr = 0;
+    else
+      newmsr = UART_MSR_CTS | UART_MSR_DSR | UART_MSR_DCD;
+  } else {
     newmsr = serial_get_msr(num);
+  }
   delta = msr_compute_delta_bits(com[num].MSR, newmsr);
 
   com[num].MSR = (com[num].MSR & UART_MSR_DELTA) | newmsr | delta;

--- a/src/base/serial/tty_io.c
+++ b/src/base/serial/tty_io.c
@@ -466,8 +466,13 @@ static int tty_uart_fill(com_t *c)
                               &c->rx_buf[c->rx_buf_end],
                               RX_BUFFER_SIZE - c->rx_buf_end));
   ioselect_complete(c->fd);
-  if (size <= 0)
+  if (size < 0)
     return 0;
+  if (size == 0) {
+    c->is_closed = TRUE;
+    if(s3_printf) s_printf("SER%d: Got 0 bytes, setting is_closed\n", c->num);
+    return 0;
+  }
   if(s3_printf) s_printf("SER%d: Got %i bytes, %i in buffer\n", c->num,
         size, RX_BUF_BYTES(c->num));
   if (debug_level('s') >= 9) {


### PR DESCRIPTION
This sets the modem status lines for a "pseudo" serial port to zero when the associated file descriptor is closed. This is useful when using DOSEMU2 to launch BBS doors and other programs designed to communicate over a modem; it allows such programs to detect when the other side of the connection has been closed.

Some caveats:

- There is no way to "reconnect" once the file descriptor has been closed, but I don't think there'd be any way to reopen the file descriptor from the other end anyway, so I don't think this is a problem
- I'm not sure if setting MSRs to `0` here is the right thing or if I should only drop DCD. I think the difference is between simulating "lost carrier" vs simulating "someone yanked the modem cord out of the serial port" - 0 seems to get applications to behave the way I want it to, though.

Re: https://github.com/dosemu2/dosemu2/discussions/2101