### PR TITLE
simx86: retry of elimination of codegen-sim.c static variables

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -82,12 +82,12 @@ static unsigned char *currentIG = NULL;
 /////////////////////////////////////////////////////////////////////////////
 
 /* working registers of the host CPU */
-wkreg DR1;	// "eax"
-wkreg DR2;	// "edx"
-wkreg AR1;	// "edi"
-wkreg AR2;	// "esi"
-wkreg SR1;	// "ebp"
-wkreg TR1;	// "ecx"
+static wkreg DR1;	// "eax"
+static wkreg DR2;	// "edx"
+static wkreg AR1;	// "edi"
+static wkreg AR2;	// "esi"
+static wkreg SR1;	// "ebp"
+static wkreg TR1;	// "ecx"
 static flgtmp RFL;
 
 /////////////////////////////////////////////////////////////////////////////
@@ -264,7 +264,7 @@ static inline int FlagSync_SZAPC (void)
 	  FlagSync_S() | FlagSync_P();
 }
 
-int FlagSync_All (void)
+static int FlagSync_All (void)
 {
 	int nf = FlagSync_SZAPC() | FlagSync_O();
 	if (debug_level('e')>1) e_printf("Sync ALL flags = %04x\n", nf);
@@ -392,7 +392,7 @@ dosaddr_t AddrGen_sim(const IGen *IG)
 	return mem_ref;
 }
 
-unsigned int Gen_sim(const IGen *IG)
+static unsigned int Gen_sim(const IGen *IG)
 {
 	int op = IG->op;
 	int mode = IG->mode;

--- a/src/base/emu-i386/simx86/codegen-sim.h
+++ b/src/base/emu-i386/simx86/codegen-sim.h
@@ -66,13 +66,6 @@ typedef struct {
 #define LF_MASK_CF	(1U << LF_BIT_CF)
 #define LF_MASK_PO	(1U << LF_BIT_PO)
 
-extern wkreg DR1;	// "eax"
-extern wkreg DR2;	// "edx"
-extern wkreg AR1;	// "edi"
-extern wkreg AR2;	// "esi"
-extern wkreg SR1;	// "ebp"
-extern wkreg TR1;	// "ecx"
-
 #define GTRACE0(s)		if (debug_level('e')>2) e_printf("(G) %-12s [%s]\n",(s),showmode(mode))
 #define GTRACE1(s,r)		if (debug_level('e')>2) e_printf("(G) %-12s %s [%s]\n",(s),\
 					showreg(r),showmode(mode))
@@ -84,8 +77,6 @@ extern wkreg TR1;	// "ecx"
 					(s),showreg(r1),showreg(r2),(int)(a),(int)(b),showmode(mode))
 #define GTRACE5(s,r1,r2,a,b,c)	if (debug_level('e')>2) e_printf("(G) %-12s %s %s %08x %08x %08x [%s]\n",\
 					(s),showreg(r1),showreg(r2),(int)(a),(int)(b),(int)(c),showmode(mode))
-extern int FlagSync_All (void);
-extern unsigned int Gen_sim(const IGen *IG);
 extern dosaddr_t AddrGen_sim(const IGen *IG);
 extern void InitGen_sim(void);
 

--- a/src/base/emu-i386/simx86/cpatch.c
+++ b/src/base/emu-i386/simx86/cpatch.c
@@ -131,14 +131,13 @@ void rep_movs_stos(struct rep_stack *stack)
 		dosaddr_t source = EMUADDR_REL(stack->esi);
 		unsigned char *esi;
 		unsigned int v = vga_access(source, addr);
+		esi = LINEAR2UNIX(source);
 		if (v) {
 			int df = ((EFLAGS & EFLAGS_DF) ? -size:size);
-			e_VgaMovs(&stack->edi, &stack->esi, ecx, df, v);
-			stack->ecx = 0;
-			goto done;
+			e_VgaMovs(addr, source, ecx, df, v);
+			ecx = 0;
 		}
-		esi = LINEAR2UNIX(source);
-		if (ecx == len) {
+		else if (ecx == len) {
 			if (EFLAGS & EFLAGS_DF) repmovs(std,b,cld);
 			else repmovs(,b,);
 		}
@@ -150,8 +149,8 @@ void rep_movs_stos(struct rep_stack *stack)
 			if (EFLAGS & EFLAGS_DF) repmovs(std,l,cld);
 			else repmovs(,l,);
 		}
-		if (EFLAGS & EFLAGS_DF) source -= len;
-		else source += len;
+		if (EFLAGS & EFLAGS_DF) {source -= len; addr -= len;}
+		else {source += len; addr += len;}
 		stack->esi = EMU_BASE32(source);
 	}
 	else if ((op & 0xfe) == 0xaa) { /* stos */
@@ -189,6 +188,8 @@ void rep_movs_stos(struct rep_stack *stack)
 			else if (EFLAGS & EFLAGS_DF) repstos(std,l,cld);
 			else repstos(,l,);
 		}
+		if (EFLAGS & EFLAGS_DF) addr -= len;
+		else addr += len;
 	}
 	else if ((op & 0xf6) == 0xa6) { /* cmps/scas */
 		int repmod = (size == 1 ? MBYTE : size == 2 ? DATA16 : 0);
@@ -207,16 +208,12 @@ void rep_movs_stos(struct rep_stack *stack)
 			IGen IG = (IGen){.op = O_MOVS_ScaD, .mode = repmod};
 			Gen_sim(&IG);
 		}
-		stack->edi = EMU_BASE32(AR1.d);
-		stack->ecx = TR1.d;
+		addr = AR1.d;
+		ecx = TR1.d;
 		stack->eflags = (stack->eflags & ~EFLAGS_CC) | FlagSync_All();
-		goto done;
 	}
-	if (EFLAGS & EFLAGS_DF) addr -= len;
-	else addr += len;
 	stack->edi = EMU_BASE32(addr);
 	stack->ecx = ecx;
-done:
 	InCompiledCode++;
 #if PROFILE
 	CpatchReps++;

--- a/src/base/emu-i386/simx86/cpatch.c
+++ b/src/base/emu-i386/simx86/cpatch.c
@@ -97,6 +97,22 @@ struct rep_stack {
 } __attribute__((packed));
 
 
+#define CMPFLAGS(asmcon,eflags,op1,op2) \
+	asm volatile("cmp %1, %2; pushf; pop %0\n\t" \
+		     : "=g" (eflags) : #asmcon (op1), #asmcon (op2))
+
+#define SCASLOOP(bitsize,asmcon,eflags,addr,eax,df,ecx,repcond) \
+	do { \
+		CMPFLAGS(asmcon,eflags,read_##bitsize(addr),(uint##bitsize##_t)eax); \
+		addr += df; \
+	} while (--ecx && (eflags & X86_EFLAGS_ZF)==repcond)
+
+#define CMPSLOOP(bitsize,asmcon,eflags,addr,source,df,ecx,repcond) \
+	do { \
+		CMPFLAGS(asmcon,eflags,read_##bitsize(addr),read_##bitsize(source)); \
+		addr += df; source += df; \
+	} while (--ecx && (eflags & X86_EFLAGS_ZF)==repcond)
+
 void rep_movs_stos(struct rep_stack *stack)
 {
 	unsigned char *paddr = stack->edi;
@@ -191,26 +207,30 @@ void rep_movs_stos(struct rep_stack *stack)
 		if (EFLAGS & EFLAGS_DF) addr -= len;
 		else addr += len;
 	}
-	else if ((op & 0xf6) == 0xa6) { /* cmps/scas */
-		int repmod = (size == 1 ? MBYTE : size == 2 ? DATA16 : 0);
-		AR1.d = EMUADDR_REL(stack->edi);
-		TR1.d = stack->ecx;
-		repmod |= MOVSDST|MREPCOND|(eip[-1]==REPNE? MREPNE:MREP);
+	else if ((op & 0xf6) == 0xa6 && ecx > 0) { /* cmps/scas */
+		int df = size * (CPUWORD(Ofs_FLAGS) & EFLAGS_DF? -1:1);
+		unsigned long repcond = (eip[-1]==REPNE ? 0 : X86_EFLAGS_ZF);
+		unsigned long eflags;
 		if ((op & 0xfe) == 0xa6) { /* cmps */
-			repmod |= MOVSSRC;
-			AR2.d = EMUADDR_REL(stack->esi);
-			IGen IG = (IGen){.op = O_MOVS_CmpD, .mode = repmod};
-			Gen_sim(&IG);
-			stack->esi = EMU_BASE32(AR2.d);
+			dosaddr_t source = EMUADDR_REL(stack->esi);
+			if (size == 1)
+				CMPSLOOP(8,q,eflags,addr,source,df,ecx,repcond);
+			else if (size == 2)
+				CMPSLOOP(16,r,eflags,addr,source,df,ecx,repcond);
+			else
+				CMPSLOOP(32,r,eflags,addr,source,df,ecx,repcond);
+			stack->esi = EMU_BASE32(source);
 		}
 		else { /* scas */
-			DR1.d = stack->eax;
-			IGen IG = (IGen){.op = O_MOVS_ScaD, .mode = repmod};
-			Gen_sim(&IG);
+			unsigned int eax = stack->eax;
+			if (size == 1)
+				SCASLOOP(8,q,eflags,addr,eax,df,ecx,repcond);
+			else if (size == 2)
+				SCASLOOP(16,r,eflags,addr,eax,df,ecx,repcond);
+			else
+				SCASLOOP(32,r,eflags,addr,eax,df,ecx,repcond);
 		}
-		addr = AR1.d;
-		ecx = TR1.d;
-		stack->eflags = (stack->eflags & ~EFLAGS_CC) | FlagSync_All();
+		stack->eflags = (stack->eflags & ~EFLAGS_CC) | (eflags & EFLAGS_CC);
 	}
 	stack->edi = EMU_BASE32(addr);
 	stack->ecx = ecx;

--- a/src/base/emu-i386/simx86/emu86.h
+++ b/src/base/emu-i386/simx86/emu86.h
@@ -776,7 +776,7 @@ void mprot_end(void);
 void prejit_sync(void);
 void init_emu_npu(void);
 
-void e_VgaMovs(unsigned char **rdi, unsigned char **rsi, unsigned int rep,
+void e_VgaMovs(dosaddr_t edi, dosaddr_t esi, unsigned int rep,
 	       int dp, unsigned int access);
 
 #endif // _EMU86_EMU86_H

--- a/src/base/emu-i386/simx86/sigsegv.c
+++ b/src/base/emu-i386/simx86/sigsegv.c
@@ -51,12 +51,9 @@
 
 /* ======================================================================= */
 
-void e_VgaMovs(unsigned char **rdi, unsigned char **rsi, unsigned int rep,
+void e_VgaMovs(dosaddr_t edi, dosaddr_t esi, unsigned int rep,
 	       int dp, unsigned int access)
 {
-  dosaddr_t edi = EMUADDR_REL(*rdi);
-  dosaddr_t esi = EMUADDR_REL(*rsi);
-
 #ifdef DEBUG_VGA
   e_printf("eVGAEmuFault: Movs ESI=%08x EDI=%08x ECX=%08x\n",esi,edi,rep);
 #endif
@@ -128,8 +125,6 @@ void e_VgaMovs(unsigned char **rdi, unsigned char **rsi, unsigned int rep,
 	}
 	break;
   }
-  *rsi = EMU_BASE32(esi);
-  *rdi = EMU_BASE32(edi);
 }
 
 #if 1


### PR DESCRIPTION
commit f75e38a6 broke Win31, but it was a side-effect of a moved `goto` label after calling `e_VgaMovs` (I suspect without testing Win31, but that's definitely a bug)
I redid the patch eliminating the goto completely. Hopefully this fixes Win31 again.
