### PR TITLE
enable UMB at b0 for dumb_video

### DIFF
--- a/etc/dosemu.conf
+++ b/etc/dosemu.conf
@@ -270,6 +270,15 @@
 
 # $_umb_b0 = (auto)
 
+# Enable 32K UMB at 0b8000.
+# This is the text-mode video memory.
+# It can be used as UMB only in dumb video mode.
+# Use "auto" to get it enabled in that mode.
+# And even in that case only few well-behaved programs will work.
+# Default: off
+
+# $_umb_b8 = (off)
+
 # Enable 48K UMB at 0f0000.
 # This is where normally a read-only BIOS resides but the DOSEMU BIOS does
 # not need it. Some (very few) programs rely on this memory being read-only

--- a/etc/dosemu.conf
+++ b/etc/dosemu.conf
@@ -266,9 +266,9 @@
 # This is where the MDA text memory used to reside, so some programs
 # write to that area without hesitation. Therefore it is rather risky
 # to enable that UMB: beware even of ansi.sys!
-# Default: off
+# Default: auto (means: enable only for dumb video mode)
 
-# $_umb_b0 = (off)
+# $_umb_b0 = (auto)
 
 # Enable 48K UMB at 0f0000.
 # This is where normally a read-only BIOS resides but the DOSEMU BIOS does

--- a/etc/global.conf
+++ b/etc/global.conf
@@ -130,6 +130,7 @@ else
   endif
   umb_a0 $_umb_a0
   umb_b0 $_umb_b0
+  umb_b8 $_umb_b8
   umb_f0 $_umb_f0
   hma $_hma
   dos_up $_dos_up

--- a/src/base/init/config.c
+++ b/src/base/init/config.c
@@ -955,6 +955,8 @@ static void config_post_process(void)
 	}
 #endif
     }
+    if (config.umb_b0 == -1)
+	config.umb_b0 = config.dumb_video;
 
     /* page-align memory sizes */
     config.ext_mem &= ~3;

--- a/src/base/init/config.c
+++ b/src/base/init/config.c
@@ -957,6 +957,8 @@ static void config_post_process(void)
     }
     if (config.umb_b0 == -1)
 	config.umb_b0 = config.dumb_video;
+    if (config.umb_b8)
+	config.umb_b8 = config.dumb_video;
 
     /* page-align memory sizes */
     config.ext_mem &= ~3;

--- a/src/base/init/lexer.l
+++ b/src/base/init/lexer.l
@@ -324,6 +324,7 @@ swap_bootdrive		RETURN(SWAP_BOOTDRIVE);
 xms			RETURN(L_XMS);
 umb_a0			RETURN(UMB_A0);
 umb_b0			RETURN(UMB_B0);
+umb_b8			RETURN(UMB_B8);
 umb_f0			RETURN(UMB_F0);
 hma			RETURN(HMA);
 dos_up			RETURN(DOS_UP);

--- a/src/base/init/parser.y
+++ b/src/base/init/parser.y
@@ -236,7 +236,7 @@ enum {
 %token MATHCO CPU CPUSPEED BOOTDRIVE SWAP_BOOTDRIVE
 %token L_XMS L_DPMI DPMI_BASE PM_DOS_API NO_NULL_CHECKS
 %token PORTS DISK DOSMEM EXT_MEM
-%token L_EMS UMB_A0 UMB_B0 UMB_F0 HMA DOS_UP
+%token L_EMS UMB_A0 UMB_B0 UMB_B8 UMB_F0 HMA DOS_UP
 %token EMS_SIZE EMS_FRAME EMS_UMA_PAGES EMS_CONV_PAGES
 %token TTYLOCKS L_SOUND L_SND_OSS L_JOYSTICK FILE_LOCK_LIMIT
 %token ABORT WARN ERROR
@@ -602,6 +602,11 @@ line:		CHARSET '{' charset_flags '}' {}
 		    {
 		    config.umb_b0 = $2;
 		    if ($2 > 0) c_printf("CONF: umb at 0b0000: %s\n", ($2) ? "on" : "off");
+		    }
+		| UMB_B8 bool
+		    {
+		    config.umb_b8 = $2;
+		    if ($2 > 0) c_printf("CONF: umb at 0b8000: %s\n", ($2) ? "on" : "off");
 		    }
 		| UMB_F0 bool
 		    {

--- a/src/base/init/parser.y
+++ b/src/base/init/parser.y
@@ -600,7 +600,7 @@ line:		CHARSET '{' charset_flags '}' {}
 		    }
 		| UMB_B0 bool
 		    {
-		    config.umb_b0 = ($2!=0);
+		    config.umb_b0 = $2;
 		    if ($2 > 0) c_printf("CONF: umb at 0b0000: %s\n", ($2) ? "on" : "off");
 		    }
 		| UMB_F0 bool

--- a/src/base/video/video.c
+++ b/src/base/video/video.c
@@ -507,7 +507,7 @@ void video_post_init(void)
     return;
   }
 
-  if (!config.vga) {
+  if (!config.vga && !config.dumb_video) {
     vga_emu_pre_init();
     render_init();
   }

--- a/src/base/video/video.c
+++ b/src/base/video/video.c
@@ -355,7 +355,13 @@ static void reserve_video_memory(void)
   if (config.umb_b0 && !config.dualmon) {
     if (!config.umb_a0)
       do_reserve_vmem(GRAPH_BASE, GRAPH_SIZE);
-    do_reserve_vmem(VGA_PHYS_TEXT_BASE, VGA_TEXT_SIZE);
+    if (!config.umb_b8)
+      do_reserve_vmem(VGA_PHYS_TEXT_BASE, VGA_TEXT_SIZE);
+  } else if (config.umb_b8) {
+    if (!config.umb_a0)
+      do_reserve_vmem(GRAPH_BASE, GRAPH_SIZE);
+    if (!config.umb_b0)
+      do_reserve_vmem(MDA_PHYS_TEXT_BASE, VGA_TEXT_SIZE);
   } else {
     if (!config.umb_a0)
       do_reserve_vmem(VMEM_BASE, VMEM_SIZE);

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -265,7 +265,7 @@ typedef struct config_info {
        int hogthreshold;
 
        int mem_size, ext_mem, xms_size, ems_size;
-       int umb_a0, umb_b0, umb_f0, hma;
+       int umb_a0, umb_b0, umb_b8, umb_f0, hma;
        unsigned int ems_frame;
        int ems_uma_pages, ems_cnv_pages;
        int dpmi, pm_dos_api, no_null_checks;


### PR DESCRIPTION
Make that UMB 64K, i.e. also 0xb800 is covered.
We don't need that range in dumb video mode, so use for UMB.