### PR TITLE
configure: Search setcap in /usr/sbin for Debian

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -354,7 +354,7 @@ PKG_CHECK_MODULES([LIBACL], [libacl], [
 )
 
 PKG_CHECK_MODULES([LIBCAP], [libcap], [
-    AC_PATH_PROGS([SETCAP], [setcap])
+    AC_PATH_PROGS([SETCAP], [setcap], [], [$PATH${PATH_SEPARATOR}/usr/sbin])
     if test -z "$SETCAP"; then
       AC_MSG_ERROR([setcap not found])
     fi


### PR DESCRIPTION
Debian installs it in /usr/sbin which is not in the user PATH.