### PR TITLE
simx86: eliminate IGen's ovds field, global OVERR_DS and OVERR_SS

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -82,9 +82,6 @@ static unsigned int P0 = (unsigned)-1;
 
 #define	Offs_From_Arg()		(signed char)(va_arg(ap,int))
 
-/* WARNING - these are signed char offsets, NOT pointers! */
-char OVERR_DS=Ofs_XDS, OVERR_SS=Ofs_XSS;
-
 /* working registers of the host CPU */
 wkreg DR1;	// "eax"
 wkreg DR2;	// "edx"
@@ -427,16 +424,17 @@ void AddrGen_sim(int op, int mode, ...)
 			long idsp;
 			unsigned char sh;
 			signed char o;
+			signed char ofs = Offs_From_Arg();
 			if (mode & MLEA) {
 				AR1.d = 0;
 			}
 			else {
-				AR1.d = CPULONG(OVERR_DS);
+				AR1.d = CPULONG(ofs);
 			}
 			idsp = va_arg(ap,int);
 			o = Offs_From_Arg();
 			sh = (unsigned char)(va_arg(ap,int));
-			GTRACE4("A_DI_2D",o,0xff,idsp,sh);
+			GTRACE5("A_DI_2D",ofs,o,0xff,idsp,sh);
 			TR1.d = (CPULONG(o) << (sh & 0x1f)) + idsp;
 			AR1.d += TR1.d;
 		}
@@ -1626,14 +1624,16 @@ void Gen_sim(int op, int mode, ...)
 			CPULONG(Ofs_EDX) = (DR1.b.b3&0x80? 0xffffffff:0);
 		}
 		break;
-	case O_XLAT:
-		GTRACE0("XLAT");
-		AR1.d = CPULONG(OVERR_DS);
+	case O_XLAT: {
+		signed char ofs = Offs_From_Arg();
+		GTRACE1("XLAT",ofs);
+		AR1.d = CPULONG(ofs);
 		TR1.d = CPULONG(Ofs_EBX) + CPUBYTE(Ofs_AL);
 		if (mode & ADDR16) {
 			TR1.d &= 0xFFFF;
 		}
 		AR1.d += TR1.d;
+		}
 		break;
 
 	case O_ROL: {		// O(if sh==1),C(if sh>0)
@@ -2267,11 +2267,12 @@ void Gen_sim(int op, int mode, ...)
 		} }
 		break;
 
-	case O_MOVS_SetA:
-		GTRACE0("O_MOVS_SetA");
+	case O_MOVS_SetA: {
+		signed char ofs = Offs_From_Arg();
+		GTRACE1("O_MOVS_SetA",ofs);
 		if (mode&ADDR16) {
 		    if (mode&MOVSSRC) {
-	    		AR2.d = CPULONG(OVERR_DS);
+			AR2.d = CPULONG(ofs);
 			DR2.d = CPUWORD(Ofs_SI); /* for overflow calc */
 			AR2.d += DR2.d;
 		    }
@@ -2285,7 +2286,7 @@ void Gen_sim(int op, int mode, ...)
 		}
 		else {
 		    if (mode&MOVSSRC) {
-	    		AR2.d = CPULONG(OVERR_DS) + CPULONG(Ofs_ESI);
+			AR2.d = CPULONG(ofs) + CPULONG(Ofs_ESI);
 		    }
 		    if (mode&MOVSDST) {
 	    		AR1.d = CPULONG(Ofs_XES) + CPULONG(Ofs_EDI);
@@ -2294,6 +2295,7 @@ void Gen_sim(int op, int mode, ...)
 		}
 		if (!(mode&(MREP|MREPNE|MOVSDST))) {
 		    AR1.d = AR2.d; /* single lodsb uses L_DI_R1 */
+		}
 		}
 		break;
 
@@ -2575,8 +2577,9 @@ void Gen_sim(int op, int mode, ...)
 		}
 		break;
 
-	case O_MOVS_SavA:
-		GTRACE0("O_MOVS_SavA");
+	case O_MOVS_SavA: {
+		signed char ofs = Offs_From_Arg();
+		GTRACE1("O_MOVS_SavA",ofs);
 		if (!(mode&(MREP|MREPNE))) {
 		    // %%edx set to DF's increment
 		    DR2.d = (signed char)CPUBYTE(Ofs_DF_INCREMENTS+OPSIZEBIT(mode));
@@ -2598,7 +2601,7 @@ void Gen_sim(int op, int mode, ...)
 	    		CPUWORD(Ofs_CX) = TR1.w.l;
 		    }
 		    if (mode&MOVSSRC) {
-	    		AR2.d -= CPULONG(OVERR_DS);
+			AR2.d -= CPULONG(ofs);
 			CPUWORD(Ofs_SI) = AR2.w.l;
 		    }
 		    if (mode&MOVSDST) {
@@ -2611,13 +2614,14 @@ void Gen_sim(int op, int mode, ...)
 	    		CPULONG(Ofs_ECX) = TR1.d;
 		    }
 		    if (mode&MOVSSRC) {
-	    		AR2.d -= CPULONG(OVERR_DS);
+			AR2.d -= CPULONG(ofs);
 			CPULONG(Ofs_ESI) = AR2.d;
 		    }
 		    if (mode&MOVSDST) {
 	    		AR1.d -= CPULONG(Ofs_XES);
 			CPULONG(Ofs_EDI) = AR1.d;
 		    }
+		}
 		}
 		break;
 	case O_SLAHF: {

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -272,10 +272,10 @@ static unsigned char *CodeGen(unsigned char *CodePtr, unsigned char *BaseGenBuf,
 		} }
 		break;
 	case A_DI_2D: {			// modrm_sibd, 32-bit mode
-		int idsp = IG->p0;
-		unsigned char sh = IG->p2;
+		int idsp = IG->p1;
+		unsigned char sh = IG->p3;
 		// movl offs(%%ebx),%%edi
-		G3M(0x8b,0x7b,IG->p1,Cp);
+		G3M(0x8b,0x7b,IG->p2,Cp);
 		// shll $count,%%ecx
 		if (sh)	{
 			// shll $1,%%edi
@@ -288,7 +288,7 @@ static unsigned char *CodeGen(unsigned char *CodePtr, unsigned char *BaseGenBuf,
 		}
 		if (!(mode & MLEA)) {
 			// addl offs(%%ebx),%%edi (seg reg offset)
-			G3M(0x03,0x7b,IG->ovds,Cp);
+			G3M(0x03,0x7b,IG->p0,Cp);
 		} }
 		break;
 	case A_SR_SH4: {	// real mode make base addr from seg
@@ -966,8 +966,8 @@ arith1:
 		}
 		break;
 	case O_XLAT:
-		// movl OVERR_DS(%%ebx),%%edi
-		G2(0x7b8b,Cp); G1(IG->ovds,Cp);
+		// movl (seg reg offset)(%%ebx),%%edi
+		G2(0x7b8b,Cp); G1(IG->p0,Cp);
 		// movzbl Ofs_AL(%%ebx),%%ecx
 		G4M(0x0f,0xb6,0x4b,Ofs_AL,Cp);
 		// movl Ofs_EBX(%%ebx),%%eax
@@ -1694,8 +1694,8 @@ shrot0:
 			    G1(INCax,Cp);
 #endif
 			}
-			// addl OVERR_DS(%%ebx),%%e[sd]i
-			G3M(0x03,modrm,IG->ovds,Cp);
+			// addl (seg reg offset)(%%ebx),%%e[sd]i
+			G3M(0x03,modrm,IG->p0,Cp);
 			if (mode&(MREP|MREPNE)) {
 			    // addl %%[re]bp,%%[re][sd]i
 			    Gen48(Cp); G2M(0x01,modrm2,Cp);
@@ -1796,8 +1796,8 @@ shrot0:
 		}
 		else {
 		    if (mode&MOVSSRC) {
-			// movl OVERR_DS(%%ebx),%%e[sd]i
-			G3M(0x8b,modrm,IG->ovds,Cp);
+			// movl (seg reg offset)(%%ebx),%%e[sd]i
+			G3M(0x8b,modrm,IG->p0,Cp);
 			// addl Ofs_ESI(%%ebx),%%e[sd]i
 			G3M(0x03,modrm,Ofs_ESI,Cp);
 		    }
@@ -1955,8 +1955,8 @@ shrot0:
 			// esi = base1 + CPU_(e)SI +- n
 			// subl %%[re]bp,%%[re]si
 			Gen48(Cp); G2M(0x29,0xee,Cp);
-			// subl OVERR_DS(%%ebx),%%esi
-			G2(0x732b,Cp); G1(IG->ovds,Cp);
+			// subl (seg reg offset)(%%ebx),%%esi
+			G2(0x732b,Cp); G1(IG->p0,Cp);
 			// movw %%si,Ofs_SI(%%ebx)
 			G4M(0x66,0x89,0x73,Ofs_SI,Cp);
 		    }
@@ -1990,8 +1990,8 @@ shrot0:
 			// esi = base1 + CPU_(e)SI +- n
 			// subl %%[re]bp,%%[re]si
 			Gen48(Cp); G2M(0x29,0xee,Cp);
-			// subl OVERR_DS(%%ebx),%%esi
-			G2(0x732b,Cp); G1(IG->ovds,Cp);
+			// subl (seg reg offset)(%%ebx),%%esi
+			G2(0x732b,Cp); G1(IG->p0,Cp);
 			// movl %%esi,Ofs_ESI(%%ebx)
 			G3M(0x89,0x73,Ofs_ESI,Cp);
 		    }
@@ -2469,7 +2469,6 @@ static void AddrGen_x86(int op, int mode, ...)
 	va_start(ap, mode);
 	IG->op = op;
 	IG->mode = mode;
-	IG->ovds = OVERR_DS;
 
 	switch(op) {
 	case A_DI_0:			// base(32), imm
@@ -2499,12 +2498,14 @@ static void AddrGen_x86(int op, int mode, ...)
 		break;
 	case A_DI_2D: {			// modrm_sibd, 32-bit mode
 		signed char o;
+		signed char ofs = (char)va_arg(ap,int);
 		unsigned char sh;
-		IG->p0 = va_arg(ap,int);
+		IG->p0 = ofs;
+		IG->p1 = va_arg(ap,int);
 		o = Offs_From_Arg();
-		IG->p1 = o;
+		IG->p2 = o;
 		sh = (unsigned char)(va_arg(ap,int));
-		IG->p2 = sh;
+		IG->p3 = sh;
 		}
 		break;
 	case A_SR_SH4: {	// real mode make base addr from seg
@@ -2547,7 +2548,6 @@ static void Gen_x86(int op, int mode, ...)
 	va_start(ap, mode);
 	IG->op = op;
 	IG->mode = mode;
-	IG->ovds = OVERR_DS;
 
 	switch(op) {
 	case L_NOP:
@@ -2561,7 +2561,6 @@ static void Gen_x86(int op, int mode, ...)
 	case O_DEC:
 	case O_MUL:
 	case O_CBWD:
-	case O_XLAT:
 	case O_PUSH:
 	case O_PUSH1:
 	case O_PUSH2F:
@@ -2569,13 +2568,11 @@ static void Gen_x86(int op, int mode, ...)
 	case O_POP1:
 	case O_POP3:
 	case O_LEAVE:
-	case O_MOVS_SetA:
 	case O_MOVS_MovD:
 	case O_MOVS_LodD:
 	case O_MOVS_StoD:
 	case O_MOVS_ScaD:
 	case O_MOVS_CmpD:
-	case O_MOVS_SavA:
 	case O_RDTSC:
 	case O_INPDX:
 	case O_OUTPDX:
@@ -2590,6 +2587,9 @@ static void Gen_x86(int op, int mode, ...)
 	case O_TEST:
 	case O_SBSELF:
 	case O_BSWAP:
+	case O_XLAT:
+	case O_MOVS_SetA:
+	case O_MOVS_SavA:
 	case O_CMPXCHG: {
 		signed char o = Offs_From_Arg();
 		IG->p0 = o;

--- a/src/base/emu-i386/simx86/emu86.h
+++ b/src/base/emu-i386/simx86/emu86.h
@@ -718,9 +718,9 @@ void prejit_unlock(void);
 void prejit_init(void);
 void prejit_done(void);
 //
-int _ModRM(unsigned char opc, unsigned int PC, int mode);
+int _ModRM(unsigned char opc, unsigned int PC, int mode, signed char overr_ds, signed char overr_ss);
 #define ModRM(o, p, m) ({ \
-    int __l = _ModRM(o, p, m); \
+    int __l = _ModRM(o, p, m, OVERR_DS, OVERR_SS); \
     if (REG1 == 0xff) { \
         CODE_FLUSH(); \
         goto illegal_op; \
@@ -731,7 +731,7 @@ int _ModRM(unsigned char opc, unsigned int PC, int mode);
     } \
     __l; \
 })
-int ModRMSim(unsigned int PC, int mode);
+int ModRMSim(unsigned int PC, int mode, signed char overr_ds, signed char overr_ss);
 int ModGetReg1(unsigned int PC, int mode);
 //
 char *e_emu_disasm(unsigned char *org, int is32, unsigned int refseg);

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -599,9 +599,6 @@ void Interp86(void)
 
 static unsigned int interp_pre(unsigned int PC, const int mode, int _flags)
 {
-		OVERR_DS = Ofs_XDS;
-		OVERR_SS = Ofs_XSS;
-
 		if (CurrIMeta<0) {
 			if (CEmuStat & (CeS_TRAP|CeS_DRTRAP|CeS_SIGPEND|CeS_RPIC|CeS_STI)) {
 				HandleEmuSignals();
@@ -775,6 +772,9 @@ static unsigned int InterpOne(unsigned int PC, int *_basemode, int _flags)
 	unsigned short ocs;
 	#define basemode (*_basemode)
 	int _mode = basemode;
+	/* WARNING - these are signed char offsets, NOT pointers! */
+	signed char OVERR_DS = Ofs_XDS;
+	signed char OVERR_SS = Ofs_XSS;
 
 override:
 	switch ((opc=Fetch(PC))) {
@@ -994,7 +994,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			if (Fetch(PC+1) >= 0xc0) {
 			    goto not_permitted;
 			}
-			PC += ModRMSim(PC, _mode);
+			PC += ModRMSim(PC, _mode, OVERR_DS, OVERR_SS);
 			r = GetCPU_WL(_mode, REG1);
 			lo = DataGetWL_S(_mode,TheCPU.mem_ref);
 			TheCPU.mem_ref += BT24(BitDATA16, _mode);
@@ -1010,7 +1010,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 /*63*/	case ARPL:     {
 			unsigned short dest, src;
 			CODE_FLUSH();
-			PC += ModRMSim(PC, _mode);
+			PC += ModRMSim(PC, _mode, OVERR_DS, OVERR_SS);
 			if (TheCPU.mode & RM_REG) {
 				dest = CPUWORD(REG3);
 			} else {
@@ -1032,7 +1032,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			break;
 		       }
 /*d7*/	case XLAT:
-			Gen(O_XLAT, _mode);
+			Gen(O_XLAT, _mode, OVERR_DS);
 			Gen(L_DI_R1, _mode|MBYTE);
 			Gen(S_REG, _mode|MBYTE, Ofs_AL);
 			PC++; break;
@@ -1487,7 +1487,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			    unsigned short sv = 0;
 			    unsigned long rv;
 			    CODE_FLUSH();
-			    PC += ModRMSim(PC, _mode);
+			    PC += ModRMSim(PC, _mode, OVERR_DS, OVERR_SS);
 			    rv = DataGetWL_U(_mode,TheCPU.mem_ref);
 			    TheCPU.mem_ref += BT24(BitDATA16, _mode);
 			    sv = GetDWord(TheCPU.mem_ref);
@@ -1511,7 +1511,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			    unsigned short sv = 0;
 			    unsigned long rv;
 			    CODE_FLUSH();
-			    PC += ModRMSim(PC, _mode);
+			    PC += ModRMSim(PC, _mode, OVERR_DS, OVERR_SS);
 			    rv = DataGetWL_U(_mode,TheCPU.mem_ref);
 			    TheCPU.mem_ref += BT24(BitDATA16, _mode);
 			    sv = GetDWord(TheCPU.mem_ref);
@@ -1536,7 +1536,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			else {
 			    unsigned short sv = 0;
 			    CODE_FLUSH();
-			    PC += ModRMSim(PC, _mode|SEGREG);
+			    PC += ModRMSim(PC, _mode|SEGREG, OVERR_DS, OVERR_SS);
 			    if (TheCPU.mode & RM_REG) {
 				sv = CPUWORD(REG3);
 			    } else {
@@ -1604,20 +1604,20 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			break;
 
 /*a4*/	case MOVSb: {	int m = _mode|(MBYTE|MOVSSRC|MOVSDST);
-			Gen(O_MOVS_SetA, m&~MOVSDST);
+			Gen(O_MOVS_SetA, m&~MOVSDST, OVERR_DS);
 			Gen(L_DI_R1, m);
-			Gen(O_MOVS_SetA, m&~MOVSSRC);
+			Gen(O_MOVS_SetA, m&~MOVSSRC, OVERR_DS);
 			Gen(S_DI, m);
-			Gen(O_MOVS_SavA, m);
+			Gen(O_MOVS_SavA, m, OVERR_DS);
 			PC++;
 			} break;
 /*a5*/	case MOVSw: {	int m = _mode|(MOVSSRC|MOVSDST);
-			Gen(O_MOVS_SetA, m&~MOVSDST);
+			Gen(O_MOVS_SetA, m&~MOVSDST, OVERR_DS);
 			Gen(L_DI_R1, m);
-			Gen(O_MOVS_SetA, m&~MOVSSRC);
+			Gen(O_MOVS_SetA, m&~MOVSSRC, OVERR_DS);
 			Gen(S_DI, m);
 			PC++;
-			Gen(O_MOVS_SavA, m);
+			Gen(O_MOVS_SavA, m, OVERR_DS);
 #ifndef SINGLESTEP
 			/* optimize common sequence MOVSw..MOVSw..MOVSb */
 			if (!(EFLAGS & TF)) {
@@ -1625,107 +1625,107 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 				m = UNPREFIX(m);
 				while (++cnt < NUMGENS && Fetch(PC) == MOVSw &&
 						!e_querymark(PC, 1)) {
-					Gen(O_MOVS_SetA, m&~MOVSDST);
+					Gen(O_MOVS_SetA, m&~MOVSDST, OVERR_DS);
 					Gen(L_DI_R1, m);
-					Gen(O_MOVS_SetA, m&~MOVSSRC);
+					Gen(O_MOVS_SetA, m&~MOVSSRC, OVERR_DS);
 					Gen(S_DI, m);
 					PC++;
-					Gen(O_MOVS_SavA, m);
+					Gen(O_MOVS_SavA, m, OVERR_DS);
 				}
 				if (Fetch(PC) == MOVSb && !e_querymark(PC, 1)) {
 					m |= MBYTE;
-					Gen(O_MOVS_SetA, m&~MOVSDST);
+					Gen(O_MOVS_SetA, m&~MOVSDST, OVERR_DS);
 					Gen(L_DI_R1, m);
-					Gen(O_MOVS_SetA, m&~MOVSSRC);
+					Gen(O_MOVS_SetA, m&~MOVSSRC, OVERR_DS);
 					Gen(S_DI, m);
 					PC++;
-					Gen(O_MOVS_SavA, m);
+					Gen(O_MOVS_SavA, m, OVERR_DS);
 				}
 			}
 #endif
 			} break;
 /*a6*/	case CMPSb: {	int m = _mode|(MBYTE|MOVSSRC|MOVSDST);
-			Gen(O_MOVS_SetA, m&~MOVSDST);
+			Gen(O_MOVS_SetA, m&~MOVSDST, OVERR_DS);
 			Gen(L_DI_R1, m);
-			Gen(O_MOVS_SetA, m&~MOVSSRC);
+			Gen(O_MOVS_SetA, m&~MOVSSRC, OVERR_DS);
 			Gen(O_MOVS_CmpD, m);
-			Gen(O_MOVS_SavA, m);
+			Gen(O_MOVS_SavA, m, OVERR_DS);
 			PC++; } break;
 /*a7*/	case CMPSw: {	int m = _mode|(MOVSSRC|MOVSDST);
-			Gen(O_MOVS_SetA, m&~MOVSDST);
+			Gen(O_MOVS_SetA, m&~MOVSDST, OVERR_DS);
 			Gen(L_DI_R1, m);
-			Gen(O_MOVS_SetA, m&~MOVSSRC);
+			Gen(O_MOVS_SetA, m&~MOVSSRC, OVERR_DS);
 			Gen(O_MOVS_CmpD, m);
-			Gen(O_MOVS_SavA, m);
+			Gen(O_MOVS_SavA, m, OVERR_DS);
 			PC++; } break;
 /*aa*/	case STOSb: {	int m = _mode|(MBYTE|MOVSDST);
-			Gen(O_MOVS_SetA, m);
+			Gen(O_MOVS_SetA, m, OVERR_DS);
 			Gen(L_REG, m, Ofs_AL);
 			Gen(S_DI, m);
-			Gen(O_MOVS_SavA, m);
+			Gen(O_MOVS_SavA, m, OVERR_DS);
 			PC++; } break;
 /*ab*/	case STOSw: {	int m = _mode|MOVSDST;
-			Gen(O_MOVS_SetA, m);
+			Gen(O_MOVS_SetA, m, OVERR_DS);
 			Gen(L_REG, m, Ofs_EAX);
 			Gen(S_DI, m); PC++;
-			Gen(O_MOVS_SavA, m);
+			Gen(O_MOVS_SavA, m, OVERR_DS);
 #ifndef SINGLESTEP
 			if (!(EFLAGS & TF)) {
 			    int cnt = 3;
 			    m = UNPREFIX(m);
 			    while (++cnt < NUMGENS && Fetch(PC) == STOSw &&
 					!e_querymark(PC, 1)) {
-				Gen(O_MOVS_SetA, m);
+				Gen(O_MOVS_SetA, m, OVERR_DS);
 				Gen(S_DI, m);
-				Gen(O_MOVS_SavA, m);
+				Gen(O_MOVS_SavA, m, OVERR_DS);
 				PC++;
 			    }
 			}
 #endif
 			} break;
 /*ac*/	case LODSb: {	int m = _mode|(MBYTE|MOVSSRC);
-			Gen(O_MOVS_SetA, m);
+			Gen(O_MOVS_SetA, m, OVERR_DS);
 			Gen(L_DI_R1, m);
 			Gen(S_REG, m, Ofs_AL); PC++;
 #ifndef SINGLESTEP
 			/* optimize common sequence LODSb-STOSb */
 			if (!(EFLAGS & TF) && Fetch(PC) == STOSb &&
 					!e_querymark(PC, 1)) {
-				Gen(O_MOVS_SetA, (m&ADDR16)|MOVSDST);
+				Gen(O_MOVS_SetA, (m&ADDR16)|MOVSDST, OVERR_DS);
 				Gen(S_DI, m);
 				m |= MOVSDST;
 				PC++;
 			}
 #endif
-			Gen(O_MOVS_SavA, m);
+			Gen(O_MOVS_SavA, m, OVERR_DS);
 			} break;
 /*ad*/	case LODSw: {	int m = _mode|MOVSSRC;
-			Gen(O_MOVS_SetA, m);
+			Gen(O_MOVS_SetA, m, OVERR_DS);
 			Gen(L_DI_R1, m);
 			Gen(S_REG, m, Ofs_EAX); PC++;
 #ifndef SINGLESTEP
 			/* optimize common sequence LODSw-STOSw */
 			if (!(EFLAGS & TF) && Fetch(PC) == STOSw &&
 					!e_querymark(PC, 1)) {
-				Gen(O_MOVS_SetA, (m&ADDR16)|MOVSDST);
+				Gen(O_MOVS_SetA, (m&ADDR16)|MOVSDST, OVERR_DS);
 				Gen(S_DI, m);
 				m |= MOVSDST;
 				PC++;
 			}
 #endif
-			Gen(O_MOVS_SavA, m);
+			Gen(O_MOVS_SavA, m, OVERR_DS);
 			} break;
 /*ae*/	case SCASb: {	int m = _mode|(MBYTE|MOVSDST);
-			Gen(O_MOVS_SetA, m);
+			Gen(O_MOVS_SetA, m, OVERR_DS);
 			Gen(L_DI_R1, m);		// mov al,[edi]
 			Gen(O_CMP_FR, m, Ofs_AL);	// cmp [ebx+reg],al
-			Gen(O_MOVS_SavA, m);
+			Gen(O_MOVS_SavA, m, OVERR_DS);
 			PC++; } break;
 /*af*/	case SCASw: {	int m = _mode|MOVSDST;
-			Gen(O_MOVS_SetA, m);
+			Gen(O_MOVS_SetA, m, OVERR_DS);
 			Gen(L_DI_R1, m);		// mov ax,[edi]
 			Gen(O_CMP_FR, m, Ofs_EAX);	// cmp [ebx+reg],ax
-			Gen(O_MOVS_SavA, m);
+			Gen(O_MOVS_SavA, m, OVERR_DS);
 			PC++; } break;
 
 /*b0*/	case MOVial:
@@ -2253,7 +2253,7 @@ repag0:
 					goto not_permitted;
 				case LODSb:
 					repmod |= (MBYTE|MOVSSRC);
-					Gen(O_MOVS_SetA, repmod);
+					Gen(O_MOVS_SetA, repmod, OVERR_DS);
 					if (repmod & (MREPNE|MREP)) {
 						Gen(O_MOVS_LodD, repmod);
 					}
@@ -2261,11 +2261,11 @@ repag0:
 						Gen(L_DI_R1, repmod);
 					}
 					Gen(S_REG, repmod, Ofs_AL);
-					Gen(O_MOVS_SavA, repmod);
+					Gen(O_MOVS_SavA, repmod, OVERR_DS);
 					PC++; break;
 				case LODSw:
 					repmod |= MOVSSRC;
-					Gen(O_MOVS_SetA, repmod);
+					Gen(O_MOVS_SetA, repmod, OVERR_DS);
 					if (repmod & (MREPNE|MREP)) {
 						Gen(O_MOVS_LodD, repmod);
 					}
@@ -2273,65 +2273,65 @@ repag0:
 						Gen(L_DI_R1, repmod);
 					}
 					Gen(S_REG, repmod, Ofs_AX);
-					Gen(O_MOVS_SavA, repmod);
+					Gen(O_MOVS_SavA, repmod, OVERR_DS);
 					PC++; break;
 				case MOVSb:
 					repmod |= (MBYTE|MOVSSRC|MOVSDST);
 					if (repmod & (MREPNE|MREP)) {
-						Gen(O_MOVS_SetA, repmod);
+						Gen(O_MOVS_SetA, repmod, OVERR_DS);
 						Gen(O_MOVS_MovD, repmod);
 					}
 					else {
-						Gen(O_MOVS_SetA, repmod&~MOVSDST);
+						Gen(O_MOVS_SetA, repmod&~MOVSDST, OVERR_DS);
 						Gen(L_DI_R1, repmod);
-						Gen(O_MOVS_SetA, repmod&~MOVSSRC);
+						Gen(O_MOVS_SetA, repmod&~MOVSSRC, OVERR_DS);
 						Gen(S_DI, repmod);
 					}
-					Gen(O_MOVS_SavA, repmod);
+					Gen(O_MOVS_SavA, repmod, OVERR_DS);
 					PC++; break;
 				case MOVSw:
 					repmod |= (MOVSSRC|MOVSDST);
 					if (repmod & (MREPNE|MREP)) {
-						Gen(O_MOVS_SetA, repmod);
+						Gen(O_MOVS_SetA, repmod, OVERR_DS);
 						Gen(O_MOVS_MovD, repmod);
 					}
 					else {
-						Gen(O_MOVS_SetA, repmod&~MOVSDST);
+						Gen(O_MOVS_SetA, repmod&~MOVSDST, OVERR_DS);
 						Gen(L_DI_R1, repmod);
-						Gen(O_MOVS_SetA, repmod&~MOVSSRC);
+						Gen(O_MOVS_SetA, repmod&~MOVSSRC, OVERR_DS);
 						Gen(S_DI, repmod);
 					}
-					Gen(O_MOVS_SavA, repmod);
+					Gen(O_MOVS_SavA, repmod, OVERR_DS);
 					PC++; break;
 				case CMPSb:
 					repmod |= (MBYTE|MOVSSRC|MOVSDST|MREPCOND);
 					if (repmod & (MREPNE|MREP)) {
-						Gen(O_MOVS_SetA, repmod);
+						Gen(O_MOVS_SetA, repmod, OVERR_DS);
 					}
 					else {
-						Gen(O_MOVS_SetA, repmod&~MOVSDST);
+						Gen(O_MOVS_SetA, repmod&~MOVSDST, OVERR_DS);
 						Gen(L_DI_R1, repmod);
-						Gen(O_MOVS_SetA, repmod&~MOVSSRC);
+						Gen(O_MOVS_SetA, repmod&~MOVSSRC, OVERR_DS);
 					}
 					Gen(O_MOVS_CmpD, repmod);
-					Gen(O_MOVS_SavA, repmod);
+					Gen(O_MOVS_SavA, repmod, OVERR_DS);
 					PC++; break;
 				case CMPSw:
 					repmod |= (MOVSSRC|MOVSDST|MREPCOND);
 					if (repmod & (MREPNE|MREP)) {
-						Gen(O_MOVS_SetA, repmod);
+						Gen(O_MOVS_SetA, repmod, OVERR_DS);
 					}
 					else {
-						Gen(O_MOVS_SetA, repmod&~MOVSDST);
+						Gen(O_MOVS_SetA, repmod&~MOVSDST, OVERR_DS);
 						Gen(L_DI_R1, repmod);
-						Gen(O_MOVS_SetA, repmod&~MOVSSRC);
+						Gen(O_MOVS_SetA, repmod&~MOVSSRC, OVERR_DS);
 					}
 					Gen(O_MOVS_CmpD, repmod);
-					Gen(O_MOVS_SavA, repmod);
+					Gen(O_MOVS_SavA, repmod, OVERR_DS);
 					PC++; break;
 				case STOSb:
 					repmod |= (MBYTE|MOVSDST);
-					Gen(O_MOVS_SetA, repmod);
+					Gen(O_MOVS_SetA, repmod, OVERR_DS);
 					Gen(L_REG, repmod|MBYTE, Ofs_AL);
 					if (repmod & (MREPNE|MREP)) {
 						Gen(O_MOVS_StoD, repmod);
@@ -2339,11 +2339,11 @@ repag0:
 					else {
 						Gen(S_DI, repmod);
 					}
-					Gen(O_MOVS_SavA, repmod);
+					Gen(O_MOVS_SavA, repmod, OVERR_DS);
 					PC++; break;
 				case STOSw:
 					repmod |= MOVSDST;
-					Gen(O_MOVS_SetA, repmod);
+					Gen(O_MOVS_SetA, repmod, OVERR_DS);
 					Gen(L_REG, repmod, Ofs_EAX);
 					if (repmod & (MREPNE|MREP)) {
 						Gen(O_MOVS_StoD, repmod);
@@ -2351,11 +2351,11 @@ repag0:
 					else {
 						Gen(S_DI, repmod);
 					}
-					Gen(O_MOVS_SavA, repmod);
+					Gen(O_MOVS_SavA, repmod, OVERR_DS);
 					PC++; break;
 				case SCASb:
 					repmod |= (MBYTE|MOVSDST|MREPCOND);
-					Gen(O_MOVS_SetA, repmod);
+					Gen(O_MOVS_SetA, repmod, OVERR_DS);
 					Gen(L_REG, repmod|MBYTE, Ofs_AL);
 					if (repmod & (MREPNE|MREP)) {
 						Gen(O_MOVS_ScaD, repmod);
@@ -2364,11 +2364,11 @@ repag0:
 						Gen(L_DI_R1, repmod);
 						Gen(O_CMP_FR, repmod, Ofs_AL);
 					}
-					Gen(O_MOVS_SavA, repmod);
+					Gen(O_MOVS_SavA, repmod, OVERR_DS);
 					PC++; break;
 				case SCASw:
 					repmod |= MOVSDST|MREPCOND;
-					Gen(O_MOVS_SetA, repmod);
+					Gen(O_MOVS_SetA, repmod, OVERR_DS);
 					Gen(L_REG, repmod, Ofs_EAX);
 					if (repmod & (MREPNE|MREP)) {
 						Gen(O_MOVS_ScaD, repmod);
@@ -2377,7 +2377,7 @@ repag0:
 						Gen(L_DI_R1, repmod);
 						Gen(O_CMP_FR, repmod, Ofs_AL);
 					}
-					Gen(O_MOVS_SavA, repmod);
+					Gen(O_MOVS_SavA, repmod, OVERR_DS);
 					PC++; break;
 				case SEGes:
 					OVERR_DS = OVERR_SS = Ofs_XES; PC++; goto repag0;
@@ -2742,7 +2742,7 @@ repag0:
 					unsigned short jcs;
 					unsigned long oip,xcs,jip=0;
 					CODE_FLUSH();
-					PC += ModRMSim(PC, _mode|NOFLDR);
+					PC += ModRMSim(PC, _mode|NOFLDR, OVERR_DS, OVERR_SS);
 					TheCPU.eip = PC - LONG_CS;
 					/* get new cs:ip */
 					jip = DataGetWL_U(_mode, TheCPU.mem_ref);
@@ -3003,7 +3003,7 @@ repag0:
 			else {
 				if ((exop&0xeb)==0x21) {
 					CODE_FLUSH();
-					PC += ModRMSim(PC, _mode|NOFLDR);
+					PC += ModRMSim(PC, _mode|NOFLDR, OVERR_DS, OVERR_SS);
 					b = _mode; sim=1;
 				}
 				else {
@@ -3044,14 +3044,14 @@ repag0:
 				case 0: /* SLDT */
 				    CODE_FLUSH();
 				    if (REALMODE()) goto illegal_op;
-				    PC += ModRMSim(PC+1, _mode) + 1;
+				    PC += ModRMSim(PC+1, _mode, OVERR_DS, OVERR_SS) + 1;
 				    error("SLDT not implemented\n");
 				    break;
 				case 1: /* STR */
 				    /* Store Task Register */
 				    CODE_FLUSH();
 				    if (REALMODE()) goto illegal_op;
-				    PC += ModRMSim(PC+1, _mode) + 1;
+				    PC += ModRMSim(PC+1, _mode, OVERR_DS, OVERR_SS) + 1;
 				    error("STR not implemented\n");
 				    break;
 				case 2: /* LLDT */
@@ -3064,7 +3064,7 @@ repag0:
 				    unsigned short sv; int tmp;
 				    CODE_FLUSH();
 				    if (REALMODE()) goto illegal_op;
-				    PC += ModRMSim(PC+1, _mode) + 1;
+				    PC += ModRMSim(PC+1, _mode, OVERR_DS, OVERR_SS) + 1;
 				    if (TheCPU.mode & RM_REG) {
 					sv = CPUWORD(REG3);
 				    } else {
@@ -3081,7 +3081,7 @@ repag0:
 				    unsigned short sv; int tmp;
 				    CODE_FLUSH();
 				    if (REALMODE()) goto illegal_op;
-				    PC += ModRMSim(PC+1, _mode) + 1;
+				    PC += ModRMSim(PC+1, _mode, OVERR_DS, OVERR_SS) + 1;
 				    if (TheCPU.mode & RM_REG) {
 					sv = CPUWORD(REG3);
 				    } else {
@@ -3138,7 +3138,7 @@ repag0:
 				unsigned short sv; int tmp;
 				CODE_FLUSH();
 				if (REALMODE()) goto illegal_op;
-				PC += ModRMSim(PC+1, _mode) + 1;
+				PC += ModRMSim(PC+1, _mode, OVERR_DS, OVERR_SS) + 1;
 				if (TheCPU.mode & RM_REG) {
 				    sv = CPUWORD(REG3);
 				} else {
@@ -3474,7 +3474,7 @@ repag0:
 				    unsigned short sv = 0;
 				    unsigned long rv;
 				    CODE_FLUSH();
-				    PC++; PC += ModRMSim(PC, _mode);
+				    PC++; PC += ModRMSim(PC, _mode, OVERR_DS, OVERR_SS);
 				    rv = DataGetWL_U(_mode,TheCPU.mem_ref);
 				    TheCPU.mem_ref += BT24(BitDATA16,_mode);
 				    sv = GetDWord(TheCPU.mem_ref);
@@ -3498,7 +3498,7 @@ repag0:
 				    unsigned short sv = 0;
 				    unsigned long rv;
 				    CODE_FLUSH();
-				    PC++; PC += ModRMSim(PC, _mode);
+				    PC++; PC += ModRMSim(PC, _mode, OVERR_DS, OVERR_SS);
 				    rv = DataGetWL_U(_mode,TheCPU.mem_ref);
 				    TheCPU.mem_ref += BT24(BitDATA16,_mode);
 				    sv = GetDWord(TheCPU.mem_ref);
@@ -3522,7 +3522,7 @@ repag0:
 				    unsigned short sv = 0;
 				    unsigned long rv;
 				    CODE_FLUSH();
-				    PC++; PC += ModRMSim(PC, _mode);
+				    PC++; PC += ModRMSim(PC, _mode, OVERR_DS, OVERR_SS);
 				    rv = DataGetWL_U(_mode,TheCPU.mem_ref);
 				    TheCPU.mem_ref += BT24(BitDATA16,_mode);
 				    sv = GetDWord(TheCPU.mem_ref);
@@ -3580,7 +3580,7 @@ repag0:
 				modrm = Fetch(PC+2);
 				if (D_MO(modrm) != 1 || D_HO(modrm) == 3)
 					goto illegal_op;
-				PC++; PC += ModRMSim(PC, _mode);
+				PC++; PC += ModRMSim(PC, _mode, OVERR_DS, OVERR_SS);
 				edxeax = ((uint64_t)rEDX << 32) | rEAX;
 				m = sim_read_qword(TheCPU.mem_ref);
 				if (edxeax == m)
@@ -3680,8 +3680,6 @@ static void _PreJit86(unsigned int PC, int basemode, int flags)
 	while (1) {
 		TheCPU.mode = basemode;
 		TheCPU.basemode = basemode;
-		OVERR_DS = Ofs_XDS;
-		OVERR_SS = Ofs_XSS;
 		P0 = PC;
 		if (debug_level('e')) {
 			char *ds;

--- a/src/base/emu-i386/simx86/modrm-gen.c
+++ b/src/base/emu-i386/simx86/modrm-gen.c
@@ -66,7 +66,7 @@ static void modrm_sib(unsigned char mod, unsigned char sib, unsigned int base)
 
 /////////////////////////////////////////////////////////////////////////////
 
-int _ModRM(unsigned char opc, unsigned int PC, int mode)
+int _ModRM(unsigned char opc, unsigned int PC, int mode, signed char overr_ds, signed char overr_ss)
 {
 	unsigned char mod,cab=Fetch(PC+1);
 	int l=2;
@@ -123,14 +123,14 @@ int _ModRM(unsigned char opc, unsigned int PC, int mode)
 	}
 	if (mod == 0 && l > 3) {
 		if (index == Ofs_ESP)
-			AddrGen(A_DI_0, mode|IMMED, OVERR_DS, dsp);
+			AddrGen(A_DI_0, mode|IMMED, overr_ds, dsp);
 		else
 			/* no SS: override on index */
-			AddrGen(A_DI_2D, mode, dsp, index, shift);
+			AddrGen(A_DI_2D, mode, overr_ds, dsp, index, shift);
 	}
 	else {
 		int overr = (base == Ofs_ESP || base == Ofs_EBP) ?
-			OVERR_SS : OVERR_DS;
+			overr_ss : overr_ds;
 		if (mod==1) {
 			dsp=(signed char)Fetch(PC+l); l++;
 		}

--- a/src/base/emu-i386/simx86/modrm-sim.c
+++ b/src/base/emu-i386/simx86/modrm-sim.c
@@ -46,14 +46,14 @@
 
 /////////////////////////////////////////////////////////////////////////////
 
-int ModRMSim(unsigned int PC, int mode)
+int ModRMSim(unsigned int PC, int mode, signed char overr_ds, signed char overr_ss)
 {
 	int l;
 	void (*AddrGen_save)(int op, int mode, ...);
 
 	AddrGen_save = AddrGen;
 	AddrGen = AddrGen_sim;
-	l = _ModRM(0, PC, mode);
+	l = _ModRM(0, PC, mode, overr_ds, overr_ss);
 	AddrGen = AddrGen_save;
 	TheCPU.mem_ref = AR1.d;
 	return l;

--- a/src/base/emu-i386/simx86/syncpu.h
+++ b/src/base/emu-i386/simx86/syncpu.h
@@ -297,7 +297,6 @@ extern union _SynCPU TheCPU_union;
 #define LONG_FS		TheCPU.fs_cache.BoundL
 #define LONG_GS		TheCPU.gs_cache.BoundL
 
-extern char OVERR_DS, OVERR_SS;
 extern unsigned int LONG_CS;
 
 #define sigalrm_pending() __atomic_load_n(&TheCPU.sigalrm_pending, \

--- a/src/base/emu-i386/simx86/trees.h
+++ b/src/base/emu-i386/simx86/trees.h
@@ -65,7 +65,7 @@ typedef struct _lnkdesc {
 } linkdesc;
 
 typedef struct _imgen {
-	unsigned int op, mode, ovds;
+	unsigned int op, mode;
 	unsigned int p0,p1,p2,p3,p4;
 } IGen;
 


### PR DESCRIPTION
These can just be passed in IG->p0 where necesssary (was already partially the case), and passed as parameters.
To make #2519 a little easier.