### PR TITLE
CI: Limit Flatpak builds to dosemu2 not forks

### DIFF
--- a/.github/workflows/ci-flatpak.yml
+++ b/.github/workflows/ci-flatpak.yml
@@ -7,6 +7,7 @@ jobs:
   build:
     name: "Flatpak"
     runs-on: ubuntu-22.04
+    if: (github.repository_owner == 'dosemu2')
     container:
       image: bilelmoussaoui/flatpak-github-actions:freedesktop-23.08
       options: --privileged


### PR DESCRIPTION
Flatpak builds always fail for forks, as we don't have the credentials to deploy nor should have.