### PR TITLE
CI: Allow the test suite to operate without needing to build dosemu

### DIFF
--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -194,6 +194,13 @@ class BaseTestCase(object):
         # Empty dosemu.conf for default values
         self.mkfile("dosemu.conf", """\n""", self.imagedir)
 
+        # Link back to std dosemu commands and scripts
+        p = self.workdir / "dosemu"
+        if environ.get("TEST_BINDIR"):
+            p.symlink_to(self.bindir / "dosemu")
+        else:
+            p.symlink_to(self.topdir / "commands" / "dosemu")
+
         # Create startup files
         self.setUpDosAutoexec()
         self.setUpDosConfig()

--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -374,7 +374,7 @@ class BaseTestCase(object):
         # mkfatimage [-b bsectfile] [{-t tracks | -k Kbytes}]
         #            [-l volume-label] [-f outfile] [-p ] [file...]
         result = Popen(
-            [str(self.topdir / "bin" / "mkfatimage16"),
+            [str(self.dosemu.parent / "mkfatimage16"),
                 "-t", tnum,
                 "-h", hnum,
                 "-f", str(self.imagedir / name),

--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -136,6 +136,7 @@ class BaseTestCase(object):
             raise ValueError("Imagedir must be non-existent, a directory or a link to a directory '%s'" % str(cls.imagedir))
 
         cls.bindir = Path(environ.get("TEST_BINDIR", cls.topdir / "src" / "bindist"))
+        cls.dosemu = Path(environ.get("TEST_DOSEMU", cls.topdir / "bin" / "dosemu"))
 
         cls.version = "BaseTestCase default"
         cls.prettyname = "NoPrettyNameSet"
@@ -436,7 +437,7 @@ class BaseTestCase(object):
     def runDosemu(self, cmd, opts=None, outfile=None, config=None, timeout=5,
                     eofisok=False, interactions=[]):
         # Note: if debugging is turned on then times increase 10x
-        dbin = "bin/dosemu"
+        dbin = str(self.dosemu)
         args = ["-f", str(self.imagedir / "dosemu.conf"),
                 "-n",
                 "-o", str(self.topdir / self.logfiles['log'][0]),
@@ -490,7 +491,7 @@ class BaseTestCase(object):
         return ret
 
     def runDosemuCmdline(self, xargs, cwd=None, config=None, timeout=30):
-        args = [str(self.topdir / "bin" / "dosemu"),
+        args = [str(self.dosemu),
                 "--Fimagedir", str(self.imagedir),
                 "-f", str(self.imagedir / "dosemu.conf"),
                 "-n",

--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -135,6 +135,8 @@ class BaseTestCase(object):
         if not cls.imagedir.is_dir():
             raise ValueError("Imagedir must be non-existent, a directory or a link to a directory '%s'" % str(cls.imagedir))
 
+        cls.bindir = Path(environ.get("TEST_BINDIR", cls.topdir / "src" / "bindist"))
+
         cls.version = "BaseTestCase default"
         cls.prettyname = "NoPrettyNameSet"
         cls.tarfile = None
@@ -201,11 +203,11 @@ class BaseTestCase(object):
 
     def setUpDosAutoexec(self):
         # Use the standard shipped autoexec
-        copy(self.topdir / "src" / "bindist" / self.autoexec, self.workdir)
+        copy(self.bindir / self.autoexec, self.workdir)
 
     def setUpDosConfig(self):
         # Use the standard shipped config
-        copy(self.topdir / "src" / "bindist" / self.confsys, self.workdir)
+        copy(self.bindir / self.confsys, self.workdir)
 
     def setUpDosVersion(self):
         # FreeCom / Comcom32 compatible

--- a/test/cpu/Makefile
+++ b/test/cpu/Makefile
@@ -1,4 +1,6 @@
-include ../../Makefile.conf
+
+# No need to include the config from the build directory
+#include ../../Makefile.conf
 
 DJGPP = i586-pc-msdosdjgpp-gcc
 DJFLAGS=-Wall -O2 -g -gdwarf-2 -fno-strict-aliasing -fno-pic -fno-pie -no-pie

--- a/test/func_libi86_testsuite.py
+++ b/test/func_libi86_testsuite.py
@@ -10,13 +10,16 @@ TESTSUITE = "/usr/ia16-elf/libexec/libi86/tests/testsuite"
 
 
 def libi86_create_items(testcase):
+    if environ.get("SKIP_EXPENSIVE"):
+        print('\nlibi86-testsuite-ia16-elf is expensive - skipping')
+        return
 
     # Enumerate the tests
     tests = []
     try:
         listing = check_output([TESTSUITE, '--list'])
     except FileNotFoundError:
-        print('libi86-testsuite-ia16-elf not installed - skipping those\n')
+        print('\nlibi86-testsuite-ia16-elf not installed - skipping')
         return
     for l in listing.split(b'\n'):
         # b'  12: bios.h.at:83       _bios_equiplist'
@@ -41,9 +44,6 @@ def libi86_create_items(testcase):
 
 
 def libi86_test_item(self, test):
-    if environ.get("SKIP_EXPENSIVE"):
-        self.skipTest("expensive test")
-
     self.mkfile("dosemu.conf", """\
 $_hdimage = "dXXXXs/c:hdtype1 +1"
 $_floppy_a = ""

--- a/test/test_dos.py
+++ b/test/test_dos.py
@@ -5072,10 +5072,6 @@ class DRDOS701TestCase(OurTestCase, unittest.TestCase):
         self.mkfile(self.autoexec, contents, newline="\r\n")
 
     def setUpDosConfig(self):
-        # Link back to std dosemu commands and scripts
-        p = self.workdir / "dosemu"
-        p.symlink_to(self.topdir / "commands" / "dosemu")
-
         # Use the (almost) standard shipped config
         contents = (self.bindir / self.confsys).read_text()
         contents = re.sub(r"[Dd]:\\", r"c:\\", contents)
@@ -5171,10 +5167,6 @@ class FRDOS120TestCase(OurTestCase, unittest.TestCase):
         self.mkfile(self.autoexec, contents, newline="\r\n")
 
     def setUpDosConfig(self):
-        # Link back to std dosemu commands and scripts
-        p = self.workdir / "dosemu"
-        p.symlink_to(self.topdir / "commands" / "dosemu")
-
         # Use the (almost) standard shipped config
         contents = (self.bindir / "c" / self.confsys).read_text()
         contents = re.sub(r"[Dd]:\\", r"c:\\", contents)
@@ -5248,10 +5240,6 @@ class FRDOS130TestCase(OurTestCase, unittest.TestCase):
         self.mkfile(self.autoexec, contents, newline="\r\n")
 
     def setUpDosConfig(self):
-        # Link back to std dosemu commands and scripts
-        p = self.workdir / "dosemu"
-        p.symlink_to(self.topdir / "commands" / "dosemu")
-
         # Use the (almost) standard shipped config
         contents = (self.bindir / "c" / self.confsys).read_text()
         contents = re.sub(r"[Dd]:\\", r"c:\\", contents)
@@ -5322,10 +5310,6 @@ class FRDOSGITTestCase(OurTestCase, unittest.TestCase):
         self.mkfile(self.autoexec, contents, newline="\r\n")
 
     def setUpDosConfig(self):
-        # Link back to std dosemu commands and scripts
-        p = self.workdir / "dosemu"
-        p.symlink_to(self.topdir / "commands" / "dosemu")
-
         # Use the (almost) standard shipped config
         contents = (self.bindir / "c" / self.confsys).read_text()
         contents = re.sub(r"[Dd]:\\", r"c:\\", contents)
@@ -5378,10 +5362,6 @@ class MSDOS622TestCase(OurTestCase, unittest.TestCase):
         self.mkfile(self.autoexec, contents, newline="\r\n")
 
     def setUpDosConfig(self):
-        # Link back to std dosemu commands and scripts
-        p = self.workdir / "dosemu"
-        p.symlink_to(self.topdir / "commands" / "dosemu")
-
         # Use the (almost) standard shipped config
         contents = (self.bindir / "c" / self.confsys).read_text()
         contents = re.sub(r"[Dd]:\\", r"c:\\", contents)
@@ -5433,10 +5413,6 @@ class MSDOS700TestCase(OurTestCase, unittest.TestCase):
         self.mkfile(self.autoexec, contents, newline="\r\n")
 
     def setUpDosConfig(self):
-        # Link back to std dosemu commands and scripts
-        p = self.workdir / "dosemu"
-        p.symlink_to(self.topdir / "commands" / "dosemu")
-
         # Use the (almost) standard shipped config
         contents = (self.bindir / "c" / self.confsys).read_text()
         contents = re.sub(r"[Dd]:\\", r"c:\\", contents)
@@ -5490,10 +5466,6 @@ class MSDOS710TestCase(OurTestCase, unittest.TestCase):
         self.mkfile(self.autoexec, contents, newline="\r\n")
 
     def setUpDosConfig(self):
-        # Link back to std dosemu commands and scripts
-        p = self.workdir / "dosemu"
-        p.symlink_to(self.topdir / "commands" / "dosemu")
-
         # Use the (almost) standard shipped config
         contents = (self.bindir / "c" / self.confsys).read_text()
         contents = re.sub(r"[Dd]:\\", r"c:\\", contents)

--- a/test/test_dos.py
+++ b/test/test_dos.py
@@ -5219,6 +5219,7 @@ class FRDOS130TestCase(OurTestCase, unittest.TestCase):
             "test_fat_label_create_noduplicate": KNOWNFAIL,
             "test_fat_label_create_predir": KNOWNFAIL,
             "test_fat_label_create_prefile": KNOWNFAIL,
+            "test_lfs_disk_info_mfs": KNOWNFAIL,
             "test_memory_emm286_borland": KNOWNFAIL,
             "test_memory_hma_alloc": KNOWNFAIL,
             "test_memory_hma_alloc3": UNSUPPORTED,

--- a/test/test_dos.py
+++ b/test/test_dos.py
@@ -5067,7 +5067,7 @@ class DRDOS701TestCase(OurTestCase, unittest.TestCase):
 
     def setUpDosAutoexec(self):
         # Use the (almost) standard shipped config
-        contents = (self.topdir / "src" / "bindist" / self.autoexec).read_text()
+        contents = (self.bindir / self.autoexec).read_text()
         contents = re.sub(r"[Dd]:\\", r"c:\\", contents)
         self.mkfile(self.autoexec, contents, newline="\r\n")
 
@@ -5077,7 +5077,7 @@ class DRDOS701TestCase(OurTestCase, unittest.TestCase):
         p.symlink_to(self.topdir / "commands" / "dosemu")
 
         # Use the (almost) standard shipped config
-        contents = (self.topdir / "src" / "bindist" / self.confsys).read_text()
+        contents = (self.bindir / self.confsys).read_text()
         contents = re.sub(r"[Dd]:\\", r"c:\\", contents)
         contents = re.sub(r"rem SWITCHES=/F", r"SWITCHES=/F", contents)
         self.mkfile(self.confsys, contents, newline="\r\n")
@@ -5166,7 +5166,7 @@ class FRDOS120TestCase(OurTestCase, unittest.TestCase):
 
     def setUpDosAutoexec(self):
         # Use the (almost) standard shipped config
-        contents = (self.topdir / "src" / "bindist" / self.autoexec).read_text()
+        contents = (self.bindir / self.autoexec).read_text()
         contents = re.sub(r"[Dd]:\\", r"c:\\", contents)
         self.mkfile(self.autoexec, contents, newline="\r\n")
 
@@ -5176,7 +5176,7 @@ class FRDOS120TestCase(OurTestCase, unittest.TestCase):
         p.symlink_to(self.topdir / "commands" / "dosemu")
 
         # Use the (almost) standard shipped config
-        contents = (self.topdir / "src" / "bindist" / "c" / self.confsys).read_text()
+        contents = (self.bindir / "c" / self.confsys).read_text()
         contents = re.sub(r"[Dd]:\\", r"c:\\", contents)
         contents = re.sub(r"rem SWITCHES=/F", r"SWITCHES=/F", contents)
         self.mkfile(self.confsys, contents, newline="\r\n")
@@ -5243,7 +5243,7 @@ class FRDOS130TestCase(OurTestCase, unittest.TestCase):
 
     def setUpDosAutoexec(self):
         # Use the (almost) standard shipped config
-        contents = (self.topdir / "src" / "bindist" / self.autoexec).read_text()
+        contents = (self.bindir / self.autoexec).read_text()
         contents = re.sub(r"[Dd]:\\", r"c:\\", contents)
         self.mkfile(self.autoexec, contents, newline="\r\n")
 
@@ -5253,7 +5253,7 @@ class FRDOS130TestCase(OurTestCase, unittest.TestCase):
         p.symlink_to(self.topdir / "commands" / "dosemu")
 
         # Use the (almost) standard shipped config
-        contents = (self.topdir / "src" / "bindist" / "c" / self.confsys).read_text()
+        contents = (self.bindir / "c" / self.confsys).read_text()
         contents = re.sub(r"[Dd]:\\", r"c:\\", contents)
         contents = re.sub(r"rem SWITCHES=/F", r"SWITCHES=/F", contents)
         self.mkfile(self.confsys, contents, newline="\r\n")
@@ -5317,7 +5317,7 @@ class FRDOSGITTestCase(OurTestCase, unittest.TestCase):
 
     def setUpDosAutoexec(self):
         # Use the (almost) standard shipped config
-        contents = (self.topdir / "src" / "bindist" / self.autoexec).read_text()
+        contents = (self.bindir / self.autoexec).read_text()
         contents = re.sub(r"[Dd]:\\", r"c:\\", contents)
         self.mkfile(self.autoexec, contents, newline="\r\n")
 
@@ -5327,7 +5327,7 @@ class FRDOSGITTestCase(OurTestCase, unittest.TestCase):
         p.symlink_to(self.topdir / "commands" / "dosemu")
 
         # Use the (almost) standard shipped config
-        contents = (self.topdir / "src" / "bindist" / "c" / self.confsys).read_text()
+        contents = (self.bindir / "c" / self.confsys).read_text()
         contents = re.sub(r"[Dd]:\\", r"c:\\", contents)
         contents = re.sub(r"rem SWITCHES=/F", r"SWITCHES=/F", contents)
         self.mkfile(self.confsys, contents, newline="\r\n")
@@ -5373,7 +5373,7 @@ class MSDOS622TestCase(OurTestCase, unittest.TestCase):
 
     def setUpDosAutoexec(self):
         # Use the (almost) standard shipped config
-        contents = (self.topdir / "src" / "bindist" / self.autoexec).read_text()
+        contents = (self.bindir / self.autoexec).read_text()
         contents = re.sub(r"[Dd]:\\", r"c:\\", contents)
         self.mkfile(self.autoexec, contents, newline="\r\n")
 
@@ -5383,7 +5383,7 @@ class MSDOS622TestCase(OurTestCase, unittest.TestCase):
         p.symlink_to(self.topdir / "commands" / "dosemu")
 
         # Use the (almost) standard shipped config
-        contents = (self.topdir / "src" / "bindist" / "c" / self.confsys).read_text()
+        contents = (self.bindir / "c" / self.confsys).read_text()
         contents = re.sub(r"[Dd]:\\", r"c:\\", contents)
         contents = re.sub(r"rem SWITCHES=/F", r"SWITCHES=/F", contents)
         self.mkfile(self.confsys, contents, newline="\r\n")
@@ -5428,7 +5428,7 @@ class MSDOS700TestCase(OurTestCase, unittest.TestCase):
 
     def setUpDosAutoexec(self):
         # Use the (almost) standard shipped config
-        contents = (self.topdir / "src" / "bindist" / self.autoexec).read_text()
+        contents = (self.bindir / self.autoexec).read_text()
         contents = re.sub(r"[Dd]:\\", r"c:\\", contents)
         self.mkfile(self.autoexec, contents, newline="\r\n")
 
@@ -5438,7 +5438,7 @@ class MSDOS700TestCase(OurTestCase, unittest.TestCase):
         p.symlink_to(self.topdir / "commands" / "dosemu")
 
         # Use the (almost) standard shipped config
-        contents = (self.topdir / "src" / "bindist" / "c" / self.confsys).read_text()
+        contents = (self.bindir / "c" / self.confsys).read_text()
         contents = re.sub(r"[Dd]:\\", r"c:\\", contents)
         contents = re.sub(r"rem SWITCHES=/F", r"SWITCHES=/F", contents)
         self.mkfile(self.confsys, contents, newline="\r\n")
@@ -5485,7 +5485,7 @@ class MSDOS710TestCase(OurTestCase, unittest.TestCase):
 
     def setUpDosAutoexec(self):
         # Use the (almost) standard shipped config
-        contents = (self.topdir / "src" / "bindist" / self.autoexec).read_text()
+        contents = (self.bindir / self.autoexec).read_text()
         contents = re.sub(r"[Dd]:\\", r"c:\\", contents)
         self.mkfile(self.autoexec, contents, newline="\r\n")
 
@@ -5495,7 +5495,7 @@ class MSDOS710TestCase(OurTestCase, unittest.TestCase):
         p.symlink_to(self.topdir / "commands" / "dosemu")
 
         # Use the (almost) standard shipped config
-        contents = (self.topdir / "src" / "bindist" / "c" / self.confsys).read_text()
+        contents = (self.bindir / "c" / self.confsys).read_text()
         contents = re.sub(r"[Dd]:\\", r"c:\\", contents)
         contents = re.sub(r"rem SWITCHES=/F", r"SWITCHES=/F", contents)
         self.mkfile(self.confsys, contents, newline="\r\n")


### PR DESCRIPTION
It can be desirable to run the test suite against the installed dosemu rather than needing to build it. A typical example would be:
~~~
# Tell the test suite to use another dosemu, not the one in the development directory
export TEST_BINDIR="/usr/share/dosemu/dosemu2-cmds-0.3"                         
export TEST_DOSEMU="/usr/bin/dosemu"                                            

# Some flags to change test selection and behaviour
export SKIP_EXPENSIVE="1"                                                       
export NO_FAILFAST="1"                                                          

# Prerequisites for test
(cd test && make -C cpu) 
test/test_dos.py  --get-test-binaries                                                    
 
# Run the tests                                                                             
test/test_dos.py FRDOS130TestCase                                               
~~~