### PR TITLE
Eliminate use of internal wkreg variables outside codegen-sim.c

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -82,11 +82,11 @@ static unsigned char *currentIG = NULL;
 /////////////////////////////////////////////////////////////////////////////
 
 /* working registers of the host CPU */
-wkreg DR1;	// "eax"
-wkreg DR2;	// "edx"
+static wkreg DR1;	// "eax"
+static wkreg DR2;	// "edx"
 wkreg AR1;	// "edi"
-wkreg AR2;	// "esi"
-wkreg SR1;	// "ebp"
+static wkreg AR2;	// "esi"
+static wkreg SR1;	// "ebp"
 wkreg TR1;	// "ecx"
 static flgtmp RFL;
 
@@ -264,7 +264,7 @@ static inline int FlagSync_SZAPC (void)
 	  FlagSync_S() | FlagSync_P();
 }
 
-int FlagSync_All (void)
+static int FlagSync_All (void)
 {
 	int nf = FlagSync_SZAPC() | FlagSync_O();
 	if (debug_level('e')>1) e_printf("Sync ALL flags = %04x\n", nf);

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -295,17 +295,104 @@ void InitGen_sim(void)
 	RFL.cout = RFL.res = 0;
 }
 
-static inline unsigned int check_v86_address_overflow(int mode, const IGen *IG)
+static inline void check_v86_address_overflow(int mode, dosaddr_t offset)
 {
-	unsigned int P0 = (unsigned int)-1;
-	if (V86MODE() && (0 == (mode & (ADDR16 | MLEA))) && TR1.d > 0xffff) {
+	if (V86MODE() && (0 == (mode & (ADDR16 | MLEA))) && offset > 0xffff)
 		TheCPU.err2 = EXCP0D_GPF;
-		P0 = FindPC((const unsigned char *)IG);
-	}
-	return P0;
 }
 
-unsigned int Gen_sim(const IGen *IG)
+dosaddr_t AddrGen_sim(const IGen *IG)
+{
+	int op = IG->op;
+	int mode = IG->mode;
+	dosaddr_t mem_ref, offset;
+	switch(op) {
+	case A_DI_0:			// base(32), imm
+	case A_DI_1: {			// base(32), {imm}, reg, {shift}
+			long idsp=0;
+			signed char ofs;
+			ofs = (signed char)IG->p0;
+			if (mode & MLEA) {		// discard base	reg
+				mem_ref = 0;	// ofs = Ofs_RZERO;
+			}
+			else mem_ref = CPULONG(ofs);
+
+			idsp = IG->p1;
+			if (op==A_DI_0) {
+				GTRACE3("A_DI_0",0xff,0xff,idsp);
+				offset = idsp;
+				check_v86_address_overflow(mode, offset);
+			}
+			else if (mode & ADDR16) {
+				signed char o = (signed char)IG->p2;
+				GTRACE3("A_DI_1",o,ofs,idsp);
+				offset = (CPUWORD(o) + idsp) & 0xffff;
+			}
+			else {
+				signed char o = (signed char)IG->p2;
+				GTRACE3("A_DI_1",o,ofs,idsp);
+				offset = CPULONG(o) + idsp;
+				check_v86_address_overflow(mode, offset);
+			}
+			mem_ref += offset;
+		}
+		break;
+	case A_DI_2: {			// base(32), {imm}, reg, reg, {shift}
+			long idsp=0;
+			signed char ofs;
+			ofs = (signed char)IG->p0;
+			if (mode & MLEA) {		// discard base	reg
+				mem_ref = 0;	// ofs = Ofs_RZERO;
+			}
+			else mem_ref = CPULONG(ofs);
+
+			idsp = IG->p1;
+			if (mode & ADDR16) {
+				signed char o1 = (signed char)IG->p2;
+				signed char o2 = (signed char)IG->p3;
+				GTRACE4("A_DI_2",o1,ofs,o2,idsp);
+				offset = CPUWORD(o1) + CPUWORD(o2) + idsp;
+				mem_ref += offset & 0xffff;
+			}
+			else {
+				signed char o1 = (signed char)IG->p2;
+				signed char o2 = (signed char)IG->p3;
+				unsigned char sh;
+				sh = (unsigned char)IG->p4;
+				GTRACE5("A_DI_2",o1,ofs,o2,idsp,sh);
+				offset = CPULONG(o1) +
+				  (CPULONG(o2) << (sh & 0x1f)) + idsp;
+				mem_ref += offset;
+				check_v86_address_overflow(mode, offset);
+			}
+		}
+		break;
+	default:
+	case A_DI_2D: {			// modrm_sibd, 32-bit mode
+			long idsp;
+			unsigned char sh;
+			signed char o;
+			signed char ofs = (signed char)IG->p0;
+			if (mode & MLEA) {
+				mem_ref = 0;
+			}
+			else {
+				mem_ref = CPULONG(ofs);
+			}
+			idsp = IG->p1;
+			o = (signed char)IG->p2;
+			sh = (unsigned char)IG->p3;
+			GTRACE5("A_DI_2D",ofs,o,0xff,idsp,sh);
+			offset = (CPULONG(o) << (sh & 0x1f)) + idsp;
+			mem_ref += offset;
+			check_v86_address_overflow(mode, offset);
+		}
+		break;
+	}
+	return mem_ref;
+}
+
+static unsigned int Gen_sim(const IGen *IG)
 {
 	int op = IG->op;
 	int mode = IG->mode;
@@ -317,87 +404,6 @@ unsigned int Gen_sim(const IGen *IG)
 
 	unsigned int P0 = (unsigned)-1;
 	switch(op) {
-	case A_DI_0:			// base(32), imm
-	case A_DI_1: {			// base(32), {imm}, reg, {shift}
-			long idsp=0;
-			signed char ofs;
-			ofs = (signed char)IG->p0;
-			if (mode & MLEA) {		// discard base	reg
-				AR1.d = 0;	// ofs = Ofs_RZERO;
-			}
-			else AR1.d = CPULONG(ofs);
-
-			idsp = IG->p1;
-			if (op==A_DI_0) {
-				GTRACE3("A_DI_0",0xff,0xff,idsp);
-				TR1.d = idsp;
-				P0 = check_v86_address_overflow(mode, IG);
-			}
-			else if (mode & ADDR16) {
-				signed char o = (signed char)IG->p2;
-				GTRACE3("A_DI_1",o,ofs,idsp);
-				TR1.d = CPUWORD(o);
-				TR1.w.l += idsp;
-			}
-			else {
-				signed char o = (signed char)IG->p2;
-				GTRACE3("A_DI_1",o,ofs,idsp);
-				TR1.d = CPULONG(o) + idsp;
-				P0 = check_v86_address_overflow(mode, IG);
-			}
-			AR1.d += TR1.d;
-		}
-		break;
-	case A_DI_2: {			// base(32), {imm}, reg, reg, {shift}
-			long idsp=0;
-			signed char ofs;
-			ofs = (signed char)IG->p0;
-			if (mode & MLEA) {		// discard base	reg
-				AR1.d = 0;	// ofs = Ofs_RZERO;
-			}
-			else AR1.d = CPULONG(ofs);
-
-			idsp = IG->p1;
-			if (mode & ADDR16) {
-				signed char o1 = (signed char)IG->p2;
-				signed char o2 = (signed char)IG->p3;
-				GTRACE4("A_DI_2",o1,ofs,o2,idsp);
-				TR1.d = CPUWORD(o1) + CPUWORD(o2) + idsp;
-				AR1.d += TR1.w.l;
-			}
-			else {
-				signed char o1 = (signed char)IG->p2;
-				signed char o2 = (signed char)IG->p3;
-				unsigned char sh;
-				sh = (unsigned char)IG->p4;
-				GTRACE5("A_DI_2",o1,ofs,o2,idsp,sh);
-				TR1.d = CPULONG(o1) +
-				  (CPULONG(o2) << (sh & 0x1f)) + idsp;
-				AR1.d += TR1.d;
-				P0 = check_v86_address_overflow(mode, IG);
-			}
-		}
-		break;
-	case A_DI_2D: {			// modrm_sibd, 32-bit mode
-			long idsp;
-			unsigned char sh;
-			signed char o;
-			signed char ofs = (signed char)IG->p0;
-			if (mode & MLEA) {
-				AR1.d = 0;
-			}
-			else {
-				AR1.d = CPULONG(ofs);
-			}
-			idsp = IG->p1;
-			o = (signed char)IG->p2;
-			sh = (unsigned char)IG->p3;
-			GTRACE5("A_DI_2D",ofs,o,0xff,idsp,sh);
-			TR1.d = (CPULONG(o) << (sh & 0x1f)) + idsp;
-			AR1.d += TR1.d;
-			P0 = check_v86_address_overflow(mode, IG);
-		}
-		break;
 	case A_SR_SH4: {	// real mode make base addr from seg
 		signed char o = (signed char)IG->p0;
 		GTRACE1("A_SR_SH4",o);
@@ -2804,6 +2810,14 @@ static unsigned Exec_sim(unsigned *mem_ref, unsigned long *flg,
 
 	FlagSync_RFL(*flg);
 	do {
+		if (IG->op >= A_DI_0 && IG->op <= A_DI_2D) {
+			AR1.d = AddrGen_sim(IG);
+			if (TheCPU.err2 == EXCP0D_GPF) {
+				P0 =  FindPC((unsigned char *)IG);
+				break;
+			}
+			IG++;
+		} // no need for "else", a non-addr op always follows
 		currentIG = (unsigned char *)IG;
 		P0 = Gen_sim(IG);
 		IG++;

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -87,7 +87,7 @@ static wkreg DR2;	// "edx"
 wkreg AR1;	// "edi"
 static wkreg AR2;	// "esi"
 static wkreg SR1;	// "ebp"
-wkreg TR1;	// "ecx"
+static wkreg TR1;	// "ecx"
 static flgtmp RFL;
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -84,7 +84,7 @@ static unsigned char *currentIG = NULL;
 /* working registers of the host CPU */
 static wkreg DR1;	// "eax"
 static wkreg DR2;	// "edx"
-wkreg AR1;	// "edi"
+static wkreg AR1;	// "edi"
 static wkreg AR2;	// "esi"
 static wkreg SR1;	// "ebp"
 static wkreg TR1;	// "ecx"
@@ -423,7 +423,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		unsigned char exop = (unsigned char)IG->p0;
 		int reg = IG->p1;
 		GTRACE2("O_FPOP",exop,reg);
-		if (Fp87_op(exop, reg)) {
+		if (Fp87_op(exop, reg, AR1.d)) {
 		    TheCPU.err2 = -96;
 		    P0 = FindPC((const unsigned char *)IG);
 		}

--- a/src/base/emu-i386/simx86/codegen-sim.h
+++ b/src/base/emu-i386/simx86/codegen-sim.h
@@ -66,8 +66,6 @@ typedef struct {
 #define LF_MASK_CF	(1U << LF_BIT_CF)
 #define LF_MASK_PO	(1U << LF_BIT_PO)
 
-extern wkreg AR1;	// "edi"
-
 #define GTRACE0(s)		if (debug_level('e')>2) e_printf("(G) %-12s [%s]\n",(s),showmode(mode))
 #define GTRACE1(s,r)		if (debug_level('e')>2) e_printf("(G) %-12s %s [%s]\n",(s),\
 					showreg(r),showmode(mode))

--- a/src/base/emu-i386/simx86/codegen-sim.h
+++ b/src/base/emu-i386/simx86/codegen-sim.h
@@ -79,7 +79,7 @@ extern wkreg AR1;	// "edi"
 					(s),showreg(r1),showreg(r2),(int)(a),(int)(b),showmode(mode))
 #define GTRACE5(s,r1,r2,a,b,c)	if (debug_level('e')>2) e_printf("(G) %-12s %s %s %08x %08x %08x [%s]\n",\
 					(s),showreg(r1),showreg(r2),(int)(a),(int)(b),(int)(c),showmode(mode))
-extern unsigned int Gen_sim(const IGen *IG);
+extern dosaddr_t AddrGen_sim(const IGen *IG);
 extern void InitGen_sim(void);
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/base/emu-i386/simx86/codegen-sim.h
+++ b/src/base/emu-i386/simx86/codegen-sim.h
@@ -67,7 +67,6 @@ typedef struct {
 #define LF_MASK_PO	(1U << LF_BIT_PO)
 
 extern wkreg AR1;	// "edi"
-extern wkreg TR1;	// "ecx"
 
 #define GTRACE0(s)		if (debug_level('e')>2) e_printf("(G) %-12s [%s]\n",(s),showmode(mode))
 #define GTRACE1(s,r)		if (debug_level('e')>2) e_printf("(G) %-12s %s [%s]\n",(s),\

--- a/src/base/emu-i386/simx86/codegen-sim.h
+++ b/src/base/emu-i386/simx86/codegen-sim.h
@@ -66,11 +66,7 @@ typedef struct {
 #define LF_MASK_CF	(1U << LF_BIT_CF)
 #define LF_MASK_PO	(1U << LF_BIT_PO)
 
-extern wkreg DR1;	// "eax"
-extern wkreg DR2;	// "edx"
 extern wkreg AR1;	// "edi"
-extern wkreg AR2;	// "esi"
-extern wkreg SR1;	// "ebp"
 extern wkreg TR1;	// "ecx"
 
 #define GTRACE0(s)		if (debug_level('e')>2) e_printf("(G) %-12s [%s]\n",(s),showmode(mode))
@@ -84,7 +80,6 @@ extern wkreg TR1;	// "ecx"
 					(s),showreg(r1),showreg(r2),(int)(a),(int)(b),showmode(mode))
 #define GTRACE5(s,r1,r2,a,b,c)	if (debug_level('e')>2) e_printf("(G) %-12s %s %s %08x %08x %08x [%s]\n",\
 					(s),showreg(r1),showreg(r2),(int)(a),(int)(b),(int)(c),showmode(mode))
-extern int FlagSync_All (void);
 extern unsigned int Gen_sim(const IGen *IG);
 extern void InitGen_sim(void);
 

--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -271,7 +271,7 @@ int NewIMeta(int npc, int *rc);
 extern int CurrIMeta;
 extern void Gen(int op, int mode, ...);
 extern void AddrGen(int op, int mode, ...);
-extern int  (*Fp87_op)(int exop, int reg);
+extern int  (*Fp87_op)(int exop, int reg, unsigned mem_ref);
 TNode *Close(unsigned int PC, int mode);
 extern unsigned char * (*CodeGen)(unsigned char *CodePtr,
 				  unsigned char *BaseGenBuf, const IGen *IG);

--- a/src/base/emu-i386/simx86/cpatch.c
+++ b/src/base/emu-i386/simx86/cpatch.c
@@ -97,6 +97,22 @@ struct rep_stack {
 } __attribute__((packed));
 
 
+#define CMPFLAGS(asmcon,eflags,op1,op2) \
+	asm volatile("cmp %1, %2; pushf; pop %0\n\t" \
+		     : "=g" (eflags) : #asmcon (op1), #asmcon (op2))
+
+#define SCASLOOP(bitsize,asmcon,eflags,addr,eax,df,ecx,repcond) \
+	do { \
+		CMPFLAGS(asmcon,eflags,read_##bitsize(addr),(uint##bitsize##_t)eax); \
+		addr += df; \
+	} while (--ecx && (eflags & X86_EFLAGS_ZF)==repcond)
+
+#define CMPSLOOP(bitsize,asmcon,eflags,addr,source,df,ecx,repcond) \
+	do { \
+		CMPFLAGS(asmcon,eflags,read_##bitsize(addr),read_##bitsize(source)); \
+		addr += df; source += df; \
+	} while (--ecx && (eflags & X86_EFLAGS_ZF)==repcond)
+
 void rep_movs_stos(struct rep_stack *stack)
 {
 	unsigned char *paddr = stack->edi;
@@ -190,33 +206,37 @@ void rep_movs_stos(struct rep_stack *stack)
 			else repstos(,l,);
 		}
 	}
-	else if ((op & 0xf6) == 0xa6) { /* cmps/scas */
-		int repmod = (size == 1 ? MBYTE : size == 2 ? DATA16 : 0);
-		AR1.d = EMUADDR_REL(stack->edi);
-		TR1.d = stack->ecx;
-		repmod |= MOVSDST|MREPCOND|(eip[-1]==REPNE? MREPNE:MREP);
+	else if ((op & 0xf6) == 0xa6 && ecx > 0) { /* cmps/scas */
+		int df = size * (CPUWORD(Ofs_FLAGS) & EFLAGS_DF? -1:1);
+		unsigned long repcond = (eip[-1]==REPNE ? 0 : X86_EFLAGS_ZF);
+		unsigned long eflags;
 		if ((op & 0xfe) == 0xa6) { /* cmps */
-			repmod |= MOVSSRC;
-			AR2.d = EMUADDR_REL(stack->esi);
-			IGen IG = (IGen){.op = O_MOVS_CmpD, .mode = repmod};
-			Gen_sim(&IG);
-			stack->esi = EMU_BASE32(AR2.d);
+			dosaddr_t source = EMUADDR_REL(stack->esi);
+			if (size == 1)
+				CMPSLOOP(8,q,eflags,addr,source,df,ecx,repcond);
+			else if (size == 2)
+				CMPSLOOP(16,r,eflags,addr,source,df,ecx,repcond);
+			else
+				CMPSLOOP(32,r,eflags,addr,source,df,ecx,repcond);
+			stack->esi = EMU_BASE32(source);
 		}
 		else { /* scas */
-			DR1.d = stack->eax;
-			IGen IG = (IGen){.op = O_MOVS_ScaD, .mode = repmod};
-			Gen_sim(&IG);
+			unsigned int eax = stack->eax;
+			if (size == 1)
+				SCASLOOP(8,q,eflags,addr,eax,df,ecx,repcond);
+			else if (size == 2)
+				SCASLOOP(16,r,eflags,addr,eax,df,ecx,repcond);
+			else
+				SCASLOOP(32,r,eflags,addr,eax,df,ecx,repcond);
 		}
-		stack->edi = EMU_BASE32(AR1.d);
-		stack->ecx = TR1.d;
-		stack->eflags = (stack->eflags & ~EFLAGS_CC) | FlagSync_All();
+		stack->eflags = (stack->eflags & ~EFLAGS_CC) | (eflags & EFLAGS_CC);
 		goto done;
 	}
 	if (EFLAGS & EFLAGS_DF) addr -= len;
 	else addr += len;
+done:
 	stack->edi = EMU_BASE32(addr);
 	stack->ecx = ecx;
-done:
 	InCompiledCode++;
 #if PROFILE
 	CpatchReps++;

--- a/src/base/emu-i386/simx86/emu86.h
+++ b/src/base/emu-i386/simx86/emu86.h
@@ -734,7 +734,7 @@ int _ModRMSim(unsigned int PC, int mode, signed char overr_ds, signed char overr
     if (REG1 == 0xff) { \
         goto illegal_op; \
     } \
-    if (V86MODE() && (0 == ((m) & (ADDR16 | MLEA))) && TR1.d > 0xffff) { \
+    if (TheCPU.err2 == EXCP0D_GPF) { \
         goto not_permitted; \
     } \
     __l; \

--- a/src/base/emu-i386/simx86/fp87-sim.c
+++ b/src/base/emu-i386/simx86/fp87-sim.c
@@ -74,8 +74,8 @@
 #define M_LOG2El 1.442695040888963407359924681001892137L
 #endif
 
-int (*Fp87_op)(int exop, int reg);
-static int Fp87_op_sim(int exop, int reg);
+int (*Fp87_op)(int exop, int reg, unsigned mem_ref);
+static int Fp87_op_sim(int exop, int reg, unsigned mem_ref);
 
 static long double WFR0, WFR1;
 
@@ -245,7 +245,7 @@ static void write_long_double(dosaddr_t addr, long double ld)
 	sim_write_word(addr+8, x.u32[2]);
 }
 
-static int Fp87_op_sim(int exop, int reg)
+static int Fp87_op_sim(int exop, int reg, unsigned mem_ref)
 {
 //	42	DA 11000nnn	FCMOVB	st(0),st(n)
 //	43	DB 11000nnn	FCMOVNB	st(0),st(n)
@@ -275,12 +275,12 @@ static int Fp87_op_sim(int exop, int reg)
 //	2F	DF xx101nnn	FILD	qw
 		DECFSPP;
 		switch(exop) {		// Fop (edi)
-		case 0x01: WFR0 = read_float(AR1.d); break;
-		case 0x03: WFR0 = (int32_t)sim_read_dword(AR1.d); break;
-		case 0x05: WFR0 = read_double(AR1.d); break;
-		case 0x07: WFR0 = (int16_t)sim_read_word(AR1.d); break;
+		case 0x01: WFR0 = read_float(mem_ref); break;
+		case 0x03: WFR0 = (int32_t)sim_read_dword(mem_ref); break;
+		case 0x05: WFR0 = read_double(mem_ref); break;
+		case 0x07: WFR0 = (int16_t)sim_read_word(mem_ref); break;
 		case 0x27: {
-			dosaddr_t p = AR1.d;
+			dosaddr_t p = mem_ref;
 			long long b = 0;
 			int i;
 			for (i = 8; i >= 0; i--) {
@@ -290,8 +290,8 @@ static int Fp87_op_sim(int exop, int reg)
 			WFR0 = ((sim_read_byte(p+9) & 0x80) ? -1 : 1) * b;
 			break;
 		}
-		case 0x2b: WFR0 = read_long_double(AR1.d); break;
-		case 0x2f: WFR0 = (int64_t)sim_read_qword(AR1.d); break;
+		case 0x2b: WFR0 = read_long_double(mem_ref); break;
+		case 0x2f: WFR0 = (int64_t)sim_read_qword(mem_ref); break;
 		}
 		*ST0 = WFR0;
 		break;
@@ -346,30 +346,30 @@ static int Fp87_op_sim(int exop, int reg)
 //	3E	DE xx111nnn	FIDIVR	w
 		WFR0 = *ST0;
 		switch(exop) {		// Fop (edi)
-		case 0x00: WFR0 += read_float(AR1.d); break;
-		case 0x02: WFR0 += (int32_t)sim_read_dword(AR1.d); break;
-		case 0x04: WFR0 += read_double(AR1.d); break;
-		case 0x06: WFR0 += (int16_t)sim_read_word(AR1.d); break;
-		case 0x08: WFR0 *= read_float(AR1.d); break;
-		case 0x0a: WFR0 *= (int32_t)sim_read_dword(AR1.d); break;
-		case 0x0c: WFR0 *= read_double(AR1.d); break;
-		case 0x0e: WFR0 *= (int16_t)sim_read_word(AR1.d); break;
-		case 0x20: WFR0 -= read_float(AR1.d); break;
-		case 0x22: WFR0 -= (int32_t)sim_read_dword(AR1.d); break;
-		case 0x24: WFR0 -= read_double(AR1.d); break;
-		case 0x26: WFR0 -= (int16_t)sim_read_word(AR1.d); break;
-		case 0x28: WFR0 = (long double)read_float(AR1.d) - WFR0; break;
-		case 0x2a: WFR0 = (long double)(int32_t)sim_read_dword(AR1.d) - WFR0; break;
-		case 0x2c: WFR0 = (long double)read_double(AR1.d) - WFR0; break;
-		case 0x2e: WFR0 = (long double)(int16_t)sim_read_word(AR1.d) - WFR0; break;
-		case 0x30: WFR0 /= read_float(AR1.d); break;
-		case 0x32: WFR0 /= (int32_t)sim_read_dword(AR1.d); break;
-		case 0x34: WFR0 /= read_double(AR1.d); break;
-		case 0x36: WFR0 /= (int16_t)sim_read_word(AR1.d); break;
-		case 0x38: WFR0 = (long double)read_float(AR1.d) / WFR0; break;
-		case 0x3a: WFR0 = (long double)(int32_t)sim_read_dword(AR1.d) / WFR0; break;
-		case 0x3c: WFR0 = (long double)read_double(AR1.d) / WFR0; break;
-		case 0x3e: WFR0 = (long double)(int16_t)sim_read_word(AR1.d) / WFR0; break;
+		case 0x00: WFR0 += read_float(mem_ref); break;
+		case 0x02: WFR0 += (int32_t)sim_read_dword(mem_ref); break;
+		case 0x04: WFR0 += read_double(mem_ref); break;
+		case 0x06: WFR0 += (int16_t)sim_read_word(mem_ref); break;
+		case 0x08: WFR0 *= read_float(mem_ref); break;
+		case 0x0a: WFR0 *= (int32_t)sim_read_dword(mem_ref); break;
+		case 0x0c: WFR0 *= read_double(mem_ref); break;
+		case 0x0e: WFR0 *= (int16_t)sim_read_word(mem_ref); break;
+		case 0x20: WFR0 -= read_float(mem_ref); break;
+		case 0x22: WFR0 -= (int32_t)sim_read_dword(mem_ref); break;
+		case 0x24: WFR0 -= read_double(mem_ref); break;
+		case 0x26: WFR0 -= (int16_t)sim_read_word(mem_ref); break;
+		case 0x28: WFR0 = (long double)read_float(mem_ref) - WFR0; break;
+		case 0x2a: WFR0 = (long double)(int32_t)sim_read_dword(mem_ref) - WFR0; break;
+		case 0x2c: WFR0 = (long double)read_double(mem_ref) - WFR0; break;
+		case 0x2e: WFR0 = (long double)(int16_t)sim_read_word(mem_ref) - WFR0; break;
+		case 0x30: WFR0 /= read_float(mem_ref); break;
+		case 0x32: WFR0 /= (int32_t)sim_read_dword(mem_ref); break;
+		case 0x34: WFR0 /= read_double(mem_ref); break;
+		case 0x36: WFR0 /= (int16_t)sim_read_word(mem_ref); break;
+		case 0x38: WFR0 = (long double)read_float(mem_ref) / WFR0; break;
+		case 0x3a: WFR0 = (long double)(int32_t)sim_read_dword(mem_ref) / WFR0; break;
+		case 0x3c: WFR0 = (long double)read_double(mem_ref) / WFR0; break;
+		case 0x3e: WFR0 = (long double)(int16_t)sim_read_word(mem_ref) / WFR0; break;
 		}
 		*ST0 = WFR0;
 		break;
@@ -409,13 +409,13 @@ static int Fp87_op_sim(int exop, int reg)
 		WFR0 = *ST0;
 		switch(exop) {		// Fop (edi), no pop
 		case 0x10:
-		case 0x18: WFR1 = (long double)read_float(AR1.d); goto fcom00;
+		case 0x18: WFR1 = (long double)read_float(mem_ref); goto fcom00;
 		case 0x12:
-		case 0x1a: WFR1 = (long double)(int32_t)sim_read_dword(AR1.d); goto fcom00;
+		case 0x1a: WFR1 = (long double)(int32_t)sim_read_dword(mem_ref); goto fcom00;
 		case 0x14:
-		case 0x1c: WFR1 = (long double)read_double(AR1.d); goto fcom00;
+		case 0x1c: WFR1 = (long double)read_double(mem_ref); goto fcom00;
 		case 0x16:
-		case 0x1e: WFR1 = (long double)(int16_t)sim_read_word(AR1.d);
+		case 0x1e: WFR1 = (long double)(int16_t)sim_read_word(mem_ref);
 fcom00:			TheCPU.fpus &= ~(FPUS_C0 | FPUS_C2 | FPUS_C3);
 			if (WFR0 < WFR1)
 			    TheCPU.fpus |= FPUS_C0;
@@ -426,9 +426,9 @@ fcom00:			TheCPU.fpus &= ~(FPUS_C0 | FPUS_C2 | FPUS_C3);
 				    TheCPU.fpus |= FPUS_C0 | FPUS_C2 | FPUS_C3;
 			    break;
 		case 0x11:
-		case 0x19: write_float(AR1.d, WFR0); break;
+		case 0x19: write_float(mem_ref, WFR0); break;
 		case 0x15:
-		case 0x1d: write_double(AR1.d, WFR0); break;
+		case 0x1d: write_double(mem_ref, WFR0); break;
 		case 0x13:
 		case 0x1b:
 		case 0x17:
@@ -443,7 +443,7 @@ fcom00:			TheCPU.fpus &= ~(FPUS_C0 | FPUS_C2 | FPUS_C3);
 			    }
 			    else if (WFR0 != *ST0) /* flag inexact */
 				TheCPU.fpus |= FPUS_PE;
-			    sim_write_word(AR1.d, (int16_t)WFR0); break;
+			    sim_write_word(mem_ref, (int16_t)WFR0); break;
 			}
 			if (isnan(WFR0) || isinf(WFR0) ||
 			    WFR0 < -(long double)0x80000000 ||
@@ -453,14 +453,14 @@ fcom00:			TheCPU.fpus &= ~(FPUS_C0 | FPUS_C2 | FPUS_C3);
 			}
 			else if (WFR0 != *ST0) /* flag inexact */
 			    TheCPU.fpus |= FPUS_PE;
-			sim_write_dword(AR1.d, (int32_t)WFR0); break; }
+			sim_write_dword(mem_ref, (int32_t)WFR0); break; }
 		}
 		if (exop&8) INCFSPP;
 		break;
 
 /*37*/	case 0x37: {
 //	37	DF xx110nnn	FBSTP
-		dosaddr_t p = AR1.d;
+		dosaddr_t p = mem_ref;
 		long long b;
 		int i;
 		WFR0 = *ST0;
@@ -490,7 +490,7 @@ fcom00:			TheCPU.fpus &= ~(FPUS_C0 | FPUS_C2 | FPUS_C3);
 /*3b*/	case 0x3b:
 //	3B	DB xx111nnn	FSTP	ext
 		WFR0 = *ST0;
-		write_long_double(AR1.d, WFR0);
+		write_long_double(mem_ref, WFR0);
 		INCFSPP;
 		break;
 /*3f*/	case 0x3f: {
@@ -505,18 +505,18 @@ fcom00:			TheCPU.fpus &= ~(FPUS_C0 | FPUS_C2 | FPUS_C3);
 		}
 		else if (WFR0 != *ST0)
 		    TheCPU.fpus |= FPUS_PE;
-		sim_write_qword(AR1.d, (int64_t)WFR0);
+		sim_write_qword(mem_ref, (int64_t)WFR0);
 		INCFSPP;
 		}
 		break;
 /*29*/	case 0x29:
 //*	29	D9 xx101nnn	FLDCW	2b
-		TheCPU.fpuc = sim_read_word(AR1.d) | 0x40;
+		TheCPU.fpuc = sim_read_word(mem_ref) | 0x40;
 		fp87_set_rounding();
 		break;
 /*39*/	case 0x39:
 //*	39	D9 xx111nnn	FSTCW	2b
-		sim_write_word(AR1.d, TheCPU.fpuc);
+		sim_write_word(mem_ref, TheCPU.fpuc);
 		break;
 
 /*67*/	case 0x67: if (reg!=0) goto fp_notok;
@@ -533,7 +533,7 @@ fcom00:			TheCPU.fpus &= ~(FPUS_C0 | FPUS_C2 | FPUS_C3);
 		fp87_save_except();
 		if (exop==0x3d) {
 			// movw	ax,(edi)
-			sim_write_word(AR1.d, TheCPU.fpus);
+			sim_write_word(mem_ref, TheCPU.fpus);
 		}
 		else {
 			CPUWORD(Ofs_AX) = TheCPU.fpus;
@@ -1006,7 +1006,7 @@ fcom00:			TheCPU.fpus &= ~(FPUS_C0 | FPUS_C2 | FPUS_C3);
 /*25*/	case 0x25: {
 //*	21	D9 xx100nnn	FLDENV	14/28byte
 //	25	DD xx100nnn	FRSTOR	94/108byte
-		    dosaddr_t p = TheCPU.mem_ref, q;
+		    dosaddr_t p = mem_ref, q;
 		    TheCPU.fpuc = sim_read_word(p) | 0x40;
 		    feclearexcept(FE_ALL_EXCEPT);
 		    fp87_set_rounding();
@@ -1093,7 +1093,7 @@ fcom00:			TheCPU.fpus &= ~(FPUS_C0 | FPUS_C2 | FPUS_C3);
 			fptag <<= 2;
 		    }
 		    TheCPU.fptag = ntag;
-		    dosaddr_t p = TheCPU.mem_ref;
+		    dosaddr_t p = mem_ref;
 		    if (reg&DATA16) {
 			sim_write_word(p, TheCPU.fpuc);
 			sim_write_word(p+2, TheCPU.fpus);
@@ -1103,7 +1103,7 @@ fcom00:			TheCPU.fpus &= ~(FPUS_C0 | FPUS_C2 | FPUS_C3);
 			q = p+14;
 		    }
 		    else {
-			dosaddr_t p = TheCPU.mem_ref;
+			dosaddr_t p = mem_ref;
 			sim_write_dword(p, TheCPU.fpuc);
 			sim_write_dword(p+4, TheCPU.fpus);
 			sim_write_dword(p+8, TheCPU.fptag);

--- a/src/base/emu-i386/simx86/fp87-x86.c
+++ b/src/base/emu-i386/simx86/fp87-x86.c
@@ -37,7 +37,7 @@
 
 #include "codegen-x86.h"
 
-static int Fp87_op_x86_sim(int exop, int reg);
+static int Fp87_op_x86_sim(int exop, int reg, unsigned mem_ref);
 
 /*
  * Only mask bits 0-5 of the control word (fpuc),
@@ -399,7 +399,7 @@ fp_ok:
 	return Cp;
 }
 
-static int Fp87_op_x86_sim(int exop, int reg)
+static int Fp87_op_x86_sim(int exop, int reg, unsigned mem_ref)
 {
 	e_printf("FPop %x.%d\n", exop, reg);
 
@@ -408,7 +408,7 @@ static int Fp87_op_x86_sim(int exop, int reg)
 /*25*/	case 0x25: {
 //*	21	D9 xx100nnn	FLDENV	14/28byte
 //	25	DD xx100nnn	FRSTOR	94/108byte
-		    void *p = LINEAR2UNIX(TheCPU.mem_ref);
+		    void *p = LINEAR2UNIX(mem_ref);
 		    if (reg&DATA16) {
 			struct float_env16 q;
 		        memcpy(&q, p, (exop == 0x21 ? 14 : 94));
@@ -482,7 +482,7 @@ static int Fp87_op_x86_sim(int exop, int reg)
 //*	31	D9 xx110nnn	FSTENV	14/28byte
 //	35	DD xx110nnn	FSAVE	94/108byte
 		    if (exop==0x31) {
-			struct float_env16 *p = (struct float_env16 *)LINEAR2UNIX(TheCPU.mem_ref);
+			struct float_env16 *p = (struct float_env16 *)LINEAR2UNIX(mem_ref);
 			if (reg&DATA16)
 			    __asm__ __volatile__ ("data16 fnstenv %0\n":"=m"(*p));
 			else
@@ -490,7 +490,7 @@ static int Fp87_op_x86_sim(int exop, int reg)
 			p->fpuc = (p->fpuc & ~0x3f) | (TheCPU.fpuc & 0x3f);
 		    }
 		    else {
-			struct float_env32 *p = (struct float_env32 *)LINEAR2UNIX(TheCPU.mem_ref);
+			struct float_env32 *p = (struct float_env32 *)LINEAR2UNIX(mem_ref);
 			if (reg&DATA16)
 			    __asm__ __volatile__ ("data16 fnsave %0\n" : "=m"(*p));
 			else

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -2956,7 +2956,7 @@ repag0:
 				TheCPU.fpstate = NULL;
 			}
 			if (sim) {
-			    if (Fp87_op(exop,b)) {
+			    if (Fp87_op(exop,b,TheCPU.mem_ref)) {
 				TheCPU.err = -96;
 				return P0;
 			    }

--- a/src/base/emu-i386/simx86/modrm-sim.c
+++ b/src/base/emu-i386/simx86/modrm-sim.c
@@ -55,9 +55,8 @@ int _ModRMSim(unsigned int PC, int mode, signed char overr_ds, signed char overr
 	if (CurrIMeta == 0) { // otherwise AddrGen isn't called (for reg-only)
 		IMeta *I = InstrMeta;
 		assert(I->ngen == 1); // needs to be exactly one intermediate op
-		Gen_sim(I->gen);
+		TheCPU.mem_ref = AddrGen_sim(I->gen);
 		CurrIMeta = -1;
-		TheCPU.mem_ref = AR1.d;
 	}
 	return l;
 }


### PR DESCRIPTION
The idea of this PR to make codegen-sim.c more self-contained and easier to optimize without as many side-effects.

The wkreg variables were used in 4 places:
cpatch.c: I've changed its calls for rep scas and rep cmps to just do it in cpatch itself; since cpatch implies x86, we can evaluate flags using inline asm.
fp87-sim: could be passed AR1.d as a simple input variable, called mem_ref.

ModRMSim: the use of TR1 wasn't needed any more as TheCPU.err2 was already set in the callee; to eliminate the use of AR1.d I've reintroduced AddrGen_sim out of Gen_sim again, but now to have it return the address (mem_ref) and completely avoid the wkreg variables. Gen_sim can then be static.
