### PR TITLE
simx86: clean up JIT codegen, seperate x86-specific code in functions

### DIFF
--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -135,7 +135,7 @@ static TNode *LastXNode = NULL;
  *		popl edx (flags)
  *		ret
  */
-unsigned char TailCode[TAILSIZE+1] =
+static unsigned char TailCode[TAILSIZE+1] =
 	{ 0xb8,0,0,0,0,0x5a,0xc3,0xf4 };
 
 #ifdef __x86_64__
@@ -189,13 +189,11 @@ void InitGen_x86(void)
  * because of the OR operator, which would cause trouble if the parameter
  * is negative */
 
-static unsigned char *CodeGen(unsigned char *CodePtr, unsigned char *BaseGenBuf,
-			      IMeta *I, int j)
+unsigned char *CodeGen(unsigned char *CodePtr, unsigned char *BaseGenBuf, const IGen *IG)
 {
 	/* evil hack, keeping state from MOVS_SavA to MOVS_SetA in
 	   a static variable */
 	static unsigned char * rep_retry_ptr = (unsigned char*)0xdeadbeef;
-	IGen *IG = &(I->gen[j]);
 	unsigned char *Cp = CodePtr;
 	unsigned char * CpTemp;
 	int mode = IG->mode;
@@ -2215,6 +2213,12 @@ shrot0:
 		}
 		break;
 
+	case JMP_TAILCODE:
+		/* copy tail instructions to the end of the code block */
+		GNX(Cp, TailCode, TAILSIZE);
+		*((unsigned int *)(Cp - TAILSIZE + TAILFIX)) = IG->p0;
+		break;
+
 	case JMP_INDIRECT: {	// input: %%{e}ax = %%{e}ip
 		if (mode&DATA16)
 			// movz{wl} %%ax,%%eax
@@ -2620,7 +2624,8 @@ static void Gen_x86(int op, int mode, ...)
 	case O_DEC_R:
 	case O_DIV:
 	case O_IDIV:
-	case O_PUSHI: {
+	case O_PUSHI:
+	case JMP_TAILCODE: {
 		int v = va_arg(ap,int);
 		IG->p0 = v;
 		}
@@ -2836,7 +2841,8 @@ static CodeBuf *ProduceCode(unsigned int PC, IMeta *I0)
 	    cp = cp1 = CodePtr;
 	    I->daddr = cp - BaseGenBuf;
 	    for (j=0; j<I->ngen; j++) {
-		CodePtr = CodeGen(CodePtr, BaseGenBuf, I, j);
+		IGen *IG = &I->gen[j];
+		CodePtr = CodeGen(CodePtr, BaseGenBuf, IG);
 		if (CodePtr-cp1 > MAX_GEND_BYTES_PER_OP) {
 		    dosemu_error("Generated code (%zd bytes) overflowed into buffer, please "
 				 "increase MAX_GEND_BYTES_PER_OP=%d\n",
@@ -2844,7 +2850,6 @@ static CodeBuf *ProduceCode(unsigned int PC, IMeta *I0)
 		    leavedos_main(0x535347);
 		}
 		if (debug_level('e')>1) {
-		    IGen *IG = &(I->gen[j]);
 		    int dg = CodePtr-cp1;
 		    e_printf("PGEN(%02d,%02d) %3d %6x %2d %08x %08x %08x %08x %08x\n",
 			i,j,IG->op,IG->mode,dg,
@@ -2865,24 +2870,6 @@ static CodeBuf *ProduceCode(unsigned int PC, IMeta *I0)
 
 	if (debug_level('e')>1)
 	    e_printf("---------------------------------------------\n");
-
-	/* If the code doesn't terminate with a jump/loop instruction
-	 * it still lacks the tail code; add it here */
-	IMeta *GL = &I0[CurrIMeta-1];
-	if (GL->gen[GL->ngen-1].op < JMP_INDIRECT) {
-		unsigned char *p = CodePtr;
-		/* copy tail instructions to the end of the code block */
-		memcpy(p, TailCode, TAILSIZE);
-		p += TAILFIX;
-		*((unsigned int *)p) = PC;
-		CodePtr += TAILSIZE;
-	}
-
-	/* show jump+tail code */
-	if ((debug_level('e')>6) && (CurrIMeta>0)) {
-		unsigned char *pl = &BaseGenBuf[GL->daddr+GL->len];
-		GCPrint(pl, BaseGenBuf, CodePtr - pl);
-	}
 
 	I0->totlen = CodePtr - BaseGenBuf;
 

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -3344,6 +3344,40 @@ static unsigned Exec_x86_asm(unsigned *mem_ref, unsigned long *flg,
 	return ePC;
 }
 
+static unsigned Exec_x86_asm_fpu(unsigned *mem_ref, unsigned long *flg,
+		unsigned char *ecpu, unsigned char *SeqStart,
+		unsigned short seqflg)
+{
+	unsigned ePC;
+	if (seqflg & F_FPOP) {
+		if (TheCPU.fpstate) {
+			loadfpstate(*TheCPU.fpstate);
+			TheCPU.fpstate = NULL;
+		}
+		/* mask exceptions in generated code */
+		unsigned short fpuc;
+		asm ("fstcw	%0" : "=m"(TheCPU.fpuc));
+		fpuc = TheCPU.fpuc | 0x3f;
+		asm ("fldcw	%0" :: "m"(fpuc));
+	}
+	ePC = Exec_x86_asm(mem_ref, flg, ecpu, SeqStart);
+	/* was there at least one FP op in the sequence? */
+	if (seqflg & F_FPOP) {
+		int exs;
+		__asm__ __volatile__ ("fstsw	%0" : "=m"(exs));
+		exs &= 0x7f;
+		if (exs) {
+			e_printf("FPU: error status %02x\n",exs);
+			if ((exs & ~TheCPU.fpuc) & 0x3f) {
+				__asm__ __volatile__ ("fnclex\n" ::: "memory");
+				e_printf("FPU exception\n");
+				TheCPU.err2 = EXCP10_COPR;
+			}
+		}
+	}
+	return ePC;
+}
+
 unsigned int Exec_x86(TNode *G)
 {
 	unsigned long flg;
@@ -3366,36 +3400,9 @@ unsigned int Exec_x86(TNode *G)
 	hitimer_t TimeStartExec;
 	if (debug_level('e')) TimeStartExec = GETTSC();
 #endif
-	if (seqflg & F_FPOP) {
-		if (TheCPU.fpstate) {
-			loadfpstate(*TheCPU.fpstate);
-			TheCPU.fpstate = NULL;
-		}
-		/* mask exceptions in generated code */
-		unsigned short fpuc;
-		asm ("fstcw	%0" : "=m"(TheCPU.fpuc));
-		fpuc = TheCPU.fpuc | 0x3f;
-		asm ("fldcw	%0" :: "m"(fpuc));
-	}
-
 	flg = Exec_x86_pre(ecpu);
-	ePC = Exec_x86_asm(&mem_ref, &flg, ecpu, SeqStart);
+	ePC = Exec_x86_asm_fpu(&mem_ref, &flg, ecpu, SeqStart, seqflg);
 	Exec_x86_post(flg, mem_ref);
-
-	/* was there at least one FP op in the sequence? */
-	if (seqflg & F_FPOP) {
-		int exs;
-		__asm__ __volatile__ ("fstsw	%0" : "=m"(exs));
-		exs &= 0x7f;
-		if (exs) {
-			e_printf("FPU: error status %02x\n",exs);
-			if ((exs & ~TheCPU.fpuc) & 0x3f) {
-				__asm__ __volatile__ ("fnclex\n" ::: "memory");
-				e_printf("FPU exception\n");
-				TheCPU.err2 = EXCP10_COPR;
-			}
-		}
-	}
 
 	if (debug_level('e')) {
 #if PROFILE >= 2

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -3346,9 +3346,6 @@ unsigned int Exec_x86(TNode *G)
 	unsigned int ePC;
 	unsigned short seqflg = G->flags;
 	unsigned char *SeqStart = G->addr;
-#if PROFILE >= 2
-	hitimer_u TimeStartExec, TimeEndExec;
-#endif
 
 	ecpu = CPUOFFS(0);
 	if (debug_level('e')>1) {
@@ -3358,6 +3355,10 @@ unsigned int Exec_x86(TNode *G)
 	}
 #ifdef ASM_DUMP
 	fprintf(aLog,"%p: exec\n",G->key);
+#endif
+#if PROFILE >= 2
+	hitimer_t TimeStartExec;
+	if (debug_level('e')) TimeStartExec = GETTSC();
 #endif
 	if (seqflg & F_FPOP) {
 		if (TheCPU.fpstate) {
@@ -3372,19 +3373,7 @@ unsigned int Exec_x86(TNode *G)
 	}
 
 	flg = Exec_x86_pre(ecpu);
-#if PROFILE >= 2
-	__asm__ __volatile__ (
-		"rdtsc\n"
-		: "=a"(TimeStartExec.t.tl),"=d"(TimeStartExec.t.th)
-	);
-#endif
 	ePC = Exec_x86_asm(&mem_ref, &flg, ecpu, SeqStart);
-#if PROFILE >= 2
-	__asm__ __volatile__ (
-		"rdtsc\n"
-		: "=a"(TimeEndExec.t.tl),"=d"(TimeEndExec.t.th)
-	);
-#endif
 	Exec_x86_post(flg, mem_ref);
 
 	/* was there at least one FP op in the sequence? */
@@ -3404,8 +3393,7 @@ unsigned int Exec_x86(TNode *G)
 
 	if (debug_level('e')) {
 #if PROFILE >= 2
-	    TimeEndExec.td -= TimeStartExec.td;
-	    ExecTime += TimeEndExec.td;
+	    ExecTime += GETTSC() - TimeStartExec;
 #endif
 	    if (debug_level('e')>1) {
 		e_printf("** End code, PC=%08x sig=%x\n",ePC,

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -3234,6 +3234,14 @@ TNode *Close_x86(unsigned int PC, int mode)
 	return G;
 }
 
+#ifdef __i386__
+  __attribute__((target("sse")))
+#endif
+static inline void prefetch(unsigned char *p)
+{
+	__builtin_prefetch(p);
+}
+
 static unsigned int Exec_x86_pre(unsigned char *ecpu)
 {
 	unsigned long flg;
@@ -3246,12 +3254,10 @@ static unsigned int Exec_x86_pre(unsigned char *ecpu)
 	flg = (flg & ~(EFLAGS_CC|EFLAGS_IF|EFLAGS_DF|EFLAGS_TF)) |
 	       (EFLAGS & EFLAGS_CC) | EFLAGS_IF;
 
-#ifndef __x86_64__
+#ifdef __i386__
 	if (config.cpuprefetcht0)
 #endif
-	    __asm__ __volatile__ (
-"		prefetcht0 %0\n"
-		: : "m"(*ecpu) );
+		prefetch(ecpu);
 
 	return flg;
 }

--- a/src/base/emu-i386/simx86/codegen-x86.h
+++ b/src/base/emu-i386/simx86/codegen-x86.h
@@ -126,8 +126,7 @@ unsigned int Exec_x86_fast(TNode *G);
 unsigned char *Fp87_op_x86(unsigned char *CodePtr, int exop, int reg);
 void InitGen_x86(void);
 void NodeUnlinker(TNode *G);
-
-extern unsigned char TailCode[];
+unsigned char *CodeGen(unsigned char *CodePtr, unsigned char *BaseGenBuf, const IGen *IG);
 
 static __inline__ int GoodNode(TNode *G, int mode)
 {

--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -145,11 +145,13 @@
 #define O_OUTPDX	110
 #define O_OUTPPC	111
 
-#define JMP_INDIRECT	112
-#define JMP_LINK	113
-#define JB_LINK		114
-#define JF_LINK		115
-#define JLOOP_LINK	116
+#define JMP_TAILCODE	112
+
+#define JMP_INDIRECT	113
+#define JMP_LINK	114
+#define JB_LINK		115
+#define JF_LINK		116
+#define JLOOP_LINK	117
 
 /////////////////////////////////////////////////////////////////////////////
 //

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -99,6 +99,15 @@ static __inline__ void SetCPU_WL(int m, signed char o, unsigned long v)
 #ifdef X86_JIT
 static TNode *DoClose(unsigned int PC, int mode, unsigned int P0)
 {
+	/* If the code doesn't terminate with a jump/loop instruction
+	 * it still lacks the tail code; add it here */
+	IMeta *GL = &InstrMeta[CurrIMeta-1];
+	if (GL->gen[GL->ngen-1].op < JMP_INDIRECT) {
+		int rc;
+		Gen(JMP_TAILCODE, mode, PC);
+		NewIMeta(PC, &rc);
+	}
+
 	assert(PC > P0);
 	if (e_querymark(P0, PC - P0)) {
 	    InvalidateNodeRange(P0, PC - P0, NULL);

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -1145,9 +1145,9 @@ static void BreakNode(TNode *G, unsigned char *eip)
   ebase = eip - G->addr;
   for (i=0; i<G->seqnum; i++) {
     if (A->daddr >= ebase) {		// found following instr
+	IGen IG = (IGen){.op = JMP_TAILCODE, .p0 = G->key + A->dnpc};
 	p = G->addr + A->daddr;		// translated IP of following instr
-	memcpy(p, TailCode, TAILSIZE);
-	*((int *)(p+TAILFIX)) = G->key + A->dnpc;
+	CodeGen(p, G->addr, &IG);
 	if (debug_level('e')>1)
 		e_printf("============ Force node closing at %08x(%p)\n",
 			 (G->key+A->dnpc),p);
@@ -1360,7 +1360,7 @@ int NewIMeta(int npc, int *rc)
 		I0->ncount += 1;
 		I->npc = npc;
 
-		if (CurrIMeta>0) {
+		if (CurrIMeta>0 && I->gen[I->ngen-1].op != JMP_TAILCODE) {
 			/* F_INHI (pop ss/mov ss) only applies to the last
 			   instruction in the sequence and not twice in
 			   a row */


### PR DESCRIPTION
Related to #2519, this moves most x86-specific code (except the node linker) from `codegen-x86.c` and `trees.c` into x86-specific functions (the rest of `codegen-x86.c` hasn't been moved to a separate file yet here, to make it easier to read the changes)

1. `TailCode` is now local to `codegen-x86.c`; tail code is managed via the new `JMP_TAILCODE`  intermediate op.
2. prefetching is managed via `__builtin_prefetch` instead of asm, still needs a bit of config logic for i386.
3. Profiling exec code is done via `GETTSC()` like the other profiling, not direct asm to `rdtsc`.
4. Remaining code from `Exec_x86` with asm moved to `Exec_x86_asm_fpu`.