### PR TITLE
simx86: Move rep_stub with other stubs, redesign its calling convention and localize cpatch code

### DIFF
--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -1793,32 +1793,47 @@ shrot0:
 
 	case O_MOVS_MovD:
 		GetDF(Cp);
-		G3M(NOP,NOP,REP,Cp);
-		if (mode&MBYTE)	{ G1(MOVSb,Cp); }
-		else {
-			Gen66(mode,Cp);
-			G1(MOVSw,Cp);
+		G1(REP,Cp);
+		if (mode&MBYTE)	{
+			G2M(MOVSb,NOP,Cp);
 		}
+		else if (mode&DATA16) {
+			G2M(OPERoverride,MOVSw,Cp);
+		}
+		else {
+			G2M(MOVSw,NOP,Cp);
+		}
+		G2M(NOP,NOP,Cp);
 		G1(CLD,Cp);
 		break;
 	case O_MOVS_LodD:
 		GetDF(Cp);
-		G3M(NOP,NOP,REP,Cp);
-		if (mode&MBYTE)	{ G1(LODSb,Cp); }
-		else {
-			Gen66(mode,Cp);
-			G1(LODSw,Cp);
+		G1(REP,Cp);
+		if (mode&MBYTE)	{
+			G2M(LODSb,NOP,Cp);
 		}
+		else if (mode&DATA16) {
+			G2M(OPERoverride,LODSw,Cp);
+		}
+		else {
+			G2M(LODSw,NOP,Cp);
+		}
+		G2M(NOP,NOP,Cp);
 		G1(CLD,Cp);
 		break;
 	case O_MOVS_StoD:
 		GetDF(Cp);
-		G3M(NOP,NOP,REP,Cp);
-		if (mode&MBYTE)	{ G1(STOSb,Cp); }
-		else {
-			Gen66(mode,Cp);
-			G1(STOSw,Cp);
+		G1(REP,Cp);
+		if (mode&MBYTE)	{
+			G2M(STOSb,NOP,Cp);
 		}
+		else if (mode&DATA16) {
+			G2M(OPERoverride,STOSw,Cp);
+		}
+		else {
+			G2M(STOSw,NOP,Cp);
+		}
+		G2M(NOP,NOP,Cp);
 		G1(CLD,Cp);
 		break;
 	case O_MOVS_ScaD:
@@ -1827,13 +1842,17 @@ shrot0:
 		// Pointer to the jecxz distance byte
 		CpTemp = Cp-1;
 		GetDF(Cp);
-		G4M(NOP,NOP,NOP,NOP,Cp);
 		G1((mode&MREP)?REP:REPNE,Cp);
-		if (mode&MBYTE)	{ G1(SCASb,Cp); }
-		else {
-			Gen66(mode,Cp);
-			G1(SCASw,Cp);
+		if (mode&MBYTE)	{
+			G2M(SCASb,NOP,Cp);
 		}
+		else if (mode&DATA16) {
+			G2M(OPERoverride,SCASw,Cp);
+		}
+		else {
+			G2M(SCASw,NOP,Cp);
+		}
+		G2M(NOP,NOP,Cp);
 		G3M(CLD,POPsi,PUSHF,Cp); // replace flags back on stack,esi=dummy
 		*CpTemp = (Cp-(CpTemp+1));
 		break;
@@ -1870,13 +1889,17 @@ shrot0:
 		// Pointer to the jecxz distance byte
 		CpTemp = Cp-1;
 		GetDF(Cp);
-		G4M(NOP,NOP,NOP,NOP,Cp);
 		G1((mode&MREP)?REP:REPNE,Cp);
-		if (mode&MBYTE)	{ G1(CMPSb,Cp); }
-		else {
-			Gen66(mode,Cp);
-			G1(CMPSw,Cp);
+		if (mode&MBYTE)	{
+			G2M(CMPSb,NOP,Cp);
 		}
+		else if (mode&DATA16) {
+			G2M(OPERoverride,CMPSw,Cp);
+		}
+		else {
+			G2M(CMPSw,NOP,Cp);
+		}
+		G2M(NOP,NOP,Cp);
 		G3M(CLD,POPax,PUSHF,Cp); // replace flags back on stack,eax=dummy
 		*CpTemp = (Cp-(CpTemp+1));
 		break;

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -149,6 +149,7 @@ void InitGen_x86(void)
 	CodeGen = CodeGen_x86;
 	Exec = Exec_x86;
 	UseLinker = USE_LINKER;
+	Cpatch_init();
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/base/emu-i386/simx86/codegen-x86.h
+++ b/src/base/emu-i386/simx86/codegen-x86.h
@@ -121,4 +121,8 @@ unsigned char *Fp87_op_x86(unsigned char *CodePtr, int exop, int reg);
 void NodeLinker(TNode *LG, TNode *G);
 void NodeUnlinker(TNode *G);
 
+int Cpatch(sigcontext_t *scp);
+int UnCpatch(unsigned char *eip);
+void Cpatch_init(void);
+
 #endif

--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -310,18 +310,4 @@ extern char OpSizeBit[];
 #define OPSIZE(m) (OpSize[(m)&(DATA16|MBYTE)])
 #define OPSIZEBIT(m) (OpSizeBit[(m)&(DATA16|MBYTE)])
 
-#ifdef X86_JIT
-int Cpatch(sigcontext_t *scp);
-int UnCpatch(unsigned char *eip);
-void stub_rep(void) asm ("stub_rep__");
-void stub_stk_16(void) asm ("stub_stk_16__");
-void stub_stk_32(void) asm ("stub_stk_32__");
-void stub_wri_8 (void) asm ("stub_wri_8__" );
-void stub_wri_16(void) asm ("stub_wri_16__");
-void stub_wri_32(void) asm ("stub_wri_32__");
-void stub_read_8 (void) asm ("stub_read_8__" );
-void stub_read_16(void) asm ("stub_read_16__");
-void stub_read_32(void) asm ("stub_read_32__");
-#endif
-
 #endif

--- a/src/base/emu-i386/simx86/cpatch.c
+++ b/src/base/emu-i386/simx86/cpatch.c
@@ -90,10 +90,8 @@ void m_munprotect(unsigned int addr, unsigned int len, unsigned char *eip)
 struct rep_stack {
 	unsigned char *esi, *edi;
 	unsigned long ecx, eflags, edx, eax;
-#ifdef __x86_64__
-	unsigned long eax_pad;
-#endif
 	unsigned char *eip;
+	unsigned long cpatch_op;
 } __attribute__((packed));
 
 
@@ -113,6 +111,8 @@ struct rep_stack {
 		addr += df; source += df; \
 	} while (--ecx && (eflags & X86_EFLAGS_ZF)==repcond)
 
+// the rep stub gets passed an argument on the stack:
+// the original op | 0x10 for operand override, | 0x40 for REPNE
 void rep_movs_stos(struct rep_stack *stack)
 {
 	unsigned char *paddr = stack->edi;
@@ -127,17 +127,13 @@ void rep_movs_stos(struct rep_stack *stack)
 	assert(InCompiledCode);
 	InCompiledCode--;
 	addr = EMUADDR_REL(paddr);
-	if (*eip == 0xf3) /* skip rep */
-		eip++;
-	else if (*eip == JMPsid) /* skip jmp and rep */
-		eip += 3;
-	op = eip[0];
+	op = stack->cpatch_op;
 	size = 1;
-	if (*eip == 0x66) {
+	if (op & 0x10) {
 		size = 2;
-		op = eip[1];
+		op &= ~0x10;
 	}
-	else if (*eip & 1)
+	else if (op & 1)
 		size = 4;
 	len *= size;
 	m_munprotect(addr - ((EFLAGS & EFLAGS_DF) ? (len - size) : 0),
@@ -207,11 +203,11 @@ void rep_movs_stos(struct rep_stack *stack)
 		if (EFLAGS & EFLAGS_DF) addr -= len;
 		else addr += len;
 	}
-	else if ((op & 0xf6) == 0xa6 && ecx > 0) { /* cmps/scas */
+	else if ((op & 0xb6) == 0xa6 && ecx > 0) { /* cmps/scas */
 		int df = size * (CPUWORD(Ofs_FLAGS) & EFLAGS_DF? -1:1);
-		unsigned long repcond = (eip[-1]==REPNE ? 0 : X86_EFLAGS_ZF);
+		unsigned long repcond = (op & 0x40) ? 0 : X86_EFLAGS_ZF;
 		unsigned long eflags;
-		if ((op & 0xfe) == 0xa6) { /* cmps */
+		if ((op & 0xbe) == 0xa6) { /* cmps */
 			dosaddr_t source = EMUADDR_REL(stack->esi);
 			if (size == 1)
 				CMPSLOOP(8,q,eflags,addr,source,df,ecx,repcond);
@@ -473,7 +469,7 @@ asm (
 "		popfl\n"		/* real CPU flags back */
 "		popl	%edx\n"
 "		popl	%eax\n"
-"1:		ret\n"
+"1:		ret	$4\n"
 );
 
 /* ======================================================================= */
@@ -517,11 +513,11 @@ asm (
 "		popq	%rdi\n"		/* restore regs */ \
 "		ret\n"
 
+// Note: 6 pushes + the argument push and call means stack stays 16-bit aligned
 asm (
 ".text\n.globl stub_rep__\n"
 "stub_rep__:	jrcxz	1f\n"		/* zero move, nothing to do */
 "		pushq	%rax\n"		/* save regs */
-"		pushq	%rax\n"		/* save rax twice for 16-alignment */
 "		pushq	%rdx\n"
 "		pushfq\n"		/* push flags for DF */
 "		pushq	%rcx\n"
@@ -536,8 +532,7 @@ asm (
 "		popfq\n"		/* real CPU flags back */
 "		popq	%rdx\n"
 "		popq	%rax\n"
-"		popq	%rax\n"
-"1:		ret\n"
+"1:		ret	$8\n"
 );
 
 #endif
@@ -556,6 +551,7 @@ asm (
 
 // using negative byte offsets
 #define Ofs_stub(x) (unsigned char)(((x) - STUBS_LEN) * sizeof(stub_func_t))
+#define Ofs_stub_rep Ofs_stub(STUB_REP)
 #define Ofs_stub_wri_8 Ofs_stub(STUB_WRI_8)
 #define Ofs_stub_wri_16 Ofs_stub(STUB_WRI_16)
 #define Ofs_stub_wri_32 Ofs_stub(STUB_WRI_32)
@@ -582,20 +578,23 @@ int Cpatch(sigcontext_t *scp)
     CpatchTotal++;
 #endif
     p = eip;
-    if ((*p==0xf3 || *p==0xf2) && p[-1] == 0x90 && p[-2] == 0x90) {
+    if ((*p==0xf2 || *p==0xf3) && (p[1] == 0x66 || p[2] == 0x90) &&
+	p[3] == 0x90 && p[4] == 0x90) {
+	unsigned char op;
+
 	// rep movs, rep stos, rep lods, rep scas, rep cmps
-	// we have a sequence:	90 90 f3 op (stos/movs/lods)
-	//		or	90 90 90 90 f2/f3 op (cmps/scas)
+	// we have a sequence:	f2/f3 op 90 90 90
+	//		or	f2/f3 66 op 90 90 (f2 for cmps/scas only)
 	if (debug_level('e')>1) e_printf("### REP patch at %p\n",eip);
-	p-=2;
-	if (p[-1] == 0x90 && p[-2] == 0x90) /* cmps/scas */
-	    p-=2;
-	G2M(0xff,0x13,p); /* call (%ebx) */
-	_scp_rip -= 2; /* make sure call (%ebx) is performed the first time */
-	if (*p == 0x90) { /* cmps/scas */
-	    G2M(JMPsid,(p[3]==0x66?3:2),p); /* jmp over rep instruction */
-	    _scp_rip -= 2;
-	}
+	op = p[1];
+	/* as all ops are between 0xa4 and 0xaf we can encode override
+	   prefix as 0x10 and repne as 0x40 */
+	if (op == OPERoverride)
+	    op = p[2] | 0x10;
+	if (p[0] == REPNE)
+	    op |= 0x40;
+	G2M(PUSHbi,op,p); /* push $op; call ofs(%ebx) */
+	JSRPATCH(p,Ofs_stub_rep);
 	return 1;
     }
 
@@ -681,12 +680,20 @@ int UnCpatch(unsigned char *eip)
 #if PROFILE
     UncpatchTotal++;
 #endif
-    if (p[1] == 0x13) {
-	p[0] = p[1] = 0x90;
-	if (p[2] == JMPsid) p[2] = p[3] = 0x90;
-    }
-    else if (p[1] == 0x53) {
-	if ((unsigned char)p[2] == Ofs_stub_wri_8) {
+    if (p[1] == 0x53) {
+	if ((unsigned char)p[2] == Ofs_stub_rep) {
+	    unsigned char op = p[-1];
+	    p -= 2;
+	    G1((op&0x40)?REPNE:REP,p);
+	    if (op & 0x10) {
+		G2M(OPERoverride,op&~0x50,p);
+	    }
+	    else {
+		G2M(op&~0x50,NOP,p);
+	    }
+	    G2M(NOP,NOP,p);
+	}
+	else if ((unsigned char)p[2] == Ofs_stub_wri_8) {
 	    *((short *)p) = 0x0488; p[2] = 0x2f;
 	}
 	else if ((unsigned char)p[2] == Ofs_stub_wri_16) {

--- a/src/base/emu-i386/simx86/cpatch.c
+++ b/src/base/emu-i386/simx86/cpatch.c
@@ -549,8 +549,23 @@ asm (
 "stub_read_32__:.globl stub_read_32__\n"STUB_READ(read_32)
 );
 
+enum {
+	STUB_REP,
+	STUB_STK_16,
+	STUB_STK_32,
+	STUB_WRI_8,
+	STUB_WRI_16,
+	STUB_WRI_32,
+	STUB_READ_8,
+	STUB_READ_16,
+	STUB_READ_32,
+	STUBS_LEN
+};
+static_assert(STUBS_LEN <= STUBS_LEN_MAX);
+
 // using negative byte offsets
-#define Ofs_stub(x) (unsigned char)(((x) - STUBS_LEN) * sizeof(stub_func_t))
+#define Ofs_stub(x) (unsigned char)(((x) - STUBS_LEN_MAX) * \
+				    sizeof(TheCPU_struct.stub_func[STUB_REP]))
 #define Ofs_stub_rep Ofs_stub(STUB_REP)
 #define Ofs_stub_wri_8 Ofs_stub(STUB_WRI_8)
 #define Ofs_stub_wri_16 Ofs_stub(STUB_WRI_16)
@@ -716,6 +731,29 @@ int UnCpatch(unsigned char *eip)
 	    eip[0],eip[1],eip[2],eip[3],eip[4]);
     }
     return 0;
+}
+
+void stub_rep(void) asm ("stub_rep__");
+void stub_stk_16(void) asm ("stub_stk_16__");
+void stub_stk_32(void) asm ("stub_stk_32__");
+void stub_wri_8 (void) asm ("stub_wri_8__" );
+void stub_wri_16(void) asm ("stub_wri_16__");
+void stub_wri_32(void) asm ("stub_wri_32__");
+void stub_read_8 (void) asm ("stub_read_8__" );
+void stub_read_16(void) asm ("stub_read_16__");
+void stub_read_32(void) asm ("stub_read_32__");
+
+void Cpatch_init(void)
+{
+    TheCPU_struct.stub_func[STUB_REP] = stub_rep;
+    TheCPU_struct.stub_func[STUB_WRI_8] = stub_wri_8;
+    TheCPU_struct.stub_func[STUB_WRI_16] = stub_wri_16;
+    TheCPU_struct.stub_func[STUB_WRI_32] = stub_wri_32;
+    TheCPU_struct.stub_func[STUB_STK_16] = stub_stk_16;
+    TheCPU_struct.stub_func[STUB_STK_32] = stub_stk_32;
+    TheCPU_struct.stub_func[STUB_READ_8] = stub_read_8;
+    TheCPU_struct.stub_func[STUB_READ_16] = stub_read_16;
+    TheCPU_struct.stub_func[STUB_READ_32] = stub_read_32;
 }
 
 /* ======================================================================= */

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -805,7 +805,7 @@ void init_emu_cpu(int cpu_type)
 	TheCPU.LDTR.Limit = 0xffff;
   }
 #ifdef X86_JIT
-  TheCPU.unprotect_stub = stub_rep;
+  TheCPU_struct.stub_func[STUB_REP] = stub_rep;
   TheCPU_struct.stub_func[STUB_WRI_8] = stub_wri_8;
   TheCPU_struct.stub_func[STUB_WRI_16] = stub_wri_16;
   TheCPU_struct.stub_func[STUB_WRI_32] = stub_wri_32;

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -763,10 +763,6 @@ void reset_emu_cpu(void)
 
 void init_emu_cpu(int cpu_type)
 {
-  if (Ofs_END > 128) {
-    error("CPUEMU: Ofs_END is too large, %zx\n", Ofs_END);
-    config.exitearly = 1;
-  }
   init_emu_npu();
 
   switch (cpu_type) {

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -804,17 +804,6 @@ void init_emu_cpu(int cpu_type)
 	TheCPU.LDTR.Base = (long)LDT;
 	TheCPU.LDTR.Limit = 0xffff;
   }
-#ifdef X86_JIT
-  TheCPU_struct.stub_func[STUB_REP] = stub_rep;
-  TheCPU_struct.stub_func[STUB_WRI_8] = stub_wri_8;
-  TheCPU_struct.stub_func[STUB_WRI_16] = stub_wri_16;
-  TheCPU_struct.stub_func[STUB_WRI_32] = stub_wri_32;
-  TheCPU_struct.stub_func[STUB_STK_16] = stub_stk_16;
-  TheCPU_struct.stub_func[STUB_STK_32] = stub_stk_32;
-  TheCPU_struct.stub_func[STUB_READ_8] = stub_read_8;
-  TheCPU_struct.stub_func[STUB_READ_16] = stub_read_16;
-  TheCPU_struct.stub_func[STUB_READ_32] = stub_read_32;
-#endif
   enter_cpu_emu();
 }
 

--- a/src/base/emu-i386/simx86/syncpu.h
+++ b/src/base/emu-i386/simx86/syncpu.h
@@ -42,14 +42,9 @@
 #include <limits.h>
 #include <stddef.h>
 
-#if ULONG_MAX > 0xffffffffUL
-#define PADDING32BIT(n)
-#else
-#define PADDING32BIT(n) unsigned int padding##n;
-#endif
-
 #ifdef X86_JIT
 enum {
+	STUB_REP,
 	STUB_STK_16,
 	STUB_STK_32,
 	STUB_WRI_8,
@@ -65,10 +60,9 @@ typedef void (*stub_func_t)(void);
 
 typedef struct {
 /* offsets up to end_mark are 8-bit */
-#define FIELD0		unprotect_stub	/* field of SynCPU at offset 00 */
-/*00*/  void (*unprotect_stub)(void); /* must be at 0 for call (%ebx) */
-/*04*/  PADDING32BIT(7)
-/*08*/	unsigned int rzero;
+#define FIELD0		rzero	/* field of SynCPU at offset 00 */
+/*00*/	unsigned int rzero;
+/*08*/	unsigned int reserved[2];
 /*0c*/	unsigned int edi;
 /*10*/	unsigned int esi;
 /*14*/	unsigned int ebp;

--- a/src/base/emu-i386/simx86/syncpu.h
+++ b/src/base/emu-i386/simx86/syncpu.h
@@ -42,22 +42,6 @@
 #include <limits.h>
 #include <stddef.h>
 
-#ifdef X86_JIT
-enum {
-	STUB_REP,
-	STUB_STK_16,
-	STUB_STK_32,
-	STUB_WRI_8,
-	STUB_WRI_16,
-	STUB_WRI_32,
-	STUB_READ_8,
-	STUB_READ_16,
-	STUB_READ_32,
-	STUBS_LEN
-};
-typedef void (*stub_func_t)(void);
-#endif
-
 typedef struct {
 /* offsets up to end_mark are 8-bit */
 #define FIELD0		rzero	/* field of SynCPU at offset 00 */
@@ -149,7 +133,9 @@ typedef struct {
 
 struct _SynCPU {
 #ifdef X86_JIT
-	stub_func_t stub_func[STUBS_LEN];
+#define STUBS_LEN_MAX 16
+	/* reserve space for max 16 stub functions used by cpatch */
+	void (*stub_func[STUBS_LEN_MAX])(void);
 #endif
 	union {
 		SynCPU s;

--- a/src/base/emu-i386/simx86/syncpu.h
+++ b/src/base/emu-i386/simx86/syncpu.h
@@ -131,6 +131,9 @@ typedef struct {
 	emu_fpregset_t fpstate;
 } SynCPU;
 
+/* JIT uses byte offsets, make sure cr[0] is still ok */
+static_assert(offsetof(SynCPU,cr[1]) == 128);
+
 struct _SynCPU {
 #ifdef X86_JIT
 #define STUBS_LEN_MAX 16
@@ -147,8 +150,6 @@ struct _SynCPU {
 
 extern struct _SynCPU TheCPU_struct;
 #define TheCPU TheCPU_struct.s
-
-#define Ofs_END		(offsetof(SynCPU,cr[1]))
 
 #define CPUOFFS(o)	(((unsigned char *)&(TheCPU.FIELD0))+o)
 


### PR DESCRIPTION
This PR moves the rep stub together with the other stubs, and the patching/unpatching works more similarly.

Now instead of analyzing the code after the "call stub", it gets passed an argument on the stack with the original opcode with a few bits for extra info (0x10 for operand override, 0x40 for repne instead of repe). This eliminates the special code for rep cmps/scas with the extra jmp.

Once `stub_rep` was moved I moved the stub code to cpatch.c that wasn't there yet as much as possible (via `Cpatch_init()`)