### PR TITLE
simx86: AddrGen cleanups after#2519

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -82,8 +82,6 @@ static unsigned char *currentIG = NULL;
 
 /////////////////////////////////////////////////////////////////////////////
 
-#define	Offs_From_Arg()		(signed char)(va_arg(ap,int))
-
 /* working registers of the host CPU */
 wkreg DR1;	// "eax"
 wkreg DR2;	// "edx"
@@ -338,108 +336,12 @@ void InitGen_sim(void)
 	RFL.valid = V_INVALID;
 }
 
-/*
- * address generator unit
- * careful - do not use eax, and NEVER change any flag!
- */
-static void AddrGen_sim(int op, int mode, ...)
+static inline void check_v86_address_overflow(int mode, const IGen *IG)
 {
-	va_list	ap;
-#if PROFILE >= 2
-	hitimer_t t0 = 0;
-	if (debug_level('e')) t0 = GETTSC();
-#endif
-
-	va_start(ap, mode);
-	switch(op) {
-	case A_DI_0:			// base(32), imm
-	case A_DI_1: {			// base(32), {imm}, reg, {shift}
-			long idsp=0;
-			signed char ofs;
-			ofs = va_arg(ap,int);
-			if (mode & MLEA) {		// discard base	reg
-				AR1.d = 0;	// ofs = Ofs_RZERO;
-			}
-			else AR1.d = CPULONG(ofs);
-
-			idsp = va_arg(ap,int);
-			if (op==A_DI_0) {
-				GTRACE3("A_DI_0",0xff,0xff,idsp);
-				TR1.d = idsp;
-			}
-			else if (mode & ADDR16) {
-				signed char o = Offs_From_Arg();
-				GTRACE3("A_DI_1",o,ofs,idsp);
-				TR1.d = CPUWORD(o);
-				TR1.w.l += idsp;
-			}
-			else {
-				signed char o = Offs_From_Arg();
-				GTRACE3("A_DI_1",o,ofs,idsp);
-				TR1.d = CPULONG(o) + idsp;
-			}
-			AR1.d += TR1.d;
-		}
-		break;
-	case A_DI_2: {			// base(32), {imm}, reg, reg, {shift}
-			long idsp=0;
-			signed char ofs;
-			ofs = va_arg(ap,int);
-			if (mode & MLEA) {		// discard base	reg
-				AR1.d = 0;	// ofs = Ofs_RZERO;
-			}
-			else AR1.d = CPULONG(ofs);
-
-			idsp = va_arg(ap,int);
-			if (mode & ADDR16) {
-				signed char o1 = Offs_From_Arg();
-				signed char o2 = Offs_From_Arg();
-				GTRACE4("A_DI_2",o1,ofs,o2,idsp);
-				TR1.d = CPUWORD(o1) + CPUWORD(o2) + idsp;
-				AR1.d += TR1.w.l;
-			}
-			else {
-				signed char o1 = Offs_From_Arg();
-				signed char o2 = Offs_From_Arg();
-				unsigned char sh;
-				sh = (unsigned char)(va_arg(ap,int));
-				GTRACE5("A_DI_2",o1,ofs,o2,idsp,sh);
-				TR1.d = CPULONG(o1) +
-				  (CPULONG(o2) << (sh & 0x1f)) + idsp;
-				AR1.d += TR1.d;
-			}
-		}
-		break;
-	case A_DI_2D: {			// modrm_sibd, 32-bit mode
-			long idsp;
-			unsigned char sh;
-			signed char o;
-			signed char ofs = Offs_From_Arg();
-			if (mode & MLEA) {
-				AR1.d = 0;
-			}
-			else {
-				AR1.d = CPULONG(ofs);
-			}
-			idsp = va_arg(ap,int);
-			o = Offs_From_Arg();
-			sh = (unsigned char)(va_arg(ap,int));
-			GTRACE5("A_DI_2D",ofs,o,0xff,idsp,sh);
-			TR1.d = (CPULONG(o) << (sh & 0x1f)) + idsp;
-			AR1.d += TR1.d;
-		}
-		break;
-	case A_SR_SH4: {	// real mode make base addr from seg
-		signed char o = Offs_From_Arg();
-		GTRACE1("A_SR_SH4",o);
-		SetSegReal(CPUWORD(o), o);
-		}
-		break;
+	if (V86MODE() && (0 == (mode & (ADDR16 | MLEA))) && TR1.d > 0xffff) {
+		TheCPU.err2 = EXCP0D_GPF;
+		P0 = FindPC((const unsigned char *)IG);
 	}
-	va_end(ap);
-#if PROFILE >= 2
-	if (debug_level('e')) GenTime += (GETTSC() - t0);
-#endif
 }
 
 void Gen_sim(const IGen *IG)
@@ -454,18 +356,93 @@ void Gen_sim(const IGen *IG)
 
 	P0 = (unsigned)-1;
 	switch(op) {
-	case A_DI_0:
-	case A_DI_1:
-	case A_DI_2:
-	case A_DI_2D:
-	case A_SR_SH4: {
-		AddrGen_sim(op, mode, IG->p0, IG->p1, IG->p2, IG->p3, IG->p4);
-		if (V86MODE() && (0 == (mode & (ADDR16 | MLEA))) && TR1.d > 0xffff) {
-			TheCPU.err2 = EXCP0D_GPF;
-			P0 = FindPC((const unsigned char *)IG);
+	case A_DI_0:			// base(32), imm
+	case A_DI_1: {			// base(32), {imm}, reg, {shift}
+			long idsp=0;
+			signed char ofs;
+			ofs = (signed char)IG->p0;
+			if (mode & MLEA) {		// discard base	reg
+				AR1.d = 0;	// ofs = Ofs_RZERO;
+			}
+			else AR1.d = CPULONG(ofs);
+
+			idsp = IG->p1;
+			if (op==A_DI_0) {
+				GTRACE3("A_DI_0",0xff,0xff,idsp);
+				TR1.d = idsp;
+				check_v86_address_overflow(mode, IG);
+			}
+			else if (mode & ADDR16) {
+				signed char o = (signed char)IG->p2;
+				GTRACE3("A_DI_1",o,ofs,idsp);
+				TR1.d = CPUWORD(o);
+				TR1.w.l += idsp;
+			}
+			else {
+				signed char o = (signed char)IG->p2;
+				GTRACE3("A_DI_1",o,ofs,idsp);
+				TR1.d = CPULONG(o) + idsp;
+				check_v86_address_overflow(mode, IG);
+			}
+			AR1.d += TR1.d;
 		}
 		break;
+	case A_DI_2: {			// base(32), {imm}, reg, reg, {shift}
+			long idsp=0;
+			signed char ofs;
+			ofs = (signed char)IG->p0;
+			if (mode & MLEA) {		// discard base	reg
+				AR1.d = 0;	// ofs = Ofs_RZERO;
+			}
+			else AR1.d = CPULONG(ofs);
+
+			idsp = IG->p1;
+			if (mode & ADDR16) {
+				signed char o1 = (signed char)IG->p2;
+				signed char o2 = (signed char)IG->p3;
+				GTRACE4("A_DI_2",o1,ofs,o2,idsp);
+				TR1.d = CPUWORD(o1) + CPUWORD(o2) + idsp;
+				AR1.d += TR1.w.l;
+			}
+			else {
+				signed char o1 = (signed char)IG->p2;
+				signed char o2 = (signed char)IG->p3;
+				unsigned char sh;
+				sh = (unsigned char)IG->p4;
+				GTRACE5("A_DI_2",o1,ofs,o2,idsp,sh);
+				TR1.d = CPULONG(o1) +
+				  (CPULONG(o2) << (sh & 0x1f)) + idsp;
+				AR1.d += TR1.d;
+				check_v86_address_overflow(mode, IG);
+			}
 		}
+		break;
+	case A_DI_2D: {			// modrm_sibd, 32-bit mode
+			long idsp;
+			unsigned char sh;
+			signed char o;
+			signed char ofs = (signed char)IG->p0;
+			if (mode & MLEA) {
+				AR1.d = 0;
+			}
+			else {
+				AR1.d = CPULONG(ofs);
+			}
+			idsp = IG->p1;
+			o = (signed char)IG->p2;
+			sh = (unsigned char)IG->p3;
+			GTRACE5("A_DI_2D",ofs,o,0xff,idsp,sh);
+			TR1.d = (CPULONG(o) << (sh & 0x1f)) + idsp;
+			AR1.d += TR1.d;
+			check_v86_address_overflow(mode, IG);
+		}
+		break;
+	case A_SR_SH4: {	// real mode make base addr from seg
+		signed char o = (signed char)IG->p0;
+		GTRACE1("A_SR_SH4",o);
+		SetSegReal(CPUWORD(o), o);
+		}
+		break;
 	case L_NOP:
 		GTRACE0("L_NOP");
 		break;

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -342,7 +342,7 @@ void InitGen_sim(void)
  * address generator unit
  * careful - do not use eax, and NEVER change any flag!
  */
-void AddrGen_sim(int op, int mode, ...)
+static void AddrGen_sim(int op, int mode, ...)
 {
 	va_list	ap;
 #if PROFILE >= 2

--- a/src/base/emu-i386/simx86/codegen-sim.h
+++ b/src/base/emu-i386/simx86/codegen-sim.h
@@ -80,7 +80,6 @@ extern wkreg TR1;	// "ecx"
 					(s),showreg(r1),showreg(r2),(int)(a),(int)(b),(int)(c),showmode(mode))
 extern void FlagSync_All (void);
 extern void Gen_sim(const IGen *IG);
-extern void AddrGen_sim(int op, int mode, ...);
 extern void InitGen_sim(void);
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -60,13 +60,10 @@
 #include "codegen-arch.h"
 #include "cpatch.h"
 
-void (*AddrGen)(int op, int mode, ...);
 unsigned char * (*CodeGen)(unsigned char *CodePtr, unsigned char *BaseGenBuf, const IGen *IG);
 unsigned (*Exec)(unsigned *mem_ref, unsigned long *flg,
 		 unsigned char *ecpu, void *SeqStart,
 		 unsigned short seqflg);
-
-static void AddrGen_IG(int op, int mode, ...);
 
 int UseLinker = 0;
 hitimer_u TimeStartExec;
@@ -108,8 +105,6 @@ void InitGen(void)
 	FetchW = jit_fetch_word;
 	FetchL = jit_fetch_dword;
 
-	AddrGen = AddrGen_IG;
-
 #ifdef X86_JIT
 	if (!CONFIG_CPUSIM)
 		InitGen_x86();
@@ -125,7 +120,7 @@ void InitGen(void)
  * address generator unit
  * careful - do not use eax, and NEVER change any flag!
  */
-static void AddrGen_IG(int op, int mode, ...)
+void AddrGen(int op, int mode, ...)
 {
 	va_list	ap;
 	IMeta *I;

--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -274,7 +274,7 @@ void InitGen(void);
 int NewIMeta(int npc, int *rc);
 extern int CurrIMeta;
 extern void Gen(int op, int mode, ...);
-extern void (*AddrGen)(int op, int mode, ...);
+extern void AddrGen(int op, int mode, ...);
 extern int  (*Fp87_op)(int exop, int reg);
 TNode *Close(unsigned int PC, int mode);
 extern unsigned char * (*CodeGen)(unsigned char *CodePtr,

--- a/src/base/emu-i386/simx86/modrm-sim.c
+++ b/src/base/emu-i386/simx86/modrm-sim.c
@@ -49,13 +49,16 @@
 int _ModRMSim(unsigned int PC, int mode, signed char overr_ds, signed char overr_ss)
 {
 	int l;
-	void (*AddrGen_save)(int op, int mode, ...);
 
-	AddrGen_save = AddrGen;
-	AddrGen = AddrGen_sim;
+	assert(CurrIMeta == -1); // this always follows a CODE_FLUSH
 	l = _ModRM(0, PC, mode, overr_ds, overr_ss);
-	AddrGen = AddrGen_save;
-	TheCPU.mem_ref = AR1.d;
+	if (CurrIMeta == 0) { // otherwise AddrGen isn't called (for reg-only)
+		IMeta *I = InstrMeta;
+		assert(I->ngen == 1); // needs to be exactly one intermediate op
+		Gen_sim(I->gen);
+		CurrIMeta = -1;
+		TheCPU.mem_ref = AR1.d;
+	}
 	return l;
 }
 


### PR DESCRIPTION
Inlining `AddrGen_sim` into `Gen_sim` makes it more efficient (no more varargs overhead), but to do that I had to change `_ModRMSim` to let `_ModRM` call the regular `AddrGen` (renamed from `AddrGen_IG`) and call `Gen_Sim` with the resulting intermediate op from `InstrMeta` if needed.

cpusim=1 is now ~7% faster than immediately after #2519 in my basic test.
