### PR TITLE
CI: Update to use current builtin actions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: package install
       run: ./ci_prereq.sh
@@ -31,7 +31,7 @@ jobs:
       run: ./ci_build.sh
 
     - name: cache binaries
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       env:
         cache-name: test-binaries
       with:


### PR DESCRIPTION
Older actions use deprecated node16, so update to avoid the warning.