### PR TITLE
Ci Update

### DIFF
--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -5,7 +5,7 @@ import re
 import traceback
 import unittest
 
-from datetime import datetime
+from datetime import datetime, timezone
 from hashlib import sha1
 from os import environ, rename
 from os.path import exists, join
@@ -222,6 +222,9 @@ class BaseTestCase(object):
         self.msg = msg
 
 # helpers
+
+    def utcnow(self):
+        return datetime.now(timezone.utc)
 
     def mkcom_with_ia16(self, fname, content, dname=None):
         if dname is None:
@@ -513,7 +516,7 @@ class MyTestResult(unittest.TextTestResult):
 
     def startTest(self, test):
         super(MyTestResult, self).startTest(test)
-        self.starttime = datetime.utcnow()
+        self.starttime = test.utcnow()
 
         name = test.id().replace('__main__', test.pname)
         test.logfiles = {
@@ -604,7 +607,7 @@ class MyTestResult(unittest.TextTestResult):
         super(unittest.TextTestResult, self).addSuccess(test)
         if self.showAll:
             if self.starttime is not None:
-                duration = datetime.utcnow() - self.starttime
+                duration = test.utcnow() - self.starttime
                 msg = (" " + test.msg) if test.msg else ""
                 self.stream.writeln("ok ({:>6.2f}s){}".format(duration.total_seconds(), msg))
             else:

--- a/test/func_libi86_testsuite.py
+++ b/test/func_libi86_testsuite.py
@@ -1,7 +1,6 @@
 
 import re
 
-from datetime import datetime
 from shutil import copy
 from subprocess import check_call, check_output, CalledProcessError, DEVNULL, TimeoutExpired
 
@@ -60,9 +59,9 @@ $_floppy_a = ""
 
     # Do just one
     try:
-        starttime = datetime.utcnow()
+        starttime = self.utcnow()
         check_call([TESTSUITE, *args, test[0]], cwd=build, timeout=60, stdout=DEVNULL, stderr=DEVNULL)
-        self.duration = datetime.utcnow() - starttime
+        self.duration = self.utcnow() - starttime
     except CalledProcessError:
         raise self.failureException("Test error") from None
     except TimeoutExpired:

--- a/test/func_memory_dpmi_dpmi10_ldt.py
+++ b/test/func_memory_dpmi_dpmi10_ldt.py
@@ -9,7 +9,7 @@ $_floppy_a = ""
 """
 
 
-def dpmi_dpmi10_ldt(self):
+def memory_dpmi_dpmi10_ldt(self):
 
 # Note: Not sure if I need this
     if 'FDPP' in self.version:

--- a/test/func_memory_dpmi_leak_check.py
+++ b/test/func_memory_dpmi_leak_check.py
@@ -1,0 +1,89 @@
+import re
+
+
+def memory_dpmi_leak_check(self, tipo):
+
+    self.mkfile("testit.bat", """\
+c:\\dpmileak TEST0 {0}
+c:\\dpmileak TEST1 {0}
+c:\\dpmileak TEST2 {0}
+c:\\dpmileak TEST3 {0}
+c:\\dpmileak TEST4 {0}
+c:\\dpmileak TEST5 {0}
+c:\\dpmileak TEST6 {0}
+c:\\dpmileak TEST7 {0}
+c:\\dpmileak TEST8 {0}
+c:\\dpmileak TEST9 {0}
+rem end
+""".format(tipo), newline="\r\n")
+
+    self.mkexe_with_djgpp("dpmileak", r"""
+#include <dos.h>
+#include <dpmi.h>
+#include <process.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdint.h>
+
+int main(int argc, char *argv[])
+{
+
+  __dpmi_meminfo info = {};
+  int dofree = 1;
+
+  if (argc < 2) {
+    printf("FAIL: Missing argument IDSTRING (normal|nofree)\n");
+    return -2;
+  }
+
+  if (argc > 2 && strcmp(argv[2], "nofree") == 0)
+    dofree = 0;
+
+  info.size = 0x20000;
+
+  if (__dpmi_allocate_memory(&info) == -1) {
+    printf("FAIL: (%s) DPMI allocation failed\n", argv[1]);
+    return -1;
+  }
+
+  printf("INFO: (%s) DPMI allocation info: HNDL=%08lx, SIZE=%08lx, ADDR=%08lx\n",
+      argv[1], info.handle, info.size, info.address);
+
+  if (dofree) {
+    if (__dpmi_free_memory(info.handle) == -1) {
+      printf("FAIL: (%s) DPMI free failed\n", argv[1]);
+      return -1;
+    }
+    printf("INFO: (%s) Successful Free\n", argv[1]);
+  } else {
+    printf("INFO: (%s) Skipping Free\n", argv[1]);
+  }
+
+  printf("DONE: (%s)", argv[1]);
+  return 0;
+}
+""")
+
+    results = self.runDosemu("testit.bat", config="""\
+$_hdimage = "dXXXXs/c:hdtype1 +1"
+$_floppy_a = ""
+""")
+
+    # INFO: (TEST0) DPMI allocation info: HNDL=00000012, SIZE=00020000, ADDR=21199000
+
+    m = re.search(r'\(TEST0\).*HNDL=([\da-f]+), SIZE=([\da-f]+), ADDR=([\da-f]+)', results)
+    self.assertIsNotNone(m, results)
+
+    FMT = r'(?m)^INFO: \(%s\).*, SIZE=%s, ADDR=%s[\r\n]+'
+
+    self.assertRegex(results, FMT % ('TEST1', m.group(2), m.group(3)))
+    self.assertRegex(results, FMT % ('TEST2', m.group(2), m.group(3)))
+    self.assertRegex(results, FMT % ('TEST3', m.group(2), m.group(3)))
+    self.assertRegex(results, FMT % ('TEST4', m.group(2), m.group(3)))
+    self.assertRegex(results, FMT % ('TEST5', m.group(2), m.group(3)))
+    self.assertRegex(results, FMT % ('TEST6', m.group(2), m.group(3)))
+    self.assertRegex(results, FMT % ('TEST7', m.group(2), m.group(3)))
+    self.assertRegex(results, FMT % ('TEST8', m.group(2), m.group(3)))
+    self.assertRegex(results, FMT % ('TEST9', m.group(2), m.group(3)))
+    self.assertNotIn("FAIL:", results)

--- a/test/func_pit_mode_2.py
+++ b/test/func_pit_mode_2.py
@@ -1,7 +1,4 @@
 
-from datetime import datetime
-
-
 def pit_mode_2(self):
 
     self.mkfile("testit.bat", """\
@@ -129,12 +126,12 @@ int main(void)
 }
 """)
 
-    starttime = datetime.utcnow()
+    starttime = self.utcnow()
     results = self.runDosemu("testit.bat", config="""\
 $_hdimage = "dXXXXs/c:hdtype1 +1"
 $_floppy_a = ""
 """, timeout=150)
-    endtime = datetime.utcnow()
+    endtime = self.utcnow()
 
     self.assertIn("Continuous timestamp test - complete", results)
     self.assertNotIn("Timestamp went backwards", results)

--- a/test/test_dos.py
+++ b/test/test_dos.py
@@ -41,6 +41,7 @@ from func_lfs_file_seek_tell import lfs_file_seek_tell
 from func_libi86_testsuite import libi86_create_items
 from func_memory_dpmi_dpmi10_ldt import memory_dpmi_dpmi10_ldt
 from func_memory_dpmi_japheth import memory_dpmi_japheth
+from func_memory_dpmi_leak_check import memory_dpmi_leak_check
 from func_memory_ems_borland import memory_ems_borland
 from func_memory_hma import (memory_hma_freespace, memory_hma_alloc, memory_hma_a20,
                              memory_hma_alloc3, memory_hma_chain)
@@ -3364,6 +3365,16 @@ $_floppy_a = ""
         """Memory DPMI-1.0 LDT"""
         memory_dpmi_dpmi10_ldt(self)
     test_memory_dpmi10_ldt.dpmitest = True
+
+    def test_memory_dpmi_leak_check_nofree(self):
+        """Memory DPMI Leak Check No Free"""
+        memory_dpmi_leak_check(self, 'nofree')
+    test_memory_dpmi_leak_check_nofree.dpmitest = True
+
+    def test_memory_dpmi_leak_check_normal(self):
+        """Memory DPMI Leak Check Normal"""
+        memory_dpmi_leak_check(self, 'normal')
+    test_memory_dpmi_leak_check_normal.dpmitest = True
 
     def test_memory_uma_strategy(self):
         """Memory UMA Strategy"""

--- a/test/test_dos.py
+++ b/test/test_dos.py
@@ -39,13 +39,13 @@ from func_label_create import (label_create, label_create_on_lfns,
 from func_lfs_file_info import lfs_file_info
 from func_lfs_file_seek_tell import lfs_file_seek_tell
 from func_libi86_testsuite import libi86_create_items
+from func_memory_dpmi_dpmi10_ldt import memory_dpmi_dpmi10_ldt
 from func_memory_dpmi_japheth import memory_dpmi_japheth
 from func_memory_ems_borland import memory_ems_borland
 from func_memory_hma import (memory_hma_freespace, memory_hma_alloc, memory_hma_a20,
                              memory_hma_alloc3, memory_hma_chain)
 from func_memory_uma import memory_uma_strategy
 from func_memory_xms import memory_xms
-from func_dpmi_dpmi10_ldt import dpmi_dpmi10_ldt
 from func_mfs_findfile import mfs_findfile
 from func_mfs_truename import mfs_truename
 from func_network import network_pktdriver_mtcp
@@ -3360,10 +3360,10 @@ $_floppy_a = ""
         memory_xms(self)
     test_memory_xms.xmstest = True
 
-    def test_dpmi10_ldt(self):
-        """DPMI-1.0 LDT"""
-        dpmi_dpmi10_ldt(self)
-    test_dpmi10_ldt.dpmitest = True
+    def test_memory_dpmi10_ldt(self):
+        """Memory DPMI-1.0 LDT"""
+        memory_dpmi_dpmi10_ldt(self)
+    test_memory_dpmi10_ldt.dpmitest = True
 
     def test_memory_uma_strategy(self):
         """Memory UMA Strategy"""

--- a/test/test_dos.py
+++ b/test/test_dos.py
@@ -1101,7 +1101,7 @@ failmsg:
             if fstype == "MFS":
                 self.assertTrue(exists(join(testdir, f + "." + e)), msg)
             else:
-                self.assertRegex(results.upper(), "%s( +|\.)%s" % (f.upper(), e.upper()))
+                self.assertRegex(results.upper(), r"%s( +|\.)%s" % (f.upper(), e.upper()))
 
         if fstype == "MFS":
             results = self.runDosemu("testit.bat", config="""\
@@ -1315,13 +1315,13 @@ failmsg:
             if fstype == "MFS":
                 self.assertTrue(exists(join(testdir, f + "." + e)), msg)
             else:
-                self.assertRegex(results.upper(), "%s( +|\.)%s" % (f.upper(), e.upper()))
+                self.assertRegex(results.upper(), r"%s( +|\.)%s" % (f.upper(), e.upper()))
 
         def assertIsNotPresent(testdir, results, fstype, f, e, msg=None):
             if fstype == "MFS":
                 self.assertFalse(exists(join(testdir, f + "." + e)), msg)
             else:
-                self.assertNotRegex(results.upper(), "%s( +|\.)%s" % (f.upper(), e.upper()))
+                self.assertNotRegex(results.upper(), r"%s( +|\.)%s" % (f.upper(), e.upper()))
 
         if fstype == "MFS":
             results = self.runDosemu("testit.bat", config="""\
@@ -2094,7 +2094,7 @@ failmsg:
             if fstype == "MFS":
                 self.assertTrue(exists(join(testdir, f + "." + e)), msg)
             else:
-                self.assertRegex(results.upper(), "%s( +|\.)%s" % (f.upper(), e.upper()), msg)
+                self.assertRegex(results.upper(), r"%s( +|\.)%s" % (f.upper(), e.upper()), msg)
 
         def assertIsPresentDir(testdir, results, fstype, f, msg=None):
             if fstype == "MFS":
@@ -2254,7 +2254,7 @@ failmsg:
             if fstype == "MFS":
                 self.assertFalse(exists(join(testdir, f + "." + e)), msg)
             else:
-                self.assertNotRegex(results.upper(), "%s( +|\.)%s" % (f.upper(), e.upper()))
+                self.assertNotRegex(results.upper(), r"%s( +|\.)%s" % (f.upper(), e.upper()))
 
         if fstype == "MFS":
             results = self.runDosemu("testit.bat", config="""\
@@ -5471,7 +5471,7 @@ if __name__ == '__main__':
                 print(str(m))
             exit(0)
         else:
-            x = re.match("^--require-attr=(\S+).*$", argv[1])
+            x = re.match(r"^--require-attr=(\S+).*$", argv[1])
             if x:
                 attr = x.groups()[0]
                 del argv[1]


### PR DESCRIPTION
1/ Avoid deprecation warnings on Python 3.12
2/ Add DPMI memory leak checks
3/ Rename DPMI LDT test to group with other memory tests in test suite output.