### PR TITLE
use clang as 386 assembler in arm

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -108,7 +108,12 @@ if test -z "$XAS"; then
         XASFLAGS="--32"
       fi
     else
-      AC_MSG_ERROR([cross-assembler not found, please install binutils-i686-linux-gnu])
+      AC_PATH_PROG([XAS], [clang])
+      if test -n "$XAS"; then
+        XASFLAGS="$ASFLAGS --target=i686-linux-gnu"
+      else
+        AC_MSG_ERROR([386 assembler not found, please install clang or binutils-i686-linux-gnu])
+      fi
     fi
   else
     XASFLAGS="--32"
@@ -119,6 +124,8 @@ AC_PATH_PROGS([LD], [ld ld.lld])
 if test -z "$LD"; then
   AC_MSG_ERROR(ld not found)
 fi
+
+#only ld.lld understand elf_i386 on arm
 AC_PATH_PROGS([AS_LD], [i686-linux-gnu-ld i386-elf-ld x86_64-linux-gnu-ld ld.lld ld])
 if test -z "$AS_LD"; then
   AS_LD="$LD"
@@ -138,7 +145,8 @@ if test -z "$OBJCOPY"; then
   OBJCOPY="$LOBJCOPY"
 fi
 
-AC_PATH_PROGS([XOBJCOPY], [i686-linux-gnu-objcopy x86_64-linux-gnu-objcopy objcopy])
+# arm llvm-objcopy understand 386 headers
+AC_PATH_PROGS([XOBJCOPY], [i686-linux-gnu-objcopy x86_64-linux-gnu-objcopy llvm-objcopy objcopy])
 if test -z "$XOBJCOPY"; then
   XOBJCOPY="$OBJCOPY"
 fi


### PR DESCRIPTION
clang should be able to assemble all the dos programs

this is tested in Ubuntu arm and android arm

```
sudo apt remove gcc binutils-i686-linux-gnu

sudo apt install lld llvm clang

./autogen.sh

./configure --enable-plugins=, --disable-searpc --disable-fdpp

sed -i "s/RM/Rmm/" src/Makefile.common.post
make -C src/dosext/dpmi

rabin2 -I src/dosext/dpmi/dpmisel.o.elf
arch     x86
baddr    0x400000
binsz    3290
bintype  elf
bits     32
canary   false
injprot  true
class    ELF32
compiler Linker: LLD 18.1.8
machine  Intel 80386
```
