### PR TITLE
Make munt autoconf failure more specific

### DIFF
--- a/src/plugin/munt/configure.ac
+++ b/src/plugin/munt/configure.ac
@@ -2,7 +2,7 @@ dnl Process this file with autoconf to produce a configure script.
 AC_INIT
 AC_CONFIG_FILES([Makefile.conf])
 AC_CHECK_LIB(mt32emu, mt32emu_create_context,,
-    AC_MSG_ERROR([munt development libs not found]))
+    AC_MSG_ERROR([munt development shared lib not found or C interface unusable]))
 AC_CHECK_HEADER([mt32emu/c_interface/c_interface.h],,
     AC_MSG_ERROR([munt development headers not found]))
 


### PR DESCRIPTION
Failure to link to libstdc++ symbols was causing the plugin to be disabled.