### PR TITLE
sdl2: Don't error the module if sdl3 is not found

### DIFF
--- a/src/plugin/sdl/configure.ac
+++ b/src/plugin/sdl/configure.ac
@@ -2,7 +2,7 @@ dnl Process this file with autoconf to produce a configure script.
 AC_INIT
 
 dnl Check for SDL3 first
-PKG_CHECK_MODULES(SDL3, [sdl3], [
+PKG_CHECK_EXISTS([sdl3], [
 	    AC_MSG_ERROR([sdl3 found, not enabling sdl2])
 ])
 


### PR DESCRIPTION
Apparently PKG_CHECK_MODULES sets up some variables that configure uses for dependency tracking, and switching to PKG_CHECK_EXISTS does not do this so allows the sdl module to build in the absence of sdl3.

[fixes #2509]