### PR TITLE
CI: Move KVM and vm86 logic for cpu into class setup

### DIFF
--- a/ci_test_prereq.sh
+++ b/ci_test_prereq.sh
@@ -17,6 +17,7 @@ sudo apt update -q
 sudo apt install -y \
   acl \
   comcom64 \
+  cpu-checker \
   nasm \
   python3-cpuinfo \
   python3-pexpect \

--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -11,6 +11,7 @@ from hashlib import sha1
 from os import environ, rename
 from os.path import exists, join
 from pathlib import Path
+from platform import system, machine, release
 from ptyprocess import PtyProcessError
 from shutil import copy, rmtree
 from subprocess import (Popen, call, check_call, check_output,
@@ -154,6 +155,8 @@ class BaseTestCase(object):
 
         cls.logfiles = {}
         cls.msg = None
+        cls.have_kvm = False
+        cls.have_vm86 = False
 
     @classmethod
     def setUpClassPost(cls):
@@ -165,6 +168,18 @@ class BaseTestCase(object):
                 exit("\nUpdate tuple TEST_BINARIES for '%s'\n" % cls.prettyname)
             if not exists(join(BINSDIR, cls.tarfile)):
                 exit("\nMissing test binary file, please run again with argument --get-test-binaries\n")
+
+        if system() == 'Linux':
+            if machine() == 'i686':
+                cls.have_vm86 = True
+
+            try:
+                check_call(["kvm-ok",], stdout=DEVNULL)
+                major, minor = release().split('.')[0:2]
+                if not (major == '6' and minor in ['11', '12', '13']):
+                    cls.have_kvm = True
+            except CalledProcessError:
+                pass
 
     @classmethod
     def tearDownClass(cls):

--- a/test/func_cpu_methods.py
+++ b/test/func_cpu_methods.py
@@ -1,4 +1,4 @@
-from os import uname, environ, access, R_OK, W_OK
+from os import environ
 from shutil import copy
 from difflib import unified_diff
 
@@ -19,10 +19,10 @@ def _dotest(self, cpu_vm, cpu_vm_dpmi):
     if ('jit' in cpu_vm_dpmi) or ('sim' in cpu_vm_dpmi):
         cpu_vm_dpmi = 'emulated'
 
-    if ('kvm' in cpu_vm or 'kvm' in cpu_vm_dpmi) and not access("/dev/kvm", W_OK|R_OK):
+    if ('kvm' in cpu_vm or 'kvm' in cpu_vm_dpmi) and not self.have_kvm:
         self.skipTest("requires KVM")
 
-    if cpu_vm == 'native' and uname()[4] != 'i686':
+    if cpu_vm == 'native' and not self.have_vm86:
         self.skipTest("native vm86() only on 32bit x86")
 
     if cpu_vm_dpmi == 'native' and environ.get("SKIP_NATIVE_DPMI"):

--- a/test/func_cpu_trap_flag.py
+++ b/test/func_cpu_trap_flag.py
@@ -1,14 +1,13 @@
 import re
 
 from cpuinfo import get_cpu_info
-from os import access, R_OK, W_OK
 
 
 def cpu_trap_flag(self, cpu_vm):
     if cpu_vm not in ("kvm", "emulated"):
         raise ValueError('invalid argument')
 
-    if cpu_vm == "kvm" and not access("/dev/kvm", W_OK|R_OK):
+    if cpu_vm == "kvm" and not self.have_kvm:
         self.skipTest("requires KVM")
 
     config = """


### PR DESCRIPTION
Note: Avoids using KVM on kernels 6.11 -> 6.13