### PR TITLE
simx86: sim cleanups following #2519

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -442,9 +442,10 @@ void AddrGen_sim(int op, int mode, ...)
 #endif
 }
 
-void Gen_sim(int op, int mode, ...)
+void Gen_sim(const IGen *IG)
 {
-	va_list ap;
+	int op = IG->op;
+	int mode = IG->mode;
 	uint32_t S1, S2;
 #if PROFILE >= 2
 	hitimer_t t0 = 0;
@@ -452,22 +453,16 @@ void Gen_sim(int op, int mode, ...)
 #endif
 
 	P0 = (unsigned)-1;
-	va_start(ap, mode);
 	switch(op) {
 	case A_DI_0:
 	case A_DI_1:
 	case A_DI_2:
 	case A_DI_2D:
 	case A_SR_SH4: {
-		int p0 = va_arg(ap,int);
-		int p1 = va_arg(ap,int);
-		int p2 = va_arg(ap,int);
-		int p3 = va_arg(ap,int);
-		int p4 = va_arg(ap,int);
-		AddrGen_sim(op, mode, p0, p1, p2, p3, p4);
+		AddrGen_sim(op, mode, IG->p0, IG->p1, IG->p2, IG->p3, IG->p4);
 		if (V86MODE() && (0 == (mode & (ADDR16 | MLEA))) && TR1.d > 0xffff) {
 			TheCPU.err2 = EXCP0D_GPF;
-			P0 = FindPC(currentIG);
+			P0 = FindPC((const unsigned char *)IG);
 		}
 		break;
 		}
@@ -481,18 +476,18 @@ void Gen_sim(int op, int mode, ...)
 		break;
 
 	case O_FOP: {
-		unsigned char exop = (unsigned char)va_arg(ap,int);
-		int reg = va_arg(ap,int);
+		unsigned char exop = (unsigned char)IG->p0;
+		int reg = IG->p1;
 		GTRACE2("O_FPOP",exop,reg);
 		if (Fp87_op(exop, reg)) {
 		    TheCPU.err2 = -96;
-		    P0 = FindPC(currentIG);
+		    P0 = FindPC((const unsigned char *)IG);
 		}
 		}
 		break;
 
 	case L_REG: {
-		signed char o = Offs_From_Arg();
+		signed char o = (signed char)IG->p0;
 		if (mode&(MBYTE|MBYTX))	{
 			GTRACE1("L_REG_BYTE",o);
 			DR1.b.bl = CPUBYTE(o);
@@ -504,7 +499,7 @@ void Gen_sim(int op, int mode, ...)
 		} }
 		break;
 	case S_REG: {
-		signed char o = Offs_From_Arg();
+		signed char o = (signed char)IG->p0;
 		if (mode&MBYTE)	{
 			GTRACE1("S_REG_BYTE",o);
 			CPUBYTE(o) = DR1.b.bl;
@@ -516,8 +511,8 @@ void Gen_sim(int op, int mode, ...)
 		} }
 		break;
 	case L_REG2REG: {
-		signed char o1 = Offs_From_Arg();
-		signed char o2 = Offs_From_Arg();
+		signed char o1 = (signed char)IG->p0;
+		signed char o2 = (signed char)IG->p1;
 		GTRACE2("REGtoREG",o1,o2);
 		if ((mode) & MBYTE) {
 			CPUBYTE(o2) = CPUBYTE(o1);
@@ -528,7 +523,7 @@ void Gen_sim(int op, int mode, ...)
 		} }
 		break;
 	case S_DI_R: {
-		signed char o = Offs_From_Arg();
+		signed char o = (signed char)IG->p0;
 		GTRACE1("S_DI_R",o);
 		if (mode & DATA16)
 			CPUWORD(o) = AR1.w.l;
@@ -537,7 +532,7 @@ void Gen_sim(int op, int mode, ...)
 		}
 		break;
 	case S_DI_IMM: {
-		int v = va_arg(ap,int);
+		int v = IG->p0;
 		dosaddr_t addr = AR1.d;
 		if (mode&MBYTE) {
 			GTRACE3("S_DI_IMM_B",0xff,0xff,v);
@@ -550,8 +545,8 @@ void Gen_sim(int op, int mode, ...)
 		break;
 
 	case L_IMM: {
-		signed char o = Offs_From_Arg();
-		int v = va_arg(ap, int);
+		signed char o = (signed char)IG->p0;
+		int v = IG->p1;
 		GTRACE3("L_IMM",o,0xff,v);
 		if (mode & MBYTE) {
 			CPUBYTE(o) = (signed char)v;
@@ -564,7 +559,7 @@ void Gen_sim(int op, int mode, ...)
 		} }
 		break;
 	case L_IMM_R1: {
-		int v = va_arg(ap, int);
+		int v = IG->p0;
 		GTRACE3("L_IMM_R1",0xff,0xff,v);
 		if (mode & MBYTE) {
 			DR1.b.bl = (signed char)v;
@@ -578,8 +573,8 @@ void Gen_sim(int op, int mode, ...)
 		break;
 	case L_MOVZS: {
 		signed char o;
-		int rcod = va_arg(ap,int);	// 0=z 1=s
-		o = Offs_From_Arg();
+		int rcod = IG->p0;	// 0=z 1=s
+		o = (signed char)IG->p1;
 		GTRACE3("L_MOVZS",o,0xff,rcod);
 		if (mode & MBYTX) {
 		    if (rcod)
@@ -604,7 +599,7 @@ void Gen_sim(int op, int mode, ...)
 		break;
 
 	case L_LXS1: {
-		signed char o = Offs_From_Arg();
+		signed char o = (signed char)IG->p0;
 		GTRACE1("L_LXS1",o);
 		if (mode&DATA16) {
 		    CPUWORD(o) = DR1.w.l = sim_read_word(AR1.d);
@@ -616,7 +611,7 @@ void Gen_sim(int op, int mode, ...)
 		} }
 		break;
 	case L_LXS2: {	/* real mode segment base from segment value */
-		signed char o = Offs_From_Arg();
+		signed char o = (signed char)IG->p0;
 		GTRACE1("L_LXS2",o);
 		DR1.d = sim_read_word(AR1.d);
 		SetSegReal(DR1.w.l, o);
@@ -660,7 +655,7 @@ void Gen_sim(int op, int mode, ...)
 
 	case O_ADD_R: {		// OSZAPC
 		register wkreg v;
-		v.d = va_arg(ap, int);
+		v.d = IG->p0;
 		RFL.mode = mode;
 		RFL.valid = V_ADD;
 		if (mode & IMMED) {GTRACE3("O_ADD_R",0xff,0xff,v.d);}
@@ -690,7 +685,7 @@ void Gen_sim(int op, int mode, ...)
 		}
 		break;
 	case O_OR_R: {		// O=0 SZP C=0
-		int v = va_arg(ap, int);
+		int v = IG->p0;
 		RFL.mode = mode | CLROVF;
 		RFL.valid = V_GEN;
 		if (mode & IMMED) {GTRACE3("O_OR_R",0xff,0xff,v);}
@@ -712,7 +707,7 @@ void Gen_sim(int op, int mode, ...)
 		}
 		break;
 	case O_AND_R: {		// O=0 SZP C=0
-		int v = va_arg(ap, int);
+		int v = IG->p0;
 		RFL.mode = mode | CLROVF;
 		RFL.valid = V_GEN;
 		if (mode & IMMED) {GTRACE3("O_AND_R",0xff,0xff,v);}
@@ -734,7 +729,7 @@ void Gen_sim(int op, int mode, ...)
 		}
 		break;
 	case O_XOR_R: {		// O=0 SZP C=0
-		int v = va_arg(ap, int);
+		int v = IG->p0;
 		RFL.mode = mode | CLROVF;
 		RFL.valid = V_GEN;
 		if (mode & IMMED) {GTRACE3("O_XOR_R",0xff,0xff,v);}
@@ -757,7 +752,7 @@ void Gen_sim(int op, int mode, ...)
 		break;
 	case O_SUB_R: {		// OSZAPC
 		register wkreg v;
-		v.d = va_arg(ap, int);
+		v.d = IG->p0;
 		RFL.mode = mode;
 		RFL.valid = V_SUB;
 		if (mode & IMMED) {GTRACE3("O_SUB_R",0xff,0xff,v.d);}
@@ -788,7 +783,7 @@ void Gen_sim(int op, int mode, ...)
 		break;
 	case O_CMP_R: {		// OSZAPC
 		register wkreg v;
-		v.d = va_arg(ap, int);
+		v.d = IG->p0;
 		RFL.mode = mode;
 		RFL.valid = V_SUB;
 		if (mode & IMMED) {GTRACE3("O_CMP_R",0xff,0xff,v.d);}
@@ -819,7 +814,7 @@ void Gen_sim(int op, int mode, ...)
 	case O_ADC_R: {		// OSZAPC
 		register wkreg v;
 		int cy;
-		v.d = va_arg(ap, int);
+		v.d = IG->p0;
 		cy = CPUBYTE(Ofs_FLAGS) & 1;
 		RFL.mode = mode;
 		RFL.valid = (cy? V_ADC:V_ADD);
@@ -852,7 +847,7 @@ void Gen_sim(int op, int mode, ...)
 	case O_SBB_R: {		// OSZAPC
 		register wkreg v;
 		int cy;
-		v.d = va_arg(ap, int);
+		v.d = IG->p0;
 		cy = CPUBYTE(Ofs_FLAGS) & 1;
 		RFL.mode = mode;
 		RFL.valid = V_SBB;
@@ -884,7 +879,7 @@ void Gen_sim(int op, int mode, ...)
 		}
 		break;
 	case O_CLEAR: {		// == XOR r,r
-		signed char o = Offs_From_Arg();
+		signed char o = (signed char)IG->p0;
 		GTRACE1("O_CLEAR",o);
 		if (mode & MBYTE) {
 		    CPUBYTE(o) = 0;
@@ -900,7 +895,7 @@ void Gen_sim(int op, int mode, ...)
 		}
 		break;
 	case O_TEST: {		// == OR r,r
-		signed char o = Offs_From_Arg();
+		signed char o = (signed char)IG->p0;
 		GTRACE1("O_TEST",o);
 		RFL.mode = mode | CLROVF;
 		RFL.valid = V_GEN;
@@ -917,7 +912,7 @@ void Gen_sim(int op, int mode, ...)
 		}
 		break;
 	case O_SBSELF: {
-		signed char o = Offs_From_Arg();
+		signed char o = (signed char)IG->p0;
 		GTRACE1("O_SBBSELF",o);
 		// if CY=0 -> reg=0,  flag=xx46, OF=0
 		// if CY=1 -> reg=-1, flag=xx97, OF=0
@@ -942,7 +937,7 @@ void Gen_sim(int op, int mode, ...)
 		}
 		break;
 	case O_INC_R: {		// OSZAP
-		signed char o = Offs_From_Arg();
+		signed char o = (signed char)IG->p0;
 		GTRACE1("O_INC_R",o);
 		RFL.mode = mode;
 		RFL.valid = V_ADD;
@@ -964,7 +959,7 @@ void Gen_sim(int op, int mode, ...)
 		}
 		break;
 	case O_DEC_R: {		// OSZAP
-		signed char o = Offs_From_Arg();
+		signed char o = (signed char)IG->p0;
 		GTRACE1("O_DEC_R",o);
 		RFL.mode = mode;
 		RFL.valid = V_SUB;
@@ -987,9 +982,9 @@ void Gen_sim(int op, int mode, ...)
 		break;
 	case O_ADD_FR: {	// OSZAPC
 		register wkreg v;
-		signed char o = Offs_From_Arg();
+		signed char o = (signed char)IG->p0;
 		v.d = 0;
-		if (mode & IMMED) v.d = va_arg(ap,int);
+		if (mode & IMMED) v.d = IG->p1;
 		RFL.mode = mode;
 		RFL.valid = V_ADD;
 		if (mode & IMMED) {GTRACE3("O_ADD_FR",0xff,0xff,v.d);}
@@ -1020,9 +1015,9 @@ void Gen_sim(int op, int mode, ...)
 		break;
 	case O_OR_FR: {		// O=0 SZP C=0
 		register wkreg v;
-		signed char o = Offs_From_Arg();
+		signed char o = (signed char)IG->p0;
 		v.d = 0;
-		if (mode & IMMED) v.d = va_arg(ap,int);
+		if (mode & IMMED) v.d = IG->p1;
 		RFL.mode = mode | CLROVF;
 		RFL.valid = V_GEN;
 		if (mode & IMMED) {GTRACE3("O_OR_FR",0xff,0xff,v.d);}
@@ -1042,10 +1037,10 @@ void Gen_sim(int op, int mode, ...)
 		break;
 	case O_ADC_FR: {	// OSZAPC
 		register wkreg v;
-		signed char o = Offs_From_Arg();
+		signed char o = (signed char)IG->p0;
 		int cy;
 		v.d = 0;
-		if (mode & IMMED) v.d = va_arg(ap,int);
+		if (mode & IMMED) v.d = IG->p1;
 		cy = CPUBYTE(Ofs_FLAGS) & 1;
 		RFL.mode = mode;
 		RFL.valid = (cy? V_ADC:V_ADD);
@@ -1077,10 +1072,10 @@ void Gen_sim(int op, int mode, ...)
 		break;
 	case O_SBB_FR: {	// OSZAPC
 		register wkreg v;
-		signed char o = Offs_From_Arg();
+		signed char o = (signed char)IG->p0;
 		int cy;
 		v.d = 0;
-		if (mode & IMMED) v.d = va_arg(ap,int);
+		if (mode & IMMED) v.d = IG->p1;
 		cy = CPUBYTE(Ofs_FLAGS) & 1;
 		RFL.mode = mode;
 		RFL.valid = V_SBB;
@@ -1113,9 +1108,9 @@ void Gen_sim(int op, int mode, ...)
 		break;
 	case O_AND_FR: {		// O=0 SZP C=0
 		register wkreg v;
-		signed char o = Offs_From_Arg();
+		signed char o = (signed char)IG->p0;
 		v.d = 0;
-		if (mode & IMMED) v.d = va_arg(ap,int);
+		if (mode & IMMED) v.d = IG->p1;
 		RFL.mode = mode | CLROVF;
 		RFL.valid = V_GEN;
 		if (mode & IMMED) {GTRACE3("O_AND_FR",0xff,0xff,v.d);}
@@ -1135,9 +1130,9 @@ void Gen_sim(int op, int mode, ...)
 		break;
 	case O_SUB_FR: {	// OSZAPC
 		register wkreg v;
-		signed char o = Offs_From_Arg();
+		signed char o = (signed char)IG->p0;
 		v.d = 0;
-		if (mode & IMMED) v.d = va_arg(ap,int);
+		if (mode & IMMED) v.d = IG->p1;
 		RFL.mode = mode;
 		RFL.valid = V_SUB;
 		if (mode & IMMED) {GTRACE3("O_SUB_FR",0xff,0xff,v.d);}
@@ -1168,9 +1163,9 @@ void Gen_sim(int op, int mode, ...)
 		break;
 	case O_XOR_FR: {		// O=0 SZP C=0
 		register wkreg v;
-		signed char o = Offs_From_Arg();
+		signed char o = (signed char)IG->p0;
 		v.d = 0;
-		if (mode & IMMED) v.d = va_arg(ap,int);
+		if (mode & IMMED) v.d = IG->p1;
 		RFL.mode = mode | CLROVF;
 		RFL.valid = V_GEN;
 		if (mode & IMMED) {GTRACE3("O_XOR_FR",0xff,0xff,v.d);}
@@ -1190,9 +1185,9 @@ void Gen_sim(int op, int mode, ...)
 		break;
 	case O_CMP_FR: {	// OSZAPC
 		register wkreg v;
-		signed char o = Offs_From_Arg();
+		signed char o = (signed char)IG->p0;
 		v.d = 0;
-		if (mode & IMMED) v.d = va_arg(ap,int);
+		if (mode & IMMED) v.d = IG->p1;
 		RFL.mode = mode;
 		RFL.valid = V_SUB;
 		if (mode & IMMED) {GTRACE3("O_CMP_FR",0xff,0xff,v.d);}
@@ -1290,7 +1285,7 @@ void Gen_sim(int op, int mode, ...)
 		}
 		break;
 	case O_CMPXCHG: {		// OSZAPC
-		signed char o = Offs_From_Arg();
+		signed char o = (signed char)IG->p0;
 		RFL.mode = mode;
 		RFL.valid = V_SUB;
 		GTRACE1("O_CMPXCHG",o);
@@ -1327,7 +1322,7 @@ void Gen_sim(int op, int mode, ...)
 		}
 		break;
 	case O_XCHG: {
-		signed char o = Offs_From_Arg();
+		signed char o = (signed char)IG->p0;
 		GTRACE1("O_XCHG",o);
 		if (mode & MBYTE) {
 			DR2.b.bl = DR1.b.bl;
@@ -1346,8 +1341,8 @@ void Gen_sim(int op, int mode, ...)
 		} }
 		break;
 	case O_XCHG_R: {
-		signed char o1 = Offs_From_Arg();
-		signed char o2 = Offs_From_Arg();
+		signed char o1 = (signed char)IG->p0;
+		signed char o2 = (signed char)IG->p1;
 		GTRACE2("O_XCHG_R",o1,o2);
 		if (mode & MBYTE) {
 			DR1.b.bl = CPUBYTE(o1);
@@ -1406,8 +1401,8 @@ void Gen_sim(int op, int mode, ...)
 		RFL.valid = V_GEN;
 		if (mode & MBYTE) {
 		    if ((mode&(IMMED|DATA16))==(IMMED|DATA16)) {
-			int b = va_arg(ap, int);
-			signed char o = Offs_From_Arg();
+			int b = IG->p0;
+			signed char o = (signed char)IG->p1;
 			GTRACE3("O_IMUL",o,0xff,b);
 			DR1.ds = (int)DR1.ws.l * b;
 			CPUWORD(o) = DR1.w.l;
@@ -1415,8 +1410,8 @@ void Gen_sim(int op, int mode, ...)
 			of = ((DR1.ds!=0) && (DR1.ds!=-1));
 		    }
 		    else if ((mode&(IMMED|DATA16))==IMMED) {
-			int b = va_arg(ap, int);
-			signed char o = Offs_From_Arg();
+			int b = IG->p0;
+			signed char o = (signed char)IG->p1;
 			int64_t v;
 			GTRACE3("O_IMUL",o,0xff,b);
 			v = (int64_t)DR1.ds * b;
@@ -1435,14 +1430,14 @@ void Gen_sim(int op, int mode, ...)
 		}
 		else if (mode&DATA16) {
 		    if (mode&IMMED) {
-			int b = va_arg(ap, int);
-			signed char o = Offs_From_Arg();
+			int b = IG->p0;
+			signed char o = (signed char)IG->p1;
 			GTRACE3("O_IMUL",o,0xff,b);
 		    	DR1.ds = (int)DR1.ws.l * b;
 		    	CPUWORD(o) = DR1.w.l;
 		    }
 		    else if (mode&MEMADR) {
-			signed char o = Offs_From_Arg();
+			signed char o = (signed char)IG->p0;
 			GTRACE1("O_IMUL",o);
 			DR1.ds = (int)(signed short)CPUWORD(o) * (int)DR1.ws.l;
 			CPUWORD(o) = DR1.w.l;
@@ -1460,14 +1455,14 @@ void Gen_sim(int op, int mode, ...)
 		else {
 		    int64_t v;
 		    if (mode&IMMED) {
-			int b = va_arg(ap, int);
-			signed char o = Offs_From_Arg();
+			int b = IG->p0;
+			signed char o = (signed char)IG->p1;
 			GTRACE3("O_IMUL",o,0xff,b);
 			v = (int64_t)DR1.ds * b;
 			CPULONG(o) = v & 0xffffffff;
 		    }
 		    else if (mode&MEMADR) {
-			signed char o = Offs_From_Arg();
+			signed char o = (signed char)IG->p0;
 			int vd = CPULONG(o);
 			GTRACE1("O_IMUL",o);
 			v = (int64_t)DR1.ds * (int64_t)vd;
@@ -1549,7 +1544,7 @@ void Gen_sim(int op, int mode, ...)
 			}
 		}
 		if (TheCPU.err2 == EXCP00_DIVZ)
-			P0 = va_arg(ap, dosaddr_t);
+			P0 = (dosaddr_t)IG->p0;
 		break;
 	case O_IDIV:		// no flags
 		GTRACE0("O_IDIV");
@@ -1607,7 +1602,7 @@ void Gen_sim(int op, int mode, ...)
 			}
 		}
 		if (TheCPU.err2 == EXCP00_DIVZ)
-			P0 = va_arg(ap, dosaddr_t);
+			P0 = (dosaddr_t)IG->p0;
 		break;
 	case O_CBWD:
 		GTRACE0("O_CBWD");
@@ -1632,7 +1627,7 @@ void Gen_sim(int op, int mode, ...)
 		}
 		break;
 	case O_XLAT: {
-		signed char ofs = Offs_From_Arg();
+		signed char ofs = (signed char)IG->p0;
 		GTRACE1("XLAT",ofs);
 		AR1.d = CPULONG(ofs);
 		TR1.d = CPULONG(Ofs_EBX) + CPUBYTE(Ofs_AL);
@@ -1644,7 +1639,7 @@ void Gen_sim(int op, int mode, ...)
 		break;
 
 	case O_ROL: {		// O(if sh==1),C(if sh>0)
-		signed char o = Offs_From_Arg();
+		signed char o = (signed char)IG->p0;
 		unsigned int sh, rbef, raft, cy, ov;
 		GTRACE1("O_ROL",o);
 		if (mode & IMMED) sh = o;
@@ -1688,7 +1683,7 @@ void Gen_sim(int op, int mode, ...)
 		}
 		break;
 	case O_RCL: {		// O(if sh==1),C(if sh>0)
-		signed char o = Offs_From_Arg();
+		signed char o = (signed char)IG->p0;
 		unsigned int sh, rbef, raft, cy, ov;
 		GTRACE1("O_RCL",o);
 		cy = CPUBYTE(Ofs_FLAGS) & 1;
@@ -1734,7 +1729,7 @@ void Gen_sim(int op, int mode, ...)
 		}
 		break;
 	case O_SHL: {		// O(if sh==1),SZPC(if sh>0)
-		signed char o = Offs_From_Arg();
+		signed char o = (signed char)IG->p0;
 		unsigned int sh, rbef, raft=0, cy=0;
 		GTRACE3("O_SHL",0xff,0xff,o);
 		if (mode & IMMED) sh = o;
@@ -1782,7 +1777,7 @@ void Gen_sim(int op, int mode, ...)
 		}
 		break;
 	case O_ROR: {		// O(if sh==1),C(if sh>0)
-		signed char o = Offs_From_Arg();
+		signed char o = (signed char)IG->p0;
 		unsigned int sh, rbef, raft, cy, ov;
 		GTRACE1("O_ROR",o);
 		if (mode & IMMED) sh = o;
@@ -1826,7 +1821,7 @@ void Gen_sim(int op, int mode, ...)
 		}
 		break;
 	case O_RCR: {		// O(if sh==1),C(if sh>0)
-		signed char o = Offs_From_Arg();
+		signed char o = (signed char)IG->p0;
 		unsigned int sh, rbef, raft, cy, ov;
 		GTRACE3("O_RCR",0xff,0xff,o);
 		cy = CPUBYTE(Ofs_FLAGS) & 1;
@@ -1873,7 +1868,7 @@ void Gen_sim(int op, int mode, ...)
 		}
 		break;
 	case O_SHR: {		// O(if sh==1),SZPC(if sh>0)
-		signed char o = Offs_From_Arg();
+		signed char o = (signed char)IG->p0;
 		unsigned int sh, rbef, raft, cy=0;
 		GTRACE3("O_SHR",0xff,0xff,o);
 		if (mode & IMMED) sh = o;
@@ -1917,7 +1912,7 @@ void Gen_sim(int op, int mode, ...)
 		}
 		break;
 	case O_SAR: {		// O(if sh==1),SZPC(if sh>0)
-		signed char o = Offs_From_Arg();
+		signed char o = (signed char)IG->p0;
 		unsigned int sh, cy=0;
 		signed int rbef, raft=0;
 		GTRACE3("O_SHR",0xff,0xff,o);
@@ -1958,9 +1953,9 @@ void Gen_sim(int op, int mode, ...)
 		break;
 
 	case O_OPAX: {	/* used by DAA..AAD */
-		int n =	va_arg(ap,int);
+		int n =	IG->p0;
 		// get n bytes from parameter stack
-		unsigned char subop = va_arg(ap,int);
+		unsigned char subop = IG->p1;
 		GTRACE3("O_OPAX",0xff,0xff,n);
 		RFL.mode = mode;
 		/* sync AF *before* changing RFL.valid */
@@ -2036,7 +2031,7 @@ void Gen_sim(int op, int mode, ...)
 				break;
 			case AAM: {
 				signed char tmp = DR1.b.bl;
-				int base = Offs_From_Arg();
+				int base = (signed char)IG->p2;
 				DR1.b.bh = tmp / base;
 				RFL.RES.d = DR1.bs.bl = tmp % base;
 				/* clear AF (undefined: found experimentally) */
@@ -2044,7 +2039,7 @@ void Gen_sim(int op, int mode, ...)
 				}
 				break;
 			case AAD: {
-				int base = Offs_From_Arg();
+				int base = (signed char)IG->p2;
 				DR1.w.l = ((DR1.b.bh * base) + DR1.b.bl) & 0xff;
 				RFL.RES.d = DR1.bs.bl; /* for flags */
 				/* clear AF (undefined: found experimentally) */
@@ -2086,7 +2081,7 @@ void Gen_sim(int op, int mode, ...)
 		break;
 
 	case O_PUSH2: {
-		signed char o = Offs_From_Arg();
+		signed char o = (signed char)IG->p0;
 		unsigned long stackm = CPULONG(Ofs_STACKM);
 		GTRACE1("O_PUSH2",o);
 		if (mode & DATA16) {
@@ -2140,7 +2135,7 @@ void Gen_sim(int op, int mode, ...)
 		} break;
 
 	case O_PUSHI: {
-		int v = va_arg(ap, int);
+		int v = IG->p0;
 		unsigned long stackm = CPULONG(Ofs_STACKM);
 		GTRACE3("O_PUSHI",0xff,0xff,v);
 		if (mode & DATA16) {
@@ -2164,7 +2159,7 @@ void Gen_sim(int op, int mode, ...)
 		} break;
 
 	case O_POP: {
-		int imm16 = (mode&MRETISP) ? va_arg(ap,int) : 0;
+		int imm16 = (mode&MRETISP) ? IG->p0 : 0;
 		long stackm = CPULONG(Ofs_STACKM);
 		GTRACE1("O_POP",imm16);
 		if (mode & DATA16) {
@@ -2202,7 +2197,7 @@ void Gen_sim(int op, int mode, ...)
 		break;
 
 	case O_POP2: {
-		signed char o = Offs_From_Arg();
+		signed char o = (signed char)IG->p0;
 		long stackm = CPULONG(Ofs_STACKM);
 		GTRACE1("O_POP2",o);
 		if (mode & DATA16) {
@@ -2263,10 +2258,10 @@ void Gen_sim(int op, int mode, ...)
 		break;
 
 	case O_INT: {
-		unsigned char intno = va_arg(ap, int);
+		unsigned char intno = IG->p0;
 		// Check bitmap, GPF if revectored
 		if (test_bit(intno, &TheCPU.int_revectored)) {
-			P0 = va_arg(ap, dosaddr_t);
+			P0 = (dosaddr_t)IG->p1;
 			TheCPU.err2 = EXCP0D_GPF;
 		}
 		else {
@@ -2275,7 +2270,7 @@ void Gen_sim(int op, int mode, ...)
 		break;
 
 	case O_MOVS_SetA: {
-		signed char ofs = Offs_From_Arg();
+		signed char ofs = (signed char)IG->p0;
 		GTRACE1("O_MOVS_SetA",ofs);
 		if (mode&ADDR16) {
 		    if (mode&MOVSSRC) {
@@ -2331,7 +2326,7 @@ void Gen_sim(int op, int mode, ...)
 			/* misaligned overflow generates trap. */
 			if(minofs & (OPSIZE(mode)-1)) {
 			    TheCPU.err2 = EXCP0D_GPF;
-			    P0 = FindPC(currentIG);
+			    P0 = FindPC((const unsigned char *)IG);
 			    break;
 			}
 
@@ -2340,7 +2335,7 @@ void Gen_sim(int op, int mode, ...)
 			if (df < 0)
 			    possible++;
 			TR1.d = possible;
-			Gen_sim(O_MOVS_MovD,mode);
+			Gen_sim(IG);
 			/* emulate overflow */
 			if (df == -1) {
 			    if(SR1.d == minofs) {
@@ -2378,7 +2373,7 @@ void Gen_sim(int op, int mode, ...)
 
 			/* do the rest */
 			TR1.d = i - possible;
-			Gen_sim(O_MOVS_MovD,mode);
+			Gen_sim(IG);
 			break;
 		    }
 		}
@@ -2462,18 +2457,18 @@ void Gen_sim(int op, int mode, ...)
 			{
 				/* misaligned overflow generates trap. */
 				TheCPU.err2 = EXCP0D_GPF;
-				P0 = FindPC(currentIG);
+				P0 = FindPC((const unsigned char *)IG);
 				break;
 			}
 			possible = minofs / (OPSIZE(mode));
 			if (df < 0)
 			    possible++;
 			TR1.d = possible;
-			Gen_sim(O_MOVS_StoD,mode);
+			Gen_sim(IG);
 			SR1.d = (df == -1 ? 0xffff : 0);
 			AR1.d -= 0x10000*df;
 			TR1.d = i - possible;
-			Gen_sim(O_MOVS_StoD,mode);
+			Gen_sim(IG);
 			break;
 		    }
 		}
@@ -2587,7 +2582,7 @@ void Gen_sim(int op, int mode, ...)
 		break;
 
 	case O_MOVS_SavA: {
-		signed char ofs = Offs_From_Arg();
+		signed char ofs = (signed char)IG->p0;
 		GTRACE1("O_MOVS_SavA",ofs);
 		if (!(mode&(MREP|MREPNE))) {
 		    // %%edx set to DF's increment
@@ -2634,7 +2629,7 @@ void Gen_sim(int op, int mode, ...)
 		}
 		break;
 	case O_SLAHF: {
-		int rcod = va_arg(ap,int)&1;	// 0=LAHF 1=SAHF
+		int rcod = IG->p0&1;	// 0=LAHF 1=SAHF
 		if (rcod==0) {		/* LAHF */
 			GTRACE0("O_LAHF");
 			FlagSync_All();
@@ -2647,7 +2642,7 @@ void Gen_sim(int op, int mode, ...)
 		} }
 		break;
 	case O_SETFL: {
-		unsigned char o1 = (unsigned char)va_arg(ap,int);
+		unsigned char o1 = (unsigned char)IG->p0;
 		switch(o1) {	// these are direct on x86
 		case CMC:
 			GTRACE0("O_CMC");
@@ -2681,7 +2676,7 @@ void Gen_sim(int op, int mode, ...)
 		} }
 		break;
 	case O_BSWAP: {
-		unsigned char o1 = (unsigned char)va_arg(ap,int);
+		unsigned char o1 = (unsigned char)IG->p0;
 		register long v;
 		GTRACE1("O_BSWAP",o1);
 		v = CPULONG(o1);
@@ -2691,7 +2686,7 @@ void Gen_sim(int op, int mode, ...)
 		}
 		break;
 	case O_SETCC: {
-		unsigned char o1 = (unsigned char)va_arg(ap,int);
+		unsigned char o1 = (unsigned char)IG->p0;
 		GTRACE3("O_SETCC",0xff,0xff,o1);
 		FlagSync_All();
 		switch(o1) {
@@ -2719,8 +2714,8 @@ void Gen_sim(int op, int mode, ...)
 		}
 		break;
 	case O_BITOP: {
-		unsigned char o1 = (unsigned char)va_arg(ap,int);
-		signed char o2 = Offs_From_Arg();
+		unsigned char o1 = (unsigned char)IG->p0;
+		signed char o2 = (signed char)IG->p1;
 		int flg;
 		GTRACE3("O_BITOP",o2,0xff,o1);
 		if (o1 == 0x1c || o1 == 0x1d) { /* bsf/bsr */
@@ -2769,12 +2764,12 @@ void Gen_sim(int op, int mode, ...)
 		}
 		} break;
 	case O_SHFD: {
-		unsigned char l_r = (unsigned char)va_arg(ap,int)&8;
-		signed char o = Offs_From_Arg();
+		unsigned char l_r = (unsigned char)IG->p0&8;
+		signed char o = (signed char)IG->p1;
 		unsigned char shc;
 		int cy;
 		if (mode & IMMED) {
-			shc = (unsigned char)va_arg(ap,int)&0x1f;
+			shc = (unsigned char)IG->p2&0x1f;
 			GTRACE4("O_SHFD",o,0xff,l_r,shc);
 		}
 		else {
@@ -2878,7 +2873,7 @@ void Gen_sim(int op, int mode, ...)
 		break;
 
 	case JMP_TAILCODE: {	// retaddr
-		P0 = va_arg(ap,unsigned int);
+		P0 = (unsigned int)IG->p0;
 		if (debug_level('e')>2) {
 			dbug_printf("** Tail code: return from %08x\n",P0);
 		} }
@@ -2891,9 +2886,9 @@ void Gen_sim(int op, int mode, ...)
 		break;
 
 	case JMP_LINK: {	// opc, dspt, retaddr, link
-		int opc = va_arg(ap,int);
-		P0 = va_arg(ap,unsigned int);
-		unsigned int d_nt = va_arg(ap,unsigned int);
+		int opc = IG->p0;
+		P0 = (unsigned int)IG->p1;
+		unsigned int d_nt = (unsigned int)IG->p2;
 		if (opc == CALLd || opc == CALLl)
 			PUSH(mode, d_nt);
 		if (debug_level('e')>2) {
@@ -2905,10 +2900,10 @@ void Gen_sim(int op, int mode, ...)
 
 	case JF_LINK:
 	case JB_LINK: {		// opc, PC, dspt, dspnt, link
-		int opc = va_arg(ap,int);
-		unsigned int PC = va_arg(ap,unsigned int);
-		unsigned int j_t = va_arg(ap,unsigned int);
-		unsigned int j_nt = va_arg(ap,unsigned int);
+		int opc = IG->p0;
+		unsigned int PC = (unsigned int)IG->p1;
+		unsigned int j_t = (unsigned int)IG->p2;
+		unsigned int j_nt = (unsigned int)IG->p3;
 		(void)PC;
 		switch(opc) {
 		case JO:      P0 = is_of_set() ? j_t : j_nt; break;
@@ -2944,9 +2939,9 @@ void Gen_sim(int op, int mode, ...)
 		}
 		break;
 	case JLOOP_LINK: {	// opc, dspt, dspnt, link
-		int opc = va_arg(ap,int);
-		unsigned int j_t = va_arg(ap,unsigned int);
-		unsigned int j_nt = va_arg(ap,unsigned int);
+		int opc = IG->p0;
+		unsigned int j_t = (unsigned int)IG->p1;
+		unsigned int j_nt = (unsigned int)IG->p2;
 		int cxv = (mode&ADDR16? --rCX : --rECX);
 		switch(opc) {
 		case LOOP:
@@ -2965,7 +2960,6 @@ void Gen_sim(int op, int mode, ...)
 
 	}
 
-	va_end(ap);
 #ifdef DEBUG_MORE
 	if (debug_level('e')>3) {
 #else
@@ -2990,7 +2984,7 @@ void Gen_sim(int op, int mode, ...)
 			if ((exs & ~TheCPU.fpuc) & 0x3f) {
 				e_printf("FPU exception\n");
 				TheCPU.err2 = EXCP10_COPR;
-				P0 = FindPC(currentIG);
+				P0 = FindPC((const unsigned char *)IG);
 			}
 		}
 	}
@@ -3018,7 +3012,7 @@ static unsigned Exec_sim(unsigned *mem_ref, unsigned long *flg,
 	P0 = (unsigned)-1;
 	do {
 		currentIG = (unsigned char *)IG;
-		Gen_sim(IG->op, IG->mode, IG->p0, IG->p1, IG->p2, IG->p3, IG->p4);
+		Gen_sim(IG);
 		IG++;
 	} while (P0 == (unsigned int)-1);
 	currentIG = NULL;

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -561,7 +561,7 @@ void Gen_sim(int op, int mode, ...)
 		break;
 	case L_MOVZS: {
 		signed char o;
-		int rcod = va_arg(ap,int)&1;	// 0=z 1=s
+		int rcod = va_arg(ap,int);	// 0=z 1=s
 		o = Offs_From_Arg();
 		GTRACE3("L_MOVZS",o,0xff,rcod);
 		if (mode & MBYTX) {
@@ -3008,10 +3008,8 @@ static unsigned Exec_sim(unsigned *mem_ref, unsigned long *flg,
 				P0 = FindPC((unsigned char *)IG);
 			}
 		} else {
-			unsigned int p0 = IG->p0;
-			if (op == L_MOVZS) p0 >>= 3;
 			currentIG = (unsigned char *)IG;
-			Gen_sim(op, IG->mode, p0, IG->p1, IG->p2, IG->p3);
+			Gen_sim(op, IG->mode, IG->p0, IG->p1, IG->p2, IG->p3);
 		}
 		IG++;
 	} while (P0 == (unsigned int)-1);

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -483,6 +483,18 @@ void Gen_sim(const IGen *IG)
 		    TheCPU.err2 = -96;
 		    P0 = FindPC((const unsigned char *)IG);
 		}
+		int exs = TheCPU.fpus & 0x7f;
+		if (debug_level('e')>3) {
+		    e_printf("  %s\n", e_trace_fp());
+		}
+		if (exs) {
+			e_printf("FPU: error status %02x\n",exs);
+			if ((exs & ~TheCPU.fpuc) & 0x3f) {
+				e_printf("FPU exception\n");
+				TheCPU.err2 = EXCP10_COPR;
+				P0 = FindPC((const unsigned char *)IG);
+			}
+		}
 		}
 		break;
 
@@ -2972,21 +2984,6 @@ void Gen_sim(const IGen *IG)
 	    dbug_printf("(R) RFL m=[%s] v=%d cout=%08x RES=%08x\n",
 		showmode(RFL.mode),RFL.valid,RFL.cout,RFL.RES.d);
 //	    if (debug_level('e')==9) dbug_printf("\n%s",e_print_regs());
-	}
-
-	if (op == O_FOP) {
-		int exs = TheCPU.fpus & 0x7f;
-		if (debug_level('e')>3) {
-		    e_printf("  %s\n", e_trace_fp());
-		}
-		if (exs) {
-			e_printf("FPU: error status %02x\n",exs);
-			if ((exs & ~TheCPU.fpuc) & 0x3f) {
-				e_printf("FPU exception\n");
-				TheCPU.err2 = EXCP10_COPR;
-				P0 = FindPC((const unsigned char *)IG);
-			}
-		}
 	}
 
 #if PROFILE >= 2

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -91,7 +91,7 @@ wkreg AR1;	// "edi"
 wkreg AR2;	// "esi"
 wkreg SR1;	// "ebp"
 wkreg TR1;	// "ecx"
-flgtmp RFL;
+static flgtmp RFL;
 
 /////////////////////////////////////////////////////////////////////////////
 
@@ -238,7 +238,7 @@ static void SetOF(void)
 
 #define SET_OF(ov) { if(ov) SetOF(); else ClearOF(); }
 
-static inline int FlagSync_O_ (void)
+static inline int FlagSync_O (void)
 {
 	int nf;
 	// OF
@@ -264,15 +264,6 @@ static inline int FlagSync_O_ (void)
 	if (debug_level('e')>1) e_printf("Sync O flag = %04x\n", nf);
 	return nf;
 }
-
-void FlagSync_O (void)
-{
-	int nf;
-	if (RFL.mode & IGNOVF) return;
-	nf = FlagSync_O_();
-	CPUWORD(Ofs_FLAGS) = (CPUWORD(Ofs_FLAGS) & 0xf7ff) | nf;
-}
-
 
 static unsigned char parity[256] =
    { 4, 0, 0, 4, 0, 4, 4, 0, 0, 4, 4, 0, 4, 0, 0, 4,
@@ -312,7 +303,7 @@ static inline int FlagSync_AP_ (void)
 	return nf;
 }
 
-void FlagSync_AP (void)
+static void FlagSync_AP (void)
 {
 	int nf = FlagSync_AP_();
 	CPUBYTE(Ofs_FLAGS) = (CPUBYTE(Ofs_FLAGS) & 0xeb) | nf;
@@ -327,7 +318,7 @@ void FlagSync_All (void)
 	if (RFL.mode & IGNOVF)
 		mk = 0xff2b;
 	else {
-		nf |= FlagSync_O_();
+		nf |= FlagSync_O();
 		mk = 0xf72b;
 	}
 	if (debug_level('e')>1) e_printf("Sync ALL flags = %04x\n", nf);

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -454,6 +454,23 @@ void Gen_sim(int op, int mode, ...)
 	P0 = (unsigned)-1;
 	va_start(ap, mode);
 	switch(op) {
+	case A_DI_0:
+	case A_DI_1:
+	case A_DI_2:
+	case A_DI_2D:
+	case A_SR_SH4: {
+		int p0 = va_arg(ap,int);
+		int p1 = va_arg(ap,int);
+		int p2 = va_arg(ap,int);
+		int p3 = va_arg(ap,int);
+		int p4 = va_arg(ap,int);
+		AddrGen_sim(op, mode, p0, p1, p2, p3, p4);
+		if (V86MODE() && (0 == (mode & (ADDR16 | MLEA))) && TR1.d > 0xffff) {
+			TheCPU.err2 = EXCP0D_GPF;
+			P0 = FindPC(currentIG);
+		}
+		break;
+		}
 	case L_NOP:
 		GTRACE0("L_NOP");
 		break;
@@ -3000,17 +3017,8 @@ static unsigned Exec_sim(unsigned *mem_ref, unsigned long *flg,
 	IGen *IG = SeqStart;
 	P0 = (unsigned)-1;
 	do {
-		int op = IG->op;
-		if (op && op <= A_SR_SH4) {
-			AddrGen_sim(op, IG->mode, IG->p0, IG->p1, IG->p2, IG->p3, IG->p4);
-			if (V86MODE() && (0 == (IG->mode & (ADDR16 | MLEA))) && TR1.d > 0xffff) {
-				TheCPU.err2 = EXCP0D_GPF;
-				P0 = FindPC((unsigned char *)IG);
-			}
-		} else {
-			currentIG = (unsigned char *)IG;
-			Gen_sim(op, IG->mode, IG->p0, IG->p1, IG->p2, IG->p3);
-		}
+		currentIG = (unsigned char *)IG;
+		Gen_sim(IG->op, IG->mode, IG->p0, IG->p1, IG->p2, IG->p3, IG->p4);
 		IG++;
 	} while (P0 == (unsigned int)-1);
 	currentIG = NULL;

--- a/src/base/emu-i386/simx86/codegen-sim.h
+++ b/src/base/emu-i386/simx86/codegen-sim.h
@@ -79,7 +79,7 @@ extern wkreg TR1;	// "ecx"
 #define GTRACE5(s,r1,r2,a,b,c)	if (debug_level('e')>2) e_printf("(G) %-12s %s %s %08x %08x %08x [%s]\n",\
 					(s),showreg(r1),showreg(r2),(int)(a),(int)(b),(int)(c),showmode(mode))
 extern void FlagSync_All (void);
-extern void Gen_sim(int op, int mode, ...);
+extern void Gen_sim(const IGen *IG);
 extern void AddrGen_sim(int op, int mode, ...);
 extern void InitGen_sim(void);
 

--- a/src/base/emu-i386/simx86/codegen-sim.h
+++ b/src/base/emu-i386/simx86/codegen-sim.h
@@ -66,7 +66,6 @@ extern wkreg AR1;	// "edi"
 extern wkreg AR2;	// "esi"
 extern wkreg SR1;	// "ebp"
 extern wkreg TR1;	// "ecx"
-extern flgtmp RFL;
 
 #define GTRACE0(s)		if (debug_level('e')>2) e_printf("(G) %-12s [%s]\n",(s),showmode(mode))
 #define GTRACE1(s,r)		if (debug_level('e')>2) e_printf("(G) %-12s %s [%s]\n",(s),\
@@ -79,8 +78,6 @@ extern flgtmp RFL;
 					(s),showreg(r1),showreg(r2),(int)(a),(int)(b),showmode(mode))
 #define GTRACE5(s,r1,r2,a,b,c)	if (debug_level('e')>2) e_printf("(G) %-12s %s %s %08x %08x %08x [%s]\n",\
 					(s),showreg(r1),showreg(r2),(int)(a),(int)(b),(int)(c),showmode(mode))
-extern void FlagSync_AP (void);
-extern void FlagSync_O (void);
 extern void FlagSync_All (void);
 extern void Gen_sim(int op, int mode, ...);
 extern void AddrGen_sim(int op, int mode, ...);

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -360,7 +360,7 @@ static unsigned char *CodeGen_x86(unsigned char *CodePtr, unsigned char *BaseGen
 		if (mode & MBYTX) {
 			if (!(mode & DATA16)) {
 				// mov{sz}bw %%al,%%eax
-				G3M(0x0f,(0xb6|IG->p0),0xc0,Cp);
+				G3M(0x0f,(0xb6|(IG->p0<<3)),0xc0,Cp);
 			}
 			else if (IG->p0) {
 				// movsbw %%al,%%ax = cbw
@@ -374,7 +374,7 @@ static unsigned char *CodeGen_x86(unsigned char *CodePtr, unsigned char *BaseGen
 		else {
 			if (mode & DATA16) {
 				// mov{sz}ww %%ax,%%ax
-				G4M(0x66,0x0f,(0xb7|IG->p0),0xc0,Cp);
+				G4M(0x66,0x0f,(0xb7|(IG->p0<<3)),0xc0,Cp);
 			}
 			else if (IG->p0) {
 				// movswl %%ax,%%eax = cwde

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -60,14 +60,12 @@
 #include "codegen-arch.h"
 #include "cpatch.h"
 
-void (*Gen)(int op, int mode, ...);
 void (*AddrGen)(int op, int mode, ...);
 unsigned char * (*CodeGen)(unsigned char *CodePtr, unsigned char *BaseGenBuf, const IGen *IG);
 unsigned (*Exec)(unsigned *mem_ref, unsigned long *flg,
 		 unsigned char *ecpu, void *SeqStart,
 		 unsigned short seqflg);
 
-static void Gen_IG(int op, int mode, ...);
 static void AddrGen_IG(int op, int mode, ...);
 
 int UseLinker = 0;
@@ -110,7 +108,6 @@ void InitGen(void)
 	FetchW = jit_fetch_word;
 	FetchL = jit_fetch_dword;
 
-	Gen = Gen_IG;
 	AddrGen = AddrGen_IG;
 
 #ifdef X86_JIT
@@ -206,7 +203,7 @@ static void AddrGen_IG(int op, int mode, ...)
 }
 
 
-static void Gen_IG(int op, int mode, ...)
+void Gen(int op, int mode, ...)
 {
 	int rcod=0;
 	va_list	ap;

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -330,7 +330,7 @@ void Gen(int op, int mode, ...)
 
 	case L_MOVZS: {
 		signed char o;
-		rcod = (va_arg(ap,int)&1)<<3;	// 0=z 8=s
+		rcod = va_arg(ap,int);	// 0=z 1=s
 		o = Offs_From_Arg();
 		IG->p0 = rcod;
 		IG->p1 = o;

--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -273,7 +273,7 @@ static __inline__ void POP_ONLY(int m)
 void InitGen(void);
 int NewIMeta(int npc, int *rc);
 extern int CurrIMeta;
-extern void (*Gen)(int op, int mode, ...);
+extern void Gen(int op, int mode, ...);
 extern void (*AddrGen)(int op, int mode, ...);
 extern int  (*Fp87_op)(int exop, int reg);
 TNode *Close(unsigned int PC, int mode);

--- a/src/base/emu-i386/simx86/cpatch.c
+++ b/src/base/emu-i386/simx86/cpatch.c
@@ -196,12 +196,14 @@ void rep_movs_stos(struct rep_stack *stack)
 		if ((op & 0xf6) == 0xa6) { /* cmps */
 			repmod |= MOVSSRC;
 			AR2.d = EMUADDR_REL(stack->esi);
-			Gen_sim(O_MOVS_CmpD, repmod);
+			IGen IG = (IGen){.op = O_MOVS_CmpD, .mode = repmod};
+			Gen_sim(&IG);
 			stack->esi = EMU_BASE32(AR2.d);
 		}
 		else { /* scas */
 			DR1.d = stack->eax;
-			Gen_sim(O_MOVS_ScaD, repmod);
+			IGen IG = (IGen){.op = O_MOVS_ScaD, .mode = repmod};
+			Gen_sim(&IG);
 		}
 		FlagSync_All();
 		stack->edi = EMU_BASE32(AR1.d);

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -1029,9 +1029,6 @@ static int e_vm86_tail(struct vm86_struct *info)
   int demusav;
 #endif
   int errcode;
-  if (CONFIG_CPUSIM) {
-    RFL.valid = V_INVALID;
-  }
     /* ---- INNER LOOP: exit with error or code>0 (vm86 fault) ---- */
   do {
       /* enter VM86 mode */
@@ -1053,8 +1050,6 @@ static int e_vm86_tail(struct vm86_struct *info)
   }
   while (xval==0);
   /* ---- INNER LOOP -- exit for exception ---------------------- */
-  if (CONFIG_CPUSIM)
-    FlagSync_All();
 
   Cpu2Reg(info);
   if (debug_level('e')>1) e_printf("---------------------\n\t   EMU86: EXCP %#x\n", xval-1);
@@ -1140,8 +1135,6 @@ int e_dpmi(cpuctx_t *scp)
 static int e_dpmi_tail(cpuctx_t *scp)
 {
   int xval,retval;
-  if (CONFIG_CPUSIM)
-    RFL.valid = V_INVALID;
   if (TheCPU.err) {
     error("DPM86: segment error %d\n", TheCPU.err);
     leavedos_main(0);
@@ -1167,8 +1160,6 @@ static int e_dpmi_tail(cpuctx_t *scp)
   }
   while (xval==0);
   /* ---- INNER LOOP -- exit for exception ---------------------- */
-  if (CONFIG_CPUSIM)
-    FlagSync_All();
 
   if (debug_level('e')>1) e_printf("DPM86: EXCP %#x eflags=%08x\n",
 	xval-1, TheCPU.eflags);

--- a/src/base/emu-i386/simx86/emu86.h
+++ b/src/base/emu-i386/simx86/emu86.h
@@ -725,13 +725,20 @@ int _ModRM(unsigned char opc, unsigned int PC, int mode, signed char overr_ds, s
         CODE_FLUSH(); \
         goto illegal_op; \
     } \
-    if (CONFIG_CPUSIM && V86MODE() && (0 == ((m) & (ADDR16 | MLEA))) && TR1.d > 0xffff) { \
-        CODE_FLUSH(); \
+    __l; \
+})
+int _ModRMSim(unsigned int PC, int mode, signed char overr_ds, signed char overr_ss);
+/* always already after a CODE_FLUSH() */
+#define ModRMSim(p, m, ods, oss) ({ \
+    int __l = _ModRMSim(p, m, ods, oss); \
+    if (REG1 == 0xff) { \
+        goto illegal_op; \
+    } \
+    if (V86MODE() && (0 == ((m) & (ADDR16 | MLEA))) && TR1.d > 0xffff) { \
         goto not_permitted; \
     } \
     __l; \
 })
-int ModRMSim(unsigned int PC, int mode, signed char overr_ds, signed char overr_ss);
 int ModGetReg1(unsigned int PC, int mode);
 //
 char *e_emu_disasm(unsigned char *org, int is32, unsigned int refseg);

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -600,15 +600,13 @@ static unsigned int interp_pre(unsigned int PC, const int mode, int _flags)
 #if 0
 		/* this obviously can't happen with current code, but
 		 * slows down execution under debug a lot */
-		if (debug_level('e') && !CONFIG_CPUSIM && e_querymark(PC, 1))
+		if (debug_level('e') && e_querymark(PC, 1))
 			error("simx86: code nodes clashed at %x\n", PC);
 #endif
-		if (CurrIMeta<0) {
-			/* if NewNode was already 1, the registers are outdated */
-			if (debug_level('e')==9) dbug_printf("\n%s",e_print_regs());
-		} else if (CONFIG_CPUSIM && debug_level('e') == 9)
-			dbug_printf("\n%s",e_print_regs());
 		if (debug_level('e')>2) {
+			if (debug_level('e')==9 && CurrIMeta<0)
+				/* if CurrIMeta was already >= 0, the registers are outdated */
+				dbug_printf("\n%s",e_print_regs());
 			char *ds;
 			unsigned short ocs = TheCPU.cs;
 			ds = e_emu_disasm(EMU_BASE32(PC),(~mode&3),ocs);
@@ -2403,11 +2401,9 @@ repag0:
 				break;
 			case Ofs_DH:	/*6*/	/* DIV AL */
 				Gen(O_DIV, _mode|MBYTE, P0);			// ah:al/[edi]->AH:AL unsigned
-				if (CONFIG_CPUSIM && TheCPU.err) return P0;
 				break;
 			case Ofs_BH:	/*7*/	/* IDIV AL */
 				Gen(O_IDIV, _mode|MBYTE, P0);		// ah:al/[edi]->AH:AL signed
-				if (CONFIG_CPUSIM && TheCPU.err) return P0;
 				break;
 			} }
 			break;
@@ -2441,11 +2437,9 @@ repag0:
 				break;
 			case Ofs_SI:	/*6*/	/* DIV AX+DX */
 				Gen(O_DIV, _mode, P0);		// (e)ax:(e)dx/[edi]->(E)AX:(E)DX unsigned
-				if (CONFIG_CPUSIM && TheCPU.err) return P0;
 				break;
 			case Ofs_DI:	/*7*/	/* IDIV AX+DX */
 				Gen(O_IDIV, _mode, P0);		// (e)ax:(e)dx/[edi]->(E)AX:(E)DX signed
-				if (CONFIG_CPUSIM && TheCPU.err) return P0;
 				break;
 			} }
 			break;

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -891,8 +891,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 
 /*9c*/	case PUSHF: {
 			if (V86MODE() && (IOPL<3)) {
-			    if (CONFIG_CPUSIM) FlagSync_All();
-			    else CODE_FLUSH();
+			    CODE_FLUSH();
 			    /* virtual-8086 monitor */
 			    if (!(TheCPU.cr[4] & CR4_VME))
 				goto not_permitted;	/* GPF */
@@ -973,7 +972,6 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			} else {
 				EFLAGS &= ~EFLAGS_ZF;
 			}
-			if (CONFIG_CPUSIM) RFL.valid = V_INVALID;
 			break;
 		       }
 /*d7*/	case XLAT:
@@ -1959,7 +1957,6 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			return PC;
 /*ce*/	case INTO:
 			CODE_FLUSH();
-			if (CONFIG_CPUSIM) FlagSync_O();
 			PC++;
 			if(EFLAGS & EFLAGS_OF)
 			{
@@ -1999,7 +1996,6 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			    !test_bit(inum, &vm86s.int_revectored)) {
 				uint32_t segoffs;
 				segoffs = read_dword(inum << 2);
-				if (CONFIG_CPUSIM) FlagSync_All();
 				temp = (EFLAGS|IOPL_MASK) & (RETURN_MASK|EFLAGS_IF);
 				if (IOPL<3) {
 					temp &= ~EFLAGS_IF;
@@ -2073,7 +2069,6 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			}
 			/* in 16bit mode the manual doesn't seem to ask to
 			 * clear reserved bits... But bit1 is always set! */
-			if (CONFIG_CPUSIM) RFL.valid = V_INVALID;
 			if (REALMODE())
 			    FLAGS = temp | 2;
 			else if (V86MODE()) {
@@ -2099,7 +2094,6 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 /*9d*/	case POPF: {
 			CODE_FLUSH();
 			temp=0; POP(_mode, &temp);
-			if (CONFIG_CPUSIM) RFL.valid = V_INVALID;
 			if (V86MODE()) {
 			    int is_tf;
 stack_return_from_vm86:
@@ -2353,7 +2347,6 @@ repag0:
 				P0 = _P0;
 				/* don't cache intermediate nodes */
 				InvalidateNodeRange(P0, PC - P0, NULL);
-				if (CONFIG_CPUSIM) FlagSync_All();
 				if (repmod & ADDR16) {
 					rCX--;
 					if (rCX == 0) break;
@@ -3007,7 +3000,6 @@ repag0:
 				    if (tmp < 0) goto illegal_op;
 				    EFLAGS &= ~EFLAGS_ZF;
 				    if (tmp) EFLAGS |= EFLAGS_ZF;
-				    if (CONFIG_CPUSIM) RFL.valid = V_INVALID;
 				    }
 				    break;
 				case 5: { /* VERW */
@@ -3024,7 +3016,6 @@ repag0:
 				    if (tmp < 0) goto illegal_op;
 				    EFLAGS &= ~EFLAGS_ZF;
 				    if (tmp) EFLAGS |= EFLAGS_ZF;
-				    if (CONFIG_CPUSIM) RFL.valid = V_INVALID;
 				    }
 				    break;
 				case 6: /* JMP indirect to IA64 code */
@@ -3079,7 +3070,6 @@ repag0:
 				}
 				if (!e_larlsl(_mode, sv)) {
 				    EFLAGS &= ~EFLAGS_ZF;
-				    if (CONFIG_CPUSIM) RFL.valid = V_INVALID;
 				}
 				else {
 				    if (opc2==0x02) {	/* LAR */
@@ -3092,7 +3082,6 @@ repag0:
 					tmp = GetSelectorByteLimit(sv);
 				    }
 				    EFLAGS |= EFLAGS_ZF;
-				    if (CONFIG_CPUSIM) RFL.valid = V_INVALID;
 				    SetCPU_WL(_mode, REG1, tmp);
 				} }
 				break;
@@ -3526,7 +3515,6 @@ repag0:
 					rEAX = m & 0xffffffff;
 				}
 				sim_write_qword(TheCPU.mem_ref, m);
-				if (CONFIG_CPUSIM) RFL.valid = V_INVALID;
 				break;
 				}
 

--- a/src/base/emu-i386/simx86/modrm-sim.c
+++ b/src/base/emu-i386/simx86/modrm-sim.c
@@ -46,7 +46,7 @@
 
 /////////////////////////////////////////////////////////////////////////////
 
-int ModRMSim(unsigned int PC, int mode, signed char overr_ds, signed char overr_ss)
+int _ModRMSim(unsigned int PC, int mode, signed char overr_ds, signed char overr_ss)
 {
 	int l;
 	void (*AddrGen_save)(int op, int mode, ...);

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -633,7 +633,7 @@ quit:;
  * corresponding original PC. This is slow but it's only used for
  * DPMI exceptions.
  */
-unsigned int FindPC(unsigned char *addr)
+unsigned int FindPC(const unsigned char *addr)
 {
   TNode *G = &CollectTree.root;
   unsigned char *ahE;

--- a/src/base/emu-i386/simx86/trees.h
+++ b/src/base/emu-i386/simx86/trees.h
@@ -154,7 +154,7 @@ TNode *Move2Tree(IMeta *I0, CodeBuf *GenCodeBuf);
 
 void InitTrees(void);
 
-unsigned int FindPC(unsigned char *addr);
+unsigned int FindPC(const unsigned char *addr);
 int InvalidateNodeRange(int addr, int len, unsigned char *eip);
 
 #ifdef DEBUG_TREE


### PR DESCRIPTION
Following #2519 some cleanups and optimizations were possible, lots of redundant `if (CONFIG_CPUSIM)`, `Gen` can be a normal function, and `Gen_sim` can be passed an `IGen *` instead of varargs. This way the loop in `Exec_sim` can be much tighter.