### PR TITLE
CI: FreeCOM test fix [#2484]

### DIFF
--- a/test/test_dosemu.py
+++ b/test/test_dosemu.py
@@ -4743,7 +4743,7 @@ $_floppy_a = ""
                 ], stderr=STDOUT, cwd=self.imagedir)
                 check_call([
                     "unzip",
-                    "-L",
+                    "-LL",
                     "-q",
                     str(self.imagedir) + '/%s.zip' % pkg,
                 ], stderr=STDOUT, cwd=self.workdir)


### PR DESCRIPTION
Force lowercase on DOS package install.
There seems to be a difference in how the DOS packages were produced this time as now the zip doesn't unpack in lowercase unless we force it so.