### PR TITLE
Fix use of echo and paste commands on MacOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -603,7 +603,7 @@ for i in $(echo $enable_plugins | tr ',' ' '); do
     fi
 done
 # remove duplicate entries
-PLUGINSUBDIRS=`echo $PLUGINSUBDIRS | tr ' ' '\n' | sort | uniq | paste -sd " "`
+PLUGINSUBDIRS=`echo $PLUGINSUBDIRS | tr ' ' '\n' | sort | uniq | paste -sd " " -`
 PLUGINS=`echo $PLUGINSUBDIRS | $SED 's/plugin\//\n\t/g'`
 
 X_PLU=`echo $PLUGINS | $SED 's/ /\n/g' | $EGREP -x 'X'`

--- a/default-configure
+++ b/default-configure
@@ -23,7 +23,7 @@ if [ ! -f $CONF_FILE ]; then
 fi
 
 CONF=`cat $CONF_FILE`
-CONF=`echo -n "$CONF"| sed '/^config {/d' | sed '/^}/d' | tr '\n' ' ' `
+CONF=`echo "$CONF"| sed '/^config {/d' | sed '/^}/d' | tr '\n' ' ' `
 
 SUFFIX=""
 while [ "$#" != "0" ]; do

--- a/etc/global.conf
+++ b/etc/global.conf
@@ -428,9 +428,9 @@ else
         $xxx_pref = strdel($xxxx, strchr($xxxx, "*"), 999);
         $xxx_suff = strsplit($xxxx, strchr($xxxx, "*") + 1, 999);
         if (strchr($xxx_pref, "/") == 0)
-          $xxxx = shell("cd '", $xxx_pref, "' 2>/dev/null && echo -n *")
+          $xxxx = shell("cd '", $xxx_pref, "' 2>/dev/null && printf '%s ' *")
         else
-          $xxxx = shell("cd '", $DOSEMU_IMAGE_DIR, "/", $xxx_pref, "' 2>/dev/null && echo -n *")
+          $xxxx = shell("cd '", $DOSEMU_IMAGE_DIR, "/", $xxx_pref, "' 2>/dev/null && printf '%s ' *")
         endif
         if ($DOSEMU_SHELL_RETURN)
           abort "**** directory ", $xxx_pref, " not accessible";

--- a/scripts/mkpluginhooks
+++ b/scripts/mkpluginhooks
@@ -20,7 +20,7 @@ gendummy() {
     if [ "$1" = "clean" ]; then
       rm -f $INC/$HDR
     else
-      echo -n "" >$INC/$HDR.$$
+      printf "" >$INC/$HDR.$$
     fi
   done
 }

--- a/src/base/init/parser.y
+++ b/src/base/init/parser.y
@@ -2524,7 +2524,7 @@ static void set_hdimage(struct disk *dptr, char *name)
 
   c_printf("Setting up hdimage %s\n", name);
   if (l && strlen(l) == 4) {
-    const char *tmpl = "eval echo -n `cat %s`";
+    const char *tmpl = "eval printf %%s \\\"`cat %s`\\\"";
     char *cmd, path[1024], *rname;
     FILE *f;
     size_t ret;


### PR DESCRIPTION
paste needs - for stdin; "echo -n" needs to be replaced by printf if needed.

Unlike in 3a315381243 I tested all cases now to make sure they work with * and eval when needed.