### PR TITLE
make: Force realpath on abs_top_builddir.

### DIFF
--- a/Makefile.conf.in
+++ b/Makefile.conf.in
@@ -23,7 +23,7 @@ fdtarball:=@fdtarball@
 username := @username@
 cmdsuff:=@cmdsuff@
 abs_top_srcdir:=@abs_top_srcdir@
-abs_top_builddir:=@abs_top_builddir@
+abs_top_builddir:=$(realpath @abs_top_builddir@)
 
 INCDIR=-I${top_builddir}/src/include -I${top_builddir}/src/plugin/include \
     -I${top_srcdir}/src/base/bios/x86 -I${top_srcdir}/src/include \


### PR DESCRIPTION
Fixes #2334.

When srcdir contains symlinks, we end up with srcdir != builddir because one has gone through realpath and the other did not.