### PR TITLE
video: pass tty name via env var [fixes #2463]

### DIFF
--- a/src/base/core/priv.c
+++ b/src/base/core/priv.c
@@ -50,6 +50,7 @@
 #ifdef X86_EMULATOR
 #include "cpu-emu.h"
 #endif
+#include "video.h"  // for using_kms()
 #include "landlock.h"
 
 /* Some handy information to have around */
@@ -526,7 +527,11 @@ void priv_init(void)
      * any thread. So set groups now and drop caps. Hopefully the logged-in
      * user doesn't need supplementary groups, having the ACLs set at login
      * time instead. */
-    if (caps) {
+    /* Not the case for input devices, which are needed under kms.
+     * See https://github.com/dosemu2/dosemu2/issues/2463#issuecomment-2918920084
+     * TODO: Remove this hack when sdl fixed!
+     */
+    if (caps && !using_kms()) {
       init_groups(euid, egid);
       groups_dropped = 1;
     }

--- a/src/base/dev/misc/pci.c
+++ b/src/base/dev/misc/pci.c
@@ -246,14 +246,25 @@ static int pci_open_proc(unsigned char bus, unsigned char device,
   static char proc_pci_name_buf[] = "/proc/bus/pci/00/00.0";
   int fd;
 
+  snprintf(proc_pci_name_buf + 14, sizeof(proc_pci_name_buf) - 14,
+      "%02hhx/%02hhx.%.1hhx", bus, device, fn);
+  Z_printf("PCI: opening %s\n", proc_pci_name_buf);
+  fd = open(proc_pci_name_buf, O_RDONLY);
+  return fd;
+}
+
+static int pci_open_proc_rw(unsigned char bus, unsigned char device,
+			 unsigned char fn)
+{
+  static char proc_pci_name_buf[] = "/proc/bus/pci/00/00.0";
+  int fd;
+
   PRIV_SAVE_AREA
   snprintf(proc_pci_name_buf + 14, sizeof(proc_pci_name_buf) - 14,
       "%02hhx/%02hhx.%.1hhx", bus, device, fn);
   Z_printf("PCI: opening %s\n", proc_pci_name_buf);
   enter_priv_on();
   fd = open(proc_pci_name_buf, O_RDWR);
-  if (fd == -1)
-    fd = open(proc_pci_name_buf, O_RDONLY);
   leave_priv_setting();
   return fd;
 }
@@ -291,7 +302,7 @@ static unsigned long pci_read_proc (unsigned char bus, unsigned char device,
 static void pci_write_proc (unsigned char bus, unsigned char device,
 			    unsigned char fn, unsigned long reg, unsigned long val, int len)
 {
-  int fd = pci_open_proc(bus, device, fn);
+  int fd = pci_open_proc_rw(bus, device, fn);
   if (fd == -1)
     return;
   Z_printf("PCI: writing reg %ld\n", reg);

--- a/src/base/init/config.c
+++ b/src/base/init/config.c
@@ -991,7 +991,7 @@ static void config_post_process(void)
 	    config.console_video = 0;
 	    dbug_printf("no console on low feature (non-suid root) DOSEMU\n");
 	}
-	if (config.console_keyb == -1)
+	if (config.console_keyb == -1 && config.console_video)
 	    config.console_keyb = KEYB_RAW;
 	if (config.speaker == SPKR_EMULATED) {
 	    register_speaker((void *)(uintptr_t)console_fd,

--- a/src/base/kbd_unicode/getfd.c
+++ b/src/base/kbd_unicode/getfd.c
@@ -6,7 +6,6 @@
 
 #include "getfd.h"
 
-#ifdef HAVE_SYS_KD_H
 /* this code comes from kbd-1.08 */
 
 #include <stdio.h>
@@ -14,7 +13,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>
-#include <sys/kd.h>
+#include "Sys/kd.h"
 #include <sys/ioctl.h>
 #include <linux/keyboard.h>
 #include "priv.h"
@@ -464,10 +463,3 @@ int read_kbd_table(struct keytable_entry *kt,
 
 	return j;
 }
-
-#else
-int open_console(void) { return -1; }
-int getfd(void) { return -1; }
-int read_kbd_table(struct keytable_entry *kt,
-			  struct keytable_entry *altkt) { return -1; }
-#endif

--- a/src/base/kbd_unicode/keyb_raw.c
+++ b/src/base/kbd_unicode/keyb_raw.c
@@ -162,8 +162,10 @@ static int set_raw_mode(void)
   if (config.console_keyb == KEYB_RAW) {
     k_printf("KBD(raw): Setting keyboard to RAW mode\n");
     err = ioctl(kbd_fd, KDSKBMODE, K_RAW);
-    if (err)
-      return err;
+    if (err) {
+      error("kbd raw mode failed: %s\n", strerror(errno));
+      config.console_keyb = KEYB_TTY;
+    }
   }
 #else
   if (config.console_keyb == KEYB_RAW)

--- a/src/base/kbd_unicode/keyb_raw.c
+++ b/src/base/kbd_unicode/keyb_raw.c
@@ -9,9 +9,7 @@
 #include <errno.h>
 #include <string.h>
 #include <sys/stat.h>
-#ifdef HAVE_SYS_KD_H
-#include <sys/kd.h>
-#endif
+#include "Sys/kd.h"
 #include <sys/ioctl.h>
 
 #include "ioselect.h"
@@ -28,14 +26,14 @@
 #define LED_CAPSLOCK	2
 
 static struct termios save_termios;	/* original terminal modes */
-#ifdef HAVE_SYS_KD_H
+#ifdef __linux__
 static int save_mode;                   /* original keyboard mode  */
 #endif
 static int kbd_fd = -1;
 
 static void set_kbd_leds(t_modifiers shiftstate)
 {
-#ifdef HAVE_SYS_KD_H
+#ifdef __linux__
   unsigned int led_state = 0;
   static t_modifiers prev_shiftstate = 0xffff;
 
@@ -59,7 +57,7 @@ static void set_kbd_leds(t_modifiers shiftstate)
 static t_shiftstate get_kbd_flags(void)
 {
   t_modifiers s = 0;
-#ifdef HAVE_SYS_KD_H
+#ifdef __linux__
   int rc;
   unsigned int led_state = 0;
 
@@ -158,7 +156,7 @@ static void print_termios(struct termios term)
 static int set_raw_mode(void)
 {
   struct termios buf = save_termios;
-#ifdef HAVE_SYS_KD_H
+#ifdef __linux__
   int err;
 
   if (config.console_keyb == KEYB_RAW) {
@@ -202,7 +200,7 @@ static int raw_keyboard_init(void)
   k_printf("KBD(raw): raw_keyboard_init()\n");
 
   kbd_fd = STDIN_FILENO;
-#ifdef HAVE_SYS_KD_H
+#ifdef __linux__
   if (config.console_keyb == KEYB_RAW)
     ioctl(kbd_fd, KDGKBMODE, &save_mode);
 #endif
@@ -243,7 +241,7 @@ static void raw_keyboard_close(void)
   if (kbd_fd != -1) {
     k_printf("KBD(raw): raw_keyboard_close: resetting keyboard to original mode\n");
     remove_from_io_select(kbd_fd);
-#ifdef HAVE_SYS_KD_H
+#ifdef __linux__
     if (config.console_keyb == KEYB_RAW) {
       ioctl(kbd_fd, KDSKBMODE, save_mode);
 

--- a/src/base/kbd_unicode/keyb_raw.c
+++ b/src/base/kbd_unicode/keyb_raw.c
@@ -11,12 +11,13 @@
 #include <sys/stat.h>
 #include "Sys/kd.h"
 #include <sys/ioctl.h>
-
+#include "vc.h"
 #include "ioselect.h"
 #include "keyboard.h"
 #include "keyb_clients.h"
 #include "translate/keysym_attributes.h"
 #include "keystate.h"
+#include "keyb_raw.h"
 
 #define KBBUF_SIZE (KEYB_QUEUE_LENGTH / 2)
 
@@ -153,15 +154,26 @@ static void print_termios(struct termios term)
 }
 #endif
 
-static int set_raw_mode(void)
+void kbdraw_priv_init(void)
 {
-  struct termios buf = save_termios;
-#ifdef __linux__
-  int err;
+  if (on_console()) {
+    kbd_fd = console_fd;
+  } else {
+    kbd_fd = STDIN_FILENO;
+    if (config.console_keyb == KEYB_RAW) {
+      k_printf("KBD(raw): not on console, using TTY mode\n");
+      config.console_keyb = KEYB_TTY;
+    }
+  }
 
+#ifdef __linux__
   if (config.console_keyb == KEYB_RAW) {
+    int err;
+
     k_printf("KBD(raw): Setting keyboard to RAW mode\n");
+    enter_priv_on();
     err = ioctl(kbd_fd, KDSKBMODE, K_RAW);
+    leave_priv_setting();
     if (err) {
       error("kbd raw mode failed: %s\n", strerror(errno));
       config.console_keyb = KEYB_TTY;
@@ -171,6 +183,11 @@ static int set_raw_mode(void)
   if (config.console_keyb == KEYB_RAW)
     config.console_keyb = KEYB_TTY;
 #endif
+}
+
+static int set_raw_mode(void)
+{
+  struct termios buf = save_termios;
   cfmakeraw(&buf);
   k_printf("KBD(raw): Setting TERMIOS Structure.\n");
   if (tcsetattr(kbd_fd, TCSAFLUSH, &buf) < 0) {
@@ -201,7 +218,6 @@ static int raw_keyboard_init(void)
 
   k_printf("KBD(raw): raw_keyboard_init()\n");
 
-  kbd_fd = STDIN_FILENO;
 #ifdef __linux__
   if (config.console_keyb == KEYB_RAW)
     ioctl(kbd_fd, KDGKBMODE, &save_mode);

--- a/src/base/kbd_unicode/keyb_raw.h
+++ b/src/base/kbd_unicode/keyb_raw.h
@@ -1,0 +1,6 @@
+#ifndef KEYB_RAW_H
+#define KEYB_RAW_H
+
+void kbdraw_priv_init(void);
+
+#endif

--- a/src/base/kbd_unicode/keyboard.c
+++ b/src/base/kbd_unicode/keyboard.c
@@ -21,6 +21,7 @@
 #include "keyboard.h"
 #include "keyb_clients.h"
 #include "keyb_server.h"
+#include "keyb_raw.h"
 
 static int initialized;
 
@@ -29,6 +30,7 @@ void keyb_priv_init(void)
 	/* this must be initialized before starting port-server */
 	keyb_8042_init();
 	open_console();
+	kbdraw_priv_init();
 }
 
 void keyb_init(void)

--- a/src/base/video/video.c
+++ b/src/base/video/video.c
@@ -310,6 +310,10 @@ void video_close(void)
     Video->close();
     v_printf("VID: video_close()->Video->close() called\n");
   }
+  if (console_fd != -1) {
+    close(console_fd);
+    console_fd = -1;
+  }
 }
 
 /* load <msize> bytes of file <name> starting at offset <foffset>
@@ -533,13 +537,22 @@ int on_console(void)
     struct stat chkbuf;
     int major, minor;
 
-    if (console_fd == -2)
+    if (console_fd == -1) {
+	const char *tname = getenv("SUDO_TTY");
+	if (!tname)
+	    tname = getenv("DOSEMU_SUDO_TTY");
+	if (!tname) {
+	    if (isatty(STDIN_FILENO))
+		console_fd = dup(STDIN_FILENO);
+	} else {
+	    console_fd = open(tname, O_RDWR | O_CLOEXEC);
+	}
+    }
+    if (console_fd == -1)
 	return 0;
 
-    console_fd = -2;
-
-    if (fstat(STDIN_FILENO, &chkbuf) != 0)
-	return 0;
+    if (fstat(console_fd, &chkbuf) != 0)
+	goto err;
 
     major = chkbuf.st_rdev >> 8;
     minor = chkbuf.st_rdev & 0xff;
@@ -547,10 +560,12 @@ int on_console(void)
     c_printf("major = %d minor = %d\n",
 	    major, minor);
     /* console major num is 4, minor 64 is the first serial line */
-    if (S_ISCHR(chkbuf.st_mode) && (major == 4) && (minor < 64)) {
-       console_fd = STDIN_FILENO;
+    if (S_ISCHR(chkbuf.st_mode) && (major == 4) && (minor < 64))
        return 1;
-    }
+
+err:
+    close(console_fd);
+    console_fd = -1;
 #endif
     return 0;
 }

--- a/src/base/video/video.c
+++ b/src/base/video/video.c
@@ -93,7 +93,7 @@ static int no_real_terminal(void)
  * graphics.
  * code adapted from libdrm (drmCheckModesettingSupported)
  */
-static int using_kms(void)
+int using_kms(void)
 {
 #ifdef __linux__
     char pci_dev_dir[1024];

--- a/src/base/video/video.c
+++ b/src/base/video/video.c
@@ -93,7 +93,7 @@ static int no_real_terminal(void)
  * graphics.
  * code adapted from libdrm (drmCheckModesettingSupported)
  */
-int using_kms(void)
+static int using_kms(void)
 {
 #ifdef __linux__
     char pci_dev_dir[1024];
@@ -206,7 +206,7 @@ static int video_init(void)
       config.X = 1;	// for compatibility, to be removed
       config.X_fullscreen = 1;
       config.X_fixed_aspect = 0;
-//      config.console_keyb = KEYB_OTHER;
+      config.console_keyb = KEYB_OTHER;
       goto done;
     } else {
       error("failed to load sdl plugin\n");

--- a/src/dosemu
+++ b/src/dosemu
@@ -135,6 +135,7 @@ while [ $# -gt 0 ] ; do
       SUDOOPTS="-E --preserve-env=HOME,USER setpriv --no-new-privs"
       # sudo doesn't set SUDO_HOME but maybe it will - use another var
       export DOSEMU_SUDO_HOME="$HOME"
+      export DOSEMU_SUDO_TTY=`tty`
       ;;
     -no-priv-sep)
       shift

--- a/src/include/video.h
+++ b/src/include/video.h
@@ -147,6 +147,5 @@ enum {
 extern int load_file(const char *name, int foffset, unsigned char *mstart, int msize);
 extern void register_video_client(struct video_system *vid);
 extern struct video_system *video_get(const char *name);
-int using_kms(void);
 
 #endif

--- a/src/include/video.h
+++ b/src/include/video.h
@@ -147,5 +147,6 @@ enum {
 extern int load_file(const char *name, int foffset, unsigned char *mstart, int msize);
 extern void register_video_client(struct video_system *vid);
 extern struct video_system *video_get(const char *name);
+int using_kms(void);
 
 #endif

--- a/src/plugin/sdl/keyb_SDL.c
+++ b/src/plugin/sdl/keyb_SDL.c
@@ -24,7 +24,6 @@
 #include <string.h>
 
 #include "emu.h"
-#include "video.h"
 #include "keyboard/keyb_clients.h"
 #include "keyboard/keyboard.h"
 #include "keyboard/keynum.h"
@@ -165,9 +164,7 @@ void SDL_process_key_release(SDL_KeyboardEvent keyevent)
 
 static int sdl_kbd_probe(void)
 {
-	/* Under KMS this is incompatible with priv sep, as sdl
-	 * opens kbd nodes too late. */
-	return (config.sdl == 1 && !using_kms());
+	return (config.sdl == 1);
 }
 
 static int sdl_kbd_init(void)

--- a/src/plugin/sdl/sdl.c
+++ b/src/plugin/sdl/sdl.c
@@ -166,7 +166,6 @@ static int border_on;
 #define MODE_CLASS() ((current_mode_class == GRAPH || use_bitmap_font ) ? \
     GRAPH : TEXT)
 static SDL_Keycode mgrab_key = SDLK_HOME;
-static int sdl_subsy;
 
 #if SDL_VERSION_ATLEAST(2,26,0)
 #define CONFIG_SDL_SELECTION 1
@@ -245,10 +244,7 @@ static int SDL_early_init(void)
   fedisableexcept(FE_DIVBYZERO);
 #endif
 //  enter_priv_on();
-  sdl_subsy = SDL_INIT_VIDEO;
-  if (!using_kms())
-    sdl_subsy |= SDL_INIT_EVENTS;
-  ret = SDL_InitSubSystem(sdl_subsy);
+  ret = SDL_InitSubSystem(SDL_INIT_VIDEO | SDL_INIT_EVENTS);
 //  leave_priv_setting();
 #ifdef FE_NOMASK_ENV
   fesetenv(&dosemu_fenv);
@@ -484,7 +480,7 @@ static int SDL_init(void)
   return 0;
 
 err:
-  SDL_QuitSubSystem(sdl_subsy);
+  SDL_QuitSubSystem(SDL_INIT_VIDEO | SDL_INIT_EVENTS);
   return -1;
 }
 
@@ -523,7 +519,7 @@ void SDL_close(void)
 #endif
   rng_destroy(&rects_rng);
   SDL_DestroyWindow(window);
-  SDL_QuitSubSystem(sdl_subsy);
+  SDL_QuitSubSystem(SDL_INIT_VIDEO | SDL_INIT_EVENTS);
 }
 
 static void do_redraw(void)


### PR DESCRIPTION
sudo now uses pty, but it will support SUDO_TTY in the future. For now we can set DOSEMU_SUDO_TTY in a script.