### PR TITLE
CI: Enable kvm for testing again

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -40,6 +40,12 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-build-${{ env.cache-name }}-
 
+    - name: Enable KVM group perms
+      run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
     - name: test
       id: test
       env:

--- a/ci_test.sh
+++ b/ci_test.sh
@@ -28,6 +28,10 @@ else
 fi
 python3 test/test_dos.py --get-test-binaries
 
+if [ -f /dev/kvm ] ; then
+  sudo setfacl -m u:${USER}:rw /dev/kvm
+fi
+
 echo
 echo "====================================================="
 echo "=        Tests run on various flavours of DOS       ="

--- a/test/func_cpu_trap_flag.py
+++ b/test/func_cpu_trap_flag.py
@@ -96,6 +96,7 @@ result:
         'AMD FX(tm)-8350 Eight-Core Processor',
         'AMD A10-7870K Radeon R7, 12 Compute Cores 4C+8G',
         'AMD Ryzen 5 5600U with Radeon Graphics',
+        'AMD EPYC 7763 64-Core Processor',
     )
 
     # get log content


### PR DESCRIPTION
After this Github blog post it seems we can now use KVM for testing again.
https://github.blog/changelog/2024-04-02-github-actions-hardware-accelerated-android-virtualization-now-available/