### PR TITLE
Simulated pagefault handler adjustments for #2519

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -3022,7 +3022,8 @@ unsigned int CloseAndExec_sim(unsigned int PC, int mode)
 
 static void emu_pagefault_handler(dosaddr_t addr, int err, uint32_t op, int len)
 {
-	if (!in_emu_cpu()) {
+	/* err = -1 is special, hitting JIT protected page */
+	if (!in_emu_cpu() || err == -1) {
 		default_sim_pagefault_handler(addr, err, op, len);
 		return;
 	}

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -66,6 +66,7 @@
 #include "dos2linux.h"
 #include "vgaemu.h"
 #include "video.h"
+#include "msdoshlp.h"
 #include "codegen.h"
 #include "codegen-sim.h"
 
@@ -3017,6 +3018,23 @@ unsigned int CloseAndExec_sim(unsigned int PC, int mode)
 	ret = P0;
 	P0 = (unsigned)-1;
 	return ret;
+}
+
+static void emu_pagefault_handler(dosaddr_t addr, int err, uint32_t op, int len)
+{
+	if (!in_emu_cpu()) {
+		default_sim_pagefault_handler(addr, err, op, len);
+		return;
+	}
+	if ((err & 2) && msdos_ldt_access(addr)) {
+		emu_ldt_write(addr, op, len);
+		return;
+	}
+	/* trigger an exception in DPMI */
+	TheCPU.err = EXCP0E_PAGE;
+	TheCPU.scp_err = err;
+	TheCPU.cr2 = addr;
+	longjmp(jmp_env, 1);
 }
 
 uint8_t sim_read_byte(dosaddr_t x)

--- a/src/base/emu-i386/simx86/protmode.c
+++ b/src/base/emu-i386/simx86/protmode.c
@@ -386,20 +386,3 @@ int emu_ldt_write(dosaddr_t addr, uint32_t op, int len)
 	if (_gs == 0) { TheCPU.gs = 0; SetSegProt(0,Ofs_GS,NULL,0); }
 	return 1;
 }
-
-void emu_pagefault_handler(dosaddr_t addr, int err, uint32_t op, int len)
-{
-	if (!in_emu_cpu()) {
-		default_sim_pagefault_handler(addr, err, op, len);
-		return;
-	}
-	if ((err & 2) && msdos_ldt_access(addr)) {
-		emu_ldt_write(addr, op, len);
-		return;
-	}
-	/* trigger an exception in DPMI */
-	TheCPU.err = EXCP0E_PAGE;
-	TheCPU.scp_err = err;
-	TheCPU.cr2 = addr;
-	longjmp(jmp_env, 1);
-}

--- a/src/base/emu-i386/simx86/protmode.h
+++ b/src/base/emu-i386/simx86/protmode.h
@@ -231,7 +231,6 @@ int e_larlsl(int mode, unsigned short sel);
 int hsw_verr(unsigned short sel);
 int hsw_verw(unsigned short sel);
 int emu_ldt_write(dosaddr_t addr, uint32_t op, int len);
-void emu_pagefault_handler(dosaddr_t addr, int err, uint32_t op, int len);
 //
 
 extern Descriptor *GDT;

--- a/src/base/misc/dos2linux.c
+++ b/src/base/misc/dos2linux.c
@@ -665,6 +665,11 @@ static inline void set_unprotected_page(dosaddr_t addr, void *uaddr)
 
 void default_sim_pagefault_handler(dosaddr_t addr, int err, uint32_t op, int len)
 {
+  if (err == -1) {
+    /* err = -1 is special, hitting JIT protected page */
+    e_invalidate(addr, len);
+    return;
+  }
   if (err & 2)
     dosemu_error("Invalid write to addr %#x, ptr %p, len %d\n",
 		 addr, MEM_BASE32(addr), len);
@@ -753,7 +758,10 @@ static int check_write_pagefault(dosaddr_t addr, void *uaddr, uint32_t op, int l
     handler(addr, 6 + dpmi_read_access(addr), op, len);
     return 1;
   }
-  if (!e_querymprot(addr) && !memcheck_is_rom(addr))
+  if (e_querymprot(addr))
+    /* handle invalidations for writes to JIT protected pages */
+    handler(addr, -1, op, len);
+  else if (!memcheck_is_rom(addr))
     set_unprotected_page(addr, uaddr);
   return 0;
 }
@@ -769,7 +777,6 @@ void do_write_byte(dosaddr_t addr, uint8_t byte, sim_pagefault_handler_t handler
     }
     if (config.mmio_tracing && mmio_check(addr))
       mmio_trace_byte(addr, byte, MMIO_WRITE);
-    e_invalidate(addr, 1);
     uaddr = dosaddr_to_unixaddr(addr);
     if (check_write_pagefault(addr, uaddr, byte, 1, handler))
       return;
@@ -792,7 +799,6 @@ void do_write_word(dosaddr_t addr, uint16_t word, sim_pagefault_handler_t handle
     }
     if (config.mmio_tracing && mmio_check(addr))
       mmio_trace_word(addr, word, MMIO_WRITE);
-    e_invalidate(addr, 2);
     uaddr = dosaddr_to_unixaddr(addr);
     if (check_write_pagefault(addr, uaddr, word, 2, handler))
       return;
@@ -815,7 +821,6 @@ void do_write_dword(dosaddr_t addr, uint32_t dword, sim_pagefault_handler_t hand
     }
     if (config.mmio_tracing && mmio_check(addr))
       mmio_trace_dword(addr, dword, MMIO_WRITE);
-    e_invalidate(addr, 4);
     uaddr = dosaddr_to_unixaddr(addr);
     if (check_write_pagefault(addr, uaddr, dword, 4, handler))
       return;


### PR DESCRIPTION
Another prep PR for #2519, to avoid the use of a global `currentIG` variable, used for node self-hits in `BreakNode`, and DPMI page faults.

Moving `emu_pagefault_handler` to `codegen-sim.c` will allow it to deal with calling `InvalidateNodeRange`, with `currentIG` as static variable.