### PR TITLE
simx86, JIT: Reduce linkdesc struct to only have taken/not-taken fields, cleanup with that

### DIFF
--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -3041,6 +3041,31 @@ static void NodeLinker(TNode *LG, TNode *G)
 #endif
 }
 
+static void unlinknode(TNode *G, linkdesc *T, char branch)
+{
+	if (!T->ref) return;
+
+	TNode *H = *T->ref;
+	backref *Bq = &H->bkr;
+	backref *B  = H->bkr.next;
+	if (debug_level('e')>2) e_printf("Unlink fwd %c ref to node %p(%08x)\n",
+					 branch, H, H->key);
+	while (B) {
+		if (*B->ref==G) {
+			Bq->next = B->next;
+			H->nrefs--;
+			free(B);
+			break;
+		}
+		Bq = B;
+		B = B->next;
+	}
+	if (B==NULL) {	// not found...
+		dbug_printf("Unlinker: FW %c ref error\n", branch);
+		leavedos_main(0x8111 + (branch == 'N'));
+	}
+	T->ref = NULL;
+}
 
 void NodeUnlinker(TNode *G)
 {
@@ -3065,36 +3090,29 @@ void NodeUnlinker(TNode *G)
 	    e_printf("Unlinker: bkr.next=%p\n",B);
 	while (B) {
 	    backref *b2 = B;
-	    if (B->branch=='T') {
+	    if (B->branch=='T' || B->branch=='N') {
 		TNode *H = *B->ref;
-		linkdesc *L = &H->clink_t;
-		if (debug_level('e')>2) e_printf("Unlinking T ref from node %p(%08x) to %08x\n",
-			H, L->target, G->key);
+		unsigned target_type;
+		linkdesc *L;
+		if (B->branch=='T') {
+			target_type = TARGET_T;
+			L = &H->clink_t;
+		}
+		else {
+			target_type = TARGET_NT;
+			L = &H->clink_nt;
+		}
+		if (debug_level('e')>2) e_printf("Unlinking %c ref from node %p(%08x) to %08x\n",
+			B->branch, H, L->target, G->key);
 		if (L->target != G->key) {
-		    dbug_printf("Unlinker: BK ref error t=%08x k=%08x\n",
-			L->target, G->key);
+		    dbug_printf("Unlinker: BK %c ref error t=%08x k=%08x\n",
+			B->branch, L->target, G->key);
 		    leavedos_main(0x8110);
 		}
 		lp = L->link;
 		((char *)lp)[-1] = 0xb8;
 		*lp = L->target;
-		L->ref = NULL; H->unlinked_jmp_targets |= TARGET_T;
-		G->nrefs--;
-	    }
-	    else if (B->branch=='N') {
-		TNode *H = *B->ref;
-		linkdesc *L = &H->clink_nt;
-		if (debug_level('e')>2) e_printf("Unlinking N ref from node %p(%08x) to %08x\n",
-			H, L->target, G->key);
-		if (L->target != G->key) {
-		    dbug_printf("Unlinker: BK ref error u=%08x k=%08x\n",
-			L->target, G->key);
-		    leavedos_main(0x8110);
-		}
-		lp = L->link;
-		((char *)lp)[-1] = 0xb8;
-		*lp = L->target;
-		L->ref = NULL; H->unlinked_jmp_targets |= TARGET_NT;
+		L->ref = NULL; H->unlinked_jmp_targets |= target_type;
 		G->nrefs--;
 	    }
 	    else {
@@ -3115,50 +3133,8 @@ void NodeUnlinker(TNode *G)
 	// nodes), which are backward refs for the other nodes
 	if (debug_level('e')>8)
 	    e_printf("Unlinker: refs=T%p N%p\n",T_t->ref,T_nt->ref);
-	if (T_t->ref) {
-	    TNode *Gt = *T_t->ref;
-	    backref *Btq = &Gt->bkr;
-	    backref *Bt  = Gt->bkr.next;
-	    if (debug_level('e')>2) e_printf("Unlink fwd T ref to node %p(%08x)\n",Gt,
-		Gt->key);
-	    while (Bt) {
-		if (*Bt->ref==G) {
-			Btq->next = Bt->next;
-			Gt->nrefs--;
-			free(Bt);
-			break;
-		}
-		Btq = Bt;
-		Bt = Bt->next;
-	    }
-	    if (Bt==NULL) {	// not found...
-		dbug_printf("Unlinker: FW T ref error\n");
-		leavedos_main(0x8111);
-	    }
-	    T_t->ref = NULL;
-	}
-	if (T_nt->ref) {
-	    TNode *Gn = *T_nt->ref;
-	    backref *Bnq = &Gn->bkr;
-	    backref *Bn  = Gn->bkr.next;
-	    if (debug_level('e')>2) e_printf("Unlink fwd N ref to node %p(%08x)\n",Gn,
-		Gn->key);
-	    while (Bn) {
-		if (*Bn->ref==G) {
-			Bnq->next = Bn->next;
-			Gn->nrefs--;
-			free(Bn);
-			break;
-		}
-		Bnq = Bn;
-		Bn = Bn->next;
-	    }
-	    if (Bn==NULL) {	// not found...
-		dbug_printf("Unlinker: FW N ref error\n");
-		leavedos_main(0x8112);
-	    }
-	    T_nt->ref = NULL;
-	}
+	unlinknode(G, T_t, 'T');
+	unlinknode(G, T_nt, 'N');
 	G->nrefs = 0;
 	memset(T_t, 0, sizeof(linkdesc));
 	memset(T_nt, 0, sizeof(linkdesc));

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -2948,7 +2948,7 @@ static void _nodeflagbackrefs(TNode *LG, unsigned short flags)
 	if ((LG->flags & flags) != flags) {
 	    /* only go as far back as long as flags change */
 	    LG->flags |= flags;
-	    for (B=LG->clink.bkr.next; B; B=B->next)
+	    for (B=LG->bkr.next; B; B=B->next)
 		_nodeflagbackrefs(*B->ref, flags);
 	}
 }
@@ -2956,7 +2956,6 @@ static void _nodeflagbackrefs(TNode *LG, unsigned short flags)
 static void NodeLinker(TNode *LG, TNode *G)
 {
 	unsigned int *lp;
-	linkdesc *T = &G->clink;
 	backref *B;
 #if PROFILE >= 2
 	hitimer_t t0 = 0;
@@ -2974,17 +2973,17 @@ static void NodeLinker(TNode *LG, TNode *G)
 
 	if (LG && (LG->alive>0)) {
 	    int ra;
-	    linkdesc *L = &LG->clink;
-	    if (L->unlinked_jmp_targets) {	// node ends with links
-		lp = L->t_link.abs;		// check 'taken' branch
-		if (L->t_target==G->key && (L->unlinked_jmp_targets & TARGET_T)) {	// points to current node?
-		    if (L->t_ref!=0) {
+	    linkdesc *L = &LG->clink_t;
+	    if (LG->unlinked_jmp_targets) {	// node ends with links
+		lp = L->link;			// check 'taken' branch
+		if (L->target==G->key && (LG->unlinked_jmp_targets & TARGET_T)) {	// points to current node?
+		    if (L->ref!=0) {
 			dbug_printf("Linker: t_ref at %08x busy\n",LG->key);
 			leavedos_main(0x8102);
 		    }
-		    L->unlinked_jmp_targets &= ~TARGET_T;
+		    LG->unlinked_jmp_targets &= ~TARGET_T;
 		    // b8 [npc] -> e9/eb reladr
-		    ra = G->addr - (unsigned char *)L->t_link.abs;
+		    ra = G->addr - (unsigned char *)L->link;
 		    if ((ra > -127) && (ra < 128)) {
 			ra -= 1; ((char *)lp)[-1] = 0xeb;
 		    }
@@ -2992,21 +2991,21 @@ static void NodeLinker(TNode *LG, TNode *G)
 			ra -= 4; ((char *)lp)[-1] = 0xe9;
 		    }
 		    *lp = ra;
-		    L->t_ref = &G->mblock->bkptr;
+		    L->ref = &G->mblock->bkptr;
 		    B = calloc(1,sizeof(backref));
 		    // head insertion
-		    B->next = T->bkr.next;
-		    T->bkr.next = B;
+		    B->next = G->bkr.next;
+		    G->bkr.next = B;
 		    B->ref = &LG->mblock->bkptr;
 		    B->branch = 'T';
-		    T->nrefs++;
+		    G->nrefs++;
 		    if (G==LG) {
 			G->flags |= F_SLFL;
 			if (debug_level('e')>1) {
 			    e_printf("Linker: node (%p:%08x:%p) SELF link\n"
 				"\t\tjmp %08x, target=%08x, t_ref %d=%p->%p\n",
 				G,G->key,G->addr,
-				ra, L->t_target, T->nrefs, L->t_ref, *L->t_ref);
+				ra, L->target, G->nrefs, L->ref, *L->ref);
 			}
 		    }
 		    else if (debug_level('e')>1) {
@@ -3015,10 +3014,10 @@ static void NodeLinker(TNode *LG, TNode *G)
 			    "\t\tjmp %08x, target=%08x, t_ref %d=%p->%p\n",
 			    LG,LG->key,LG->addr,
 			    G,G->key,G->addr,
-			    ra, L->t_target, T->nrefs, L->t_ref, *L->t_ref);
+			    ra, L->target, G->nrefs, L->ref, *L->ref);
 		    }
 		    _nodeflagbackrefs(LG, G->flags);
-		    if (debug_level('e')>8) { backref *bk = T->bkr.next;
+		    if (debug_level('e')>8) { backref *bk = G->bkr.next;
 #ifdef DEBUG_LINKER
 			if (bk==NULL) { dbug_printf("bkr null\n"); leavedos_main(0x8108); }
 #endif
@@ -3026,16 +3025,17 @@ static void NodeLinker(TNode *LG, TNode *G)
 			bk->ref,*bk->ref); bk=bk->next; }
 		    }
 		}
-		if (L->unlinked_jmp_targets & TARGET_NT) {  // if it has a 'not taken' link
-		    lp = L->nt_link.abs;	// check 'not taken' branch
-		    if (L->nt_target==G->key) {	// points to current node?
-			if (L->nt_ref!=0) {
+		if (LG->unlinked_jmp_targets & TARGET_NT) {  // if it has a 'not taken' link
+		    L = &LG->clink_nt;
+		    lp = L->link;		// check 'not taken' branch
+		    if (L->target==G->key) {	// points to current node?
+			if (L->ref!=0) {
 			    dbug_printf("Linker: nt_ref at %08x busy\n",LG->key);
 			    leavedos_main(0x8103);
 			}
-			L->unlinked_jmp_targets &= ~TARGET_NT;
+			LG->unlinked_jmp_targets &= ~TARGET_NT;
 			// b8 [npc] -> e9/eb reladr
-			ra = G->addr - (unsigned char *)L->nt_link.abs;
+			ra = G->addr - (unsigned char *)L->link;
 			if ((ra > -127) && (ra < 128)) {
 			    ra -= 1; ((char *)lp)[-1] = 0xeb;
 			}
@@ -3043,21 +3043,21 @@ static void NodeLinker(TNode *LG, TNode *G)
 			    ra -= 4; ((char *)lp)[-1] = 0xe9;
 			}
 			*lp = ra;
-			L->nt_ref = &G->mblock->bkptr;
+			L->ref = &G->mblock->bkptr;
 			B = calloc(1,sizeof(backref));
 			// head insertion
-			B->next = T->bkr.next;
-			T->bkr.next = B;
+			B->next = G->bkr.next;
+			G->bkr.next = B;
 			B->ref = &LG->mblock->bkptr;
 			B->branch = 'N';
-			T->nrefs++;
+			G->nrefs++;
 			if (G==LG) {
 			    G->flags |= F_SLFL;
 			    if (debug_level('e')>1) {
 				e_printf("Linker: node (%p:%08x:%p) SELF link\n"
 				"\t\tjmp %08x, target=%08x, nt_ref %d=%p->%p\n",
 				G,G->key,G->addr,
-				ra, L->nt_target, T->nrefs, L->nt_ref, *L->nt_ref);
+				ra, L->target, G->nrefs, L->ref, *L->ref);
 			    }
 			}
 			else if (debug_level('e')>1) {
@@ -3066,10 +3066,10 @@ static void NodeLinker(TNode *LG, TNode *G)
 				"\t\tjmp %08x, target=%08x, nt_ref %d=%p->%p\n",
 				LG,LG->key,LG->addr,
 				G,G->key,G->addr,
-				ra, L->nt_target, T->nrefs, L->nt_ref, *L->nt_ref);
+				ra, L->target, G->nrefs, L->ref, *L->ref);
 			}
 			_nodeflagbackrefs(LG, G->flags);
-			if (debug_level('e')>8) { backref *bk = T->bkr.next;
+			if (debug_level('e')>8) { backref *bk = G->bkr.next;
 #ifdef DEBUG_LINKER
 			    if (bk==NULL) { dbug_printf("bkr null\n"); leavedos_main(0x8109); }
 #endif
@@ -3089,8 +3089,9 @@ static void NodeLinker(TNode *LG, TNode *G)
 void NodeUnlinker(TNode *G)
 {
 	unsigned int *lp;
-	linkdesc *T = &G->clink;
-	backref *B = T->bkr.next;
+	linkdesc *T_t = &G->clink_t;
+	linkdesc *T_nt = &G->clink_nt;
+	backref *B = G->bkr.next;
 #if PROFILE >= 2
 	hitimer_t t0 = 0;
 #endif
@@ -3110,35 +3111,35 @@ void NodeUnlinker(TNode *G)
 	    backref *b2 = B;
 	    if (B->branch=='T') {
 		TNode *H = *B->ref;
-		linkdesc *L = &H->clink;
+		linkdesc *L = &H->clink_t;
 		if (debug_level('e')>2) e_printf("Unlinking T ref from node %p(%08x) to %08x\n",
-			H, L->t_target, G->key);
-		if (L->t_target != G->key) {
+			H, L->target, G->key);
+		if (L->target != G->key) {
 		    dbug_printf("Unlinker: BK ref error t=%08x k=%08x\n",
-			L->t_target, G->key);
+			L->target, G->key);
 		    leavedos_main(0x8110);
 		}
-		lp = L->t_link.abs;
+		lp = L->link;
 		((char *)lp)[-1] = 0xb8;
-		*lp = L->t_target;
-		L->t_ref = NULL; L->unlinked_jmp_targets |= TARGET_T;
-		T->nrefs--;
+		*lp = L->target;
+		L->ref = NULL; H->unlinked_jmp_targets |= TARGET_T;
+		G->nrefs--;
 	    }
 	    else if (B->branch=='N') {
 		TNode *H = *B->ref;
-		linkdesc *L = &H->clink;
+		linkdesc *L = &H->clink_nt;
 		if (debug_level('e')>2) e_printf("Unlinking N ref from node %p(%08x) to %08x\n",
-			H, L->nt_target, G->key);
-		if (L->nt_target != G->key) {
+			H, L->target, G->key);
+		if (L->target != G->key) {
 		    dbug_printf("Unlinker: BK ref error u=%08x k=%08x\n",
-			L->nt_target, G->key);
+			L->target, G->key);
 		    leavedos_main(0x8110);
 		}
-		lp = L->nt_link.abs;
+		lp = L->link;
 		((char *)lp)[-1] = 0xb8;
-		*lp = L->nt_target;
-		L->nt_ref = NULL; L->unlinked_jmp_targets |= TARGET_NT;
-		T->nrefs--;
+		*lp = L->target;
+		L->ref = NULL; H->unlinked_jmp_targets |= TARGET_NT;
+		G->nrefs--;
 	    }
 	    else {
 		e_printf("Invalid unlink [%c] ref %p from node ?(?) to %08x\n",
@@ -3149,7 +3150,7 @@ void NodeUnlinker(TNode *G)
 	    free(b2);
 	}
 
-	if (T->nrefs) {
+	if (G->nrefs) {
 	    dbug_printf("Unlinker: nrefs error\n");
 	    leavedos_main(0x8115);
 	}
@@ -3157,17 +3158,17 @@ void NodeUnlinker(TNode *G)
 	// unlink forward references (from the current node to other
 	// nodes), which are backward refs for the other nodes
 	if (debug_level('e')>8)
-	    e_printf("Unlinker: refs=T%p N%p\n",T->t_ref,T->nt_ref);
-	if (T->t_ref) {
-	    TNode *Gt = *T->t_ref;
-	    backref *Btq = &Gt->clink.bkr;
-	    backref *Bt  = Gt->clink.bkr.next;
+	    e_printf("Unlinker: refs=T%p N%p\n",T_t->ref,T_nt->ref);
+	if (T_t->ref) {
+	    TNode *Gt = *T_t->ref;
+	    backref *Btq = &Gt->bkr;
+	    backref *Bt  = Gt->bkr.next;
 	    if (debug_level('e')>2) e_printf("Unlink fwd T ref to node %p(%08x)\n",Gt,
 		Gt->key);
 	    while (Bt) {
 		if (*Bt->ref==G) {
 			Btq->next = Bt->next;
-			Gt->clink.nrefs--;
+			Gt->nrefs--;
 			free(Bt);
 			break;
 		}
@@ -3178,18 +3179,18 @@ void NodeUnlinker(TNode *G)
 		dbug_printf("Unlinker: FW T ref error\n");
 		leavedos_main(0x8111);
 	    }
-	    T->t_ref = NULL;
+	    T_t->ref = NULL;
 	}
-	if (T->nt_ref) {
-	    TNode *Gn = *T->nt_ref;
-	    backref *Bnq = &Gn->clink.bkr;
-	    backref *Bn  = Gn->clink.bkr.next;
+	if (T_nt->ref) {
+	    TNode *Gn = *T_nt->ref;
+	    backref *Bnq = &Gn->bkr;
+	    backref *Bn  = Gn->bkr.next;
 	    if (debug_level('e')>2) e_printf("Unlink fwd N ref to node %p(%08x)\n",Gn,
 		Gn->key);
 	    while (Bn) {
 		if (*Bn->ref==G) {
 			Bnq->next = Bn->next;
-			Gn->clink.nrefs--;
+			Gn->nrefs--;
 			free(Bn);
 			break;
 		}
@@ -3200,9 +3201,13 @@ void NodeUnlinker(TNode *G)
 		dbug_printf("Unlinker: FW N ref error\n");
 		leavedos_main(0x8112);
 	    }
-	    T->nt_ref = NULL;
+	    T_nt->ref = NULL;
 	}
-	memset(T, 0, sizeof(linkdesc));
+	G->nrefs = 0;
+	memset(T_t, 0, sizeof(linkdesc));
+	memset(T_nt, 0, sizeof(linkdesc));
+	G->unlinked_jmp_targets = 0;
+	memset(&G->bkr, 0, sizeof(backref));
 #if PROFILE >= 2
 	if (debug_level('e')) LinkTime += (GETTSC() - t0);
 #endif
@@ -3519,9 +3524,9 @@ unsigned int Exec_x86_fast(TNode *G)
 	do {
 		ePC = Exec_x86_asm(&mem_ref, &flg, ecpu, G->addr);
 		if (G->alive > 0 && LastXNode && LastXNode->alive > 0) {
-			if (LastXNode->clink.unlinked_jmp_targets &&
-			    (LastXNode->clink.t_target == G->key ||
-			     LastXNode->clink.nt_target == G->key))
+			if (LastXNode->unlinked_jmp_targets &&
+			    (LastXNode->clink_t.target == G->key ||
+			     LastXNode->clink_nt.target == G->key))
 				NodeLinker(LastXNode, G);
 			LastXNode = G;
 		}

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -2953,10 +2953,71 @@ static void _nodeflagbackrefs(TNode *LG, unsigned short flags)
 	}
 }
 
+static void linknode(TNode *LG, TNode *G, linkdesc *L, unsigned target_type)
+{
+	backref *B;
+	int ra;
+	unsigned int *lp = L->link;		// check 'taken' branch
+
+	// points to current node?
+	if (L->target!=G->key || !(LG->unlinked_jmp_targets & target_type))
+		return;
+
+	if (L->ref!=0) {
+		dbug_printf("Linker: ref at %08x busy\n",LG->key);
+		leavedos_main(0x8102 + (target_type == TARGET_NT));
+	}
+	LG->unlinked_jmp_targets &= ~target_type;
+	// b8 [npc] -> e9/eb reladr
+	ra = G->addr - (unsigned char *)L->link;
+	if ((ra > -127) && (ra < 128)) {
+		ra -= 1; ((char *)lp)[-1] = 0xeb;
+	}
+	else {
+		ra -= 4; ((char *)lp)[-1] = 0xe9;
+	}
+	*lp = ra;
+	L->ref = &G->mblock->bkptr;
+	B = calloc(1,sizeof(backref));
+	// head insertion
+	B->next = G->bkr.next;
+	G->bkr.next = B;
+	B->ref = &LG->mblock->bkptr;
+	B->branch = target_type == TARGET_T ? 'T' : 'N';
+	G->nrefs++;
+	if (G==LG) {
+		G->flags |= F_SLFL;
+		if (debug_level('e')>1) {
+			e_printf("Linker: node (%p:%08x:%p) SELF link\n"
+				 "\t\tjmp %08x, target=%08x, %c_ref %d=%p->%p\n",
+				 G,G->key,G->addr,
+				 ra, L->target, B->branch, G->nrefs, L->ref, *L->ref);
+		}
+	}
+	else if (debug_level('e')>1) {
+		e_printf("Linker: previous node (%p:%08x:%p)\n"
+			 "\t\tlinked to (%p:%08x:%p)\n"
+			 "\t\tjmp %08x, target=%08x, %c_ref %d=%p->%p\n",
+			 LG,LG->key,LG->addr,
+			 G,G->key,G->addr,
+			 ra, L->target, B->branch, G->nrefs, L->ref, *L->ref);
+	}
+	_nodeflagbackrefs(LG, G->flags);
+	if (debug_level('e')>8) {
+		backref *bk = G->bkr.next;
+#ifdef DEBUG_LINKER
+		if (bk==NULL) {
+			dbug_printf("bkr null\n");
+			leavedos_main(0x8108 + (target_type == TARGET_NT));
+		}
+#endif
+		while (bk) { dbug_printf("bkref=%c%p->%p\n",bk->branch,
+			bk->ref,*bk->ref); bk=bk->next; }
+	}
+}
+
 static void NodeLinker(TNode *LG, TNode *G)
 {
-	unsigned int *lp;
-	backref *B;
 #if PROFILE >= 2
 	hitimer_t t0 = 0;
 #endif
@@ -2971,114 +3032,9 @@ static void NodeLinker(TNode *LG, TNode *G)
 #endif
 	if (debug_level('e')>8 && LG) e_printf("NodeLinker: %08x->%08x\n",LG->key,G->key);
 
-	if (LG && (LG->alive>0)) {
-	    int ra;
-	    linkdesc *L = &LG->clink_t;
-	    if (LG->unlinked_jmp_targets) {	// node ends with links
-		lp = L->link;			// check 'taken' branch
-		if (L->target==G->key && (LG->unlinked_jmp_targets & TARGET_T)) {	// points to current node?
-		    if (L->ref!=0) {
-			dbug_printf("Linker: t_ref at %08x busy\n",LG->key);
-			leavedos_main(0x8102);
-		    }
-		    LG->unlinked_jmp_targets &= ~TARGET_T;
-		    // b8 [npc] -> e9/eb reladr
-		    ra = G->addr - (unsigned char *)L->link;
-		    if ((ra > -127) && (ra < 128)) {
-			ra -= 1; ((char *)lp)[-1] = 0xeb;
-		    }
-		    else {
-			ra -= 4; ((char *)lp)[-1] = 0xe9;
-		    }
-		    *lp = ra;
-		    L->ref = &G->mblock->bkptr;
-		    B = calloc(1,sizeof(backref));
-		    // head insertion
-		    B->next = G->bkr.next;
-		    G->bkr.next = B;
-		    B->ref = &LG->mblock->bkptr;
-		    B->branch = 'T';
-		    G->nrefs++;
-		    if (G==LG) {
-			G->flags |= F_SLFL;
-			if (debug_level('e')>1) {
-			    e_printf("Linker: node (%p:%08x:%p) SELF link\n"
-				"\t\tjmp %08x, target=%08x, t_ref %d=%p->%p\n",
-				G,G->key,G->addr,
-				ra, L->target, G->nrefs, L->ref, *L->ref);
-			}
-		    }
-		    else if (debug_level('e')>1) {
-			e_printf("Linker: previous node (%p:%08x:%p)\n"
-			    "\t\tlinked to (%p:%08x:%p)\n"
-			    "\t\tjmp %08x, target=%08x, t_ref %d=%p->%p\n",
-			    LG,LG->key,LG->addr,
-			    G,G->key,G->addr,
-			    ra, L->target, G->nrefs, L->ref, *L->ref);
-		    }
-		    _nodeflagbackrefs(LG, G->flags);
-		    if (debug_level('e')>8) { backref *bk = G->bkr.next;
-#ifdef DEBUG_LINKER
-			if (bk==NULL) { dbug_printf("bkr null\n"); leavedos_main(0x8108); }
-#endif
-			while (bk) { dbug_printf("bkref=%c%p->%p\n",bk->branch,
-			bk->ref,*bk->ref); bk=bk->next; }
-		    }
-		}
-		if (LG->unlinked_jmp_targets & TARGET_NT) {  // if it has a 'not taken' link
-		    L = &LG->clink_nt;
-		    lp = L->link;		// check 'not taken' branch
-		    if (L->target==G->key) {	// points to current node?
-			if (L->ref!=0) {
-			    dbug_printf("Linker: nt_ref at %08x busy\n",LG->key);
-			    leavedos_main(0x8103);
-			}
-			LG->unlinked_jmp_targets &= ~TARGET_NT;
-			// b8 [npc] -> e9/eb reladr
-			ra = G->addr - (unsigned char *)L->link;
-			if ((ra > -127) && (ra < 128)) {
-			    ra -= 1; ((char *)lp)[-1] = 0xeb;
-			}
-			else {
-			    ra -= 4; ((char *)lp)[-1] = 0xe9;
-			}
-			*lp = ra;
-			L->ref = &G->mblock->bkptr;
-			B = calloc(1,sizeof(backref));
-			// head insertion
-			B->next = G->bkr.next;
-			G->bkr.next = B;
-			B->ref = &LG->mblock->bkptr;
-			B->branch = 'N';
-			G->nrefs++;
-			if (G==LG) {
-			    G->flags |= F_SLFL;
-			    if (debug_level('e')>1) {
-				e_printf("Linker: node (%p:%08x:%p) SELF link\n"
-				"\t\tjmp %08x, target=%08x, nt_ref %d=%p->%p\n",
-				G,G->key,G->addr,
-				ra, L->target, G->nrefs, L->ref, *L->ref);
-			    }
-			}
-			else if (debug_level('e')>1) {
-			    e_printf("Linker: previous node (%p:%08x:%p)\n"
-				"\t\tlinked to (%p:%08x:%p)\n"
-				"\t\tjmp %08x, target=%08x, nt_ref %d=%p->%p\n",
-				LG,LG->key,LG->addr,
-				G,G->key,G->addr,
-				ra, L->target, G->nrefs, L->ref, *L->ref);
-			}
-			_nodeflagbackrefs(LG, G->flags);
-			if (debug_level('e')>8) { backref *bk = G->bkr.next;
-#ifdef DEBUG_LINKER
-			    if (bk==NULL) { dbug_printf("bkr null\n"); leavedos_main(0x8109); }
-#endif
-				while (bk) { dbug_printf("bkref=%c%p->%p\n",bk->branch,
-				bk->ref,*bk->ref); bk=bk->next; }
-			}
-		    }
-		}
-	    }
+	if (LG && LG->alive>0 && LG->unlinked_jmp_targets) {	// node ends with links
+		linknode(LG, G, &LG->clink_t, TARGET_T);
+		linknode(LG, G, &LG->clink_nt, TARGET_NT);
 	}
 #if PROFILE >= 2
 	if (debug_level('e')) LinkTime += (GETTSC() - t0);

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -387,7 +387,11 @@ static void avltr_delete(const int key)
 	    t->mblock->bkptr = t;
 	    s->addr = NULL;
 	    s->mblock = NULL;
-	    memset(&s->clink, 0, sizeof(linkdesc));
+	    s->nrefs = 0;
+	    memset(&s->clink_t, 0, sizeof(linkdesc));
+	    memset(&s->clink_nt, 0, sizeof(linkdesc));
+	    s->unlinked_jmp_targets = 0;
+	    memset(&s->bkr, 0, sizeof(backref));
 	    s->key = 0;
 
 	    if (s->rtag == PLUS) r->link[0] = s->link[1];
@@ -402,15 +406,15 @@ static void avltr_delete(const int key)
   if (debug_level('e')>2) e_printf("Remove node %p\n",p);
 #endif
 #ifdef DEBUG_LINKER
-	if (p->clink.nrefs) {
-	    dbug_printf("Cannot delete - nrefs=%d\n",p->clink.nrefs);
+	if (p->nrefs) {
+	    dbug_printf("Cannot delete - nrefs=%d\n",p->nrefs);
 	    leavedos_main(0x9140);
 	}
-	if (p->clink.bkr.next) {
+	if (p->bkr.next) {
 	    dbug_printf("Cannot delete - bkr busy\n");
 	    leavedos_main(0x9141);
 	}
-	if (p->clink.t_ref || p->clink.nt_ref) {
+	if (p->clink_t.ref || p->clink_nt.ref) {
 	    dbug_printf("Cannot delete - ref busy\n");
 	    leavedos_main(0x9142);
 	}
@@ -596,7 +600,7 @@ void avltr_destroy(void)
 		  p = p->link[1];
 		  break;
 	      }
-	      B = p->clink.bkr.next;
+	      B = p->bkr.next;
 	      while (B) {
 		  backref *B2 = B;
 		  B = B->next;
@@ -995,27 +999,27 @@ TNode *Move2Tree(IMeta *I0, CodeBuf *GenCodeBuf)
   nG->addr = (unsigned char *)&mallmb->meta[nap];
 
   /* setup structures for inter-node linking */
-  nG->clink.unlinked_jmp_targets = 0;
+  nG->unlinked_jmp_targets = 0;
   op = I0[CurrIMeta-1].gen[I0[CurrIMeta-1].ngen-1].op;
   if (op >= JMP_LINK) {
-    nG->clink.t_link.abs = (unsigned int *)(nG->addr + nG->len - TAILSIZE + TAILFIX);
-    nG->clink.t_target = *nG->clink.t_link.abs;
-    nG->clink.unlinked_jmp_targets |= TARGET_T;
+    nG->clink_t.link = (unsigned int *)(nG->addr + nG->len - TAILSIZE + TAILFIX);
+    nG->clink_t.target = *nG->clink_t.link;
+    nG->unlinked_jmp_targets |= TARGET_T;
   }
   else
-    nG->clink.t_link.abs = NULL;
+    nG->clink_t.link = NULL;
   if (op > JMP_LINK) {
-    nG->clink.nt_link.abs = (unsigned int *)
+    nG->clink_nt.link = (unsigned int *)
       (nG->addr + nG->len - 2*TAILSIZE + TAILFIX - (op == JB_LINK ? CKSIGNSIZE : 0));
-    nG->clink.nt_target = *nG->clink.nt_link.abs;
-    nG->clink.unlinked_jmp_targets |= TARGET_NT;
+    nG->clink_nt.target = *nG->clink_nt.link;
+    nG->unlinked_jmp_targets |= TARGET_NT;
   }
   else
-    nG->clink.nt_link.abs = 0;
+    nG->clink_nt.link = 0;
   if ((debug_level('e')>3) && op >= JMP_LINK)
 	dbug_printf("Link %d: %p:%08x\n",op,
-		nG->clink.nt_link.abs,
-		(op>JMP_LINK? *nG->clink.nt_link.abs:0));
+		nG->clink_nt.link,
+		(op>JMP_LINK? *nG->clink_nt.link:0));
 
   /* setup source/xlated instruction offsets */
   ap = nG->pmeta;

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -664,14 +664,54 @@ unsigned int FindPC(unsigned char *addr)
 
 #ifdef DEBUG_LINKER
 
+static void checklink(const TNode *G, const linkdesc *L, char branch)
+{
+  if (!L->link) return;
+
+  const unsigned char *p = ((unsigned char *)L->link) - 1;
+  if (L->ref) {
+	    const TNode *GL = *L->ref;
+	    if (debug_level('e')>5)
+		e_printf("  %c: ref=%p link=%p\n",
+			 branch,GL,L->link);
+	    if ((*p!=0xe9)&&(*p!=0xeb)) {
+		error("bad %c link jmp\n", branch); goto nquit;
+	    }
+	    if (debug_level('e')>5)
+		e_printf("  %c: links to %p at %08x with jmp %08x\n",branch,GL,GL->key,
+		*L->link);
+	    const backref *B = GL->bkr.next;
+	    if ((B==NULL) || (GL->nrefs < 1)) {
+		error("bad backref B=%p n=%d\n",B,GL->nrefs);
+		goto nquit;
+	    }
+	    int n = 0;
+	    int brt = 0;
+	    while (B) {
+		if (B->ref==&G->mblock->bkptr) {
+		    n++;
+		    brt += B->branch;
+		    if (debug_level('e')>5) e_printf("  %c: backref %d from %p\n",branch,n,GL);
+		}
+		B = B->next;
+	    }
+	    if (n < 1 || n > 2 || (n == 2 && brt != 'N' + 'T')) {
+		error("0 or >1 backrefs1 (%i)\n", n); goto nquit;
+	    }
+  }
+  else {
+	    if (*p!=0xb8) {
+		error("bad %c link jmp\n", branch); goto nquit;
+	    }
+  }
+  return;
+nquit:
+  leavedos_main(0x9143);
+}
+
 static void CheckLinks(void)
 {
   TNode *G = &CollectTree.root;
-  TNode *GL;
-  unsigned char *p;
-  linkdesc *L;
-  backref *B;
-  int n, brt;
 
   for (;;) {
     /* walk to next node */
@@ -689,88 +729,12 @@ static void CheckLinks(void)
 	continue;
     }
     if (debug_level('e')>5) e_printf("Node %p at %08x selfr=%p\n",G,G->key,
-    	G->mblock->bkptr);
+	G->mblock->bkptr);
     if (G->mblock->bkptr != G) {
 	error("bad selfref\n"); goto nquit;
     }
-    L = &G->clink_t;
-    if (L->link) {
-	if (L->ref) {
-	    GL = *L->ref;
-	    if (debug_level('e')>5)
-		e_printf("  T: ref=%p link=%p\n",
-		    GL,L->link);
-	    p = ((unsigned char *)L->link) - 1;
-	    if ((*p!=0xe9)&&(*p!=0xeb)) {
-		error("bad t_link jmp\n"); goto nquit;
-	    }
-	    if (debug_level('e')>5)
-		e_printf("  T: links to %p at %08x with jmp %08x\n",GL,GL->key,
-		*L->link);
-	    B = GL->bkr.next;
-	    if ((B==NULL) || (GL->nrefs < 1)) {
-		error("bad backref B=%p n=%d\n",B,GL->nrefs);
-		goto nquit;
-	    }
-	    n = 0;
-	    brt = 0;
-	    while (B) {
-		if (B->ref==&G->mblock->bkptr) {
-		    n++;
-		    brt += B->branch;
-		    if (debug_level('e')>5) e_printf("  T: backref %d from %p\n",n,GL);
-		}
-		B = B->next;
-	    }
-	    if (n < 1 || n > 2 || (n == 2 && brt != 'N' + 'T')) {
-		error("0 or >1 backrefs1 (%i)\n", n); goto nquit;
-	    }
-	}
-	else {
-	    p = ((unsigned char *)L->link) - 1;
-	    if (*p!=0xb8) {
-		error("bad t_link jmp\n"); goto nquit;
-	    }
-	}
-	L = &G->clink_nt;
-	if (L->ref) {
-	    GL = *L->ref;
-	    if (debug_level('e')>5)
-		e_printf("  N: ref=%p link=%p\n",
-		    GL,L->link);
-	    p = ((unsigned char *)L->link) - 1;
-	    if ((*p!=0xe9)&&(*p!=0xeb)) {
-		error("bad nt_link jmp\n"); goto nquit;
-	    }
-	    if (debug_level('e')>5)
-		e_printf("  N: links to %p at %08x with jmp %08x\n",GL,GL->key,
-		*L->link);
-	    B = GL->bkr.next;
-	    if ((B==NULL) || (GL->nrefs < 1)) {
-		error("bad backref B=%p n=%d\n",B,GL->nrefs);
-		goto nquit;
-	    }
-	    n = 0;
-	    brt = 0;
-	    while (B) {
-		if (B->ref==&G->mblock->bkptr) {
-		    n++;
-		    brt += B->branch;
-		    if (debug_level('e')>5) e_printf("  N: backref %d from %p\n",n,GL);
-		}
-		B = B->next;
-	    }
-	    if (n < 1 || n > 2 || (n == 2 && brt != 'N' + 'T')) {
-		error("0 or >1 backrefs2 (%i)\n", n); goto nquit;
-	    }
-	}
-	else if (L->link) {
-	    p = ((unsigned char *)L->link) - 1;
-	    if (*p!=0xb8) {
-		error("bad nt_link jmp\n"); goto nquit;
-	    }
-	}
-    }
+    checklink(G, &G->clink_t, 'T');
+    checklink(G, &G->clink_nt, 'N');
   }
 nquit:
   leavedos_main(0x9143);

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -79,6 +79,10 @@ int NodesNotFound = 0;
 int TreeCleanups = 0;
 #endif
 
+#ifdef DEBUG_TREE
+static void DumpTree (FILE *fd);
+#endif
+
 #define FINDTREE_CACHE_HASH_MASK 0xfff
 static TNode *findtree_cache[FINDTREE_CACHE_HASH_MASK+1];
 static pthread_mutex_t cache_mtx = PTHREAD_MUTEX_INITIALIZER;
@@ -776,7 +780,7 @@ nquit:
 
 #ifdef DEBUG_TREE
 
-void DumpTree (FILE *fd)
+static void DumpTree (FILE *fd)
 {
   TNode *G = &CollectTree.root;
   linkdesc *L;
@@ -807,18 +811,19 @@ void DumpTree (FILE *fd)
 		G->bal,G->cache,G->pad,G->rtag);
     fprintf(fd,"     source:     instr=%d, len=%#x\n",G->seqnum,G->seqlen);
     fprintf(fd,"     translated: len=%#x\n",G->len);
-    L = &G->clink;
-    fprintf(fd,"     LINK type=%d refs=%d\n",L->t_type,L->nrefs);
-    if (L->t_type >= JMP_LINK) {
-	fprintf(fd,"         T ref=%p patch=%08x at %p\n",L->t_ref,
-		L->t_undo,L->t_link.abs);
-	if (L->t_type>JMP_LINK) {
-	    fprintf(fd,"         N ref=%p patch=%08x at %p\n",L->nt_ref,
-		L->nt_undo,L->nt_link.abs);
+    L = &G->clink_t;
+    fprintf(fd,"     LINK refs=%d\n",G->nrefs);
+    if (L->link) {
+	fprintf(fd,"         T ref=%p patch=%08x at %p\n",L->ref,
+		L->target,L->link);
+	L = &G->clink_nt;
+	if (L->link) {
+	    fprintf(fd,"         N ref=%p patch=%08x at %p\n",L->ref,
+		L->target,L->link);
 	}
     }
-    if (L->nrefs) {
-	B = L->bkr.next;
+    if (G->nrefs) {
+	B = G->bkr.next;
 	while (B) {
 	    fprintf(fd,"         bkref %c -> %p\n",B->branch,B->ref);
 	    B = B->next;

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -997,12 +997,10 @@ TNode *Move2Tree(IMeta *I0, CodeBuf *GenCodeBuf)
   /* setup structures for inter-node linking */
   nG->clink.unlinked_jmp_targets = 0;
   op = I0[CurrIMeta-1].gen[I0[CurrIMeta-1].ngen-1].op;
-  if (op != JMP_INDIRECT) {
+  if (op >= JMP_LINK) {
     nG->clink.t_link.abs = (unsigned int *)(nG->addr + nG->len - TAILSIZE + TAILFIX);
-    if (op >= JMP_LINK) {
-      nG->clink.t_target = *nG->clink.t_link.abs;
-      nG->clink.unlinked_jmp_targets |= TARGET_T;
-    }
+    nG->clink.t_target = *nG->clink.t_link.abs;
+    nG->clink.unlinked_jmp_targets |= TARGET_T;
   }
   else
     nG->clink.t_link.abs = NULL;

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -665,7 +665,7 @@ static void CheckLinks(void)
   TNode *G = &CollectTree.root;
   TNode *GL;
   unsigned char *p;
-  linkdesc *L, *T;
+  linkdesc *L;
   backref *B;
   int n, brt;
 
@@ -689,24 +689,23 @@ static void CheckLinks(void)
     if (G->mblock->bkptr != G) {
 	error("bad selfref\n"); goto nquit;
     }
-    L = &G->clink;
-    if (L->t_type >= JMP_LINK) {
-	if (L->t_ref) {
-	    GL = *L->t_ref;
+    L = &G->clink_t;
+    if (L->link) {
+	if (L->ref) {
+	    GL = *L->ref;
 	    if (debug_level('e')>5)
 		e_printf("  T: ref=%p link=%p\n",
-		    GL,L->t_link.abs);
-	    p = ((unsigned char *)L->t_link.abs) - 1;
+		    GL,L->link);
+	    p = ((unsigned char *)L->link) - 1;
 	    if ((*p!=0xe9)&&(*p!=0xeb)) {
 		error("bad t_link jmp\n"); goto nquit;
 	    }
 	    if (debug_level('e')>5)
 		e_printf("  T: links to %p at %08x with jmp %08x\n",GL,GL->key,
-		*L->t_link.abs);
-	    T = &GL->clink;
-	    B = T->bkr.next;
-	    if ((B==NULL) || (T->nrefs < 1)) {
-		error("bad backref B=%p n=%d\n",B,T->nrefs);
+		*L->link);
+	    B = GL->bkr.next;
+	    if ((B==NULL) || (GL->nrefs < 1)) {
+		error("bad backref B=%p n=%d\n",B,GL->nrefs);
 		goto nquit;
 	    }
 	    n = 0;
@@ -724,27 +723,27 @@ static void CheckLinks(void)
 	    }
 	}
 	else {
-	    p = ((unsigned char *)L->t_link.abs) - 1;
+	    p = ((unsigned char *)L->link) - 1;
 	    if (*p!=0xb8) {
 		error("bad t_link jmp\n"); goto nquit;
 	    }
 	}
-	if (L->nt_ref) {
-	    GL = *L->nt_ref;
+	L = &G->clink_nt;
+	if (L->ref) {
+	    GL = *L->ref;
 	    if (debug_level('e')>5)
 		e_printf("  N: ref=%p link=%p\n",
-		    GL,L->nt_link.abs);
-	    p = ((unsigned char *)L->nt_link.abs) - 1;
+		    GL,L->link);
+	    p = ((unsigned char *)L->link) - 1;
 	    if ((*p!=0xe9)&&(*p!=0xeb)) {
 		error("bad nt_link jmp\n"); goto nquit;
 	    }
 	    if (debug_level('e')>5)
 		e_printf("  N: links to %p at %08x with jmp %08x\n",GL,GL->key,
-		*L->nt_link.abs);
-	    T = &GL->clink;
-	    B = T->bkr.next;
-	    if ((B==NULL) || (T->nrefs < 1)) {
-		error("bad backref B=%p n=%d\n",B,T->nrefs);
+		*L->link);
+	    B = GL->bkr.next;
+	    if ((B==NULL) || (GL->nrefs < 1)) {
+		error("bad backref B=%p n=%d\n",B,GL->nrefs);
 		goto nquit;
 	    }
 	    n = 0;
@@ -761,8 +760,8 @@ static void CheckLinks(void)
 		error("0 or >1 backrefs2 (%i)\n", n); goto nquit;
 	    }
 	}
-	else if (L->nt_link.abs) {
-	    p = ((unsigned char *)L->nt_link.abs) - 1;
+	else if (L->link) {
+	    p = ((unsigned char *)L->link) - 1;
 	    if (*p!=0xb8) {
 		error("bad nt_link jmp\n"); goto nquit;
 	    }

--- a/src/base/emu-i386/simx86/trees.h
+++ b/src/base/emu-i386/simx86/trees.h
@@ -59,17 +59,9 @@ typedef struct _bkref {
 #define TARGET_NT 2
 
 typedef struct _lnkdesc {
-	unsigned short nrefs;
-	union {
-		unsigned int *abs;
-	} t_link;
-	union {
-		unsigned int *abs;
-	} nt_link;
-	unsigned int t_target, nt_target;
-	unsigned unlinked_jmp_targets;
-	struct avltr_node **t_ref, **nt_ref;
-	backref bkr;
+	unsigned int *link;
+	unsigned int target;
+	struct avltr_node **ref;
 } linkdesc;
 
 typedef struct _imgen {
@@ -130,7 +122,11 @@ typedef struct avltr_node
 	Addr2Pc *pmeta;
 	unsigned short len, flags, seqlen, seqnum __attribute__ ((packed));
 	int seqbase;
-	linkdesc clink;
+	unsigned short nrefs;
+	linkdesc clink_t;
+	linkdesc clink_nt;
+	unsigned unlinked_jmp_targets;
+	backref bkr;
 	unsigned cs;
 	unsigned mode;
 } TNode;

--- a/src/base/emu-i386/simx86/trees.h
+++ b/src/base/emu-i386/simx86/trees.h
@@ -161,4 +161,8 @@ unsigned int FindPC(unsigned char *addr);
 int InvalidateNodeRange(int addr, int len, unsigned char *eip);
 #endif
 
+#ifdef DEBUG_TREE
+extern FILE *tLog;
+#endif
+
 #endif


### PR DESCRIPTION
Some almost-duplicate code in the node linker/unlinker, and link checker could be merged by having a simpler linkdesc struct. I also fixed the DEBUG_TREE and DEBUG_LINKER code, and verified it works with DEBUG_LINKER set.