### PR TITLE
dj64: API v17 with elfparse64 call-back [#2398]

### DIFF
--- a/src/base/init/config.c
+++ b/src/base/init/config.c
@@ -1186,8 +1186,7 @@ config_init(int argc, char **argv)
     int             err;
     int             was_exec = 0, was_T1 = 0;
     const char * const getopt_string =
-       "23456A::B::C::c::D:d:E:e:f:H:hi:I:K:k::L:l:M:mNno:P:qSsT::t::VvwXx:Y"
-       "gp"/*NOPs kept for compat (not documented in usage())*/;
+       "23456A::B::C::c::D:d:E:e:f:g:H:hi:I:K:k::L:l:M:mNno:P:pqSsT::t::VvwXx:Y";
 
     basename = strrchr(argv[0], '/');   /* parse the program name */
     basename = basename ? basename + 1 : argv[0];
@@ -1330,22 +1329,42 @@ config_init(int argc, char **argv)
 	case 'L':
 	    dbug_printf("%s\n", optarg);
 	    break;
-	case 'l':
+	case 'l': {
 #ifdef USE_DJDEV64
-	    if (!exists_file(optarg)) {
+	    char *p = expand_path(optarg);
+	    if (!p || !exists_file(p)) {
 		error("Path %s does not exist\n", optarg);
 		config.exitearly = 1;
 		break;
 	    }
 	    free(config.elfload);
-	    config.elfload = strdup(optarg);
-	    permit_file_ro(optarg);
+	    config.elfload = p;
+	    permit_file_ro(p);
 	    was_exec++;
 #else
 	    error("dj64 support not compiled in\n");
 	    config.exitearly = 1;
 #endif
 	    break;
+	}
+	case 'g': {
+#ifdef USE_DJDEV64
+	    char *p = expand_path(optarg);
+	    if (!p || !exists_file(p)) {
+		error("Path %s does not exist\n", optarg);
+		config.exitearly = 1;
+		break;
+	    }
+	    free(config.elfload2);
+	    config.elfload2 = p;
+	    permit_file_ro(p);
+	    was_exec++;
+#else
+	    error("dj64 support not compiled in\n");
+	    config.exitearly = 1;
+#endif
+	    break;
+	}
 	case 'd': {
 	    char *p = strdup(optarg);
 	    char *d = strchr(p, ':');
@@ -1400,8 +1419,6 @@ config_init(int argc, char **argv)
 		else
 			fprintf(stderr,"error in CPU user override\n");
 	    }
-	    break;
-	case 'g': /* obsolete "graphics" option */
 	    break;
 	case 'A':
 	    config.hdiskboot = 0;

--- a/src/dosemu
+++ b/src/dosemu
@@ -148,6 +148,13 @@ while [ $# -gt 0 ] ; do
       OPTS="$OPTS -l $1"
       shift
       ;;
+    -g)
+      shift
+      SUDO=setpriv
+      SUDOOPTS="--no-new-privs"
+      OPTS="$OPTS -g $1"
+      shift
+      ;;
     -t | -t[a-z] | -t[a-z][a-z] | -t[a-z][a-z][a-z])
       exec 4>&2 2>~/.dosemu/stderr.log.$BASHPID
       SUFFIX="$SUFFIX \"$1\""

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -3557,6 +3557,26 @@ static void dpmi_dj64_open(cpuctx_t *scp)
   }
 }
 
+static void dpmi_dj64_elfload(cpuctx_t *scp)
+{
+  int handle = _LWORD(eax);
+  int djh;
+  void *dlh = load_plugin("dj64");
+
+  _eflags |= CF;
+  if (!dlh || !djdev64 || handle || !config.elfload2)
+    return;
+  djh = djdev64->elfopen(config.elfload2, _LWORD(ecx));
+  if (djh != -1) {
+    _eflags &= ~CF;
+    _eax = djh;
+    _es = dpmi_sel();
+    _edi = djdev64->call(djh);
+    _esi = djdev64->ctrl(djh);
+    D_printf("DPMI: dj64 loading %s\n", config.elfload2);
+  }
+}
+
 static void dpmi_dj64_close(cpuctx_t *scp)
 {
   int handle = (_LWORD(esi) << 16) | _LWORD(edi);
@@ -3572,6 +3592,15 @@ static void dpmi_dj64_close(cpuctx_t *scp)
   }
   djdev64->close(_eax);
   ptr->flags &= ~PMBF_DJ64;  // to not close again on exit
+  _eflags &= ~CF;
+}
+
+static void dpmi_dj64_elfclose(cpuctx_t *scp)
+{
+  _eflags |= CF;
+  if (!djdev64 || !config.elfload2)
+    return;
+  djdev64->close(_eax);
   _eflags &= ~CF;
 }
 
@@ -5133,8 +5162,14 @@ static void do_dpmi_hlt(cpuctx_t *scp, uint8_t *lina, void *sp)
           case 3:
             _eax = 2;  // version
             break;
+          case 4:
+            dpmi_dj64_elfload(scp);
+            break;
+          case 5:
+            dpmi_dj64_elfclose(scp);
+            break;
           default:
-            error("dj64: unknown cmd %x\n", _eax);
+            error("dj64: unknown cmd %x\n", _ebx);
             break;
           }
 #endif

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -361,6 +361,7 @@ typedef struct config_info {
         char *unix_path;
         char *dos_path;
         char *elfload;
+        char *elfload2;
 
         char *unix_exec;
         char *lredir_paths;

--- a/src/plugin/dj64/config/plugin_config.h
+++ b/src/plugin/dj64/config/plugin_config.h
@@ -9,6 +9,7 @@ struct djdev64_ops {
     unsigned (*ctrl)(int handle);
     unsigned (*stub)(void);
     unsigned (*exec)(char *path);
+    int (*elfopen)(const char *path, unsigned short flags);
 };
 
 void register_djdev64(const struct djdev64_ops *ops);

--- a/src/plugin/dj64/djdev64.c
+++ b/src/plugin/dj64/djdev64.c
@@ -36,7 +36,7 @@
 #if DJ64_API_VER < 11
 #error wrong djdev64 version
 #endif
-#if DJ64_API_VER != 16
+#if DJ64_API_VER != 17
 #warning djdev64 version mismatch
 #endif
 
@@ -274,6 +274,39 @@ static int dj64_elfload(int num)
 }
 #endif
 
+#if DJ64_API_VER >= 17
+static char *dj64_elfparse64(int num, uint32_t addr, uint32_t size,
+        uint32_t mbase, uint32_t *r_size, uint32_t *r_entry)
+{
+    char *elf;
+    uint32_t sz;
+    void *eh;
+    int err;
+
+    if (num || !config.elfload2)
+        return NULL;
+    elf = djelf64_parse(config.elfload2, &sz);
+    if (!elf)
+        return NULL;
+    *r_size = sz;
+    eh = djelf_open(elf, sz);
+    if (!eh)
+        goto err1;
+    err = djelf_reloc(eh, dosaddr_to_unixaddr(mbase + addr), size,
+            addr, r_entry);
+    djelf_close(eh);
+    if (err) {
+        error("djelf_reloc() failed\n");
+        goto err1;
+    }
+    return elf;
+
+err1:
+    free(elf);
+    return NULL;
+}
+#endif
+
 const struct dj64_api api = {
     .addr2ptr = dj64_addr2ptr,
     .addr2ptr2 = dj64_addr2ptr2,
@@ -295,12 +328,14 @@ const struct dj64_api api = {
 #if DJ64_API_VER >= 16
     .uget = ustore_get,
 #endif
+#if DJ64_API_VER >= 17
+    .elfparse64 = dj64_elfparse64,
+#endif
 };
 
-static int do_open(const char *path, unsigned short flags)
+static int _do_open(const char *path, unsigned full_flags)
 {
     int ret;
-    unsigned full_flags = flags;
 
 #if USE_ASAN
     full_flags |= DJ64F_DLMOPEN;
@@ -318,6 +353,20 @@ static int do_open(const char *path, unsigned short flags)
         ctrl_off = hlt_register_handler_pm(hlt_hdlr);
     }
     return ret;
+}
+
+static int do_open(const char *path, unsigned short flags)
+{
+    return _do_open(path, flags);
+}
+
+static int do_open2(const char *path, unsigned short flags)
+{
+#if DJ64_API_VER >= 17
+    return _do_open(path, flags | DJ64F_NOMANGLE);
+#else
+    return -1;
+#endif
 }
 
 static void do_close(int handle)
@@ -451,6 +500,9 @@ static const struct djdev64_ops ops = {
     .stub = stub_entry,
 #if DJ64_API_VER >= 12
     .exec = exec_entry,
+#endif
+#if DJ64_API_VER >= 17
+    .elfopen = do_open2,
 #endif
 };
 


### PR DESCRIPTION
This call-back allows to implement external ELF64 parsers, as I don't want to bloat dj64dev with that crap any more. In fact, this call-back is incapable of supporting all currently existing ELF formats of dj64dev. For example the ELF format used for static linking, can't be supported with this call-back right now, and likely never will.
Note that since old ELF files do not require any extra parsing (over what is already implemented in dj64dev), simply returning NULL allows them to work with the new infrastructure quite fine.

Added -g switch to load new ELF files.
Old ELFs that are loaded with -l, can also be loaded with -g. Added the needed DPMI infrastructure and the parser.