### PR TITLE
CI: Update artifact action

### DIFF
--- a/.github/workflows/ci-flatpak.yml
+++ b/.github/workflows/ci-flatpak.yml
@@ -30,7 +30,7 @@ jobs:
         cp -r images index.html javascripts params.json stylesheets pub
 
     - name: Upload
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@v4
       with:
         path: pub
 


### PR DESCRIPTION
Should remove the message:

Deprecation notice: v1, v2, and v3 of the artifact actions The following artifacts were uploaded using a version of actions/upload-artifact that is scheduled for deprecation: "dosemu2-x86_64". Please update your workflow to use v4 of the artifact actions. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/