### PR TITLE
simx86: try to run prejitter unlocked [#2393]

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -447,6 +447,8 @@ void AddrGen_sim(int op, int mode, ...)
 		SetSegReal(CPUWORD(o), o);
 		if (o == Ofs_SS)
 			CEmuStat |= CeS_MOVSS;
+		if (o == Ofs_CS)
+			LONG_CS = _LONG_CS;
 		}
 		break;
 	}
@@ -615,6 +617,8 @@ void Gen_sim(int op, int mode, ...)
 		GTRACE1("L_LXS2",o);
 		DR1.d = sim_read_word(AR1.d);
 		SetSegReal(DR1.w.l, o);
+		if (o == Ofs_CS)
+			LONG_CS = _LONG_CS;
 		}
 		break;
 	case L_ZXAX:

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -3437,7 +3437,7 @@ unsigned int Exec_x86(TNode *G)
 			if ((exs & ~TheCPU.fpuc) & 0x3f) {
 				__asm__ __volatile__ ("fnclex\n" ::: "memory");
 				e_printf("FPU exception\n");
-				TheCPU.err = EXCP10_COPR;
+				TheCPU.err2 = EXCP10_COPR;
 			}
 		}
 	}
@@ -3529,7 +3529,7 @@ unsigned int Exec_x86_fast(TNode *G)
 			CEmuStat|=CeS_SIGPEND;
 			break;
 		}
-	} while (!TheCPU.err && (G=FindTree(ePC)) &&
+	} while (!TheCPU.err2 && (G=FindTree(ePC)) &&
 		 GoodNode(G, mode) && !(G->flags & (F_FPOP|F_INHI)));
 
 	Exec_x86_post(flg, mem_ref);

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -805,6 +805,7 @@ void init_emu_cpu(int cpu_type)
     InitTrees();
     sem_init(&prejit_sem, 0, 0);
     pthread_create(&prejit_thr, NULL, prejit_thread, NULL);
+    prejit_init();
   }
 #else
   InitGen_sim();
@@ -908,6 +909,7 @@ static void print_statistics(void)
 	dbug_printf("Nodes executed    %16d\n",TotalNodesExecd);
 	dbug_printf("Prejitted execed  %16d\n",PrejitNodesExecd);
 	dbug_printf("Nodes prejitted   %16d\n",NodesPrejitted);
+	dbug_printf("Speculative prej  %16d\n",SpecPrejits);
 	if (TotalNodesExecd) {
 		unsigned long long k;
 		k = ((long long)NodesFound * 100UL) /
@@ -956,6 +958,7 @@ void leave_cpu_emu(void)
 	dbug_printf("======================= LEAVE CPU-EMU ===============\n");
 	if (debug_level('e')) print_statistics();
 	if (!CONFIG_CPUSIM) {
+		prejit_done();
 		pthread_cancel(prejit_thr);
 		pthread_join(prejit_thr, NULL);
 		sem_destroy(&prejit_sem);
@@ -1599,6 +1602,7 @@ static int lockcnt;
 
 void prejit_lock(void)
 {
+    prejit_sync();
     /* No actual locking: just wait til prejit stops. */
     pthread_mutex_lock(&run_mtx);
     lockcnt++;

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -554,6 +554,7 @@ static void Reg2Cpu(struct vm86_struct *info)
 
   /* FPU state is loaded later on demand for JIT, not used for simulator */
   TheCPU.fpstate = &vm86_fpu_state;
+  LONG_CS = _LONG_CS;
   if (debug_level('e')>1) {
 	if (debug_level('e')==9) e_printf("Reg2Cpu< vm86=%08x dpm=%08x emu=%08x\n%s\n",
 		regs->eflags,get_FLAGS(TheCPU.eflags),TheCPU.eflags,
@@ -740,6 +741,7 @@ erseg:
 			e_print_regs());
   }
   TheCPU.mode = mode;
+  LONG_CS = _LONG_CS;
 }
 
 

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -68,9 +68,7 @@ hitimer_t AddTime, SearchTime, ExecTime, CleanupTime; // for debug
 hitimer_t GenTime, LinkTime;
 #endif
 
-static pthread_mutex_t prejit_mtx;
-static pthread_mutexattr_t prejit_mattr;
-static pthread_cond_t prejit_cnd = PTHREAD_COND_INITIALIZER;
+static pthread_cond_t run_cnd = PTHREAD_COND_INITIALIZER;
 static int prejit_running;
 static pthread_mutex_t run_mtx = PTHREAD_MUTEX_INITIALIZER;
 static pthread_t prejit_thr;
@@ -809,9 +807,6 @@ void init_emu_cpu(int cpu_type)
 #else
   InitGen_sim();
 #endif
-  pthread_mutexattr_init(&prejit_mattr);
-  pthread_mutexattr_settype(&prejit_mattr, PTHREAD_MUTEX_RECURSIVE);
-  pthread_mutex_init(&prejit_mtx, &prejit_mattr);
 
   IDT = NULL;
   if (GDT==NULL) {
@@ -963,8 +958,6 @@ void leave_cpu_emu(void)
 		pthread_join(prejit_thr, NULL);
 		sem_destroy(&prejit_sem);
 	}
-	pthread_mutex_destroy(&prejit_mtx);
-	pthread_mutexattr_destroy(&prejit_mattr);
 	flush_log();
 }
 
@@ -1217,14 +1210,12 @@ static void *prejit_thread(void *arg)
 {
   while (1) {
     sem_wait(&prejit_sem);
-    pthread_mutex_lock(&prejit_mtx);
     PreJit86(LONG_CS + TheCPU.eip, TheCPU.mode);
     fesetenv(&dosemu_fenv);
     pthread_mutex_lock(&run_mtx);
     prejit_running = 0;
     pthread_mutex_unlock(&run_mtx);
-    pthread_mutex_unlock(&prejit_mtx);
-    pthread_cond_signal(&prejit_cnd);
+    pthread_cond_signal(&run_cnd);
   }
   return NULL;
 }
@@ -1245,8 +1236,9 @@ static int prejit_vm86(struct vm86_struct *info)
   pthread_mutex_unlock(&run_mtx);
   if (r)
     return 0;
-#endif
+#else
   prejit_lock();
+#endif
   TheCPU.err = 0;
   TheCPU.mode = ADDR16 | DATA16 | MREALA;
   TheCPU.StackMask = 0x0000ffff;
@@ -1266,7 +1258,6 @@ static int prejit_vm86(struct vm86_struct *info)
     }
     CEmuStat &= ~CeS_PREJIT_RM;
     if (TheCPU.err != EXCP_GOBACK) {
-      pthread_mutex_unlock(&prejit_mtx);
       assert(ret != PREJIT_RV_OFFS);
       return ret - PREJIT_RV_OFFS;
     }
@@ -1276,7 +1267,9 @@ static int prejit_vm86(struct vm86_struct *info)
   pthread_mutex_lock(&run_mtx);
   prejit_running = 1;
   pthread_mutex_unlock(&run_mtx);
+#if !PREJIT_ASYNC
   prejit_unlock();
+#endif
   sem_post(&prejit_sem);
   return 0;
 }
@@ -1294,8 +1287,9 @@ static int prejit_dpmi(cpuctx_t *scp)
   pthread_mutex_unlock(&run_mtx);
   if (r)
     return 0;
-#endif
+#else
   prejit_lock();
+#endif
   TheCPU.err = 0;
   Scp2CpuD(scp);  // don't inline as this updates TheCPU.MODE!
 #if PREJIT_EXEC
@@ -1320,7 +1314,6 @@ static int prejit_dpmi(cpuctx_t *scp)
     }
     CEmuStat &= ~CeS_PREJIT_PM;
     if (TheCPU.err != EXCP_GOBACK) {
-      pthread_mutex_unlock(&prejit_mtx);
       assert(ret != PREJIT_RV_OFFS);
       return ret - PREJIT_RV_OFFS;
     }
@@ -1330,7 +1323,9 @@ static int prejit_dpmi(cpuctx_t *scp)
   pthread_mutex_lock(&run_mtx);
   prejit_running = 1;
   pthread_mutex_unlock(&run_mtx);
+#if !PREJIT_ASYNC
   prejit_unlock();
+#endif
   sem_post(&prejit_sem);
   return 0;
 }
@@ -1598,16 +1593,24 @@ int _CPU_VM_DPMI(void)
     return config.cpu_vm_dpmi;
 }
 
+static int lockcnt;
+
 void prejit_lock(void)
 {
-    pthread_mutex_lock(&prejit_mtx);
+    /* No actual locking: just wait til prejit stops. */
+    pthread_mutex_lock(&run_mtx);
+    lockcnt++;
     while (prejit_running)
-	cond_wait(&prejit_cnd, &prejit_mtx);
+	cond_wait(&run_cnd, &run_mtx);
+    pthread_mutex_unlock(&run_mtx);
 }
 
 void prejit_unlock(void)
 {
-    pthread_mutex_unlock(&prejit_mtx);
+    pthread_mutex_lock(&run_mtx);
+    assert(lockcnt > 0);
+    lockcnt--;
+    pthread_mutex_unlock(&run_mtx);
 }
 
 /* ======================================================================= */

--- a/src/base/emu-i386/simx86/emu86.h
+++ b/src/base/emu-i386/simx86/emu86.h
@@ -57,6 +57,7 @@ extern int CpatchStkWrites;
 extern int CpatchInvalidates;
 extern int CPagesDropped;
 extern int MaxCPages;
+extern int SpecPrejits;
 #endif
 
 #ifdef X86_JIT
@@ -714,6 +715,8 @@ void Interp86(void);
 void PreJit86(unsigned int PC, int mode);
 void prejit_lock(void);
 void prejit_unlock(void);
+void prejit_init(void);
+void prejit_done(void);
 //
 int _ModRM(unsigned char opc, unsigned int PC, int mode);
 #define ModRM(o, p, m) ({ \
@@ -761,11 +764,13 @@ int e_querymark(unsigned int addr, size_t len);
 int e_querymark_all(unsigned int addr, size_t len);
 void mprot_init(void);
 void mprot_end(void);
+void prejit_sync(void);
 #else
 #define e_querymark(x,y) 0
 #define e_querymark_all(x,y) 0
 #define mprot_init()
 #define mprot_end()
+#define prejit_sync()
 #endif
 void init_emu_npu(void);
 

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -34,18 +34,34 @@
 
 #include <stddef.h>
 #include <string.h>
+#include <pthread.h>
 #include "emu86.h"
 #include "codegen-arch.h"
 #include "port.h"
 #include "emudpmi.h"
 #include "mhpdbg.h"
 #include "video.h"
+#include "utilities.h"
 
 #if PROFILE
 int EmuSignals = 0;
 #endif
 
+#ifdef X86_JIT
 #define FLG_PREJIT 1
+#define FLG_SPECULATIVE 2
+static pthread_cond_t run_cnd = PTHREAD_COND_INITIALIZER;
+static int prejit_running;
+static pthread_mutex_t run_mtx = PTHREAD_MUTEX_INITIALIZER;
+static pthread_t prejit_thr;
+static sem_t prejit_sem;
+static void *prejit_thread(void *arg);
+static void prejit_run(unsigned int PC);
+static unsigned int prejit_PC;
+#if PROFILE
+int SpecPrejits;
+#endif
+#endif
 
 /* countdown to exit after handling VGAEMU faults, reset by
    planar VGA reads and writes */
@@ -436,15 +452,40 @@ static unsigned int JumpGen(unsigned int P2, int mode, int opc, int pskip,
 	if (_P1 == (unsigned)-1) {
 #ifdef X86_JIT
 		if (!CONFIG_CPUSIM) {
+			int can_speculate = 1;
 			TNode *G;
 			NewIMeta(P0, &_rc);
+			switch (opc) {
+			/* With uncond JMP or RET nothing to speculate. */
+			case JMPld:
+			case JMPsid: case JMPd:
+			case RETl: case RETlisp: case JMPli:
+			case RET: case RETisp: case JMPi:
+				can_speculate = 0;
+				break;
+			}
 			G = DoClose(_P0, TheCPU.basemode, InstrMeta[0].npc);
+			if (!G)
+				return P0;
 			if (_flags & FLG_PREJIT) {
 				G->flags |= F_PREJ;
 				NodesPrejitted++;
 				TheCPU.err = EXCP_GOBACK;
 			} else {
+				if (can_speculate) {
+					if (debug_level('e')) {
+						char *ds;
+						unsigned short ocs = TheCPU.cs;
+						ds = e_emu_disasm(EMU_BASE32(P2),(~TheCPU.basemode&3),ocs);
+						e_printf("prejit after  %s\n", ds);
+						ds = e_emu_disasm(EMU_BASE32(_P0),(~TheCPU.basemode&3),ocs);
+						e_printf("prejit at  %s\n", ds);
+					}
+					prejit_run(_P0);
+				}
 				_P1 = Exec_x86(G);
+				if (can_speculate)
+					prejit_sync();
 				TheCPU.err = TheCPU.err2;
 				LONG_CS = _LONG_CS;
 			}
@@ -731,6 +772,7 @@ static unsigned int _Interp86(unsigned int PC, int basemode)
 #endif
 	while (1) {
 		TheCPU.mode = basemode;
+		TheCPU.basemode = basemode;
 		PC = interp_pre(PC, basemode, 0);
 		if (TheCPU.err)
 			return PC;
@@ -1876,8 +1918,8 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			    TheCPU.err = EXCP_GOBACK; return PC;
 			}
 #endif
-			}
-			break;
+		    }
+		    break;
 
 /*c2*/	case RETisp: {
 			int dr = (signed short)FetchW(PC+1);
@@ -3641,11 +3683,28 @@ void instr_emu_sim_reset_count(void)
 }
 
 #ifdef X86_JIT
-static void _PreJit86(unsigned int PC, int basemode)
+static void _PreJit86(unsigned int PC, int basemode, int flags)
 {
 	unsigned int P0;
 
 	while (1) {
+		TheCPU.mode = basemode;
+		TheCPU.basemode = basemode;
+		OVERR_DS = Ofs_XDS;
+		OVERR_SS = Ofs_XSS;
+		P0 = PC;
+		if (debug_level('e')) {
+			char *ds;
+			unsigned short ocs = TheCPU.cs;
+			ds = e_emu_disasm(EMU_BASE32(PC),(~basemode&3),ocs);
+			e_printf("  %s\n", ds);
+		}
+		PC = InterpOne(PC, &basemode, flags);
+		if (TheCPU.err)
+			return;
+		PC = interp_post(PC, basemode, P0, flags);
+		if (TheCPU.err)
+			return;
 		if (e_querymark(PC, 1)) {
 			if (CurrIMeta>0) {
 				TNode *G = DoClose(PC, basemode,
@@ -3654,31 +3713,67 @@ static void _PreJit86(unsigned int PC, int basemode)
 			}
 			return;
 		}
-		TheCPU.mode = basemode;
-		OVERR_DS = Ofs_XDS;
-		OVERR_SS = Ofs_XSS;
-		P0 = PC;
-		if (debug_level('e')>2) {
-			char *ds;
-			unsigned short ocs = TheCPU.cs;
-			ds = e_emu_disasm(EMU_BASE32(PC),(~basemode&3),ocs);
-			e_printf("  %s\n", ds);
-		}
-		PC = InterpOne(PC, &basemode, FLG_PREJIT);
-		if (TheCPU.err)
-			return;
-		PC = interp_post(PC, basemode, P0, FLG_PREJIT);
-		if (TheCPU.err)
-			return;
 	}
 }
 
 void PreJit86(unsigned int PC, int basemode)
 {
+	if (e_querymark(PC, 1))
+		return;
 	TheCPU.basemode = basemode;
 	TheCPU.err2 = 0;
 	LONG_CS = _LONG_CS;
-	_PreJit86(PC, basemode);
+	_PreJit86(PC, basemode, FLG_PREJIT);
 	e_mdrop();
+}
+
+static void *prejit_thread(void *arg)
+{
+  while (1) {
+    sem_wait(&prejit_sem);
+    _PreJit86(__atomic_load_n(&prejit_PC, __ATOMIC_RELAXED), TheCPU.basemode,
+	    FLG_PREJIT | FLG_SPECULATIVE);
+    pthread_mutex_lock(&run_mtx);
+    prejit_running = 0;
+    pthread_mutex_unlock(&run_mtx);
+    pthread_cond_signal(&run_cnd);
+  }
+  return NULL;
+}
+
+static void prejit_run(unsigned int PC)
+{
+  if (e_querymark(PC, 1))
+    return;
+#if PROFILE
+  SpecPrejits++;
+#endif
+  __atomic_store_n(&prejit_PC, PC, __ATOMIC_RELAXED);
+  pthread_mutex_lock(&run_mtx);
+  assert(!prejit_running);
+  prejit_running = 1;
+  pthread_mutex_unlock(&run_mtx);
+  sem_post(&prejit_sem);
+}
+
+void prejit_sync(void)
+{
+  pthread_mutex_lock(&run_mtx);
+  while (prejit_running)
+    cond_wait(&run_cnd, &run_mtx);
+  pthread_mutex_unlock(&run_mtx);
+}
+
+void prejit_init(void)
+{
+  sem_init(&prejit_sem, 0, 0);
+  pthread_create(&prejit_thr, NULL, prejit_thread, NULL);
+}
+
+void prejit_done(void)
+{
+  pthread_cancel(prejit_thr);
+  pthread_join(prejit_thr, NULL);
+  sem_destroy(&prejit_sem);
 }
 #endif

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -45,6 +45,8 @@
 int EmuSignals = 0;
 #endif
 
+#define FLG_PREJIT 1
+
 /* countdown to exit after handling VGAEMU faults, reset by
    planar VGA reads and writes */
 static int interp_inst_emu_count;
@@ -414,38 +416,36 @@ static unsigned int _JumpGen(unsigned int P2, int mode, int opc,
 	return (unsigned)-1;
 }
 
+static unsigned int JumpGen(unsigned int P2, int mode, int opc, int pskip,
+	unsigned int P0, int _flags)
+{
+	unsigned int _P0, _P1;
+	int _rc;
+	_P1 = _JumpGen(P2, mode, opc, pskip, &_P0);
+	if (_P1 == (unsigned)-1) {
 #ifdef X86_JIT
-#define JumpGen(P2, mode, opc, pskip) ({ \
-	unsigned int _P0, _P1; \
-	int _rc; \
-	_P1 = _JumpGen(P2, mode, opc, pskip, &_P0); \
-	if (_P1 == (unsigned)-1) { \
-		if (!CONFIG_CPUSIM) \
-			NewIMeta(P0, &_rc); \
-		if (_flags & FLG_PREJIT) { \
-			TNode *G = DoClose(_P0, basemode, InstrMeta[0].npc); \
-			G->flags |= F_PREJ; \
-			NodesPrejitted++; \
-			TheCPU.err = EXCP_GOBACK; \
-		} else { \
-			_P1 = DoCloseAndExec(_P0, basemode); \
-		} \
-	} \
-	if (sigalrm_pending()) \
-		CEmuStat |= CeS_SIGPEND; \
-	_P1; \
-})
+		if (!CONFIG_CPUSIM) {
+			TNode *G;
+			NewIMeta(P0, &_rc);
+			G = DoClose(_P0, TheCPU.basemode, InstrMeta[0].npc);
+			if (_flags & FLG_PREJIT) {
+				G->flags |= F_PREJ;
+				NodesPrejitted++;
+				TheCPU.err = EXCP_GOBACK;
+			} else {
+				_P1 = Exec_x86(G);
+			}
+		} else {
+			_P1 = CloseAndExec_sim(_P0, TheCPU.basemode);
+		}
 #else
-#define JumpGen(P2, mode, opc, pskip) ({ \
-	unsigned int _P0, _P1; \
-	_P1 = _JumpGen(P2, mode, opc, pskip, &_P0); \
-	if (_P1 == (unsigned)-1) \
-		_P1 = DoCloseAndExec(_P0, basemode); \
-	if (sigalrm_pending()) \
-		CEmuStat |= CeS_SIGPEND; \
-	_P1; \
-})
+		_P1 = DoCloseAndExec(_P0, TheCPU.basemode);
 #endif
+	}
+	if (sigalrm_pending())
+		CEmuStat |= CeS_SIGPEND;
+	return _P1;
+}
 
 /////////////////////////////////////////////////////////////////////////////
 
@@ -552,11 +552,13 @@ static void HandleEmuSignals(void)
 
 static unsigned int _Interp86(unsigned int PC, int mod0);
 static unsigned int InterpOne(unsigned int PC, int *_basemode, int _flags);
-#define FLG_PREJIT 1
 
 void Interp86(void)
 {
-    unsigned int ret = _Interp86(LONG_CS + TheCPU.eip, TheCPU.mode);
+    unsigned int ret;
+
+    TheCPU.basemode = TheCPU.mode;
+    ret = _Interp86(LONG_CS + TheCPU.eip, TheCPU.mode);
     assert(CurrIMeta<0);
     TheCPU.eip = ret - LONG_CS;
 }
@@ -1291,7 +1293,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 /*e1*/	case LOOPZ_LOOPE:
 /*e2*/	case LOOP:
 /*e3*/	case JCXZ:	{
-			  PC = JumpGen(PC, _mode, opc, 2);
+			  PC = JumpGen(PC, _mode, opc, 2, P0, _flags);
 			  if (TheCPU.err) return PC;
 			}
 			break;
@@ -1796,7 +1798,8 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 
 /*e9*/	case JMPd:
 /*e8*/	case CALLd:
-		    PC = JumpGen(PC, _mode, opc, 1 + BT24(BitDATA16,_mode));
+		    PC = JumpGen(PC, _mode, opc, 1 + BT24(BitDATA16,_mode),
+			    P0, _flags);
 		    if (TheCPU.err) return PC;
 		    break;
 
@@ -1806,7 +1809,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			int len = 3 + BT24(BitDATA16,_mode);
 			dosaddr_t oip = PC + len - LONG_CS;
 			ocs = TheCPU.cs;
-			PC = JumpGen(PC, _mode, opc, len);
+			PC = JumpGen(PC, _mode, opc, len, P0, _flags);
 			if (debug_level('e')>2) {
 			    if (opc==CALLl)
 				e_printf("CALL_FAR: ret=%04x:%08x\n  calling:	   %04x:%08x\n",
@@ -1862,14 +1865,14 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 /*c2*/	case RETisp: {
 			int dr = (signed short)FetchW(PC+1);
 			Gen(O_POP, _mode|MRETISP, dr);
-			PC = JumpGen(PC, _mode, opc, 3);
+			PC = JumpGen(PC, _mode, opc, 3, P0, _flags);
 			if (debug_level('e')>2)
 				e_printf("RET: ret=%08x inc_sp=%d\n",PC-LONG_CS,dr);
 			if (TheCPU.err) return PC; }
 			break;
 /*c3*/	case RET:
 			Gen(O_POP, _mode);
-			PC = JumpGen(PC, _mode, opc, 1);
+			PC = JumpGen(PC, _mode, opc, 1, P0, _flags);
 			if (debug_level('e')>2) e_printf("RET: ret=%08x\n",PC-LONG_CS);
 			if (TheCPU.err) return PC;
 			break;
@@ -1943,7 +1946,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 				Gen(O_POP, _mode);
 				Gen(S_REG, _mode, Ofs_EIP);
 				Gen(O_POP, _mode|MRETISP, dr);
-				PC = JumpGen(PC, _mode, opc, 3);
+				PC = JumpGen(PC, _mode, opc, 3, P0, _flags);
 				if (debug_level('e')>2)
 					e_printf("RET_%d: ret=%08x\n",dr,TheCPU.eip);
 				if (TheCPU.err) return PC;
@@ -1997,10 +2000,11 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 				Gen(O_SETFL, _mode, INT);
 				Gen(L_LXS1, _mode, Ofs_EIP);
 				Gen(L_DI_R1, _mode);
-				PC = JumpGen(PC, _mode, opc, 2);
+				PC = JumpGen(PC, _mode, opc, 2, P0, _flags);
 				if (debug_level('e')>1)
 					dbug_printf("EMU86: directly called int %#x ax=%#x at %#x:%#x\n",
 						    inum, TheCPU.eax, TheCPU.cs, PC - LONG_CS);
+				if (TheCPU.err) return PC;
 				break;
 			}
 			CODE_FLUSH();
@@ -2053,7 +2057,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			Gen(O_POP, _mode);
 			Gen(S_REG, _mode, Ofs_EIP);
 			Gen(O_POP, _mode);
-			PC = JumpGen(PC, _mode, opc, 1);
+			PC = JumpGen(PC, _mode, opc, 1, P0, _flags);
 			if (debug_level('e')>1)
 			    e_printf("RET_FAR: ret=%04x:%08x\n",TheCPU.cs,TheCPU.eip);
 			if (TheCPU.err) return PC;
@@ -2629,7 +2633,8 @@ repag0:
 				break;
 			case Ofs_SP:	/*4*/	 // JMP near indirect
 				PC = JumpGen(PC, _mode, (opc<<8)|REG1,
-					ModRM(opc, PC, _mode|NOFLDR|MLOAD));
+					ModRM(opc, PC, _mode|NOFLDR|MLOAD),
+					P0, _flags);
 				if (TheCPU.err) return PC;
 				break;
 			case Ofs_DX: {	/*2*/	 // CALL near indirect
@@ -2641,7 +2646,8 @@ repag0:
 					Gen(L_REG, _mode, REG3);
 				else
 					Gen(L_DI_R1, _mode);
-				PC = JumpGen(PC, _mode, (opc<<8)|REG1, len);
+				PC = JumpGen(PC, _mode, (opc<<8)|REG1, len,
+					P0, _flags);
 				if (debug_level('e')>2)
 					e_printf("CALL indirect: ret=%08x\n\tcalling: %08x\n",
 						 ret,PC-LONG_CS);
@@ -2667,7 +2673,8 @@ repag0:
 					}
 					Gen(L_LXS1, _mode, Ofs_EIP);
 					Gen(L_DI_R1, _mode);
-					PC = JumpGen(PC, _mode, (opc<<8)|REG1, len);
+					PC = JumpGen(PC, _mode, (opc<<8)|REG1, len,
+						P0, _flags);
 					if (debug_level('e')>2) {
 					    unsigned short jcs = TheCPU.cs;
 					    dosaddr_t jip = PC - LONG_CS;
@@ -3217,7 +3224,8 @@ repag0:
 			case JNLEimmdisp:	/*8f*/
 				{
 				  PC = JumpGen(PC, _mode, JO+(opc2-JOimmdisp),
-					       2 + BT24(BitDATA16,_mode));
+					       2 + BT24(BitDATA16,_mode),
+					       P0, _flags);
 				  if (TheCPU.err) return PC;
 				}
 				break;
@@ -3650,6 +3658,7 @@ static void _PreJit86(unsigned int PC, int basemode)
 
 void PreJit86(unsigned int PC, int basemode)
 {
+	TheCPU.basemode = basemode;
 	_PreJit86(PC, basemode);
 	e_mdrop();
 }

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -50,6 +50,7 @@ int EmuSignals = 0;
 /* countdown to exit after handling VGAEMU faults, reset by
    planar VGA reads and writes */
 static int interp_inst_emu_count;
+unsigned int LONG_CS;
 
 static int ArOpsR[] =
 	{ O_ADD_R, O_OR_R, O_ADC_R, O_SBB_R, O_AND_R, O_SUB_R, O_XOR_R, O_CMP_R };
@@ -79,6 +80,7 @@ static __inline__ void SetCPU_WL(int m, signed char o, unsigned long v)
 #ifdef X86_JIT
 static TNode *DoClose(unsigned int PC, int mode, unsigned int P0)
 {
+	assert(PC > P0);
 	if (e_querymark(P0, PC - P0)) {
 	    InvalidateNodeRange(P0, PC - P0, NULL);
 	    if (!e_querymprotrange_full(P0, PC - P0)) {
@@ -102,6 +104,7 @@ static unsigned int DoCloseAndExec(unsigned int PC, int mode)
 	    return P0;
 	ret = Exec_x86(G);
 	TheCPU.err = TheCPU.err2;
+	LONG_CS = _LONG_CS;
 	return ret;
     } else {
 	return CloseAndExec_sim(PC, mode);
@@ -201,7 +204,12 @@ static int _MAKESEG(int mode, int *basemode, int ofs, unsigned short sv)
 	return 0;
 }
 
-#define MAKESEG(mode, ofs, sv) _MAKESEG(mode, &basemode, ofs, sv)
+#define MAKESEG(mode, ofs, sv) ({ \
+    int _rv = _MAKESEG(mode, &basemode, ofs, sv); \
+    if (ofs == Ofs_CS) \
+      LONG_CS = _LONG_CS; \
+    _rv; \
+})
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -252,7 +260,7 @@ static unsigned int _JumpGen(unsigned int P2, int mode, int opc,
 		if (mode&DATA16) d_t &= 0xffff;
 
 		/* jump address for taken branch */
-		j_t = d_t  + LONG_CS;
+		j_t = d_t + LONG_CS;
 	}
 
 	/* displacement for not taken branch */
@@ -438,6 +446,7 @@ static unsigned int JumpGen(unsigned int P2, int mode, int opc, int pskip,
 			} else {
 				_P1 = Exec_x86(G);
 				TheCPU.err = TheCPU.err2;
+				LONG_CS = _LONG_CS;
 			}
 		} else {
 			_P1 = CloseAndExec_sim(_P0, TheCPU.basemode);
@@ -505,6 +514,7 @@ static unsigned int FindExecCode(unsigned int PC)
 #endif
 			PC = Exec_x86(G);
 		TheCPU.err = TheCPU.err2;
+		LONG_CS = _LONG_CS;
 #if PROFILE
 		if (G->flags & F_PREJ)
 			PrejitNodesExecd++;
@@ -564,6 +574,7 @@ void Interp86(void)
 
     TheCPU.basemode = TheCPU.mode;
     TheCPU.err2 = 0;
+    LONG_CS = _LONG_CS;
     ret = _Interp86(LONG_CS + TheCPU.eip, TheCPU.mode);
     assert(CurrIMeta<0);
     TheCPU.eip = ret - LONG_CS;
@@ -3666,6 +3677,7 @@ void PreJit86(unsigned int PC, int basemode)
 {
 	TheCPU.basemode = basemode;
 	TheCPU.err2 = 0;
+	LONG_CS = _LONG_CS;
 	_PreJit86(PC, basemode);
 	e_mdrop();
 }

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -95,11 +95,14 @@ static unsigned int DoCloseAndExec(unsigned int PC, int mode)
 {
 #ifdef X86_JIT
     if (!CONFIG_CPUSIM) {
+	int ret;
 	unsigned P0 = InstrMeta[0].npc;
 	TNode *G = DoClose(PC, mode, P0);
 	if (!G)
 	    return P0;
-	return Exec_x86(G);
+	ret = Exec_x86(G);
+	TheCPU.err = TheCPU.err2;
+	return ret;
     } else {
 	return CloseAndExec_sim(PC, mode);
     }
@@ -434,6 +437,7 @@ static unsigned int JumpGen(unsigned int P2, int mode, int opc, int pskip,
 				TheCPU.err = EXCP_GOBACK;
 			} else {
 				_P1 = Exec_x86(G);
+				TheCPU.err = TheCPU.err2;
 			}
 		} else {
 			_P1 = CloseAndExec_sim(_P0, TheCPU.basemode);
@@ -500,6 +504,7 @@ static unsigned int FindExecCode(unsigned int PC)
 		else
 #endif
 			PC = Exec_x86(G);
+		TheCPU.err = TheCPU.err2;
 #if PROFILE
 		if (G->flags & F_PREJ)
 			PrejitNodesExecd++;
@@ -558,6 +563,7 @@ void Interp86(void)
     unsigned int ret;
 
     TheCPU.basemode = TheCPU.mode;
+    TheCPU.err2 = 0;
     ret = _Interp86(LONG_CS + TheCPU.eip, TheCPU.mode);
     assert(CurrIMeta<0);
     TheCPU.eip = ret - LONG_CS;
@@ -3659,6 +3665,7 @@ static void _PreJit86(unsigned int PC, int basemode)
 void PreJit86(unsigned int PC, int basemode)
 {
 	TheCPU.basemode = basemode;
+	TheCPU.err2 = 0;
 	_PreJit86(PC, basemode);
 	e_mdrop();
 }

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -100,9 +100,12 @@ static TNode *DoClose(unsigned int PC, int mode, unsigned int P0)
 	if (e_querymark(P0, PC - P0)) {
 	    InvalidateNodeRange(P0, PC - P0, NULL);
 	    if (!e_querymprotrange_full(P0, PC - P0)) {
+		unsigned int abeg, aend;
+		abeg = P0 & _PAGE_MASK;
+		aend = PC & _PAGE_MASK;
 		/* re-populate cache */
-		Fetch(P0);
-		Fetch(PC);
+		for (; abeg <= aend; abeg += PAGE_SIZE)
+			Fetch(abeg);
 	    }
 	}
 	return Close_x86(PC, mode);
@@ -634,12 +637,13 @@ static unsigned int interp_pre(unsigned int PC, const int mode, int _flags)
 			if (EFLAGS & TF)
 				CEmuStat |= CeS_TRAP;
 		} else {
+			/* don't exit with opened node - breaks prejitter */
+#if 0
 			if (CEmuStat & (CeS_SIGPEND|CeS_RPIC)) {
-				unsigned int P0 = PC;
-				CODE_FLUSH2(mode);
 				HandleEmuSignals();
 				if (TheCPU.err) return PC;
 			}
+#endif
 		}
 #ifdef X86_JIT
 		if (!CONFIG_CPUSIM && e_querymark(PC, 1)) {

--- a/src/base/emu-i386/simx86/memory.c
+++ b/src/base/emu-i386/simx86/memory.c
@@ -78,7 +78,7 @@ struct cache_ent {
 	int alive_cnt;
 	void *data;
 };
-#define CLIST_MAX 8
+#define CLIST_MAX 256
 static struct cache_ent clist[CLIST_MAX];
 static int num_clist;
 

--- a/src/base/emu-i386/simx86/syncpu.h
+++ b/src/base/emu-i386/simx86/syncpu.h
@@ -110,6 +110,7 @@ typedef struct {
 /*80*/	//unsigned int end_mark[0] = cr[4]
 	unsigned int tr[2];
 
+	int err2;
 	int err;
 	unsigned int mode;
 	unsigned int basemode;
@@ -237,7 +238,7 @@ extern union _SynCPU TheCPU_union;
 #define Ofs_stub_read_8	(unsigned int)(offsetof(SynCPU,stub_read_8)-SCBASE)
 #define Ofs_stub_read_16	(unsigned int)(offsetof(SynCPU,stub_read_16)-SCBASE)
 #define Ofs_stub_read_32	(unsigned int)(offsetof(SynCPU,stub_read_32)-SCBASE)
-#define Ofs_ERR		(unsigned int)(offsetof(SynCPU,err)-SCBASE)
+#define Ofs_ERR		(unsigned int)(offsetof(SynCPU,err2)-SCBASE)
 #define Ofs_int_revectored	(unsigned int)(offsetof(SynCPU,int_revectored)-SCBASE)
 
 #define rAX		CPUWORD(Ofs_AX)

--- a/src/base/emu-i386/simx86/syncpu.h
+++ b/src/base/emu-i386/simx86/syncpu.h
@@ -112,6 +112,7 @@ typedef struct {
 
 	int err;
 	unsigned int mode;
+	unsigned int basemode;
 	unsigned int sreg1;
 	unsigned int dreg1;
 	unsigned int xreg1;

--- a/src/base/emu-i386/simx86/syncpu.h
+++ b/src/base/emu-i386/simx86/syncpu.h
@@ -290,7 +290,7 @@ extern union _SynCPU TheCPU_union;
 #define FS_DTR		TheCPU.fs_cache
 #define GS_DTR		TheCPU.gs_cache
 
-#define LONG_CS		TheCPU.cs_cache.BoundL
+#define _LONG_CS	TheCPU.cs_cache.BoundL
 #define LONG_DS		TheCPU.ds_cache.BoundL
 #define LONG_ES		TheCPU.es_cache.BoundL
 #define LONG_SS		TheCPU.ss_cache.BoundL
@@ -298,6 +298,7 @@ extern union _SynCPU TheCPU_union;
 #define LONG_GS		TheCPU.gs_cache.BoundL
 
 extern char OVERR_DS, OVERR_SS;
+extern unsigned int LONG_CS;
 
 #define sigalrm_pending() __atomic_load_n(&TheCPU.sigalrm_pending, \
   __ATOMIC_RELAXED)

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -1351,10 +1351,10 @@ int NewIMeta(int npc, int *rc)
 		// add new opcode metadata
 		IMeta *I,*I0;
 
-		if (CurrIMeta>=MAXINODES) {
+		if (CurrIMeta>=MAXINODES-1) {
 			*rc = -1; goto quit;
 		}
-		I  = &InstrMeta[CurrIMeta];
+		I = &InstrMeta[CurrIMeta];
 		if (CurrIMeta==0) {		// no open code sequences
 			if (debug_level('e')>2) e_printf("============ Opening sequence at %08x\n",npc);
 			I0 = I;
@@ -1385,7 +1385,7 @@ int NewIMeta(int npc, int *rc)
 #endif
 		CurrIMeta++;
 		/* provoke caller to flush if we are about to overflow */
-		*rc = (CurrIMeta >= MAXINODES ? -1 : 1);
+		*rc = (CurrIMeta >= MAXINODES-1 ? -1 : 1);
 		I++;
 		I->ngen = 0;
 		I->flags = 0;

--- a/src/base/emu-i386/simx86/trees.h
+++ b/src/base/emu-i386/simx86/trees.h
@@ -82,13 +82,14 @@ typedef struct _imgen {
 } IGen;
 
 typedef struct _ianpc {
-	unsigned short daddr __attribute__ ((packed));
-	signed short dnpc __attribute__ ((packed));
+	unsigned int daddr;
+	signed short dnpc;
 } Addr2Pc;
 
 typedef struct _imeta {
 	int seqbase, npc;
-	unsigned short ncount, len, flags, seqlen, totlen, daddr;
+	unsigned short ncount, flags, seqlen;
+	unsigned int len, totlen, daddr;
 	linkdesc clink;
 	int ngen;
 	IGen gen[NUMGENS];


### PR DESCRIPTION
To further extend prejitter use, we need to avoid the global mutex. Try the simplest approach: just remove the global mutex and instead wait on a condvar til prejitter stops.