### PR TITLE
MacOS runtime fixes (locking, xattr, async signals, cpuinfo)

### DIFF
--- a/src/arch/linux/async/signal.c
+++ b/src/arch/linux/async/signal.c
@@ -772,7 +772,7 @@ static void SIGIO_call(void *arg){
 }
 #endif
 
-static void sigasync0(int sig)
+static int sigasync0(int sig)
 {
   pthread_t tid = pthread_self();
   if (!pthread_equal(tid, dosemu_pthread_self)) {
@@ -780,22 +780,28 @@ static void sigasync0(int sig)
     char name[128];
     pthread_getname_np(tid, name, sizeof(name));
     dosemu_error("Async signal %i from thread %s\n", sig, name);
+#elif defined(__APPLE__)
+    /* somehow SIGALRM often gets unblocked in threads on MacOS,
+       forwarding to main thread */
+    pthread_kill(dosemu_pthread_self, sig);
 #else
     dosemu_error("Async signal %i from thread\n", sig);
 #endif
+    return 0;
   }
+  return 1;
 }
 
 static void sigasync(int sig, siginfo_t *si, void *uc)
 {
-  sigasync0(sig);
-  if (sighandlers[sig])
+  if (sigasync0(sig) && sighandlers[sig])
 	  sighandlers[sig](si);
 }
 
 static void sigasync_std(int sig, siginfo_t *si, void *uc)
 {
-  sigasync0(sig);
+  if (!sigasync0(sig))
+    return;
   if (!asighandlers[sig]) {
     error("handler for sig %i not registered\n", sig);
     return;

--- a/src/base/init/config.c
+++ b/src/base/init/config.c
@@ -12,6 +12,9 @@
 #include <limits.h>
 #include <sys/utsname.h>
 #include <sys/stat.h>
+#ifdef __APPLE__
+#include <sys/sysctl.h>
+#endif
 
 #include "version.h"
 #include "emu.h"
@@ -812,6 +815,34 @@ void secure_option_preparse(int *argc, char **argv)
 
 static void read_cpu_info(void)
 {
+#ifdef __APPLE__
+    long long chz = 0;
+    int val;
+    size_t len = sizeof(val);
+    config.realcpu = CPU_586;
+    config.cpuprefetcht0 = 1;
+    config.umip = 0; /* only needed for KVM, not used on MacOS */
+    if (config.mathco) {
+      sysctlbyname("hw.optional.floatingpoint", &val, &len, NULL, 0);
+      config.mathco = val;
+    }
+#ifdef __i386__
+    /* 32-bit Intel Macs untested but here for completeness */
+    sysctlbyname("hw.optional.sse", &val, &len, NULL, 0);
+    config.cpusse = val;
+    config.cpufxsr = val;
+#endif
+    sysctlbyname("hw.ncpu", &val, &len, NULL, 0);
+    config.smp = val > 1 ? 1 : 0;
+    len = sizeof(chz);
+    sysctlbyname("machdep.tsc.frequency", &chz, &len, NULL, 0);
+    /* speed division factor to get 1us from CPU clock */
+    config.cpu_spd = (LLF_US*1000000)/chz;
+    /* speed division factor to get 838ns from CPU clock */
+    config.cpu_tick_spd = (LLF_TICKS*1000000)/chz;
+    config.CPUSpeedInMhz = (chz+500000)/1000000;
+    warn ("CPU-EMU speed is %d MHz\n",config.CPUSpeedInMhz);
+#else
     char *cpuflags, *cpu;
     int k = 3;
     int err;
@@ -921,6 +952,7 @@ static void read_cpu_info(void)
       config.smp = 1;		/* for checking overrides, later */
     }
     close_proc_scan();
+#endif
 }
 
 static void config_post_process(void)

--- a/src/dosext/mfs/rlocks.c
+++ b/src/dosext/mfs/rlocks.c
@@ -161,9 +161,13 @@ int region_lock_offs(int fd, long long start, unsigned long len, int wr)
   int ret;
 
   /* needs to lock against lock changes in another process */
+#ifndef __APPLE__
+  /* on MacOS this kind of lock is incompatible with F_OFD_GETLK,
+     which then sets l_pid to -1 */
   ret = flock(fd, LOCK_EX);
   if (ret)
     return -1;
+#endif
   fl.l_type = wr ? F_WRLCK : F_RDLCK;
   fl.l_start = start;
   fl.l_len = len;

--- a/src/dosext/mfs/xattr.c
+++ b/src/dosext/mfs/xattr.c
@@ -43,11 +43,15 @@
 #define fsetxattr(fd,name,value,size,flags) fsetxattr(fd,name,value,size,0,flags)
 #endif
 
+#ifndef ENOATTR
+#define ENOATTR ENODATA
+#endif
+
 static int do_extr_xattr(const char *xbuf, ssize_t size, const char *name)
 {
   if (size == -1) {
     int errn = errno;
-    if (errn == ENODATA)
+    if (errn == ENODATA || errn == ENOATTR)
       return 0;
     error("MFS: failed to get xattrs for %s, %s\n", name, strerror(errn));
     return -1;


### PR DESCRIPTION
With these fixes it runs smoothly for me in cpusim mode (`$_cpuemu = (1)`) without any startup complaints.
JIT still needs some fixes, mainly because MAP_32BIT doesn't work very well on MacOS.

The signal workaround is quite ugly I admit, I just kept getting `Async signal 14 from thread` where 14 is SIGALRM, even tough the threads should have SIGALRM masked. Maybe one can replace `setitimer` by an event timer these days and completely avoid SIGALRM. But then there's still SIGWINCH as well, and maybe some others.