### PR TITLE
CI: Ensure the output logfiles always exist

### DIFF
--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -659,6 +659,9 @@ class MyTestResult(unittest.TextTestResult):
             self.stream.flush()
         self.failures.append((test, self.gather_info_for_failure(err, test)))
         self._mirrorOutput = True
+        for _, l in test.logfiles.items():
+            if not l[0].is_file():
+                l[0].write_text("Failed before any output was received\n")
         if getattr(test, 'shouldStop', None) is not None:
             self.shouldStop = test.shouldStop
         if getattr(self, 'failfast', False):


### PR DESCRIPTION
Since the CI script tests the existence of the log files to establish if any tests failed, ensure that upon failure they are created if the test exited early.