### PR TITLE
CI: Remove user and group settings on tap i/f

### DIFF
--- a/test/dosemu_tap_interface.sh
+++ b/test/dosemu_tap_interface.sh
@@ -12,11 +12,7 @@
 #      chmod 0440 /etc/sudoers.d/dosemu
 
 if [ "$1" = "setup" ] ; then
-	if getent group dosemu2 >/dev/null; then
-		ip tuntap add mode tap group dosemu2 tap0
-	else
-		ip tuntap add mode tap user ${SUDO_UID} tap0
-	fi
+	ip tuntap add mode tap tap0
 	brctl addif virbr0 tap0
 	ifconfig tap0 promisc up
 


### PR DESCRIPTION
There seems to be an unintuititve permissions check used for tun/tap interfaces, let's just forget about enabling just enough for us to work and enable it for everybody.