### PR TITLE
Fix setjmp/longjmp from Gen_Sim simulated PF exceptions

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -3029,12 +3029,18 @@ static void emu_pagefault_handler(dosaddr_t addr, int err, uint32_t op, int len)
 		return;
 	}
 	/* trigger an exception in DPMI */
-	TheCPU.err2 = EXCP0E_PAGE;
+	/* Need to shutdown prejitter to touch LONG_CS and TheCPU.err
+	   to return to _Interp86() */
+	prejit_sync();
+	TheCPU.err = EXCP0E_PAGE;
 	TheCPU.scp_err = err;
 	TheCPU.cr2 = addr;
-	if (currentIG)
+	if (currentIG) {
+		LONG_CS = _LONG_CS;
 		P0 = FindPC(currentIG);
-	else
+		TheCPU.eip = P0 - LONG_CS;
+		longjmp(jmp_env, 2);
+	} else
 		/* for faulting sim_read/write directly from interp.c */
 		longjmp(jmp_env, 1);
 }

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -676,10 +676,12 @@ static unsigned int interp_post(unsigned int PC, const int mode, unsigned P0,
 static unsigned int _Interp86(unsigned int PC, int basemode)
 {
 	volatile unsigned int P0 = PC; /* volatile because of setjmp */
+	int val;
 
-	if (PROTMODE() && setjmp(jmp_env)) {
-		/* long jump to here from simulated page fault */
-		return P0;
+	if (PROTMODE() && (val = setjmp(jmp_env))) {
+		/* long jump to here from simulated page fault
+		   val == 2 comes from Gen_Sim, with different cs:eip */
+		return val == 2 ? LONG_CS + TheCPU.eip : P0;
 	}
 
 	TheCPU.err = 0;


### PR DESCRIPTION
Unfortunately it isn't quite correct to return to Gen_Sim, as e.g. rep movsw has a series of sim_read/writes, any of which may fail, and we need to catch the first, not just detect TheCPU.err2 after the reads/writes are done. Also needs to wait for the spec prejitter (if enabled) to finish as otherwise we can't touch TheCPU.err and LONG_CS (both are needed in _Interp86).