### PR TITLE
Simx86: split stubs off main SynCPU, eliminate signed char offsets.

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -310,8 +310,8 @@ dosaddr_t AddrGen_sim(const IGen *IG)
 	case A_DI_0:			// base(32), imm
 	case A_DI_1: {			// base(32), {imm}, reg, {shift}
 			long idsp=0;
-			signed char ofs;
-			ofs = (signed char)IG->p0;
+			unsigned int ofs;
+			ofs = IG->p0;
 			if (mode & MLEA) {		// discard base	reg
 				mem_ref = 0;	// ofs = Ofs_RZERO;
 			}
@@ -324,12 +324,12 @@ dosaddr_t AddrGen_sim(const IGen *IG)
 				check_v86_address_overflow(mode, offset);
 			}
 			else if (mode & ADDR16) {
-				signed char o = (signed char)IG->p2;
+				unsigned int o = IG->p2;
 				GTRACE3("A_DI_1",o,ofs,idsp);
 				offset = (CPUWORD(o) + idsp) & 0xffff;
 			}
 			else {
-				signed char o = (signed char)IG->p2;
+				unsigned int o = IG->p2;
 				GTRACE3("A_DI_1",o,ofs,idsp);
 				offset = CPULONG(o) + idsp;
 				check_v86_address_overflow(mode, offset);
@@ -339,8 +339,8 @@ dosaddr_t AddrGen_sim(const IGen *IG)
 		break;
 	case A_DI_2: {			// base(32), {imm}, reg, reg, {shift}
 			long idsp=0;
-			signed char ofs;
-			ofs = (signed char)IG->p0;
+			unsigned int ofs;
+			ofs = IG->p0;
 			if (mode & MLEA) {		// discard base	reg
 				mem_ref = 0;	// ofs = Ofs_RZERO;
 			}
@@ -348,15 +348,15 @@ dosaddr_t AddrGen_sim(const IGen *IG)
 
 			idsp = IG->p1;
 			if (mode & ADDR16) {
-				signed char o1 = (signed char)IG->p2;
-				signed char o2 = (signed char)IG->p3;
+				unsigned int o1 = IG->p2;
+				unsigned int o2 = IG->p3;
 				GTRACE4("A_DI_2",o1,ofs,o2,idsp);
 				offset = CPUWORD(o1) + CPUWORD(o2) + idsp;
 				mem_ref += offset & 0xffff;
 			}
 			else {
-				signed char o1 = (signed char)IG->p2;
-				signed char o2 = (signed char)IG->p3;
+				unsigned int o1 = IG->p2;
+				unsigned int o2 = IG->p3;
 				unsigned char sh;
 				sh = (unsigned char)IG->p4;
 				GTRACE5("A_DI_2",o1,ofs,o2,idsp,sh);
@@ -371,8 +371,8 @@ dosaddr_t AddrGen_sim(const IGen *IG)
 	case A_DI_2D: {			// modrm_sibd, 32-bit mode
 			long idsp;
 			unsigned char sh;
-			signed char o;
-			signed char ofs = (signed char)IG->p0;
+			unsigned int o;
+			unsigned int ofs = IG->p0;
 			if (mode & MLEA) {
 				mem_ref = 0;
 			}
@@ -380,7 +380,7 @@ dosaddr_t AddrGen_sim(const IGen *IG)
 				mem_ref = CPULONG(ofs);
 			}
 			idsp = IG->p1;
-			o = (signed char)IG->p2;
+			o = IG->p2;
 			sh = (unsigned char)IG->p3;
 			GTRACE5("A_DI_2D",ofs,o,0xff,idsp,sh);
 			offset = (CPULONG(o) << (sh & 0x1f)) + idsp;
@@ -405,7 +405,7 @@ static unsigned int Gen_sim(const IGen *IG)
 	unsigned int P0 = (unsigned)-1;
 	switch(op) {
 	case A_SR_SH4: {	// real mode make base addr from seg
-		signed char o = (signed char)IG->p0;
+		unsigned int o = IG->p0;
 		GTRACE1("A_SR_SH4",o);
 		SetSegReal(CPUWORD(o), o);
 		}
@@ -443,7 +443,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		break;
 
 	case L_REG: {
-		signed char o = (signed char)IG->p0;
+		unsigned int o = IG->p0;
 		if (mode&(MBYTE|MBYTX))	{
 			GTRACE1("L_REG_BYTE",o);
 			DR1.b.bl = CPUBYTE(o);
@@ -455,7 +455,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		} }
 		break;
 	case S_REG: {
-		signed char o = (signed char)IG->p0;
+		unsigned int o = IG->p0;
 		if (mode&MBYTE)	{
 			GTRACE1("S_REG_BYTE",o);
 			CPUBYTE(o) = DR1.b.bl;
@@ -467,8 +467,8 @@ static unsigned int Gen_sim(const IGen *IG)
 		} }
 		break;
 	case L_REG2REG: {
-		signed char o1 = (signed char)IG->p0;
-		signed char o2 = (signed char)IG->p1;
+		unsigned int o1 = IG->p0;
+		unsigned int o2 = IG->p1;
 		GTRACE2("REGtoREG",o1,o2);
 		if ((mode) & MBYTE) {
 			CPUBYTE(o2) = CPUBYTE(o1);
@@ -479,7 +479,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		} }
 		break;
 	case S_DI_R: {
-		signed char o = (signed char)IG->p0;
+		unsigned int o = IG->p0;
 		GTRACE1("S_DI_R",o);
 		if (mode & DATA16)
 			CPUWORD(o) = AR1.w.l;
@@ -501,7 +501,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		break;
 
 	case L_IMM: {
-		signed char o = (signed char)IG->p0;
+		unsigned int o = IG->p0;
 		int v = IG->p1;
 		GTRACE3("L_IMM",o,0xff,v);
 		if (mode & MBYTE) {
@@ -528,9 +528,9 @@ static unsigned int Gen_sim(const IGen *IG)
 		} }
 		break;
 	case L_MOVZS: {
-		signed char o;
+		unsigned int o;
 		int rcod = IG->p0;	// 0=z 1=s
-		o = (signed char)IG->p1;
+		o = IG->p1;
 		GTRACE3("L_MOVZS",o,0xff,rcod);
 		if (mode & MBYTX) {
 		    if (rcod)
@@ -555,7 +555,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		break;
 
 	case L_LXS1: {
-		signed char o = (signed char)IG->p0;
+		unsigned int o = IG->p0;
 		GTRACE1("L_LXS1",o);
 		if (mode&DATA16) {
 		    CPUWORD(o) = DR1.w.l = sim_read_word(AR1.d);
@@ -567,7 +567,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		} }
 		break;
 	case L_LXS2: {	/* real mode segment base from segment value */
-		signed char o = (signed char)IG->p0;
+		unsigned int o = IG->p0;
 		GTRACE1("L_LXS2",o);
 		DR1.d = sim_read_word(AR1.d);
 		SetSegReal(DR1.w.l, o);
@@ -816,7 +816,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		}
 		break;
 	case O_CLEAR: {		// == XOR r,r
-		signed char o = (signed char)IG->p0;
+		unsigned int o = IG->p0;
 		GTRACE1("O_CLEAR",o);
 		if (mode & MBYTE) {
 		    CPUBYTE(o) = 0;
@@ -832,7 +832,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		}
 		break;
 	case O_TEST: {		// == OR r,r
-		signed char o = (signed char)IG->p0;
+		unsigned int o = IG->p0;
 		GTRACE1("O_TEST",o);
 		if (mode & MBYTE) {
 		    RFL.res = (int8_t)CPUBYTE(o);
@@ -847,7 +847,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		}
 		break;
 	case O_SBSELF: {
-		signed char o = (signed char)IG->p0;
+		unsigned int o = IG->p0;
 		GTRACE1("O_SBBSELF",o);
 		// if CY=0 -> reg=0,  flag=xx46, OF=0
 		// if CY=1 -> reg=-1, flag=xx97, OF=0
@@ -871,7 +871,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		}
 		break;
 	case O_INC_R: {		// OSZAP
-		signed char o = (signed char)IG->p0;
+		unsigned int o = IG->p0;
 		GTRACE1("O_INC_R",o);
 		if (mode & MBYTE) {
 		    S1 = CPUBYTE(o);
@@ -891,7 +891,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		}
 		break;
 	case O_DEC_R: {		// OSZAP
-		signed char o = (signed char)IG->p0;
+		unsigned int o = IG->p0;
 		GTRACE1("O_DEC_R",o);
 		if (mode & MBYTE) {
 		    S1 = CPUBYTE(o);
@@ -912,7 +912,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		break;
 	case O_ADD_FR: {	// OSZAPC
 		register wkreg v;
-		signed char o = (signed char)IG->p0;
+		unsigned int o = IG->p0;
 		v.d = 0;
 		if (mode & IMMED) v.d = IG->p1;
 		if (mode & IMMED) {GTRACE3("O_ADD_FR",0xff,0xff,v.d);}
@@ -943,7 +943,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		break;
 	case O_OR_FR: {		// O=0 SZP C=0
 		register wkreg v;
-		signed char o = (signed char)IG->p0;
+		unsigned int o = IG->p0;
 		v.d = 0;
 		if (mode & IMMED) v.d = IG->p1;
 		if (mode & IMMED) {GTRACE3("O_OR_FR",0xff,0xff,v.d);}
@@ -963,7 +963,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		break;
 	case O_ADC_FR: {	// OSZAPC
 		register wkreg v;
-		signed char o = (signed char)IG->p0;
+		unsigned int o = IG->p0;
 		int cy;
 		v.d = 0;
 		if (mode & IMMED) v.d = IG->p1;
@@ -996,7 +996,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		break;
 	case O_SBB_FR: {	// OSZAPC
 		register wkreg v;
-		signed char o = (signed char)IG->p0;
+		unsigned int o = IG->p0;
 		int cy;
 		v.d = 0;
 		if (mode & IMMED) v.d = IG->p1;
@@ -1030,7 +1030,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		break;
 	case O_AND_FR: {		// O=0 SZP C=0
 		register wkreg v;
-		signed char o = (signed char)IG->p0;
+		unsigned int o = IG->p0;
 		v.d = 0;
 		if (mode & IMMED) v.d = IG->p1;
 		if (mode & IMMED) {GTRACE3("O_AND_FR",0xff,0xff,v.d);}
@@ -1050,7 +1050,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		break;
 	case O_SUB_FR: {	// OSZAPC
 		register wkreg v;
-		signed char o = (signed char)IG->p0;
+		unsigned int o = IG->p0;
 		v.d = 0;
 		if (mode & IMMED) v.d = IG->p1;
 		if (mode & IMMED) {GTRACE3("O_SUB_FR",0xff,0xff,v.d);}
@@ -1081,7 +1081,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		break;
 	case O_XOR_FR: {		// O=0 SZP C=0
 		register wkreg v;
-		signed char o = (signed char)IG->p0;
+		unsigned int o = IG->p0;
 		v.d = 0;
 		if (mode & IMMED) v.d = IG->p1;
 		if (mode & IMMED) {GTRACE3("O_XOR_FR",0xff,0xff,v.d);}
@@ -1101,7 +1101,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		break;
 	case O_CMP_FR: {	// OSZAPC
 		register wkreg v;
-		signed char o = (signed char)IG->p0;
+		unsigned int o = IG->p0;
 		v.d = 0;
 		if (mode & IMMED) v.d = IG->p1;
 		if (mode & IMMED) {GTRACE3("O_CMP_FR",0xff,0xff,v.d);}
@@ -1190,7 +1190,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		}
 		break;
 	case O_CMPXCHG: {		// OSZAPC
-		signed char o = (signed char)IG->p0;
+		unsigned int o = IG->p0;
 		GTRACE1("O_CMPXCHG",o);
 		if (mode & MBYTE) {
 		    S1 = CPUBYTE(Ofs_AL);
@@ -1222,7 +1222,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		}
 		break;
 	case O_XCHG: {
-		signed char o = (signed char)IG->p0;
+		unsigned int o = IG->p0;
 		GTRACE1("O_XCHG",o);
 		if (mode & MBYTE) {
 			DR2.b.bl = DR1.b.bl;
@@ -1241,8 +1241,8 @@ static unsigned int Gen_sim(const IGen *IG)
 		} }
 		break;
 	case O_XCHG_R: {
-		signed char o1 = (signed char)IG->p0;
-		signed char o2 = (signed char)IG->p1;
+		unsigned int o1 = IG->p0;
+		unsigned int o2 = IG->p1;
 		GTRACE2("O_XCHG_R",o1,o2);
 		if (mode & MBYTE) {
 			DR1.b.bl = CPUBYTE(o1);
@@ -1294,7 +1294,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		if (mode & MBYTE) {
 		    if ((mode&(IMMED|DATA16))==(IMMED|DATA16)) {
 			int b = IG->p0;
-			signed char o = (signed char)IG->p1;
+			unsigned int o = IG->p1;
 			GTRACE3("O_IMUL",o,0xff,b);
 			DR1.ds = (int)DR1.ws.l * b;
 			CPUWORD(o) = DR1.w.l;
@@ -1303,7 +1303,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		    }
 		    else if ((mode&(IMMED|DATA16))==IMMED) {
 			int b = IG->p0;
-			signed char o = (signed char)IG->p1;
+			unsigned int o = IG->p1;
 			int64_t v;
 			GTRACE3("O_IMUL",o,0xff,b);
 			v = (int64_t)DR1.ds * b;
@@ -1323,13 +1323,13 @@ static unsigned int Gen_sim(const IGen *IG)
 		else if (mode&DATA16) {
 		    if (mode&IMMED) {
 			int b = IG->p0;
-			signed char o = (signed char)IG->p1;
+			unsigned int o = IG->p1;
 			GTRACE3("O_IMUL",o,0xff,b);
 		    	DR1.ds = (int)DR1.ws.l * b;
 		    	CPUWORD(o) = DR1.w.l;
 		    }
 		    else if (mode&MEMADR) {
-			signed char o = (signed char)IG->p0;
+			unsigned int o = IG->p0;
 			GTRACE1("O_IMUL",o);
 			DR1.ds = (int)(signed short)CPUWORD(o) * (int)DR1.ws.l;
 			CPUWORD(o) = DR1.w.l;
@@ -1348,13 +1348,13 @@ static unsigned int Gen_sim(const IGen *IG)
 		    int64_t v;
 		    if (mode&IMMED) {
 			int b = IG->p0;
-			signed char o = (signed char)IG->p1;
+			unsigned int o = IG->p1;
 			GTRACE3("O_IMUL",o,0xff,b);
 			v = (int64_t)DR1.ds * b;
 			CPULONG(o) = v & 0xffffffff;
 		    }
 		    else if (mode&MEMADR) {
-			signed char o = (signed char)IG->p0;
+			unsigned int o = IG->p0;
 			int vd = CPULONG(o);
 			GTRACE1("O_IMUL",o);
 			v = (int64_t)DR1.ds * (int64_t)vd;
@@ -1516,7 +1516,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		}
 		break;
 	case O_XLAT: {
-		signed char ofs = (signed char)IG->p0;
+		unsigned int ofs = IG->p0;
 		GTRACE1("XLAT",ofs);
 		AR1.d = CPULONG(ofs);
 		TR1.d = CPULONG(Ofs_EBX) + CPUBYTE(Ofs_AL);
@@ -1528,7 +1528,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		break;
 
 	case O_ROL: {		// O(if sh==1),C(if sh>0)
-		signed char o = (signed char)IG->p0;
+		unsigned int o = IG->p0;
 		unsigned int sh, rbef, raft, cy;
 		GTRACE1("O_ROL",o);
 		if (mode & IMMED) sh = o;
@@ -1566,7 +1566,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		}
 		break;
 	case O_RCL: {		// O(if sh==1),C(if sh>0)
-		signed char o = (signed char)IG->p0;
+		unsigned int o = IG->p0;
 		unsigned int sh, rbef, raft, cy;
 		GTRACE1("O_RCL",o);
 		cy = is_cf_set();
@@ -1605,7 +1605,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		}
 		break;
 	case O_SHL: {		// O(if sh==1),SZPC(if sh>0)
-		signed char o = (signed char)IG->p0;
+		unsigned int o = IG->p0;
 		unsigned int sh, rbef, raft=0, cy=0;
 		GTRACE3("O_SHL",0xff,0xff,o);
 		if (mode & IMMED) sh = o;
@@ -1643,7 +1643,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		}
 		break;
 	case O_ROR: {		// O(if sh==1),C(if sh>0)
-		signed char o = (signed char)IG->p0;
+		unsigned int o = IG->p0;
 		unsigned int sh, rbef, raft, cy;
 		GTRACE1("O_ROR",o);
 		if (mode & IMMED) sh = o;
@@ -1681,7 +1681,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		}
 		break;
 	case O_RCR: {		// O(if sh==1),C(if sh>0)
-		signed char o = (signed char)IG->p0;
+		unsigned int o = IG->p0;
 		unsigned int sh, rbef, raft, cy;
 		GTRACE3("O_RCR",0xff,0xff,o);
 		cy = is_cf_set();
@@ -1722,7 +1722,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		}
 		break;
 	case O_SHR: {		// O(if sh==1),SZPC(if sh>0)
-		signed char o = (signed char)IG->p0;
+		unsigned int o = IG->p0;
 		unsigned int sh, rbef, raft, cy=0;
 		GTRACE3("O_SHR",0xff,0xff,o);
 		if (mode & IMMED) sh = o;
@@ -1751,7 +1751,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		}
 		break;
 	case O_SAR: {		// O(if sh==1),SZPC(if sh>0)
-		signed char o = (signed char)IG->p0;
+		unsigned int o = IG->p0;
 		unsigned int sh, cy=0;
 		signed int rbef, raft=0;
 		GTRACE3("O_SHR",0xff,0xff,o);
@@ -1903,7 +1903,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		break;
 
 	case O_PUSH2: {
-		signed char o = (signed char)IG->p0;
+		unsigned int o = IG->p0;
 		unsigned long stackm = CPULONG(Ofs_STACKM);
 		GTRACE1("O_PUSH2",o);
 		if (mode & DATA16) {
@@ -2019,7 +2019,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		break;
 
 	case O_POP2: {
-		signed char o = (signed char)IG->p0;
+		unsigned int o = IG->p0;
 		long stackm = CPULONG(Ofs_STACKM);
 		GTRACE1("O_POP2",o);
 		if (mode & DATA16) {
@@ -2092,7 +2092,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		break;
 
 	case O_MOVS_SetA: {
-		signed char ofs = (signed char)IG->p0;
+		unsigned int ofs = IG->p0;
 		GTRACE1("O_MOVS_SetA",ofs);
 		if (mode&ADDR16) {
 		    if (mode&MOVSSRC) {
@@ -2404,7 +2404,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		break;
 
 	case O_MOVS_SavA: {
-		signed char ofs = (signed char)IG->p0;
+		unsigned int ofs = IG->p0;
 		GTRACE1("O_MOVS_SavA",ofs);
 		if (!(mode&(MREP|MREPNE))) {
 		    // %%edx set to DF's increment
@@ -2534,7 +2534,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		break;
 	case O_BITOP: {
 		unsigned char o1 = (unsigned char)IG->p0;
-		signed char o2 = (signed char)IG->p1;
+		unsigned int o2 = IG->p1;
 		GTRACE3("O_BITOP",o2,0xff,o1);
 		if (o1 == 0x1c || o1 == 0x1d) { /* bsf/bsr */
 			if (mode & DATA16) DR1.d = DR1.w.l;
@@ -2580,7 +2580,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		} break;
 	case O_SHFD: {
 		unsigned char l_r = (unsigned char)IG->p0&8;
-		signed char o = (signed char)IG->p1;
+		unsigned int o = IG->p1;
 		unsigned char shc;
 		int cy;
 		if (mode & IMMED) {

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -420,15 +420,12 @@ static unsigned char *CodeGen_x86(unsigned char *CodePtr, unsigned char *BaseGen
 
 	case L_DI_R1:
 		if (mode&(MBYTE|MBYTX)) {
-		    G3(0x2f048a,Cp); G1(0x90,Cp);
-		}
-		else if (mode&DATA16) {
-		    G1(0x66,Cp); G3(0x2f048b,Cp);
+		    G3(0x2f048a,Cp);
 		}
 		else {
-		    G3(0x2f048b,Cp); G1(0x90,Cp);
+		    Gen66(mode,Cp);
+		    G3(0x2f048b,Cp);
 		}
-		G2(0x9090,Cp);
 		break;
 	case S_DI:
 		if (mode&MBYTE) {

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -71,8 +71,6 @@ static TNode *LastXNode = NULL;
 
 /////////////////////////////////////////////////////////////////////////////
 
-#define	Offs_From_Arg()		(signed char)(va_arg(ap,int))
-
 /*
  * This function is only here for looking at the generated binary code
  * with objdump.
@@ -145,47 +143,35 @@ void AddrGen(int op, int mode, ...)
 	switch(op) {
 	case A_DI_0:			// base(32), imm
 	case A_DI_1: {			// base(32), {imm}, reg, {shift}
-		signed char ofs = (char)va_arg(ap,int);
-		signed char o;
-		IG->p0 = ofs;
-		IG->p1 = va_arg(ap,int);
+		IG->p0 = va_arg(ap,unsigned int);
+		IG->p1 = va_arg(ap,unsigned int);
 		if (op==A_DI_0)	break;
-		o = Offs_From_Arg();
-		IG->p2 = o;
+		IG->p2 = va_arg(ap,unsigned int);
 		}
 		break;
 	case A_DI_2: {			// base(32), {imm}, reg, reg, {shift}
-		signed char o1,o2;
-		signed char ofs = (char)va_arg(ap,int);
 		unsigned char sh;
-		IG->p0 = ofs;
-		IG->p1 = va_arg(ap,int);
-		o1 = Offs_From_Arg();
-		o2 = Offs_From_Arg();
-		IG->p2 = o1;
-		IG->p3 = o2;
-		sh = (unsigned char)(va_arg(ap,int));
+		IG->p0 = va_arg(ap,unsigned int);
+		IG->p1 = va_arg(ap,unsigned int);
+		IG->p2 = va_arg(ap,unsigned int);
+		IG->p3 = va_arg(ap,unsigned int);
+		sh = (unsigned char)(va_arg(ap,unsigned int));
 		IG->p4 = sh;
 		}
 		break;
 	case A_DI_2D: {			// modrm_sibd, 32-bit mode
-		signed char o;
-		signed char ofs = (char)va_arg(ap,int);
 		unsigned char sh;
-		IG->p0 = ofs;
-		IG->p1 = va_arg(ap,int);
-		o = Offs_From_Arg();
-		IG->p2 = o;
-		sh = (unsigned char)(va_arg(ap,int));
+		IG->p0 = va_arg(ap,unsigned int);
+		IG->p1 = va_arg(ap,unsigned int);
+		IG->p2 = va_arg(ap,unsigned int);
+		sh = (unsigned char)(va_arg(ap,unsigned int));
 		IG->p3 = sh;
 		}
 		break;
 	case A_SR_SH4: {	// real mode make base addr from seg
-		signed char o1 = Offs_From_Arg();
-		signed char o2 = Offs_From_Arg();
-		IG->p0 = o1;
-		IG->p1 = o2;
-		if (o1 == Ofs_SS)
+		IG->p0 = va_arg(ap,unsigned int);
+		IG->p1 = va_arg(ap,unsigned int);
+		if (IG->p0 == Ofs_SS)
 			I->flags |= F_INHI;
 		}
 		break;
@@ -262,22 +248,7 @@ void Gen(int op, int mode, ...)
 	case O_XLAT:
 	case O_MOVS_SetA:
 	case O_MOVS_SavA:
-	case O_CMPXCHG: {
-		signed char o = Offs_From_Arg();
-		IG->p0 = o;
-		}
-		break;
-
-	case L_REG2REG:
-	case L_LXS2:	/* real mode segment base from segment value */
-	case O_XCHG_R: {
-		signed char o1 = Offs_From_Arg();
-		signed char o2 = Offs_From_Arg();
-		IG->p0 = o1;
-		IG->p1 = o2;
-		}
-		break;
-
+	case O_CMPXCHG:
 	case S_DI_IMM:
 	case L_IMM_R1:
 	case O_ADD_R:				// acc = acc op	reg
@@ -293,10 +264,19 @@ void Gen(int op, int mode, ...)
 	case O_DIV:
 	case O_IDIV:
 	case O_PUSHI:
-	case JMP_TAILCODE: {
-		int v = va_arg(ap,int);
-		IG->p0 = v;
-		}
+	case O_PUSH2:
+	case O_POP2:
+	case JMP_TAILCODE:
+		IG->p0 = va_arg(ap,unsigned int);
+		break;
+
+	case L_REG2REG:
+	case L_LXS2:	/* real mode segment base from segment value */
+	case O_XCHG_R:
+	case L_IMM:
+	case L_MOVZS:
+		IG->p0 = va_arg(ap,unsigned int);
+		IG->p1 = va_arg(ap,unsigned int);
 		break;
 
 	case O_ADD_FR:				// reg = reg op	acc/imm
@@ -306,43 +286,20 @@ void Gen(int op, int mode, ...)
 	case O_AND_FR:
 	case O_SUB_FR:
 	case O_XOR_FR:
-	case O_CMP_FR: {
-		signed char o = Offs_From_Arg();
-		IG->p0 = o;
-		if (mode & IMMED) {
-			int v = va_arg(ap,int);
-			IG->p1 = v;
-		} }
-		break;
-
-	case L_IMM: {
-		signed char o = Offs_From_Arg();
-		int v = va_arg(ap,int);
-		IG->p0 = o;
-		IG->p1 = v;
-		}
-		break;
-
-	case L_MOVZS: {
-		signed char o;
-		rcod = va_arg(ap,int);	// 0=z 1=s
-		o = Offs_From_Arg();
-		IG->p0 = rcod;
-		IG->p1 = o;
-		}
+	case O_CMP_FR:
+		IG->p0 = va_arg(ap,unsigned int);
+		if (mode & IMMED)
+			IG->p1 = va_arg(ap,unsigned int);
 		break;
 
 	case O_IMUL:
 		if (mode&IMMED) {
-			int v = va_arg(ap,int);
-			signed char o = Offs_From_Arg();
-			IG->p0 = v;
-			IG->p1 = o;
+			IG->p0 = va_arg(ap,unsigned int);
+			IG->p1 = va_arg(ap,unsigned int);
 		}
 		if (!(mode&MBYTE)) {
 			if (mode&MEMADR) {
-				signed char o = Offs_From_Arg();
-				IG->p0 = o;
+				IG->p0 = va_arg(ap,unsigned int);
 			}
 		}
 		break;
@@ -355,39 +312,33 @@ void Gen(int op, int mode, ...)
 	case O_SHR:
 	case O_SAR:
 		if (mode & IMMED) {
-			unsigned char sh = (unsigned char)va_arg(ap,int);
+			unsigned char sh = (unsigned char)va_arg(ap,unsigned int);
 			IG->p0 = sh;
 		}
 		break;
 
 	case O_OPAX: {	/* used by DAA..AAD */
-			int n =	va_arg(ap,int);
+			int n =	va_arg(ap,unsigned int);
 			IG->p0 = n;
 			// get n>0,n<3 bytes from parameter stack
-			IG->p1 = va_arg(ap,int);
-			if (n==2) IG->p2 = va_arg(ap,int);
+			IG->p1 = va_arg(ap,unsigned int);
+			if (n==2) IG->p2 = va_arg(ap,unsigned int);
 		}
 		break;
 
 	case O_POP:
-		if (mode & MRETISP) IG->p0 = va_arg(ap,int);
+		if (mode & MRETISP) IG->p0 = va_arg(ap,unsigned int);
 		break;
 
-	case O_PUSH2:
-	case O_POP2: {
-		signed char o = Offs_From_Arg();
-		IG->p0 = o;
-		}
-		break;
 
 	case O_SLAHF:
-		rcod = va_arg(ap,int)&1;	// 0=LAHF 1=SAHF
+		rcod = va_arg(ap,unsigned int)&1;	// 0=LAHF 1=SAHF
 		IG->p0 = rcod;
 		break;
 
 	case O_SETFL:
 	case O_SETCC: {
-		unsigned char n = (unsigned char)va_arg(ap,int);
+		unsigned char n = (unsigned char)va_arg(ap,unsigned int);
 		IG->p0 = n;
 		}
 		break;
@@ -396,28 +347,23 @@ void Gen(int op, int mode, ...)
 		I->flags |= F_FPOP;
 		// fall through
 	case O_INT: {
-		unsigned char exop = (unsigned char)va_arg(ap,int);
+		unsigned char exop = (unsigned char)va_arg(ap,unsigned int);
 		IG->p0 = exop;
-		IG->p1 = va_arg(ap,int);	// reg
+		IG->p1 = va_arg(ap,unsigned int);	// reg
 		}
 		break;
 
-	case O_BITOP: {
-		unsigned char n = (unsigned char)va_arg(ap,int);
-		signed char o = Offs_From_Arg();
-		IG->p0 = n;
-		IG->p1 = o;
-		} break;
+	case O_BITOP:
+		IG->p0 = (unsigned char)va_arg(ap,unsigned int);
+		IG->p1 = va_arg(ap,unsigned int);
+		break;
 
-	case O_SHFD: {
-		unsigned char l_r = (unsigned char)va_arg(ap,int)&8;
-		signed char o = Offs_From_Arg();
-		IG->p0 = l_r;
-		IG->p1 = o;
+	case O_SHFD:
+		IG->p0 = (unsigned char)va_arg(ap,unsigned int)&8;
+		IG->p1 = va_arg(ap,unsigned int);
 		if (mode & IMMED) {
-			unsigned char shc = (unsigned char)va_arg(ap,int)&0x1f;
+			unsigned char shc = (unsigned char)va_arg(ap,unsigned int)&0x1f;
 			IG->p2 = shc;
-		}
 		} break;
 
 	case JMP_INDIRECT:
@@ -425,20 +371,20 @@ void Gen(int op, int mode, ...)
 
 	case JMP_LINK:		// opc, dspt, retaddr, link
 	case JLOOP_LINK: {
-		unsigned char opc = (unsigned char)va_arg(ap,int);
+		unsigned char opc = (unsigned char)va_arg(ap,unsigned int);
 		IG->p0 = opc;
-		IG->p1 = va_arg(ap,int);	// dspt
-		IG->p2 = va_arg(ap,int);	// dspnt
+		IG->p1 = va_arg(ap,unsigned int);	// dspt
+		IG->p2 = va_arg(ap,unsigned int);	// dspnt
 		}
 		break;
 
 	case JF_LINK:
 	case JB_LINK: {		// opc, PC, dspt, dspnt, link
-		unsigned char opc = (unsigned char)va_arg(ap,int);
+		unsigned char opc = (unsigned char)va_arg(ap,unsigned int);
 		IG->p0 = opc;
-		IG->p1 = va_arg(ap,int);	// jpc
-		IG->p2 = va_arg(ap,int);	// dspt
-		IG->p3 = va_arg(ap,int);	// dspnt
+		IG->p1 = va_arg(ap,unsigned int);	// jpc
+		IG->p2 = va_arg(ap,unsigned int);	// dspt
+		IG->p3 = va_arg(ap,unsigned int);	// dspnt
 		}
 		break;
 

--- a/src/base/emu-i386/simx86/cpatch.c
+++ b/src/base/emu-i386/simx86/cpatch.c
@@ -554,6 +554,17 @@ asm (
 "stub_read_32__:.globl stub_read_32__\n"STUB_READ(read_32)
 );
 
+// using negative byte offsets
+#define Ofs_stub(x) (unsigned char)(((x) - STUBS_LEN) * sizeof(stub_func_t))
+#define Ofs_stub_wri_8 Ofs_stub(STUB_WRI_8)
+#define Ofs_stub_wri_16 Ofs_stub(STUB_WRI_16)
+#define Ofs_stub_wri_32 Ofs_stub(STUB_WRI_32)
+#define Ofs_stub_stk_16 Ofs_stub(STUB_STK_16)
+#define Ofs_stub_stk_32 Ofs_stub(STUB_STK_32)
+#define Ofs_stub_read_8 Ofs_stub(STUB_READ_8)
+#define Ofs_stub_read_16 Ofs_stub(STUB_READ_16)
+#define Ofs_stub_read_32 Ofs_stub(STUB_READ_32)
+
 /* call N(%ebx) */
 #define JSRPATCH(p,N) *((short *)(p))=0x53ff;p[2]=N;
 

--- a/src/base/emu-i386/simx86/cpatch.c
+++ b/src/base/emu-i386/simx86/cpatch.c
@@ -556,7 +556,6 @@ asm (
 
 /* call N(%ebx) */
 #define JSRPATCH(p,N) *((short *)(p))=0x53ff;p[2]=N;
-#define JSRPATCHL(p,N) *((short *)(p))=0x93ff; *((int *)((p)+2))=N;
 
 /*
  * enters here only from a fault
@@ -639,18 +638,18 @@ int Cpatch(sigcontext_t *scp)
     if (v==0x2f048a) {		// movb (%%edi,%%ebp,1),%%al
 	// we have a sequence:	8a 04 2f 90 90 90
 	if (debug_level('e')>1) e_printf("### Byte read patch at %p\n",eip);
-	JSRPATCHL(p,Ofs_stub_read_8);
+	JSRPATCH(p,Ofs_stub_read_8);
 	return 1;
     }
     if (v==0x2f048b) {		// mov (%%edi,%%ebp,1),%%{e}ax
-	// we have a sequence:	8b 04 2f 90 90 90
-	//		or	66 8b 04 2f 90 90
+	// we have a sequence:	8b 04 2f
+	//		or	66 8b 04 2f
 	if (debug_level('e')>1) e_printf("### Word/Long read patch at %p\n",eip);
 	if (w16) {
-	    p--; JSRPATCHL(p,Ofs_stub_read_16);
+	    p[-1] = 0x90; JSRPATCH(p,Ofs_stub_read_16);
 	}
 	else {
-	    JSRPATCHL(p,Ofs_stub_read_32);
+	    JSRPATCH(p,Ofs_stub_read_32);
 	}
 	return 1;
     }

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -96,7 +96,7 @@ static int _in_dpmi_emu;
 #define AW(v, n) __atomic_store_n(&_##v, n, __ATOMIC_RELAXED)
 jmp_buf jmp_env;
 
-union _SynCPU TheCPU_union;
+struct _SynCPU TheCPU_struct;
 
 int InCompiledCode;
 
@@ -764,7 +764,7 @@ void reset_emu_cpu(void)
 void init_emu_cpu(int cpu_type)
 {
   if (Ofs_END > 128) {
-    error("CPUEMU: Ofs_END is too large, %i\n", Ofs_END);
+    error("CPUEMU: Ofs_END is too large, %zx\n", Ofs_END);
     config.exitearly = 1;
   }
   init_emu_npu();
@@ -806,14 +806,14 @@ void init_emu_cpu(int cpu_type)
   }
 #ifdef X86_JIT
   TheCPU.unprotect_stub = stub_rep;
-  TheCPU.stub_wri_8 = stub_wri_8;
-  TheCPU.stub_wri_16 = stub_wri_16;
-  TheCPU.stub_wri_32 = stub_wri_32;
-  TheCPU.stub_stk_16 = stub_stk_16;
-  TheCPU.stub_stk_32 = stub_stk_32;
-  TheCPU.stub_read_8 = stub_read_8;
-  TheCPU.stub_read_16 = stub_read_16;
-  TheCPU.stub_read_32 = stub_read_32;
+  TheCPU_struct.stub_func[STUB_WRI_8] = stub_wri_8;
+  TheCPU_struct.stub_func[STUB_WRI_16] = stub_wri_16;
+  TheCPU_struct.stub_func[STUB_WRI_32] = stub_wri_32;
+  TheCPU_struct.stub_func[STUB_STK_16] = stub_stk_16;
+  TheCPU_struct.stub_func[STUB_STK_32] = stub_stk_32;
+  TheCPU_struct.stub_func[STUB_READ_8] = stub_read_8;
+  TheCPU_struct.stub_func[STUB_READ_16] = stub_read_16;
+  TheCPU_struct.stub_func[STUB_READ_32] = stub_read_32;
 #endif
   enter_cpu_emu();
 }

--- a/src/base/emu-i386/simx86/syncpu.h
+++ b/src/base/emu-i386/simx86/syncpu.h
@@ -48,29 +48,24 @@
 #define PADDING32BIT(n) unsigned int padding##n;
 #endif
 
+#ifdef X86_JIT
+enum {
+	STUB_STK_16,
+	STUB_STK_32,
+	STUB_WRI_8,
+	STUB_WRI_16,
+	STUB_WRI_32,
+	STUB_READ_8,
+	STUB_READ_16,
+	STUB_READ_32,
+	STUBS_LEN
+};
+typedef void (*stub_func_t)(void);
+#endif
+
 typedef struct {
-/* offsets are 8-bit signed */
+/* offsets up to end_mark are 8-bit */
 #define FIELD0		unprotect_stub	/* field of SynCPU at offset 00 */
-/* ------------------------------------------------ */
-/*80*/	unsigned long long reserve[8];
-/* ------------------------------------------------ */
-/*c0*/  void (*stub_read_8)(void);
-/*c4*/  PADDING32BIT(0)
-/*c8*/  void (*stub_read_16)(void);
-/*cc*/  PADDING32BIT(1)
-/*d0*/  void (*stub_read_32)(void);
-/*d4*/  PADDING32BIT(2)
-/*d8*/  void (*stub_stk_16)(void);
-/*dc*/  PADDING32BIT(3)
-/*e0*/  void (*stub_stk_32)(void);
-/*e4*/  PADDING32BIT(4)
-/*e8*/  void (*stub_wri_8)(void);
-/*ec*/  PADDING32BIT(5)
-/*f0*/  void (*stub_wri_16)(void);
-/*f4*/  PADDING32BIT(6)
-/*f8*/  void (*stub_wri_32)(void);
-/*fc*/  PADDING32BIT(7)
-/* ------------------------------------------------ */
 /*00*/  void (*unprotect_stub)(void); /* must be at 0 for call (%ebx) */
 /*04*/  PADDING32BIT(7)
 /*08*/	unsigned int rzero;
@@ -158,78 +153,73 @@ typedef struct {
 	emu_fpregset_t fpstate;
 } SynCPU;
 
-union _SynCPU {
-	SynCPU s;
-	unsigned char b[sizeof(SynCPU)];
-	unsigned short w[sizeof(SynCPU)/2];
-	unsigned int d[sizeof(SynCPU)/4];
+struct _SynCPU {
+#ifdef X86_JIT
+	stub_func_t stub_func[STUBS_LEN];
+#endif
+	union {
+		SynCPU s;
+		unsigned char b[sizeof(SynCPU)];
+		unsigned short w[sizeof(SynCPU)/2];
+		unsigned int d[sizeof(SynCPU)/4];
+	};
 };
 
-extern union _SynCPU TheCPU_union;
-#define TheCPU TheCPU_union.s
+extern struct _SynCPU TheCPU_struct;
+#define TheCPU TheCPU_struct.s
 
-#define SCBASE		offsetof(SynCPU,FIELD0)
-#define Ofs_END		(int)(offsetof(SynCPU,cr[1])-SCBASE)
+#define Ofs_END		(offsetof(SynCPU,cr[1]))
 
-#define SC(o) ((signed char)(o))
-#define CPUOFFS(o)	(((unsigned char *)&(TheCPU.FIELD0))+SC(o))
+#define CPUOFFS(o)	(((unsigned char *)&(TheCPU.FIELD0))+o)
 
-#define CPUBYTE(o)	TheCPU_union.b[SCBASE+SC(o)]
-#define CPUWORD(o)	TheCPU_union.w[(SCBASE+SC(o))/2]
-#define CPULONG(o)	TheCPU_union.d[(SCBASE+SC(o))/4]
+#define CPUBYTE(o)	TheCPU_struct.b[o]
+#define CPUWORD(o)	TheCPU_struct.w[o/2]
+#define CPULONG(o)	TheCPU_struct.d[o/4]
 
 #define rEAX		TheCPU.eax
-#define Ofs_EAX		(unsigned char)(offsetof(SynCPU,eax)-SCBASE)
+#define Ofs_EAX		(offsetof(SynCPU,eax))
 #define rECX		TheCPU.ecx
-#define Ofs_ECX		(unsigned char)(offsetof(SynCPU,ecx)-SCBASE)
+#define Ofs_ECX		(offsetof(SynCPU,ecx))
 #define rEDX		TheCPU.edx
-#define Ofs_EDX		(unsigned char)(offsetof(SynCPU,edx)-SCBASE)
+#define Ofs_EDX		(offsetof(SynCPU,edx))
 #define rEBX		TheCPU.ebx
-#define Ofs_EBX		(unsigned char)(offsetof(SynCPU,ebx)-SCBASE)
+#define Ofs_EBX		(offsetof(SynCPU,ebx))
 #define rESP		TheCPU.esp
-#define Ofs_ESP		(unsigned char)(offsetof(SynCPU,esp)-SCBASE)
+#define Ofs_ESP		(offsetof(SynCPU,esp))
 #define rEBP		TheCPU.ebp
-#define Ofs_EBP		(unsigned char)(offsetof(SynCPU,ebp)-SCBASE)
+#define Ofs_EBP		(offsetof(SynCPU,ebp))
 #define rESI		TheCPU.esi
-#define Ofs_ESI		(unsigned char)(offsetof(SynCPU,esi)-SCBASE)
+#define Ofs_ESI		(offsetof(SynCPU,esi))
 #define rEDI		TheCPU.edi
-#define Ofs_EDI		(unsigned char)(offsetof(SynCPU,edi)-SCBASE)
-#define Ofs_EIP		(unsigned char)(offsetof(SynCPU,eip)-SCBASE)
+#define Ofs_EDI		(offsetof(SynCPU,edi))
+#define Ofs_EIP		(offsetof(SynCPU,eip))
 
-#define Ofs_CS		(unsigned char)(offsetof(SynCPU,cs)-SCBASE)
-#define Ofs_DS		(unsigned char)(offsetof(SynCPU,ds)-SCBASE)
-#define Ofs_ES		(unsigned char)(offsetof(SynCPU,es)-SCBASE)
-#define Ofs_SS		(unsigned char)(offsetof(SynCPU,ss)-SCBASE)
-#define Ofs_FS		(unsigned char)(offsetof(SynCPU,fs)-SCBASE)
-#define Ofs_GS		(unsigned char)(offsetof(SynCPU,gs)-SCBASE)
-#define Ofs_EFLAGS	(unsigned char)(offsetof(SynCPU,eflags)-SCBASE)
-#define Ofs_CR0		(unsigned char)(offsetof(SynCPU,cr[0])-SCBASE)
-#define Ofs_STACKM	(unsigned char)(offsetof(SynCPU,StackMask)-SCBASE)
-//#define Ofs_ETIME	(unsigned char)(offsetof(SynCPU,EMUtime)-SCBASE)
-#define Ofs_RZERO	(unsigned char)(offsetof(SynCPU,rzero)-SCBASE)
-#define Ofs_SIGAPEND	(unsigned char)(offsetof(SynCPU,sigalrm_pending)-SCBASE)
-#define Ofs_DF_INCREMENTS (unsigned char)(offsetof(SynCPU,df_increments)-SCBASE)
+#define Ofs_CS		(offsetof(SynCPU,cs))
+#define Ofs_DS		(offsetof(SynCPU,ds))
+#define Ofs_ES		(offsetof(SynCPU,es))
+#define Ofs_SS		(offsetof(SynCPU,ss))
+#define Ofs_FS		(offsetof(SynCPU,fs))
+#define Ofs_GS		(offsetof(SynCPU,gs))
+#define Ofs_EFLAGS	(offsetof(SynCPU,eflags))
+#define Ofs_CR0		(offsetof(SynCPU,cr[0]))
+#define Ofs_STACKM	(offsetof(SynCPU,StackMask))
+//#define Ofs_ETIME	(offsetof(SynCPU,EMUtime))
+#define Ofs_RZERO	(offsetof(SynCPU,rzero))
+#define Ofs_SIGAPEND	(offsetof(SynCPU,sigalrm_pending))
+#define Ofs_DF_INCREMENTS (offsetof(SynCPU,df_increments))
 
-#define Ofs_FPUC	(unsigned char)(offsetof(SynCPU,fpuc)-SCBASE)
+#define Ofs_FPUC	(offsetof(SynCPU,fpuc))
 
 // 'Base' is 1st field of xs_cache
-#define Ofs_XDS		(unsigned char)(offsetof(SynCPU,ds_cache)-SCBASE)
-#define Ofs_XSS		(unsigned char)(offsetof(SynCPU,ss_cache)-SCBASE)
-#define Ofs_XES		(unsigned char)(offsetof(SynCPU,es_cache)-SCBASE)
-#define Ofs_XCS		(unsigned char)(offsetof(SynCPU,cs_cache)-SCBASE)
-#define Ofs_XFS		(unsigned char)(offsetof(SynCPU,fs_cache)-SCBASE)
-#define Ofs_XGS		(unsigned char)(offsetof(SynCPU,gs_cache)-SCBASE)
+#define Ofs_XDS		(offsetof(SynCPU,ds_cache))
+#define Ofs_XSS		(offsetof(SynCPU,ss_cache))
+#define Ofs_XES		(offsetof(SynCPU,es_cache))
+#define Ofs_XCS		(offsetof(SynCPU,cs_cache))
+#define Ofs_XFS		(offsetof(SynCPU,fs_cache))
+#define Ofs_XGS		(offsetof(SynCPU,gs_cache))
 
-#define Ofs_stub_wri_8	(unsigned char)(offsetof(SynCPU,stub_wri_8)-SCBASE)
-#define Ofs_stub_wri_16	(unsigned char)(offsetof(SynCPU,stub_wri_16)-SCBASE)
-#define Ofs_stub_wri_32	(unsigned char)(offsetof(SynCPU,stub_wri_32)-SCBASE)
-#define Ofs_stub_stk_16	(unsigned char)(offsetof(SynCPU,stub_stk_16)-SCBASE)
-#define Ofs_stub_stk_32	(unsigned char)(offsetof(SynCPU,stub_stk_32)-SCBASE)
-#define Ofs_stub_read_8	(unsigned char)(offsetof(SynCPU,stub_read_8)-SCBASE)
-#define Ofs_stub_read_16	(unsigned char)(offsetof(SynCPU,stub_read_16)-SCBASE)
-#define Ofs_stub_read_32	(unsigned char)(offsetof(SynCPU,stub_read_32)-SCBASE)
-#define Ofs_ERR		(unsigned int)(offsetof(SynCPU,err2)-SCBASE)
-#define Ofs_int_revectored	(unsigned int)(offsetof(SynCPU,int_revectored)-SCBASE)
+#define Ofs_ERR		(offsetof(SynCPU,err2))
+#define Ofs_int_revectored	(offsetof(SynCPU,int_revectored))
 
 #define rAX		CPUWORD(Ofs_AX)
 #define Ofs_AX		(Ofs_EAX)

--- a/src/base/emu-i386/simx86/syncpu.h
+++ b/src/base/emu-i386/simx86/syncpu.h
@@ -52,18 +52,24 @@ typedef struct {
 /* offsets are 8-bit signed */
 #define FIELD0		unprotect_stub	/* field of SynCPU at offset 00 */
 /* ------------------------------------------------ */
-/*80*/	unsigned long long reserve[11];
+/*80*/	unsigned long long reserve[8];
 /* ------------------------------------------------ */
+/*c0*/  void (*stub_read_8)(void);
+/*c4*/  PADDING32BIT(0)
+/*c8*/  void (*stub_read_16)(void);
+/*cc*/  PADDING32BIT(1)
+/*d0*/  void (*stub_read_32)(void);
+/*d4*/  PADDING32BIT(2)
 /*d8*/  void (*stub_stk_16)(void);
-/*dc*/  PADDING32BIT(2)
+/*dc*/  PADDING32BIT(3)
 /*e0*/  void (*stub_stk_32)(void);
-/*e4*/  PADDING32BIT(3)
+/*e4*/  PADDING32BIT(4)
 /*e8*/  void (*stub_wri_8)(void);
-/*ec*/  PADDING32BIT(4)
+/*ec*/  PADDING32BIT(5)
 /*f0*/  void (*stub_wri_16)(void);
-/*f4*/  PADDING32BIT(5)
+/*f4*/  PADDING32BIT(6)
 /*f8*/  void (*stub_wri_32)(void);
-/*fc*/  PADDING32BIT(6)
+/*fc*/  PADDING32BIT(7)
 /* ------------------------------------------------ */
 /*00*/  void (*unprotect_stub)(void); /* must be at 0 for call (%ebx) */
 /*04*/  PADDING32BIT(7)
@@ -143,10 +149,6 @@ typedef struct {
 	unsigned short TR_SEL;
 	DTR  TR;
 
-	void (*stub_read_8)(void);
-	void (*stub_read_16)(void);
-	void (*stub_read_32)(void);
-
 	/* should be moved to TSS once implemented */
 	struct revectored_struct int_revectored;
 
@@ -223,9 +225,9 @@ extern union _SynCPU TheCPU_union;
 #define Ofs_stub_wri_32	(unsigned char)(offsetof(SynCPU,stub_wri_32)-SCBASE)
 #define Ofs_stub_stk_16	(unsigned char)(offsetof(SynCPU,stub_stk_16)-SCBASE)
 #define Ofs_stub_stk_32	(unsigned char)(offsetof(SynCPU,stub_stk_32)-SCBASE)
-#define Ofs_stub_read_8	(unsigned int)(offsetof(SynCPU,stub_read_8)-SCBASE)
-#define Ofs_stub_read_16	(unsigned int)(offsetof(SynCPU,stub_read_16)-SCBASE)
-#define Ofs_stub_read_32	(unsigned int)(offsetof(SynCPU,stub_read_32)-SCBASE)
+#define Ofs_stub_read_8	(unsigned char)(offsetof(SynCPU,stub_read_8)-SCBASE)
+#define Ofs_stub_read_16	(unsigned char)(offsetof(SynCPU,stub_read_16)-SCBASE)
+#define Ofs_stub_read_32	(unsigned char)(offsetof(SynCPU,stub_read_32)-SCBASE)
 #define Ofs_ERR		(unsigned int)(offsetof(SynCPU,err2)-SCBASE)
 #define Ofs_int_revectored	(unsigned int)(offsetof(SynCPU,int_revectored)-SCBASE)
 


### PR DESCRIPTION
Follow up to #2552: the stubs are converted to a function pointer array, separate (stuffed in front of) from SynCPU/TheCPU.
As all non-stub offsets are positive, eliminated the need to use `signed char` for offsets.

Even CPatch casts to `unsigned char` for the negative stub offsets but that's because it's just a byte value to patch in `*p` of type `unsigned char *`, it's not added in C code.

I'll move `unprotect_stub` out of the main `SynCPU` later for consistency.