### PR TITLE
CI: Don't miss the error if the conversion to ASCII fails

### DIFF
--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -513,14 +513,15 @@ class BaseTestCase(object):
         self.logfiles['xpt'][1] = "output.log"
         ret = 'No output'
         try:
-            ret = check_output(args, cwd=cwd, timeout=timeout, stderr=STDOUT).decode('ASCII')
+            ret = check_output(args, cwd=cwd, timeout=timeout, stderr=STDOUT).decode(
+                'ASCII', errors='backslashreplace')
         except CalledProcessError as e:
             if e.output is not None:
-                ret = e.output.decode('ASCII')
+                ret = e.output.decode('ASCII', errors='backslashreplace')
             ret += '\nNonZeroReturn:%d\n' % e.returncode
         except TimeoutExpired as e:
             if e.output is not None:
-                ret = e.output.decode('ASCII')
+                ret = e.output.decode('ASCII', errors='backslashreplace')
             ret += '\nTimeout:%d seconds\n' % timeout
             # Now wait for any further logging from dosemu as hopefully it's
             # dying.

--- a/test/func_label_create.py
+++ b/test/func_label_create.py
@@ -705,6 +705,7 @@ int main(int argc, char *argv[])
 
     # Check afterwards with mtools that each lfn still exists
     args = ['mdir', '-i', str(self.imagedir / image)]
-    output = check_output(args, timeout=5, stderr=STDOUT).decode('ASCII')
+    output = check_output(args, timeout=5, stderr=STDOUT).decode(
+        'ASCII', errors='backslashreplace')
     for n in names:
         self.assertIn(n, output)


### PR DESCRIPTION
Should avoid the error text being lost in #2388