### PR TITLE
use TMPDIR over /tmp

### DIFF
--- a/src/base/init/config.c
+++ b/src/base/init/config.c
@@ -1273,7 +1273,8 @@ config_init(int argc, char **argv)
 	snprintf(buf, sizeof(buf), "dosemu2_%i_%i", getuid(), get_suid());
     else
 	snprintf(buf, sizeof(buf), "dosemu2_%i", getuid());
-    dosemu_tmpdir = mkdir_under("/tmp", buf);
+    char *tmp = getenv("TMPDIR");
+    dosemu_tmpdir = mkdir_under(tmp ? tmp : "/tmp", buf);
     if (!dosemu_tmpdir) {
 	error("failed to create tmpdir\n");
 	exit(1);

--- a/src/base/init/config.c
+++ b/src/base/init/config.c
@@ -1274,7 +1274,7 @@ config_init(int argc, char **argv)
     else
 	snprintf(buf, sizeof(buf), "dosemu2_%i", getuid());
     char *tmp = getenv("TMPDIR");
-    dosemu_tmpdir = mkdir_under(tmp ? tmp : "/tmp", buf);
+    dosemu_tmpdir = mkdir_under(tmp ?: "/tmp", buf);
     if (!dosemu_tmpdir) {
 	error("failed to create tmpdir\n");
 	exit(1);

--- a/src/base/lib/mapping/mapfile.c
+++ b/src/base/lib/mapping/mapfile.c
@@ -107,10 +107,12 @@ static void *alias_mapping_file(int cap, void *target, size_t mapsize, int prote
 
 static int do_open_file(void)
 {
-  char tmp[] = "/tmp/dosemu2_mapfile_XXXXXX";
+	char *tmp = getenv("TMPDIR");
+  char tmpf[256];
+  sprintf(tmpf, "%s/dosemu2_mapfile_XXXXXX", tmp?tmp:"/tmp");
   int fd = mkstemp(tmp);
   if (fd == -1) {
-    perror("mkstemp()");
+    perror("mapfile mkstemp()");
     return -1;
   }
   unlink(tmp);

--- a/src/base/lib/misc/shlock.c
+++ b/src/base/lib/misc/shlock.c
@@ -127,7 +127,7 @@ void *shlock_open(const char *dir, const char *name, int excl, int block)
   /* create tmp file in tmp dir */
   tmp_fd = mkstemp(ttspec);
   if (tmp_fd == -1) {
-    perror("mkstemp()");
+    perror("shlock mkstemp()");
     rmdir(dtspec);
     goto err_free_d;
   }

--- a/src/dosext/mfs/rlocks.c
+++ b/src/dosext/mfs/rlocks.c
@@ -182,7 +182,9 @@ void region_unlock_offs(int fd)
 #if FUNLCK_WA
 void open_mlemu(int *r_fds)
 {
-  char mltmpl[] = "/tmp/dosemu2_mlemu_XXXXXX";
+  char *tmp = getenv("TMPDIR");
+  char mltmpl[256];
+  sprintf(mltmpl, "%s/dosemu2_mlemu_XXXXXX", tmp ? tmp : "/tmp");
   int fd0, fd1;
   struct flock fl;
   int err;
@@ -191,7 +193,7 @@ void open_mlemu(int *r_fds)
   /* create 2 fds, 1 for mirroring locks and 1 for testing locks */
   fd0 = mkstemp(mltmpl);
   if (fd0 == -1) {
-    perror("mkstemp()");
+    perror("rlocks mkstemp()");
     return;
   }
   fd1 = open(mltmpl, O_RDONLY | O_CLOEXEC);


### PR DESCRIPTION
this allows the Ubuntu build to run in termux with glibc-runner

in Ubuntu

```
git clone --depth=1 https://github.com/dosemu2/dosemu2
./autogen.sh
./configure --enable-plugins=fdpp,console,charsets --enable-debug --disable-searpc --prefix=$HOME/dosemu --with-fdtarball=dosemu-freedos-1.0-bin.tgz
make install
```

in termux

```
apt install glibc-runner libacl-glibc libcap-glibc glib-glibc
grun -c out/usr/libexec/dosemu2/dosemu2.bin
grun -s
export LD_LIBRARY_PATH="$(pwd)/out/usr/lib/dosemu:$(pwd)/out/usr/lib/aarch64-linux-gnu"
export DOSEMU2_COMCOM_DIR=$(pwd)/freedos
usr/libexec/dosemu2/dosemu2.bin
FreeCom version 0.84-pre2 XMS_Swap [Aug 28 2006 00:29:00]
C:\>
```

# termux build status

this is part of my android effort in https://github.com/john-peterson/tur/tree/dosemu/tur/dosemu

- use llvm instead of binutils-i686-linux-gnu
- prefix all system paths /var /tmp etc
- bionic libc support 



