### PR TITLE
CI: Add test for long command lines via environment

### DIFF
--- a/test/func_command_com_cmdline_length.py
+++ b/test/func_command_com_cmdline_length.py
@@ -15,15 +15,15 @@ section .text
     push    cs
     pop     ds
 
-    mov     ax, 3c00h			; create file
+    mov     ax, 3c00h           ; create PSP file
     mov     cx, 0
-    mov     dx, fname
+    mov     dx, fname1
     int     21h
     jc      prfailcreate
 
     mov     word [fhndl], ax
 
-    mov     ax, 4000h			; write testdata
+    mov     ax, 4000h           ; write testdata
     mov     bx, word [fhndl]
     mov     cx, 200h            ; PSP + following 0x100 bytes
     mov     dx, 0               ; cs:0000 is PSP
@@ -32,7 +32,36 @@ section .text
     cmp     ax, 512
     jne     prnumwrite
 
-    mov     ax, 3e00h			; close file
+    mov     ax, 3e00h           ; close file
+    mov     bx, word [fhndl]
+    int     21h
+
+
+    mov     ax, 3c00h           ; create ENV file
+    mov     cx, 0
+    mov     dx, fname2
+    int     21h
+    jc      prfailcreate
+
+    mov     word [fhndl], ax
+
+    mov     ax, 4000h           ; write testdata
+    mov     bx, word [fhndl]
+    mov     cx, word [2ch]      ; seg of env block is at cs:2c
+    dec     cx                  ; move back to include MCB
+    push    ds
+    mov     ds, cx
+    mov     cx, word [03h]      ; size in paragraphs from MCB
+    shl     cx, 4               ; convert to bytes
+    mov     word cs:[flen], cx  ; save for later
+    mov     dx, 16              ; move forward to start of env block
+    int     21h
+    pop     ds
+    jc      prfailwrite
+    cmp     ax, word [flen]
+    jne     prnumwrite
+
+    mov     ax, 3e00h           ; close file
     mov     bx, word [fhndl]
     int     21h
 
@@ -62,11 +91,17 @@ exit:
 
 section .data
 
-fname:
+fname1:
     db  "psp_dump.bin", 0
 
+fname2:
+    db  "env_dump.bin", 0
+
 fhndl:
-    dw   0
+    dw  0
+
+flen:
+    dw  0
 
 failcreate:
     db "Create Operation Failed",13,10,'$'
@@ -77,26 +112,25 @@ numwrite:
 """)
 
     tests = {  # args, expected response
-        'multiarg01': ( r'X TEST____ 1234567890 23456789',
-                     b'\x1d TEST____ 1234567890 23456789\x0d'),
+        'multiarg01': (r'X TEST____ 1234567890 234567890',
+                    b'\x1e TEST____ 1234567890 234567890\x0d'),
 
-        'singlearg01': (r'X TEST_____12345678901234567890',
-                     b'\x1e TEST_____12345678901234567890\x0d'),
-        'singlearg02': (r'X TEST_____12345678901234567890123456789012345678901234567890',
-                     b'\x3c TEST_____12345678901234567890123456789012345678901234567890\x0d'),
-        'singlearg03': (r'X TEST_____12345678901234567890123456789012345678901234567890123456789012345678901234567890',
-                     b'\x5a TEST_____12345678901234567890123456789012345678901234567890123456789012345678901234567890\x0d'),
-        'singlearg04': (r'X TEST_____12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890',
-                     b'\x78 TEST_____12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890\x0d'),
-        'singlearg05': (r'X TEST_____1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345',
-                     b'\x7d TEST_____1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345\x0d'),
-        'singlearg06': (r'X TEST_____12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456',
-                     b'\x7e TEST_____12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456\x0d'),
+        'singlearg01':(r'X TEST_____12345678901234567890123456789012345678901234567890',
+                    b'\x3c TEST_____12345678901234567890123456789012345678901234567890\x0d'),
+        'singlearg02':(r'X TEST_____12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456',
+                    b'\x7e TEST_____12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456\x0d'),
 
-        'truncate01': ( r'X TEST_____123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567',
-                     b'\x7e TEST_____12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456\x0d'),
-        'truncate02': ( r'X TEST_____12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890',
-                     b'\x7e TEST_____12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456\x0d'),
+        #  For old behaviour (<= MS-DOS 6.22)
+        'old_dos01':  (r'X TEST_____123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567',
+                    b'\x7e TEST_____12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456\x0d'),
+        'old_dos02':  (r'X TEST_____12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890',
+                    b'\x7e TEST_____12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456\x0d'),
+
+        #  For new behaviour that supports extra long command lines via CMDLINE environment variable
+        'new_dos01': ( r'X TEST_____123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567',
+                       b'X TEST_____123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567'),
+        'new_dos02': ( r'X TEST_____12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890',
+                       b'X TEST_____12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890'),
     }
 
     self.mkfile("testit.bat", "%s\nrem end\n" % tests[name][0], newline="\r\n")
@@ -105,14 +139,30 @@ numwrite:
 $_hdimage = "dXXXXs/c:hdtype1 +1"
 """)
 
-    def fmt(b):
-        cnt = '% 3d,' % b[0]
-        tail = str(b[1:])
-        return cnt + tail
+    buffer1 = (self.workdir / 'psp_dump.bin').read_bytes()[0x80:]
+    buffer2 = (self.workdir / 'env_dump.bin').read_bytes()
+    endofenv = buffer2.find(b'\x00\x00')
+    if endofenv != -1:
+        buffer2 = buffer2[0:endofenv + 2]
 
-    buffer = (self.workdir / 'psp_dump.bin').read_bytes()[0x80:]
     expected = tests[name][1]
-    pascal_len = buffer[0]
-    received = buffer[0:1 + pascal_len + 1]
-    self.assertEqual(fmt(expected), fmt(received))
 
+    pascal_len = buffer1[0]
+
+    if pascal_len < 0x7f:
+        def fmt(b):
+            cnt = '% 3d,' % b[0]
+            tail = str(b[1:])
+            return cnt + tail
+
+        expected = fmt(expected)
+        received = fmt(buffer1[0:1 + pascal_len + 1])
+
+    else:
+        start = buffer2.find(b'CMDLINE=')
+        self.assertGreaterEqual(start, 0, 'No CMDLINE variable in env block, env follows: ' + str(buffer2))
+        start += len('CMDLINE=')
+        end = buffer2.find(b'\x00', start)
+        received = buffer2[start:end]
+
+    self.assertEqual(expected, received)

--- a/test/test_dosemu.py
+++ b/test/test_dosemu.py
@@ -3105,41 +3105,33 @@ $_debug = "-D+d"
 
         self.assertIn(self.systype, systypeline)
 
+    def test_command_com_cmdline_length_new_dos01(self):
+        """Command.com cmdline length(127) new DOS (env var) 01"""
+        command_com_cmdline_length(self, 'new_dos01')
+
+    def test_command_com_cmdline_length_new_dos02(self):
+        """Command.com cmdline length(150) new DOS (env var) 02"""
+        command_com_cmdline_length(self, 'new_dos02')
+
     def test_command_com_cmdline_length_multiargs01(self):
-        """Command.com cmdline length multiple args 01"""
+        """Command.com cmdline length( 30) multiple args 01"""
         command_com_cmdline_length(self, 'multiarg01')
 
     def test_command_com_cmdline_length_singlearg01(self):
-        """Command.com cmdline length single arg 01"""
+        """Command.com cmdline length( 60) single arg 01"""
         command_com_cmdline_length(self, 'singlearg01')
 
     def test_command_com_cmdline_length_singlearg02(self):
-        """Command.com cmdline length single arg 02"""
+        """Command.com cmdline length(126) single arg 02"""
         command_com_cmdline_length(self, 'singlearg02')
 
-    def test_command_com_cmdline_length_singlearg03(self):
-        """Command.com cmdline length single arg 03"""
-        command_com_cmdline_length(self, 'singlearg03')
+    def test_command_com_cmdline_length_old_dos01(self):
+        """Command.com cmdline length(127) old DOS (truncate) 01"""
+        command_com_cmdline_length(self, 'old_dos01')
 
-    def test_command_com_cmdline_length_singlearg04(self):
-        """Command.com cmdline length single arg 04"""
-        command_com_cmdline_length(self, 'singlearg04')
-
-    def test_command_com_cmdline_length_singlearg05(self):
-        """Command.com cmdline length single arg 05"""
-        command_com_cmdline_length(self, 'singlearg05')
-
-    def test_command_com_cmdline_length_singlearg06(self):
-        """Command.com cmdline length single arg 06"""
-        command_com_cmdline_length(self, 'singlearg06')
-
-    def test_command_com_cmdline_length_truncate01(self):
-        """Command.com cmdline length truncation 01"""
-        command_com_cmdline_length(self, 'truncate01')
-
-    def test_command_com_cmdline_length_truncate02(self):
-        """Command.com cmdline length truncation 02"""
-        command_com_cmdline_length(self, 'truncate02')
+    def test_command_com_cmdline_length_old_dos02(self):
+        """Command.com cmdline length(150) old DOS (truncate) 02"""
+        command_com_cmdline_length(self, 'old_dos02')
 
     def test_command_com_command_copy(self):
         """Command.com command copy"""
@@ -4932,8 +4924,10 @@ $_floppy_a = ""
 DRDOS701TestCase = drdos701(OurTestCase, {
     "test_comcom_r200fix_real": UNSUPPORTED,
     "test_comcom_r200fix_protected": UNSUPPORTED,
-    "test_command_com_cmdline_length_truncate01": UNSUPPORTED,
-    "test_command_com_cmdline_length_truncate02": UNSUPPORTED,
+    "test_command_com_cmdline_length_new_dos01": UNSUPPORTED,
+    "test_command_com_cmdline_length_new_dos02": UNSUPPORTED,
+    "test_command_com_cmdline_length_old_dos01": UNSUPPORTED,
+    "test_command_com_cmdline_length_old_dos02": UNSUPPORTED,
     r"test_fat_ds3_share_open_setfattrs_(one|two)_process": KNOWNFAIL,
     r"test_..._ds3_share_open_rename_one_process_fcb": KNOWNFAIL,
     r"test_..._fcb_rename_simple": KNOWNFAIL,
@@ -4959,8 +4953,8 @@ DRDOS701TestCase = drdos701(OurTestCase, {
 FRDOS120TestCase = frdos120(OurTestCase, {
     "test_comcom_r200fix_real": UNSUPPORTED,
     "test_comcom_r200fix_protected": UNSUPPORTED,
-    "test_command_com_cmdline_length_truncate01": UNSUPPORTED,
-    "test_command_com_cmdline_length_truncate02": UNSUPPORTED,
+    "test_command_com_cmdline_length_old_dos01": UNSUPPORTED,
+    "test_command_com_cmdline_length_old_dos02": UNSUPPORTED,
     "test_fat_fcb_rename_target_exists": KNOWNFAIL,
     "test_fat_fcb_rename_source_missing": KNOWNFAIL,
     "test_fat_fcb_rename_wild_1": KNOWNFAIL,
@@ -5016,8 +5010,8 @@ FRDOS120TestCase = frdos120(OurTestCase, {
 FRDOS130TestCase = frdos130(OurTestCase, {
     "test_comcom_r200fix_real": UNSUPPORTED,
     "test_comcom_r200fix_protected": UNSUPPORTED,
-    "test_command_com_cmdline_length_truncate01": UNSUPPORTED,
-    "test_command_com_cmdline_length_truncate02": UNSUPPORTED,
+    "test_command_com_cmdline_length_old_dos01": UNSUPPORTED,
+    "test_command_com_cmdline_length_old_dos02": UNSUPPORTED,
     "test_command_com_keyword_exist": KNOWNFAIL,
     "test_create_new_psp": KNOWNFAIL,
     "test_fat_ds3_lock_readlckd": KNOWNFAIL,
@@ -5055,8 +5049,8 @@ FRDOS130TestCase = frdos130(OurTestCase, {
 FRDOSGITTestCase = frdosgit(OurTestCase, {
     "test_comcom_r200fix_real": UNSUPPORTED,
     "test_comcom_r200fix_protected": UNSUPPORTED,
-    "test_command_com_cmdline_length_truncate01": UNSUPPORTED,
-    "test_command_com_cmdline_length_truncate02": UNSUPPORTED,
+    "test_command_com_cmdline_length_old_dos01": UNSUPPORTED,
+    "test_command_com_cmdline_length_old_dos02": UNSUPPORTED,
     "test_fat_ds3_lock_concurrent": KNOWNFAIL,
     "test_fat_ds3_lock_readlckd": KNOWNFAIL,
     "test_fat_ds3_lock_two_handles": KNOWNFAIL,
@@ -5083,6 +5077,8 @@ FRDOSGITTestCase = frdosgit(OurTestCase, {
 MSDOS622TestCase = msdos622(OurTestCase, {
     "test_comcom_r200fix_real": UNSUPPORTED,
     "test_comcom_r200fix_protected": UNSUPPORTED,
+    "test_command_com_cmdline_length_new_dos01": UNSUPPORTED,
+    "test_command_com_cmdline_length_new_dos02": UNSUPPORTED,
     "test_fat32_img_d_writable": UNSUPPORTED,
     "test_lfn_volume_info_fat16": KNOWNFAIL,
     "test_lfn_volume_info_fat32": UNSUPPORTED,
@@ -5097,8 +5093,8 @@ MSDOS622TestCase = msdos622(OurTestCase, {
 MSDOS700TestCase = msdos700(OurTestCase, {
     "test_comcom_r200fix_real": UNSUPPORTED,
     "test_comcom_r200fix_protected": UNSUPPORTED,
-    "test_command_com_cmdline_length_truncate01": UNSUPPORTED,
-    "test_command_com_cmdline_length_truncate02": UNSUPPORTED,
+    "test_command_com_cmdline_length_old_dos01": UNSUPPORTED,
+    "test_command_com_cmdline_length_old_dos02": UNSUPPORTED,
     "test_fat32_img_d_writable": UNSUPPORTED,
     "test_fat_label_create_bpb32": UNSUPPORTED,
     "test_lfn_volume_info_fat16": KNOWNFAIL,
@@ -5110,12 +5106,14 @@ MSDOS700TestCase = msdos700(OurTestCase, {
 MSDOS710TestCase = msdos710(OurTestCase, {
     "test_comcom_r200fix_real": UNSUPPORTED,
     "test_comcom_r200fix_protected": UNSUPPORTED,
-    "test_command_com_cmdline_length_truncate01": UNSUPPORTED,
-    "test_command_com_cmdline_length_truncate02": UNSUPPORTED,
+    "test_command_com_cmdline_length_old_dos01": UNSUPPORTED,
+    "test_command_com_cmdline_length_old_dos02": UNSUPPORTED,
 })
 
 PPDOSGITTestCase = ppdosgit(OurTestCase, {
     "test_comcom_r200fix_protected": UNSUPPORTED,
+    "test_command_com_cmdline_length_old_dos01": UNSUPPORTED,
+    "test_command_com_cmdline_length_old_dos02": UNSUPPORTED,
     "test_floppy_img": UNSUPPORTED,
     "test_floppy_vfs": UNSUPPORTED,
 })


### PR DESCRIPTION
I added the code to read the env block and CMDLINE variable, and two new tests with long lines.  It seems that OpenDOS 7.01 is broken regarding long lines, both with truncation and using the environment. If you add CMDLINE variable support to Comcom64 then the following two lines will need changing in the TestCase definition in test_dosemu.py
from
~~~
    "test_command_com_cmdline_length_environ01": UNSUPPORTED,
    "test_command_com_cmdline_length_environ02": UNSUPPORTED,
~~~
to
~~~
     "test_command_com_cmdline_length_truncate01": UNSUPPORTED,
     "test_command_com_cmdline_length_truncate02": UNSUPPORTED,
~~~