### PR TITLE
Dynamic library related fixes for MacOS

### DIFF
--- a/Makefile.conf.in
+++ b/Makefile.conf.in
@@ -2,8 +2,14 @@
 #
 # This file is included by all Makefiles
 
+OS = @CONFIG_HOST@
 DOSBIN = dosemu2.bin
-DOSLIB = libdosemu2.so.0.1
+SOVERSION = 0.1
+ifeq ($(OS),Darwin)
+DOSLIB = libdosemu2.$(SOVERSION).dylib
+else
+DOSLIB = libdosemu2.so.$(SOVERSION)
+endif
 
 PACKAGE_TARNAME:=@PACKAGE_TARNAME@
 prefix:=@prefix@
@@ -74,7 +80,6 @@ ST_PLUGINSUBDIRS := @ST_PLUGINSUBDIRS@
 
 HAVE_LIBBFD := @HAVE_LIBBFD@
 
-OS=@CONFIG_HOST@
 RANLIB:=@RANLIB@
 
 PACKAGE_NAME:=@PACKAGE_TARNAME@

--- a/src/arch/linux/Makefile.main
+++ b/src/arch/linux/Makefile.main
@@ -84,7 +84,8 @@ ifeq ($(OS),Darwin)
 	$(LD) $(ALL_LDFLAGS) -o $@ \
 	   -Wl,-all_load $(LIBS_) $(LIBS) \
 	   -Wl,-map,$(BINPATH)/bin/dosemu.map \
-	   -shared
+	   -dynamiclib -install_name $(libdir)/$(DOSLIB) \
+	   -compatibility_version $(SOVERSION) -current_version $(SOVERSION)
 else
 	$(LD) $(ALL_LDFLAGS) -o $@ \
 	   -Wl,--whole-archive $(LIBS_) -Wl,--no-whole-archive $(LIBS) \
@@ -93,10 +94,11 @@ else
 	   $(SO_LDFLAGS)
 endif
 
-$(BINPATH)/bin/libdosemu2.so: $(BINPATH)/bin/$(DOSLIB)
+DOSLIBLINKNAME=$(subst .$(SOVERSION),,$(DOSLIB))
+$(BINPATH)/bin/$(DOSLIBLINKNAME): $(BINPATH)/bin/$(DOSLIB)
 	$(LN_S) -f $(DOSLIB) $@
 
-$(BINPATH)/bin/$(DOSBIN): base/core/main.o $(BINPATH)/bin/libdosemu2.so
+$(BINPATH)/bin/$(DOSBIN): base/core/main.o $(BINPATH)/bin/$(DOSLIBLINKNAME)
 	$(LD) $(DOSBIN_LDFLAGS) $(LDFLAGS) -o $@ $< -L $(BINPATH)/bin -ldosemu2
 
 $(BINPATH)/bin/dosemu: $(SRCPATH)/dosemu.systemwide $(SRCPATH)/dosemu \
@@ -176,7 +178,7 @@ endif
 	$(INSTALL) -m 0755 $(top_builddir)/bin/$(DOSBIN) $(DESTDIR)$(libexecdir)/dosemu2
 	$(INSTALL) -d $(DESTDIR)$(libdir)
 	$(INSTALL) -m 0755 $(top_builddir)/bin/$(DOSLIB) $(DESTDIR)$(libdir)
-	$(LN_S) -f $(DOSLIB) $(DESTDIR)$(libdir)/libdosemu2.so
+	$(LN_S) -f $(DOSLIB) $(DESTDIR)$(libdir)/$(DOSLIBLINKNAME)
 	$(INSTALL) -d $(DESTDIR)$(includedir)/$(PACKAGE_NAME)
 	$(INSTALL) -m 0644 -D $(SRCPATH)/include/$(PACKAGE_NAME)/* $(DESTDIR)$(includedir)/$(PACKAGE_NAME)
 ifneq ($(PRIV_SEP),)
@@ -270,7 +272,7 @@ uninstall:
 	$(RM) -r $(DESTDIR)$(dosemudir)
 	$(RM) -r $(DESTDIR)$(libexecdir)/$(PACKAGE_NAME)
 	$(RM) -r $(DESTDIR)$(includedir)/$(PACKAGE_NAME)
-	$(RM) $(DESTDIR)$(libdir)/libdosemu2.so
+	$(RM) $(DESTDIR)$(libdir)/$(DOSLIBLINKNAME)
 	$(RM) $(DESTDIR)$(libdir)/$(DOSLIB)
 	$(RM) $(DESTDIR)$(prefix)/lib/sysusers.d/$(PACKAGE_NAME).conf
 	$(RM) $(DESTDIR)$(bindir)/dosemu

--- a/src/dosemu
+++ b/src/dosemu
@@ -16,10 +16,18 @@ get_binary() {
         --Flibdir $LOCAL_BUILD_PATH/etc \
         --Fplugindir $BINDIR \
         "
-    if [ -z "$LD_LIBRARY_PATH" ]; then
-      export LD_LIBRARY_PATH="$BINDIR"
+    if [ $(uname -s) == "Darwin" ]; then
+      if [ -z "$DYLD_LIBRARY_PATH" ]; then
+        export DYLD_LIBRARY_PATH="$BINDIR"
+      else
+        export DYLD_LIBRARY_PATH="$BINDIR:$DYLD_LIBRARY_PATH"
+      fi
     else
-      export LD_LIBRARY_PATH="$BINDIR:$LD_LIBRARY_PATH"
+      if [ -z "$LD_LIBRARY_PATH" ]; then
+        export LD_LIBRARY_PATH="$BINDIR"
+      else
+        export LD_LIBRARY_PATH="$BINDIR:$LD_LIBRARY_PATH"
+      fi
     fi
 
   else


### PR DESCRIPTION
Should you .dylib with proper flags instead of .so for dynamic libdosemu2 (not for plugins), use DYLD_LIBRARY_PATH instead of LD_LIBRARY_PATH.