### PR TITLE
coopth: add coopth_leave_[vm86|pm]() [fixes #2170]

### DIFF
--- a/src/base/emu-i386/coopth_vm86.c
+++ b/src/base/emu-i386/coopth_vm86.c
@@ -284,3 +284,11 @@ int coopth_get_thread_count_in_process_vm86(void)
     }
     return cnt;
 }
+
+void coopth_leave_vm86(void)
+{
+    struct co_vm86 *thr = &coopth86[coopth_get_tid()];
+    coopth_leave_internal();
+    assert(thr->post);
+    thr->post();
+}

--- a/src/dosext/dpmi/coopth_pm.c
+++ b/src/dosext/dpmi/coopth_pm.c
@@ -183,3 +183,11 @@ int coopth_create_pm_multi(const char *name, coopth_func_t func,
     *hlt_off = ret + offs;
     return num;
 }
+
+void coopth_leave_pm(cpuctx_t *scp)
+{
+    struct co_pm *thr = &coopthpm[coopth_get_tid()];
+    coopth_leave_internal();
+    assert(thr->post);
+    thr->post(scp);
+}

--- a/src/dosext/dpmi/coopth_pm.h
+++ b/src/dosext/dpmi/coopth_pm.h
@@ -9,4 +9,6 @@ int coopth_create_pm_multi(const char *name, coopth_func_t func,
 	void (*post)(cpuctx_t *), void *hlt_state, unsigned offs,
 	int len, unsigned int *hlt_off, int r_offs[]);
 
+void coopth_leave_pm(cpuctx_t *scp);
+
 #endif

--- a/src/dosext/dpmi/msdoshlp.c
+++ b/src/dosext/dpmi/msdoshlp.c
@@ -577,8 +577,7 @@ void doshlp_quit_dpmi(cpuctx_t *scp)
 	.offset = DPMI_SEL_OFF(DPMI_msdos),
 	.selector = dpmi_sel(),
     };
-    coopth_leave();
-    do_dpmi_iret(scp);
+    coopth_leave_pm(scp);
     _eax = 0x4c01;
     do_callf(scp, pma);
 }

--- a/src/include/coopth.h
+++ b/src/include/coopth.h
@@ -29,6 +29,7 @@ int coopth_create(const char *name, coopth_func_t func);
 int coopth_create_multi(const char *name, int len, coopth_func_t func);
 int coopth_create_vm86(const char *name, coopth_func_t func,
 	void (*post)(void), uint16_t *hlt_off);
+void coopth_leave_vm86(void);
 int coopth_start(int tid, void *arg);
 int coopth_set_permanent_post_handler(int tid, coopth_hndl_t func);
 int coopth_set_ctx_handlers(int tid, coopth_hndl_t pre, coopth_hndl_t post,

--- a/src/include/coopth_be.h
+++ b/src/include/coopth_be.h
@@ -55,5 +55,6 @@ int coopth_flush_internal(unsigned id, void (*helper)(void));
 struct crun_ret coopth_run_thread_internal(int tid);
 int coopth_wants_sleep_internal(unsigned id);
 void coopth_call_post_internal(int tid);
+void coopth_leave_internal(void);
 
 #endif

--- a/src/include/coopth_pm.h
+++ b/src/include/coopth_pm.h
@@ -1,0 +1,16 @@
+/*
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+#include "../dosext/dpmi/coopth_pm.h"

--- a/src/plugin/dj64/djdev64.c
+++ b/src/plugin/dj64/djdev64.c
@@ -26,6 +26,7 @@
 #include "emudpmi.h"
 #include "msdoshlp.h"
 #include "coopth.h"
+#include "coopth_pm.h"
 #include "hlt.h"
 #include "dos2linux.h"
 #include "stub_ex.h"
@@ -166,7 +167,7 @@ static void dj64_asm_noret(dpmi_regs *regs, dpmi_paddr pma, uint8_t *sp,
 {
     struct pmaddr_s abt = doshlp_get_abort_helper();
     cpuctx_t *scp = coopth_pop_user_data_cur();
-    coopth_leave();
+    coopth_leave_pm(scp);
     copy_stk(scp, sp, len);
     copy_gp(scp, regs);
     _cs = abt.selector;
@@ -239,7 +240,9 @@ static void stub_thr(void *arg)
     envp[i] = NULL;
 
     djstub_main(argc, argv, envp, _eax, &scp2);
-    coopth_leave();
+    coopth_leave_pm(scp);
+    scp2.esp += 8;
+    assert(_esp == scp2.esp);
     *scp = scp2;
 }
 

--- a/src/plugin/fdpp/fdpp.c
+++ b/src/plugin/fdpp/fdpp.c
@@ -65,7 +65,7 @@ static void fdpp_call_noret(struct vm86_regs *regs, uint16_t seg,
 	uint16_t off, uint8_t *sp, uint8_t len)
 {
     REGS = *regs;
-    coopth_leave();
+    coopth_leave_vm86();
     copy_stk(sp, len);
     jmp_to(0xffff, 0);
     fake_call_to(seg, off);


### PR DESCRIPTION
coopth_leave() doesn't call user's retf handler to allow handler chaining (as in exthlp_thr()). But it was forgotten to be called in most places, so add the helper functions that calls it after coopth_leave().