### PR TITLE
simx86: syncpu cleanup

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -2866,7 +2866,7 @@ static void emu_pagefault_handler(dosaddr_t addr, int err, uint32_t op, int len)
 	prejit_sync();
 	TheCPU.err = EXCP0E_PAGE;
 	TheCPU.scp_err = err;
-	TheCPU.cr2 = addr;
+	TheCPU.cr[2] = addr;
 	if (currentIG) {
 		LONG_CS = _LONG_CS;
 		unsigned int P0 = FindPC(currentIG);

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -1913,7 +1913,7 @@ unsigned int Gen_sim(const IGen *IG)
 			sim_write_word(AR2.d + SR1.d, DR1.w.l);
 		}
 		else {
-			DR1.d = CPULONG(o);
+			DR1.d = (mode & SEGREG) ? CPUWORD(o) : CPULONG(o);
 			SR1.d -= 4;
 			SR1.d &= stackm;
 			sim_write_dword(AR2.d + SR1.d, DR1.d);

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -816,8 +816,8 @@ arith1:
 			// movw Ofs_AX(%%ebx),%%ax
 			G4M(OPERoverride,0x8b,0x43,Ofs_AX,Cp);
 			/* exception trap: save current PC */
-			// movl $eip,Ofs_CR2(%%ebx)
-			G2M(0xc7,0x43,Cp); G1(Ofs_CR2,Cp); G4(IG->p0,Cp);
+			// movl $eip,Ofs_EIP(%%ebx)
+			G2M(0xc7,0x43,Cp); G1(Ofs_EIP,Cp); G4(IG->p0,Cp);
 			// div %%cl,%%al
 			G2M(0xf6,0xf1,Cp);
 			// movw %%ax,Ofs_AX(%%ebx)
@@ -829,8 +829,8 @@ arith1:
 			// movw Ofs_DX(%%ebx),%%dx
 			G4M(OPERoverride,0x8b,0x53,Ofs_DX,Cp);
 			/* exception trap: save current PC */
-			// movl $eip,Ofs_CR2(%%ebx)
-			G2(0x43c7,Cp); G1(Ofs_CR2,Cp); G4(IG->p0,Cp);
+			// movl $eip,Ofs_EIP(%%ebx)
+			G2(0x43c7,Cp); G1(Ofs_EIP,Cp); G4(IG->p0,Cp);
 			// div %%cx,%%ax
 			G3M(OPERoverride,0xf7,0xf1,Cp);
 			// movw %%ax,Ofs_AX(%%ebx)
@@ -844,8 +844,8 @@ arith1:
 			// movl Ofs_EDX(%%ebx),%%edx
 			G3M(0x8b,0x53,Ofs_EDX,Cp);
 			/* exception trap: save current PC */
-			// movl $eip,Ofs_CR2(%%ebx)
-			G2(0x43c7,Cp); G1(Ofs_CR2,Cp); G4(IG->p0,Cp);
+			// movl $eip,Ofs_EIP(%%ebx)
+			G2(0x43c7,Cp); G1(Ofs_EIP,Cp); G4(IG->p0,Cp);
 			// div %%ecx,%%eax
 			G2M(0xf7,0xf1,Cp);
 			// movl %%eax,Ofs_EAX(%%ebx)
@@ -863,8 +863,8 @@ arith1:
 			// movw Ofs_AX(%%ebx),%%ax
 			G4M(OPERoverride,0x8b,0x43,Ofs_AX,Cp);
 			/* exception trap: save current PC */
-			// movl $eip,Ofs_CR2(%%ebx)
-			G2(0x43c7,Cp); G1(Ofs_CR2,Cp); G4(IG->p0,Cp);
+			// movl $eip,Ofs_EIP(%%ebx)
+			G2(0x43c7,Cp); G1(Ofs_EIP,Cp); G4(IG->p0,Cp);
 			// idiv %%cl,%%al
 			G2M(0xf6,0xf9,Cp);
 			// movw %%ax,Ofs_AX(%%ebx)
@@ -876,8 +876,8 @@ arith1:
 			// movw Ofs_DX(%%ebx),%%dx
 			G4M(OPERoverride,0x8b,0x53,Ofs_DX,Cp);
 			/* exception trap: save current PC */
-			// movl $eip,Ofs_CR2(%%ebx)
-			G2(0x43c7,Cp); G1(Ofs_CR2,Cp); G4(IG->p0,Cp);
+			// movl $eip,Ofs_EIP(%%ebx)
+			G2(0x43c7,Cp); G1(Ofs_EIP,Cp); G4(IG->p0,Cp);
 			// idiv %%cx,%%ax
 			G3M(OPERoverride,0xf7,0xf9,Cp);
 			// movw %%ax,Ofs_AX(%%ebx)
@@ -891,8 +891,8 @@ arith1:
 			// movl Ofs_EDX(%%ebx),%%edx
 			G3M(0x8b,0x53,Ofs_EDX,Cp);
 			/* exception trap: save current PC */
-			// movl $eip,Ofs_CR2(%%ebx)
-			G2(0x43c7,Cp); G1(Ofs_CR2,Cp); G4(IG->p0,Cp);
+			// movl $eip,Ofs_EIP(%%ebx)
+			G2(0x43c7,Cp); G1(Ofs_EIP,Cp); G4(IG->p0,Cp);
 			// idiv %%ecx,%%eax
 			G2M(0xf7,0xf9,Cp);
 			// movl %%eax,Ofs_EAX(%%ebx)

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -1162,8 +1162,8 @@ shrot0:
 
 	case O_PUSH2: {		/* register push only */
 		const unsigned char pseq16[] = {
-			// movl offs(%%ebx),%%eax
-/*00*/			0x8b,0x43,0x00,
+			// movl offs(%%ebx),%%ax
+/*00*/			0x66,0x8b,0x43,0x00,
 			// leal -2(%%ecx),%%ecx
 			0x8d,0x49,0xfe,
 			// andl StackMask(%%ebx),%%ecx
@@ -1184,8 +1184,8 @@ shrot0:
 #endif
 		};
 		const unsigned char pseq32[] = {
-			// movl offs(%%ebx),%%eax
-/*00*/			0x8b,0x43,0x00,
+			// nop; movl offs(%%ebx),%%eax
+/*00*/			0x90,0x8b,0x43,0x00,
 			// leal -4(%%ecx),%%ecx
 			0x8d,0x49,0xfc,
 			// andl StackMask(%%ebx),%%ecx
@@ -1211,7 +1211,12 @@ shrot0:
 		if (mode&DATA16) p=pseq16,sz=sizeof(pseq16);
 			else p=pseq32,sz=sizeof(pseq32);
 		q=Cp; GNX(Cp, p, sz);
-		q[2] = IG->p0;
+		q[3] = IG->p0;
+		if ((mode & (SEGREG|DATA16)) == SEGREG) {
+			// change to movzx for 32bit segreg
+			q[0] = 0x0f;
+			q[1] = 0xb7;
+		}
 		} break;
 
 	case O_PUSH3:

--- a/src/base/emu-i386/simx86/cpatch.c
+++ b/src/base/emu-i386/simx86/cpatch.c
@@ -591,7 +591,7 @@ int Cpatch(sigcontext_t *scp)
 #endif
 	/* check for optimized multiple register push */
 	if (p[0]==0x89) return 1; //O_PUSH3
-	p += 12;
+	p += 13;
 	if (p[0]==0xff) return 1; // already JSRPATCH'ed
 	if (*p==0x66) w16=1,p++; else w16=0;
 	v = *((int *)p) & 0xffffff;

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -632,7 +632,7 @@ static void Scp2Cpu(cpuctx_t *scp)
 
   TheCPU.scp_err = 0;
   TheCPU.ss = _ss;
-  TheCPU.cr2 = _cr2;
+  TheCPU.cr[2] = _cr2;
   TheCPU.df_increments = (TheCPU.eflags&DF)?0xfcfeff:0x040201;
 
   TheCPU.fpstate = &vm86_fpu_state;
@@ -666,7 +666,7 @@ static void Cpu2Scp(cpuctx_t *scp, int trapno)
 
   _err = TheCPU.scp_err;
   _ss = TheCPU.ss;
-  _cr2 = TheCPU.cr2;
+  _cr2 = TheCPU.cr[2];
   _trapno = trapno;
   /* Error code format:
    * b31-b16 = 0 (undef)
@@ -1087,7 +1087,7 @@ static int e_vm86_tail(struct vm86_struct *info)
 	      }
 	    default: {
 		/* FAULT, handled via signal callback */
-		vm86_fault(xval-1, TheCPU.scp_err, TheCPU.cr2);
+		vm86_fault(xval-1, TheCPU.scp_err, TheCPU.cr[2]);
 		retval = VM86_SIGNAL;
 		break;
 	    }

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -623,15 +623,7 @@ static void Scp2Cpu(cpuctx_t *scp)
   TheCPU.eip = _eip;
   TheCPU.eflags = _eflags | 2;
 
-  TheCPU.cs = _cs;
-  TheCPU.fs = _fs;
-  TheCPU.gs = _gs;
-
-  TheCPU.ds = _ds;
-  TheCPU.es = _es;
-
   TheCPU.scp_err = 0;
-  TheCPU.ss = _ss;
   TheCPU.cr[2] = _cr2;
   TheCPU.df_increments = (TheCPU.eflags&DF)?0xfcfeff:0x040201;
 
@@ -713,20 +705,20 @@ static void Scp2CpuD(cpuctx_t *scp)
   /* make clear we are in PM now */
   TheCPU.cr[0] |= 1;
   mode |= ADDR16;
-  TheCPU.err = SetSegProt(mode&ADDR16,Ofs_CS,&big,TheCPU.cs);
+  TheCPU.err = SetSegProt(mode&ADDR16,Ofs_CS,&big,_cs);
   if (TheCPU.err) goto erseg;
   if (big) mode=0; else mode |= DATA16;
 
-  TheCPU.err = SetSegProt(mode&ADDR16,Ofs_DS,&big,TheCPU.ds);
+  TheCPU.err = SetSegProt(mode&ADDR16,Ofs_DS,&big,_ds);
   if (TheCPU.err) goto erseg;
-  TheCPU.err = SetSegProt(mode&ADDR16,Ofs_SS,&big,TheCPU.ss);
+  TheCPU.err = SetSegProt(mode&ADDR16,Ofs_SS,&big,_ss);
   if (TheCPU.err) goto erseg;
   TheCPU.StackMask = (big? 0xffffffff : 0x0000ffff);
-  TheCPU.err = SetSegProt(mode&ADDR16,Ofs_ES,&big,TheCPU.es);
+  TheCPU.err = SetSegProt(mode&ADDR16,Ofs_ES,&big,_es);
   if (TheCPU.err) goto erseg;
-  TheCPU.err = SetSegProt(mode&ADDR16,Ofs_FS,&big,TheCPU.fs);
+  TheCPU.err = SetSegProt(mode&ADDR16,Ofs_FS,&big,_fs);
   if (TheCPU.err) goto erseg;
-  TheCPU.err = SetSegProt(mode&ADDR16,Ofs_GS,&big,TheCPU.gs);
+  TheCPU.err = SetSegProt(mode&ADDR16,Ofs_GS,&big,_gs);
 erseg:
   if (debug_level('e')>1) {
 	e_printf("Scp2CpuD%s: CS:IP=%08x:%08x\n%s\n",

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -178,12 +178,12 @@ void e_priv_iopl(int pl)
 
 void InvalidateSegs(void)
 {
-    CS_DTR.Attrib=0;
-    SS_DTR.Attrib=0;
-    DS_DTR.Attrib=0;
-    ES_DTR.Attrib=0;
-    FS_DTR.Attrib=0;
-    GS_DTR.Attrib=0;
+    CS_DTR.BoundH = CS_DTR.BoundL + SDTR_INVALID_LIMIT;
+    DS_DTR.BoundH = DS_DTR.BoundL + SDTR_INVALID_LIMIT;
+    ES_DTR.BoundH = ES_DTR.BoundL + SDTR_INVALID_LIMIT;
+    FS_DTR.BoundH = FS_DTR.BoundL + SDTR_INVALID_LIMIT;
+    GS_DTR.BoundH = GS_DTR.BoundL + SDTR_INVALID_LIMIT;
+    SS_DTR.BoundH = SS_DTR.BoundL + SDTR_INVALID_LIMIT;
 }
 
 /* ======================================================================= */
@@ -705,6 +705,7 @@ static void Scp2CpuD(cpuctx_t *scp)
   /* make clear we are in PM now */
   TheCPU.cr[0] |= 1;
   mode |= ADDR16;
+  InvalidateSegs(); // makes sure real mode segs aren't confused with PM sels
   TheCPU.err = SetSegProt(mode&ADDR16,Ofs_CS,&big,_cs);
   if (TheCPU.err) goto erseg;
   if (big) mode=0; else mode |= DATA16;

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -183,7 +183,6 @@ static unsigned int do_flush(unsigned P0, unsigned _P0,
 
 static int _MAKESEG(int mode, int *basemode, int ofs, unsigned short sv)
 {
-	SDTR tseg, *segc;
 	int e;
 	unsigned char big;
 
@@ -193,17 +192,9 @@ static int _MAKESEG(int mode, int *basemode, int ofs, unsigned short sv)
 		return SetSegReal(sv,ofs);
 	}
 
-	segc = (SDTR *)CPUOFFS(e_ofsseg[(ofs>>2)]);
-//	if (segc==NULL) return EXCP06_ILLOP;
-
-	memcpy(&tseg,segc,sizeof(SDTR));
 	e = SetSegProt(mode&ADDR16, ofs, &big, sv);
-	/* must NOT change segreg and LONG_xx if error! */
-	if (e) {
-		memcpy(segc,&tseg,sizeof(SDTR));
+	if (e)
 		return e;
-	}
-	CPUWORD(ofs) = sv;
 	if (ofs==Ofs_CS) {
 		if (big) *basemode &= ~(ADDR16|DATA16);
 		else *basemode |= (ADDR16|DATA16);

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -2419,10 +2419,10 @@ repag0:
 				Gen(O_IMUL, _mode|MBYTE);		// al*[edi]->AX signed
 				break;
 			case Ofs_DH:	/*6*/	/* DIV AL */
-				Gen(O_DIV, _mode|MBYTE, P0);			// ah:al/[edi]->AH:AL unsigned
+				Gen(O_DIV, _mode|MBYTE, P0 - LONG_CS);			// ah:al/[edi]->AH:AL unsigned
 				break;
 			case Ofs_BH:	/*7*/	/* IDIV AL */
-				Gen(O_IDIV, _mode|MBYTE, P0);		// ah:al/[edi]->AH:AL signed
+				Gen(O_IDIV, _mode|MBYTE, P0 - LONG_CS);		// ah:al/[edi]->AH:AL signed
 				break;
 			} }
 			break;
@@ -2455,10 +2455,10 @@ repag0:
 				Gen(O_IMUL, _mode);			// (e)ax*[edi]->(E)DX:(E)AX signed
 				break;
 			case Ofs_SI:	/*6*/	/* DIV AX+DX */
-				Gen(O_DIV, _mode, P0);		// (e)ax:(e)dx/[edi]->(E)AX:(E)DX unsigned
+				Gen(O_DIV, _mode, P0 - LONG_CS);		// (e)ax:(e)dx/[edi]->(E)AX:(E)DX unsigned
 				break;
 			case Ofs_DI:	/*7*/	/* IDIV AX+DX */
-				Gen(O_IDIV, _mode, P0);		// (e)ax:(e)dx/[edi]->(E)AX:(E)DX signed
+				Gen(O_IDIV, _mode, P0 - LONG_CS);		// (e)ax:(e)dx/[edi]->(E)AX:(E)DX signed
 				break;
 			} }
 			break;

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -340,7 +340,7 @@ static unsigned int _JumpGen(unsigned int P2, int mode, int opc,
 		break;
 	case JMPld: {   /* uncond jmp far */
 		unsigned short jcs = FetchW(P2 + pskip - 2);
-		Gen(L_IMM, mode, Ofs_CS, jcs);
+		Gen(L_IMM, mode|DATA16, Ofs_CS, jcs);
 		AddrGen(A_SR_SH4, mode, Ofs_CS, Ofs_XCS);
 	}
 	/* no break */
@@ -354,9 +354,11 @@ static unsigned int _JumpGen(unsigned int P2, int mode, int opc,
 		break;
 	case CALLl: {   /* call far */
 		unsigned short jcs = FetchW(P2 + pskip - 2);
-		Gen(L_REG, mode, Ofs_CS);
+		Gen(L_REG, mode|DATA16, Ofs_CS);
+		if (!(mode & DATA16)) // 32-bit segreg padding
+		    Gen(L_ZXAX, mode);
 		Gen(O_PUSH, mode);
-		Gen(L_IMM, mode, Ofs_CS, jcs);
+		Gen(L_IMM, mode|DATA16, Ofs_CS, jcs);
 		AddrGen(A_SR_SH4, mode, Ofs_CS, Ofs_XCS);
 	}
 	/* no break */
@@ -368,7 +370,7 @@ static unsigned int _JumpGen(unsigned int P2, int mode, int opc,
 		break;
 	case RETl: case RETlisp: case JMPli: case CALLli: // far ret, indirect
 	case INT:
-		Gen(S_REG, mode, Ofs_CS);
+		Gen(S_REG, mode|DATA16, Ofs_CS);
 		AddrGen(A_SR_SH4, mode, Ofs_CS, Ofs_XCS);
 		Gen(L_REG, mode, Ofs_EIP);
 		/* fall through */
@@ -1157,6 +1159,8 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			/* optimized multiple register push */
 			while (1) {
 			    int op;
+			    if (opc > 8 && !(_mode & DATA16)) // 32-bit segreg
+				m |= SEGREG;
 			    Gen(O_PUSH2, m, R1Tab_l[opc-1]);
 			    PC++;
 			    opc = OpIsPush[op = Fetch(PC)];
@@ -1164,7 +1168,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			    if (++cnt >= NUMGENS || (!opc && !is_66) ||
 				    e_querymark(PC, 1 + is_66))
 				break;
-			    m &= ~DATA16;
+			    m &= ~(DATA16|SEGREG);
 			    if (is_66) {	// prefix 0x66
 				m |= (~basemode & DATA16);
 				if ((opc=OpIsPush[(op = Fetch(PC+1))])!=0) PC++;
@@ -1181,7 +1185,11 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			Gen(O_PUSH3, m); } else
 #endif
 			{
-			Gen(L_REG, _mode, R1Tab_l[opc-1]);
+			if (opc > 8 && !(_mode & DATA16)) { // 32-bit segreg
+			    Gen(L_REG, _mode|DATA16, R1Tab_l[opc-1]);
+			    Gen(L_ZXAX, _mode);
+			} else
+			    Gen(L_REG, _mode, R1Tab_l[opc-1]);
 			Gen(O_PUSH, _mode); PC++;
 			}
 			break;
@@ -2652,7 +2660,9 @@ repag0:
 					if (REG1==Ofs_BX) {
 					    /* ok, now push old cs:eip */
 					    oip = PC + len - LONG_CS;
-					    Gen(L_REG, _mode, Ofs_CS);
+					    Gen(L_REG, _mode|DATA16, Ofs_CS);
+					    if (!(_mode & DATA16)) // padding
+						Gen(L_ZXAX, _mode);
 					    Gen(O_PUSH, _mode);
 					    Gen(O_PUSHI, _mode, oip);
 					}

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -1484,7 +1484,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			if (REALADDR()) {
 			    int seg;
 			    PC += ModRM(opc, PC, _mode|SEGREG|DATA16|MLOAD);
-			    seg = e_ofsseg[REG1>>2];
+			    seg = e_ofsseg(REG1);
 			    if (seg == Ofs_XCS) {
 				CODE_FLUSH();
 				goto illegal_op;

--- a/src/base/emu-i386/simx86/protmode.c
+++ b/src/base/emu-i386/simx86/protmode.c
@@ -104,19 +104,19 @@ int SetSegProt(int a16, int ofs, unsigned char *big, unsigned long sel)
 
 	sd = (SDTR *)CPUOFFS(e_ofsseg[(ofs>>2)]);
 
-	if ((sd->Oldsel==sel)&&((sd->Attrib&3)==1)) {
+	if ((CPUWORD(ofs)==sel)&&((sd->Attrib&3)==1)) {
 	    if (debug_level('e') >= 9)
 		e_printf("SetSeg PROT %s%04lx cached\n",MKOFSNAM(ofs,buf),sel);
 	    if (big) *big = (sd->Attrib&4? 0xff:0);
 	    return 0;
 	}
-	sd->Oldsel = sel;
 	sd->Attrib = 0;
 	TheCPU.scp_err = sel & 0xfffc;
 
 	if (sel < 4) {
 	    if ((ofs==Ofs_CS)||(ofs==Ofs_SS)) return EXCP0D_GPF;
 	    sd->BoundL = 0xc0000000;
+	    CPUWORD(ofs) = sel;
 	    return 0;	/* DS..GS can be 0 for some while */
 	}
 
@@ -154,6 +154,7 @@ int SetSegProt(int a16, int ofs, unsigned char *big, unsigned long sel)
 	        e_printf("GDT system segment %#lx type %d\n",sel,sx);
 	    if (sx==DT_NO_XFER) return EXCP0D_GPF;
 	    sd->BoundH = 0;	  /* try to trap if not checked */
+	    CPUWORD(ofs) = sel;
 	    return 0;	  /* will check sys segment again later */
 	}
 	lbig = (wFlags & DF_32)? 0xff : 0;
@@ -204,6 +205,7 @@ int SetSegProt(int a16, int ofs, unsigned char *big, unsigned long sel)
 			sel, sd->BoundL, sd->BoundH, wFlags, lbig&1);
 	}
 	TheCPU.scp_err = 0;
+	CPUWORD(ofs) = sel;
 	return 0;
 }
 

--- a/src/base/emu-i386/simx86/protmode.c
+++ b/src/base/emu-i386/simx86/protmode.c
@@ -65,20 +65,16 @@ static unsigned short sysxfer[] = {
 	DT_XFER_CG32, DT_NO_XFER, DT_XFER_IG32, DT_XFER_TRP32
 };
 
-static char ofsnam[] =	"??? ??? ??? GS: FS: ES: DS: ??? "
-			"??? ??? ??? ??? ??? ??? ??? ??? "
-			"??? ??? CS: ??? SS: ??? ??? ??? ";
+static char ofsnam[] =	"ES: CS: SS: DS: FS: GS:";
 
 static unsigned char ofsseg[] = {
-	0,   0,       0, Ofs_XGS, Ofs_XFS, Ofs_XES, Ofs_XDS, 0,
-	0,   0,       0,       0,       0,       0,       0, 0,
-	0,   0, Ofs_XCS,       0, Ofs_XSS,       0,       0, 0 };
+	Ofs_XES, Ofs_XCS, Ofs_XSS, Ofs_XDS, Ofs_XFS, Ofs_XGS };
 
-#define MKOFSNAM(o,b)   (memcpy((b), (ofsnam+(o)), 3), ((b)[3]=0), (b))
+#define MKOFSNAM(o,b)   (memcpy((b), (ofsnam+(((o)-Ofs_ES)<<1)), 3), ((b)[3]=0), (b))
 
 unsigned char e_ofsseg(int ofs)
 {
-	return ofsseg[ofs >> 2];
+	return ofsseg[(ofs-Ofs_ES)>>1];
 }
 
 int SetSegReal(unsigned short sel, int ofs)

--- a/src/base/emu-i386/simx86/protmode.c
+++ b/src/base/emu-i386/simx86/protmode.c
@@ -69,19 +69,24 @@ static char ofsnam[] =	"??? ??? ??? GS: FS: ES: DS: ??? "
 			"??? ??? ??? ??? ??? ??? ??? ??? "
 			"??? ??? CS: ??? SS: ??? ??? ??? ";
 
-unsigned char e_ofsseg[] = {
+static unsigned char ofsseg[] = {
 	0,   0,       0, Ofs_XGS, Ofs_XFS, Ofs_XES, Ofs_XDS, 0,
 	0,   0,       0,       0,       0,       0,       0, 0,
 	0,   0, Ofs_XCS,       0, Ofs_XSS,       0,       0, 0 };
 
 #define MKOFSNAM(o,b)   (memcpy((b), (ofsnam+(o)), 3), ((b)[3]=0), (b))
 
+unsigned char e_ofsseg(int ofs)
+{
+	return ofsseg[ofs >> 2];
+}
+
 int SetSegReal(unsigned short sel, int ofs)
 {
 	static char buf[4];
 	SDTR *sd;
 
-	sd = (SDTR *)CPUOFFS(e_ofsseg[(ofs>>2)]);
+	sd = (SDTR *)CPUOFFS(e_ofsseg(ofs));
 
 	CPUWORD(ofs) = sel;
 	sd->BoundL = sel<<4;
@@ -101,7 +106,7 @@ int SetSegProt(int a16, int ofs, unsigned char *big, unsigned long sel)
 	Descriptor *dt;
 	SDTR *sd;
 
-	sd = (SDTR *)CPUOFFS(e_ofsseg[(ofs>>2)]);
+	sd = (SDTR *)CPUOFFS(e_ofsseg(ofs));
 
 	if (CPUWORD(ofs) == sel && (sd->BoundH - sd->BoundL) != SDTR_INVALID_LIMIT) {
 	    if (debug_level('e') >= 9)

--- a/src/base/emu-i386/simx86/protmode.c
+++ b/src/base/emu-i386/simx86/protmode.c
@@ -86,7 +86,6 @@ int SetSegReal(unsigned short sel, int ofs)
 	CPUWORD(ofs) = sel;
 	sd->BoundL = sel<<4;
 	sd->BoundH = sd->BoundL + 0xffff;
-	sd->Attrib = 2;
 
 	if (debug_level('e')>1)
 	    dbug_printf("SetSeg REAL %s%04x\n",MKOFSNAM(ofs,buf),sel);
@@ -104,18 +103,18 @@ int SetSegProt(int a16, int ofs, unsigned char *big, unsigned long sel)
 
 	sd = (SDTR *)CPUOFFS(e_ofsseg[(ofs>>2)]);
 
-	if ((CPUWORD(ofs)==sel)&&((sd->Attrib&3)==1)) {
+	if (CPUWORD(ofs) == sel && (sd->BoundH - sd->BoundL) != SDTR_INVALID_LIMIT) {
 	    if (debug_level('e') >= 9)
 		e_printf("SetSeg PROT %s%04lx cached\n",MKOFSNAM(ofs,buf),sel);
-	    if (big) *big = (sd->Attrib&4? 0xff:0);
+	    if (big) *big = (GetSelectorFlags(sel) & DF_32)? 0xff : 0;
 	    return 0;
 	}
-	sd->Attrib = 0;
 	TheCPU.scp_err = sel & 0xfffc;
 
 	if (sel < 4) {
 	    if ((ofs==Ofs_CS)||(ofs==Ofs_SS)) return EXCP0D_GPF;
 	    sd->BoundL = 0xc0000000;
+	    sd->BoundH = sd->BoundL;
 	    CPUWORD(ofs) = sel;
 	    return 0;	/* DS..GS can be 0 for some while */
 	}
@@ -153,6 +152,7 @@ int SetSegProt(int a16, int ofs, unsigned char *big, unsigned long sel)
 	    if (debug_level('e')>3)
 	        e_printf("GDT system segment %#lx type %d\n",sel,sx);
 	    if (sx==DT_NO_XFER) return EXCP0D_GPF;
+	    sd->BoundL = 0;
 	    sd->BoundH = 0;	  /* try to trap if not checked */
 	    CPUWORD(ofs) = sel;
 	    return 0;	  /* will check sys segment again later */
@@ -195,7 +195,6 @@ int SetSegProt(int a16, int ofs, unsigned char *big, unsigned long sel)
 	SetFlagAccessed(sel);
 	sd->BoundL = GetPhysicalAddress(sel);
 	sd->BoundH = sd->BoundL + GetSelectorByteLimit(sel);
-	sd->Attrib = (lbig&4) | 1;
 	if (debug_level('e')>7)
 	    e_printf("SetSeg PROT %s%04lx\n",MKOFSNAM(ofs,buf),sel);
 

--- a/src/base/emu-i386/simx86/protmode.h
+++ b/src/base/emu-i386/simx86/protmode.h
@@ -39,7 +39,6 @@
 
 typedef struct {
 	unsigned int BoundL,BoundH;
-	unsigned short Oldsel, Attrib __attribute__ ((packed));
 } SDTR;
 
 // used to invalidate SDTRs, setting BoundH=BoundL+SDTR_INVALID_LIMIT

--- a/src/base/emu-i386/simx86/protmode.h
+++ b/src/base/emu-i386/simx86/protmode.h
@@ -42,6 +42,10 @@ typedef struct {
 	unsigned short Oldsel, Attrib __attribute__ ((packed));
 } SDTR;
 
+// used to invalidate SDTRs, setting BoundH=BoundL+SDTR_INVALID_LIMIT
+// as big limits always have the 12 low bits set to 1
+#define SDTR_INVALID_LIMIT 0x80000000
+
 typedef struct {
 	unsigned int Base;
 	unsigned int Limit;

--- a/src/base/emu-i386/simx86/protmode.h
+++ b/src/base/emu-i386/simx86/protmode.h
@@ -227,7 +227,7 @@ typedef struct {
 
 #define SELECTOR_PADDRESS(sel) GetPhysicalAddress(sel)
 //
-extern unsigned char e_ofsseg[];
+extern unsigned char e_ofsseg(int ofs);
 //
 int SetSegProt(int a16, int ofs, unsigned char *big, unsigned long sel);
 int SetSegReal(unsigned short sel, int ofs);

--- a/src/base/emu-i386/simx86/sigsegv.c
+++ b/src/base/emu-i386/simx86/sigsegv.c
@@ -415,9 +415,8 @@ int e_handle_fault(sigcontext_t *scp)
 		return 0;
 	}
 	TheCPU.err2 = EXCP00_DIVZ + _scp_trapno;
-	_scp_eax = TheCPU.cr2;
+	_scp_eax = _LONG_CS + TheCPU.eip;
 	_scp_edx = _scp_eflags;
-	TheCPU.cr2 = 0; // EMUADDR_REL(LINP(_scp_cr2));
 	_scp_rip = *(long *)_scp_rsp;
 	_scp_rsp += sizeof(long);
 	return 1;

--- a/src/base/emu-i386/simx86/sigsegv.c
+++ b/src/base/emu-i386/simx86/sigsegv.c
@@ -269,7 +269,7 @@ static int e_emu_pagefault(sigcontext_t *scp, int pmode)
 	e_printf("FindPC: found %x\n",_scp_eax);
 	_scp_edx = *(long *)_scp_rsp; // flags
 	_scp_rsp += sizeof(long);
-	TheCPU.cr2 = cr2;
+	TheCPU.cr[2] = cr2;
 	_scp_rip = *(long *)_scp_rsp;
 	_scp_rsp += sizeof(long);
 	return 1;

--- a/src/base/emu-i386/simx86/syncpu.h
+++ b/src/base/emu-i386/simx86/syncpu.h
@@ -52,15 +52,7 @@ typedef struct {
 /* offsets are 8-bit signed */
 #define FIELD0		unprotect_stub	/* field of SynCPU at offset 00 */
 /* ------------------------------------------------ */
-/*80*/  long double   *fpregs;
-/*84*/  PADDING32BIT(1)
-/*88*/	unsigned long long reserve;
-/*90*/	SDTR gs_cache;
-/*9c*/	SDTR fs_cache;
-/*a8*/	SDTR es_cache;
-/*b4*/	SDTR ds_cache;
-/*c0*/	SDTR cs_cache;
-/*cc*/	SDTR ss_cache;
+/*80*/	unsigned long long reserve[11];
 /* ------------------------------------------------ */
 /*d8*/  void (*stub_stk_16)(void);
 /*dc*/  PADDING32BIT(2)
@@ -76,40 +68,36 @@ typedef struct {
 /*00*/  void (*unprotect_stub)(void); /* must be at 0 for call (%ebx) */
 /*04*/  PADDING32BIT(7)
 /*08*/	unsigned int rzero;
-/*0c*/	unsigned short gs, __gsh;
-/*10*/	unsigned short fs, __fsh;
-/*14*/	unsigned short es, __esh;
-/*18*/	unsigned short ds, __dsh;
-/*1c*/	unsigned int edi;
-/*20*/	unsigned int esi;
-/*24*/	unsigned int ebp;
-/*28*/	unsigned int esp;
-/*2c*/	unsigned int ebx;
-/*30*/	unsigned int edx;
-/*34*/	unsigned int ecx;
-/*38*/	unsigned int eax;
-/*3c*/	unsigned int trapno;
-/*40*/	unsigned int scp_err;
-/*44*/	unsigned int eip;
-/*48*/	unsigned short cs, __csh;
-/*4c*/	unsigned int eflags;
-/* ----end of i386 sigcontext 1:1 correspondence--- */
-/*50*/	unsigned short ss, __ssh;
-/*54*/	unsigned int cr2;
+/*0c*/	unsigned int edi;
+/*10*/	unsigned int esi;
+/*14*/	unsigned int ebp;
+/*18*/	unsigned int esp;
+/*1c*/	unsigned int ebx;
+/*20*/	unsigned int edx;
+/*24*/	unsigned int ecx;
+/*28*/	unsigned int eax;
+/*2c*/	unsigned int eip;
+/*30*/	unsigned int eflags;
+/*34*/	unsigned short es, cs, ss, ds, fs, gs;
+/*40*/	SDTR es_cache;
+/*48*/	SDTR cs_cache;
+/*50*/	SDTR ss_cache;
+/*58*/	SDTR ds_cache;
+/*60*/	SDTR fs_cache;
+/*68*/	SDTR gs_cache;
 /* ------------------------------------------------ */
-/*58*/	unsigned short fpuc, fpus;
-/*5c*/	unsigned short fpstt, fptag;
+/*70*/	unsigned short fpuc;
 /* ------------------------------------------------ */
-/*60*/	/*sig_atomic_t*/unsigned sigalrm_pending;
-/*64*/	volatile /*sig_atomic_t*/unsigned sigprof_pending;
-/*68*/	unsigned int StackMask;
-/*6c*/ 	unsigned int df_increments; /* either 0x040201 or 0xfcfeff */
+/*72*/	/*sig_atomic_t*/unsigned short sigalrm_pending;
+/*74*/	unsigned int StackMask;
+/*78*/ 	unsigned int df_increments; /* either 0x040201 or 0xfcfeff */
 	/* begin of cr array */
-/*70*/	unsigned int cr[5]; /* only cr[0] is used in compiled code */
+/*7c*/	unsigned int cr[5]; /* only cr[0] is used in compiled code */
 /* ------------------------------------------------ */
-/*80*/	//unsigned int end_mark[0] = cr[4]
+/*80*/	//unsigned int end_mark[0] = cr[1]
 	unsigned int tr[2];
 
+	unsigned int scp_err;
 	int err2;
 	int err;
 	unsigned int mode;
@@ -117,6 +105,12 @@ typedef struct {
 	unsigned int sreg1;
 	unsigned int dreg1;
 	unsigned int xreg1;
+
+	volatile /*sig_atomic_t*/unsigned sigprof_pending;
+
+	unsigned short fpus;
+	unsigned short fpstt, fptag;
+	long double   *fpregs;
 
 /*
  * DR0-3 = linear address of breakpoint 0-3
@@ -173,7 +167,7 @@ extern union _SynCPU TheCPU_union;
 #define TheCPU TheCPU_union.s
 
 #define SCBASE		offsetof(SynCPU,FIELD0)
-#define Ofs_END		(int)(offsetof(SynCPU,cr[4])-SCBASE)
+#define Ofs_END		(int)(offsetof(SynCPU,cr[1])-SCBASE)
 
 #define SC(o) ((signed char)(o))
 #define CPUOFFS(o)	(((unsigned char *)&(TheCPU.FIELD0))+SC(o))
@@ -208,19 +202,13 @@ extern union _SynCPU TheCPU_union;
 #define Ofs_GS		(unsigned char)(offsetof(SynCPU,gs)-SCBASE)
 #define Ofs_EFLAGS	(unsigned char)(offsetof(SynCPU,eflags)-SCBASE)
 #define Ofs_CR0		(unsigned char)(offsetof(SynCPU,cr[0])-SCBASE)
-#define Ofs_CR2		(unsigned char)(offsetof(SynCPU,cr2)-SCBASE)
 #define Ofs_STACKM	(unsigned char)(offsetof(SynCPU,StackMask)-SCBASE)
 //#define Ofs_ETIME	(unsigned char)(offsetof(SynCPU,EMUtime)-SCBASE)
 #define Ofs_RZERO	(unsigned char)(offsetof(SynCPU,rzero)-SCBASE)
 #define Ofs_SIGAPEND	(unsigned char)(offsetof(SynCPU,sigalrm_pending)-SCBASE)
-#define Ofs_SIGFPEND	(unsigned char)(offsetof(SynCPU,sigprof_pending)-SCBASE)
 #define Ofs_DF_INCREMENTS (unsigned char)(offsetof(SynCPU,df_increments)-SCBASE)
 
-#define Ofs_FPR		(unsigned char)(offsetof(SynCPU,fpregs)-SCBASE)
-#define Ofs_FPSTT	(unsigned char)(offsetof(SynCPU,fpstt)-SCBASE)
-#define Ofs_FPUS	(unsigned char)(offsetof(SynCPU,fpus)-SCBASE)
 #define Ofs_FPUC	(unsigned char)(offsetof(SynCPU,fpuc)-SCBASE)
-#define Ofs_FPTAG	(unsigned char)(offsetof(SynCPU,fptag)-SCBASE)
 
 // 'Base' is 1st field of xs_cache
 #define Ofs_XDS		(unsigned char)(offsetof(SynCPU,ds_cache)-SCBASE)


### PR DESCRIPTION
The idea is to only use positive byte offsets for sim, which could eliminate adding 128 to every offset (in a later PR). The negative offsets are still useful for shorter calls to cpatch functions but are now only used by the JIT.

Segment registers are now all put together in CPU encoding order, so any accidental high word access (to and from `__csh` and co) had to be eliminated. The segment descriptor caches only have a base and a base+limit. Some other fields were never used at all, or never by offset, sometimes as a remnant of the olden days when a large part was memcpy'd to and from an i386 sigcontext struct.