### PR TITLE
build dosemu2 as a solib [#2398]

### DIFF
--- a/Makefile.conf.in
+++ b/Makefile.conf.in
@@ -3,6 +3,7 @@
 # This file is included by all Makefiles
 
 DOSBIN = dosemu2.bin
+DOSLIB = libdosemu2.so
 
 PACKAGE_TARNAME:=@PACKAGE_TARNAME@
 prefix:=@prefix@

--- a/configure.ac
+++ b/configure.ac
@@ -725,8 +725,10 @@ if test "$machine" = "i386" -o "$with_target_bits" = "32" -o \
 else
     AC_MSG_NOTICE(Compiling as PIE for $machine...)
     DOSEMU_CFLAGS="$DOSEMU_CFLAGS -fpie"
-    DOSEMU_LDFLAGS="$DOSEMU_LDFLAGS -pie"
+    DOSBIN_LDFLAGS="$DOSEMU_LDFLAGS -pie"
 fi
+
+DOSEMU_CFLAGS="$DOSEMU_CFLAGS -fpic"
 
 if test "$CONFIG_HOST" = "Linux"; then
   if test "$machine" = "i386" -o "$machine" = "x86_64"; then

--- a/dosemu2.spec
+++ b/dosemu2.spec
@@ -106,6 +106,7 @@ make DESTDIR=%{buildroot} install
 %files
 %defattr(-,root,root)
 %{_bindir}/*
+%{_libdir}/*
 %{_sysusersdir}/dosemu2.conf
 %dir %{_libexecdir}/dosemu2
 %attr(06755, dosemu2, dosemu2) %{_libexecdir}/dosemu2/dosemu2.bin

--- a/src/arch/linux/Makefile.main
+++ b/src/arch/linux/Makefile.main
@@ -79,16 +79,22 @@ $(top_builddir)/etc/Xfonts/%.pcf.gz: $(REALTOPDIR)/etc/%.bdf | $(top_builddir)/e
 
 $(LIBS_): | $(top_builddir)/lib
 
-$(BINPATH)/bin/$(DOSBIN): $(LIBS_)
+$(BINPATH)/bin/$(DOSLIB): $(LIBS_)
 ifeq ($(OS),Darwin)
-	$(LD) $(ALL_LDFLAGS) $(DOSBIN_LDFLAGS) -o $@ \
+	$(LD) $(ALL_LDFLAGS) -o $@ \
 	   -Wl,-all_load $(LIBS_) $(LIBS) \
-	   -Wl,-map,$(BINPATH)/bin/dosemu.map
+	   -Wl,-map,$(BINPATH)/bin/dosemu.map \
+	   -shared -Wl,-Bsymbolic
 else
-	$(LD) $(ALL_LDFLAGS) $(DOSBIN_LDFLAGS) -o $@ \
+	$(LD) $(ALL_LDFLAGS) -o $@ \
 	   -Wl,--whole-archive $(LIBS_) -Wl,--no-whole-archive $(LIBS) \
-	   -Wl,-Map=$(BINPATH)/bin/dosemu.map
+	   -Wl,-Map=$(BINPATH)/bin/dosemu.map \
+	   -shared -Wl,-Bsymbolic
 endif
+
+$(BINPATH)/bin/$(DOSBIN): base/core/main.o $(BINPATH)/bin/$(DOSLIB)
+	$(LD) $(DOSBIN_LDFLAGS) -o $@ $< -L $(BINPATH)/bin -ldosemu2 \
+	  -Wl,-rpath,$(libdir)
 
 $(BINPATH)/bin/dosemu: $(SRCPATH)/dosemu.systemwide $(SRCPATH)/dosemu \
   $(top_builddir)/Makefile.conf
@@ -164,6 +170,7 @@ endif
 	$(INSTALL) -m 0644 $(REALTOPDIR)/etc/sysusers.conf $(DESTDIR)$(prefix)/lib/sysusers.d/$(PACKAGE_NAME).conf
 	$(INSTALL) -d $(DESTDIR)$(libexecdir)/dosemu2
 	$(INSTALL) -m 0755 $(top_builddir)/bin/$(DOSBIN) $(DESTDIR)$(libexecdir)/dosemu2
+	$(INSTALL) -m 0755 $(top_builddir)/bin/$(DOSLIB) $(DESTDIR)$(libdir)
 ifneq ($(PRIV_SEP),)
 	if getent passwd $(username); then \
 	  if chown $(username):$(username) $(DESTDIR)$(libexecdir)/dosemu2/$(DOSBIN); then \
@@ -254,6 +261,7 @@ endif
 uninstall:
 	$(RM) -r $(DESTDIR)$(dosemudir)
 	$(RM) -r $(DESTDIR)$(libexecdir)/$(PACKAGE_NAME)
+	$(RM) $(DESTDIR)$(libdir)/$(DOSLIB)
 	$(RM) $(DESTDIR)$(prefix)/lib/sysusers.d/$(PACKAGE_NAME).conf
 	$(RM) $(DESTDIR)$(bindir)/dosemu
 	$(RM) $(DESTDIR)$(bindir)/mkfatimage16

--- a/src/base/core/emu.c
+++ b/src/base/core/emu.c
@@ -281,7 +281,7 @@ static int c_chk(void)
  * DANG_END_FUNCTION
  *
  */
-int main(int argc, char **argv, char * const *envp)
+int emulate(int argc, char **argv, char * const *envp)
 {
     dosemu_envp = envp;
     setlocale(LC_ALL,"");

--- a/src/base/core/main.c
+++ b/src/base/core/main.c
@@ -1,0 +1,6 @@
+#include "emu.h"
+
+int main(int argc, char **argv, char * const *envp)
+{
+    return emulate(argc, argv, envp);
+}

--- a/src/dosemu
+++ b/src/dosemu
@@ -16,6 +16,12 @@ get_binary() {
         --Flibdir $LOCAL_BUILD_PATH/etc \
         --Fplugindir $BINDIR \
         "
+    if [ -z "$LD_LIBRARY_PATH" ]; then
+      export LD_LIBRARY_PATH="$BINDIR"
+    else
+      export LD_LIBRARY_PATH="$BINDIR:$LD_LIBRARY_PATH"
+    fi
+
   else
     BINARY="$prefix"/libexec/dosemu2/dosemu2.bin
     if [ ! -f "$BINARY" ]; then

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -506,6 +506,7 @@ extern int register_exit_handler(void (*handler)(void));
 void tcp_helper(struct vm86_regs *);
 void ipx_helper(struct vm86_regs *);
 void free_fonts(void);
+int emulate(int argc, char **argv, char * const *envp);
 
 typedef struct emu_hlt_s emu_hlt_t;
 extern void *vm86_hlt_state;


### PR DESCRIPTION
Not something I really like to do... but the change is rather small and this seems to be the only way of embedding dosemu2 into the standalone ELF files.