### PR TITLE
simx86: fix rep scas/cmps cpatch code

### DIFF
--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -1825,7 +1825,7 @@ shrot0:
 		// Pointer to the jecxz distance byte
 		CpTemp = Cp-1;
 		GetDF(Cp);
-		G2M(NOP,NOP,Cp);
+		G4M(NOP,NOP,NOP,NOP,Cp);
 		G1((mode&MREP)?REP:REPNE,Cp);
 		if (mode&MBYTE)	{ G1(SCASb,Cp); }
 		else {
@@ -1868,7 +1868,7 @@ shrot0:
 		// Pointer to the jecxz distance byte
 		CpTemp = Cp-1;
 		GetDF(Cp);
-		G2M(NOP,NOP,Cp);
+		G4M(NOP,NOP,NOP,NOP,Cp);
 		G1((mode&MREP)?REP:REPNE,Cp);
 		if (mode&MBYTE)	{ G1(CMPSb,Cp); }
 		else {

--- a/src/base/emu-i386/simx86/cpatch.c
+++ b/src/base/emu-i386/simx86/cpatch.c
@@ -113,6 +113,8 @@ void rep_movs_stos(struct rep_stack *stack)
 	addr = EMUADDR_REL(paddr);
 	if (*eip == 0xf3) /* skip rep */
 		eip++;
+	else if (*eip == JMPsid) /* skip jmp and rep */
+		eip += 3;
 	op = eip[0];
 	size = 1;
 	if (*eip == 0x66) {
@@ -557,10 +559,18 @@ int Cpatch(sigcontext_t *scp)
     p = eip;
     if ((*p==0xf3 || *p==0xf2) && p[-1] == 0x90 && p[-2] == 0x90) {
 	// rep movs, rep stos, rep lods, rep scas, rep cmps
+	// we have a sequence:	90 90 f3 op (stos/movs/lods)
+	//		or	90 90 90 90 f2/f3 op (cmps/scas)
 	if (debug_level('e')>1) e_printf("### REP patch at %p\n",eip);
 	p-=2;
+	if (p[-1] == 0x90 && p[-2] == 0x90) /* cmps/scas */
+	    p-=2;
 	G2M(0xff,0x13,p); /* call (%ebx) */
 	_scp_rip -= 2; /* make sure call (%ebx) is performed the first time */
+	if (*p == 0x90) { /* cmps/scas */
+	    G2M(JMPsid,(p[3]==0x66?3:2),p); /* jmp over rep instruction */
+	    _scp_rip -= 2;
+	}
 	return 1;
     }
 
@@ -648,6 +658,7 @@ int UnCpatch(unsigned char *eip)
 #endif
     if (p[1] == 0x13) {
 	p[0] = p[1] = 0x90;
+	if (p[2] == JMPsid) p[2] = p[3] = 0x90;
     }
     else if (p[1] == 0x53) {
 	if ((unsigned char)p[2] == Ofs_stub_wri_8) {


### PR DESCRIPTION
I now actually tested the code by forcing a patch. The trick of putting a "call (%ebx)" in front of the rep (and analyzing the type of rep code in the patch) works ok for rep stos/movs but not for cmps/scas since the repz/repnz after the call will still do at least one iteration if cx>0 independently of the zero flag. So the patch needs to insert a jmp over the rep instruction.