### PR TITLE
Ukrainian locale maps to cp1125

### DIFF
--- a/etc/locales.conf
+++ b/etc/locales.conf
@@ -71,5 +71,6 @@
         { "lang": "sw_TZ", "codepage": "cp858" },
         { "lang": "sw_UG", "codepage": "cp858" },
         { "lang": "ru_RU", "codepage": "cp866", "country": 007 },
+        { "lang": "uk_UA", "codepage": "cp1125", "country": 380},
     ]
 }


### PR DESCRIPTION
This maps the locale for Ukrainian in Ukraine to codepage 1125, which is already supported by dosemu. It's a variant of cp866 with support for Ukrainian-specific letters:
![image](https://github.com/user-attachments/assets/27564964-a840-4ae7-9b37-a0ad7848ea93)
