### PR TITLE
jit: try to not unprotect pages [closes #2302]

### DIFF
--- a/src/base/emu-i386/simx86/cpatch.c
+++ b/src/base/emu-i386/simx86/cpatch.c
@@ -53,21 +53,11 @@ void m_munprotect(unsigned int addr, unsigned int len, unsigned char *eip)
 			e_printf("CODE %08x hit in DATA %p patch\n",addr,eip);
 	}
 	/* if only data in aliased low memory is hit, nothing to do */
-	if (addr < LOWMEM_SIZE + HMASIZE) {
-		if (e_querymark(addr, len))
-			// no need to invalidate the whole page here,
-			// as the page does not need to be unprotected
-			InvalidateNodeRange(addr,len,eip);
+	if (!e_querymark(addr, len))
 		return;
-	}
-	/* Always unprotect and clear all code in the pages
-	 * for DPMI data and code
-	 * Maybe the stub was set up before that code was parsed.
-	 * Clear that code */
-/*	if (UnCpatch((void *)(eip-3))) leavedos_main(0); */
-	len = PAGE_ALIGN(addr + len) - (addr & _PAGE_MASK);
-	addr &= _PAGE_MASK;
-	InvalidateNodeRange(addr,len,eip);
+	// no need to invalidate the whole page here,
+	// as the page does not need to be unprotected
+	InvalidateNodeRange(addr, len, eip);
 }
 
 #define repmovs(std,letter,cld)			       \

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -1299,21 +1299,15 @@ void e_invalidate(unsigned data, int cnt)
 	/* nothing to invalidate if there are no page protections */
 	if (!e_querymprotrange(data, cnt))
 		return;
-	/* for low mappings only invalidate if code, not if data */
-	if (data < LOWMEM_SIZE + HMASIZE) {
 #ifdef HOST_ARCH_X86
-		/* e_querymprotrange prevents coming here for sim */
-		assert (!config.cpusim);
-		if (e_querymark(data, cnt)) {
-			// no need to invalidate the whole page here,
-			// as the page does not need to be unprotected
-			InvalidateNodeRange(data, cnt, 0);
-			return;
-		}
-#endif
+	/* e_querymprotrange prevents coming here for sim */
+	assert(!config.cpusim);
+	if (!e_querymark(data, cnt))
 		return;
-	}
-	do_invalidate(data, cnt);
+	// no need to invalidate the whole page here,
+	// as the page does not need to be unprotected
+	InvalidateNodeRange(data, cnt, 0);
+#endif
 }
 
 void e_invalidate_pa(unsigned pa, int cnt)


### PR DESCRIPTION
Since jit now works in a separate address space, we don't have to unprotect full pages. So in case of a data hit do nothing, and in case of a code hit only invalidate the code nodes in range.