### PR TITLE
init: linearize lowmem_base

### DIFF
--- a/src/base/lib/mapping/mapping.c
+++ b/src/base/lib/mapping/mapping.c
@@ -812,6 +812,8 @@ void register_hardware_ram_virtual2(int type, unsigned base, unsigned int size,
     int cap = MAPPING_INIT_LOWRAM;
     if (type == 'L')
       cap |= MAPPING_LOWMEM;
+    if (base + size > ALIAS_SIZE)
+      cap |= MAPPING_EXTMEM;
     mmap_kvm(cap, base, size, uaddr, va, prot);
   }
 }


### PR DESCRIPTION
It can now follow the VA rather than PA, as with DPMI aliasing lowmem_base is as large as the entire VA space.
This simplifies the code and allows to keep restore_mapping() simple. KVM and int15 still see the non-identity mapping, but the weird cross-maps are completely removed.