### PR TITLE
CPU test fixes

### DIFF
--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -520,7 +520,7 @@ static void Reg2Cpu(struct vm86_struct *info)
   * changed asynchronously by signals)
   * Note that IOPL=3 in the emulated flags so cpuemu works directly with
     IF, not VIF */
-  TheCPU.eflags = (regs->eflags & SAFE_MASK) | IOPL_MASK;
+  TheCPU.eflags = (regs->eflags & SAFE_MASK) | IOPL_MASK | EFLAGS_SET;
   if (regs->eflags & VIF)
     TheCPU.eflags |= EFLAGS_IF;
   TheCPU.eflags |= (VM | RF);	// RF is cosmetic...

--- a/test/cpu/test-i386.c
+++ b/test/cpu/test-i386.c
@@ -1436,6 +1436,11 @@ void test_segs(void)
     TEST_ARPL("arpl", "w", 0x12345678 | 3, 0x762123c | 1);
     TEST_ARPL("arpl", "w", 0x12345678 | 1, 0x762123c | 3);
     TEST_ARPL("arpl", "w", 0x12345678 | 1, 0x762123c | 1);
+
+#ifdef __DJGPP__
+    __dpmi_free_ldt_descriptor(MK_SEL(1));
+    __dpmi_free_ldt_descriptor(MK_SEL(2));
+#endif
 }
 
 /* 16 bit code test */
@@ -1473,7 +1478,7 @@ void test_code16(void)
     unsigned base, limit;
     unsigned char buf[8];
     __dpmi_get_segment_base_address(_my_cs(), &csbase);
-    /* descriptor was already allocated before */
+    __dpmi_allocate_specific_ldt_descriptor(MK_SEL(1));
     __dpmi_get_descriptor(MK_SEL(1), &buf);
     base = csbase + (unsigned long)&code16_start;
     limit = &code16_end - &code16_start;
@@ -1505,6 +1510,10 @@ void test_code16(void)
                   : "=a" (res)
                   : "m" (jmp): "memory", "cc");
     printf("func3() = 0x%08x\n", res);
+
+#ifdef __DJGPP__
+    __dpmi_free_ldt_descriptor(MK_SEL(1));
+#endif
 }
 #endif
 
@@ -2182,6 +2191,10 @@ void test_exceptions(void)
 #endif
 #if TEST_SIGTRAP
     signal(SIGTRAP, SIG_DFL);
+#endif
+
+#ifdef __DJGPP__
+    __dpmi_free_ldt_descriptor(MK_SEL(1));
 #endif
 }
 


### PR DESCRIPTION
I identified two issues through running the test/cpu/test-i386 test:
1. Flags in test_vm86() were not setting the fixed bit (2)
2. It crashed in test_segs() because of a non-present bit in the LDT descriptor (this used to work more or less by accident because the tests were ordered differently before 978b222925)

These issues didn't show up in CI because the above tests are excluded because the results can be arch-dependent (run with `dosbin --common-tests`)