### PR TITLE
simx86: use local variable mem_ref instead of static AR1.d

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -2576,8 +2576,18 @@ static unsigned int Gen_sim(const IGen *IG)
 			if (mode & RM_REG)
 				DR2.d &= 0x1f;
 		}
-		if ((mode & RM_REG) || o1 >= 0x20) {
-		    if ((o1 & ~0x18) == 0x03 || (o1 & ~0x18) == 0x20) {
+		if (!(mode & RM_REG) && o1 < 0x20) {
+			/* add bit offset to effective address */
+			AR1.d += (mode&DATA16) ? 2*(DR2.d>>4) : 4*(DR2.d>>5);
+			if (mode & DATA16) {
+				DR1.d = sim_read_word(AR1.d);
+			}
+			else {
+				DR1.d = sim_read_dword(AR1.d);
+			}
+		}
+		if (mode & DATA16) DR1.d = DR1.w.l;
+		if ((o1 & ~0x18) == 0x03 || (o1 & ~0x18) == 0x20) {
 			SET_CF((DR1.d >> DR2.d) & 1);
 			switch (o1 & 0x18) {
 			case 0x00: break;
@@ -2586,10 +2596,14 @@ static unsigned int Gen_sim(const IGen *IG)
 			case 0x18: DR1.d ^= 1U << DR2.d; break;
 			default: break;
 			}
-		    }
-		} else {
-		    /* add bit offset to effective address */
-		    AR1.d += (mode&DATA16) ? 2*(DR2.d>>4) : 4*(DR2.d>>5);
+		}
+		if (!(mode & RM_REG) && o1 < 0x20 && o1 != 0x03) {
+			if (mode & DATA16) {
+				sim_write_word(AR1.d, DR1.w.l);
+			}
+			else {
+				sim_write_dword(AR1.d, DR1.d);
+			}
 		}
 		} break;
 	case O_SHFD: {

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -83,7 +83,6 @@ static unsigned char *currentIG = NULL;
 
 /* working registers of the host CPU */
 static wkreg DR1;	// "eax"
-static wkreg AR1;	// "edi"
 static flgtmp RFL;
 
 /////////////////////////////////////////////////////////////////////////////
@@ -384,11 +383,56 @@ dosaddr_t AddrGen_sim(const IGen *IG)
 			check_v86_address_overflow(mode, offset);
 		}
 		break;
+	case O_XLAT: {
+		unsigned int ofs = IG->p0;
+		unsigned int offset;
+		GTRACE1("XLAT",ofs);
+		mem_ref = CPULONG(ofs);
+		offset = CPULONG(Ofs_EBX) + CPUBYTE(Ofs_AL);
+		if (mode & ADDR16) {
+			offset &= 0xFFFF;
+		}
+		mem_ref += offset;
+		}
+		break;
+	case O_INT: {
+		unsigned char intno = IG->p0;
+		// Check bitmap, GPF if revectored
+		if (test_bit(intno, &TheCPU.int_revectored)) {
+			TheCPU.err2 = EXCP0D_GPF;
+			mem_ref = (dosaddr_t)-1;
+		}
+		else {
+			mem_ref = intno * 4;
+		} }
+		break;
+	case O_MOVS_SetA: {
+		unsigned int ofs = IG->p0;
+		GTRACE1("O_MOVS_SetA",ofs);
+		if (mode&ADDR16) {
+		    if (mode&MOVSSRC) {
+			mem_ref = CPULONG(ofs);
+			mem_ref += CPUWORD(Ofs_SI);
+		    } else {
+			mem_ref = CPULONG(Ofs_XES);
+			mem_ref += CPUWORD(Ofs_DI);
+
+		    }
+		}
+		else {
+		    if (mode&MOVSSRC) {
+			mem_ref = CPULONG(ofs) + CPULONG(Ofs_ESI);
+		    } else {
+			mem_ref = CPULONG(Ofs_XES) + CPULONG(Ofs_EDI);
+		    }
+		}
+		}
+		break;
 	}
 	return mem_ref;
 }
 
-static unsigned int Gen_sim(const IGen *IG)
+static unsigned int Gen_sim(const IGen *IG, dosaddr_t mem_ref)
 {
 	int op = IG->op;
 	int mode = IG->mode;
@@ -419,7 +463,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		unsigned char exop = (unsigned char)IG->p0;
 		int reg = IG->p1;
 		GTRACE2("O_FPOP",exop,reg);
-		if (Fp87_op(exop, reg, AR1.d)) {
+		if (Fp87_op(exop, reg, mem_ref)) {
 		    TheCPU.err2 = -96;
 		    P0 = FindPC((const unsigned char *)IG);
 		}
@@ -478,14 +522,14 @@ static unsigned int Gen_sim(const IGen *IG)
 		unsigned int o = IG->p0;
 		GTRACE1("S_DI_R",o);
 		if (mode & DATA16)
-			CPUWORD(o) = AR1.w.l;
+			CPUWORD(o) = mem_ref;
 		else
-			CPULONG(o) = AR1.d;
+			CPULONG(o) = mem_ref;
 		}
 		break;
 	case S_DI_IMM: {
 		int v = IG->p0;
-		dosaddr_t addr = AR1.d;
+		dosaddr_t addr = mem_ref;
 		if (mode&MBYTE) {
 			GTRACE3("S_DI_IMM_B",0xff,0xff,v);
 			sim_write_byte(addr, v);
@@ -554,16 +598,16 @@ static unsigned int Gen_sim(const IGen *IG)
 		unsigned int o = IG->p0;
 		GTRACE1("L_LXS1",o);
 		if (mode&DATA16) {
-		    CPUWORD(o) = DR1.w.l = sim_read_word(AR1.d);
+		    CPUWORD(o) = DR1.w.l = sim_read_word(mem_ref);
 		}
 		else {
-		    CPULONG(o) = DR1.d = sim_read_dword(AR1.d);
+		    CPULONG(o) = DR1.d = sim_read_dword(mem_ref);
 		} }
 		break;
 	case L_LXS2: {	/* real mode segment base from segment value */
 		unsigned int o = IG->p0;
 		GTRACE1("L_LXS2",o);
-		DR1.d = sim_read_word(AR1.d + BT24(BitDATA16, mode));
+		DR1.d = sim_read_word(mem_ref + BT24(BitDATA16, mode));
 		SetSegReal(DR1.w.l, o);
 		}
 		break;
@@ -573,7 +617,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		break;
 
 	case L_DI_R1: {
-		dosaddr_t addr = AR1.d;
+		dosaddr_t addr = mem_ref;
 		GTRACE0("L_DI");
 		if (mode & (MBYTE|MBYTX)) {
 		    DR1.b.bl = sim_read_byte(addr);
@@ -588,7 +632,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		}
 		break;
 	case S_DI: {
-		dosaddr_t addr = AR1.d;
+		dosaddr_t addr = mem_ref;
 		GTRACE0("S_DI");
 		if (mode&MBYTE) {
 		    sim_write_byte(addr, DR1.b.bl);
@@ -1510,19 +1554,6 @@ static unsigned int Gen_sim(const IGen *IG)
 			CPULONG(Ofs_EDX) = (DR1.b.b3&0x80? 0xffffffff:0);
 		}
 		break;
-	case O_XLAT: {
-		unsigned int ofs = IG->p0;
-		unsigned int offset;
-		GTRACE1("XLAT",ofs);
-		AR1.d = CPULONG(ofs);
-		offset = CPULONG(Ofs_EBX) + CPUBYTE(Ofs_AL);
-		if (mode & ADDR16) {
-			offset &= 0xFFFF;
-		}
-		AR1.d += offset;
-		}
-		break;
-
 	case O_ROL: {		// O(if sh==1),C(if sh>0)
 		unsigned int o = IG->p0;
 		unsigned int sh, rbef, raft, cy;
@@ -2082,46 +2113,12 @@ static unsigned int Gen_sim(const IGen *IG)
 		}
 		break;
 
-	case O_INT: {
-		unsigned char intno = IG->p0;
-		// Check bitmap, GPF if revectored
-		if (test_bit(intno, &TheCPU.int_revectored)) {
-			P0 = (dosaddr_t)IG->p1;
-			TheCPU.err2 = EXCP0D_GPF;
-		}
-		else {
-			AR1.d = intno * 4;
-		} }
-		break;
-
-	case O_MOVS_SetA: {
-		unsigned int ofs = IG->p0;
-		GTRACE1("O_MOVS_SetA",ofs);
-		if (mode&ADDR16) {
-		    if (mode&MOVSSRC) {
-			AR1.d = CPULONG(ofs);
-			AR1.d += CPUWORD(Ofs_SI);
-		    } else {
-	    		AR1.d = CPULONG(Ofs_XES);
-			AR1.d += CPUWORD(Ofs_DI);
-
-		    }
-		}
-		else {
-		    if (mode&MOVSSRC) {
-			AR1.d = CPULONG(ofs) + CPULONG(Ofs_ESI);
-		    } else {
-	    		AR1.d = CPULONG(Ofs_XES) + CPULONG(Ofs_EDI);
-		    }
-		}
-		}
-		break;
-
 	case O_MOVS_MovD: {
-		wkreg SR1, DR2, AR2;
+		wkreg SR1, DR2, AR1, AR2;
 		unsigned int i;
 		DR2.d = CPUWORD(Ofs_SI); /* for overflow calc */
 		SR1.d = CPUWORD(Ofs_DI); /* for overflow calc */
+		AR1.d = mem_ref;
 		AR2.d = CPULONG(Ofs_XES);
 		if (mode&ADDR16) {
 		    AR2.d += CPUWORD(Ofs_DI);
@@ -2166,7 +2163,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		    }
 		}
 		dest = AR2.d;
-		src = AR1.d;
+		src = mem_ref;
 		if (df<0) {
 		    if (mode&MBYTE) {
 			while (i--) sim_write_byte(dest--, sim_read_byte(src--));
@@ -2246,7 +2243,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		if (mode&(MREP|MREPNE))	{
 		    dbug_printf("odd: REP LODS %d\n",i);
 		}
-		addr = AR1.d;
+		addr = mem_ref;
 		if (mode&MBYTE) {
 		    while (i--) { DR1.b.bl = sim_read_byte(addr); addr += df; }
 		}
@@ -2260,9 +2257,10 @@ static unsigned int Gen_sim(const IGen *IG)
 		}
 		break;
 	case O_MOVS_StoD: {
-		wkreg SR1;
+		wkreg SR1, AR1;
 		unsigned int i;
 		SR1.d = CPUWORD(Ofs_DI); /* for overflow calc */
+		AR1.d = mem_ref;
 		if (mode&ADDR16)
 		    i = (mode&(MREP|MREPNE)? CPUWORD(Ofs_CX) : 1);
 		else
@@ -2333,7 +2331,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		GTRACE4("O_MOVS_ScaD",0xff,0xff,df,i);
 		if (i == 0) break; /* eCX = 0, no-op, no flags updated */
 		z = k = (mode&MREP? 1:0);
-		addr = AR1.d - di;
+		addr = mem_ref - di;
 		while (i && (z==k)) {
 		    if (mode&MBYTE) {
 			S1 = DR1.b.bl;
@@ -2398,7 +2396,7 @@ static unsigned int Gen_sim(const IGen *IG)
 		if (i == 0) break; /* eCX = 0, no-op, no flags updated */
 		z = k = (mode&MREP? 1:0);
 		si = (mode&ADDR16) ? CPUWORD(Ofs_SI) : CPULONG(Ofs_ESI);
-		addr2 = AR1.d - si;
+		addr2 = mem_ref - si;
 		while (i && (z==k)) {
 		    if (mode&MBYTE) {
 			S1 = sim_read_byte(addr2+si);
@@ -2578,12 +2576,12 @@ static unsigned int Gen_sim(const IGen *IG)
 		}
 		if (!(mode & RM_REG) && o1 < 0x20) {
 			/* add bit offset to effective address */
-			AR1.d += (mode&DATA16) ? 2*(DR2.d>>4) : 4*(DR2.d>>5);
+			mem_ref += (mode&DATA16) ? 2*(DR2.d>>4) : 4*(DR2.d>>5);
 			if (mode & DATA16) {
-				DR1.d = sim_read_word(AR1.d);
+				DR1.d = sim_read_word(mem_ref);
 			}
 			else {
-				DR1.d = sim_read_dword(AR1.d);
+				DR1.d = sim_read_dword(mem_ref);
 			}
 		}
 		if (mode & DATA16) DR1.d = DR1.w.l;
@@ -2599,10 +2597,10 @@ static unsigned int Gen_sim(const IGen *IG)
 		}
 		if (!(mode & RM_REG) && o1 < 0x20 && o1 != 0x03) {
 			if (mode & DATA16) {
-				sim_write_word(AR1.d, DR1.w.l);
+				sim_write_word(mem_ref, DR1.w.l);
 			}
 			else {
-				sim_write_dword(AR1.d, DR1.d);
+				sim_write_dword(mem_ref, DR1.d);
 			}
 		}
 		} break;
@@ -2807,7 +2805,7 @@ static unsigned int Gen_sim(const IGen *IG)
 	if (debug_level('e')>6) {
 #endif
 	    dbug_printf("(R) DR1=%08x AR1=%08x\n",
-		DR1.d,AR1.d);
+		DR1.d,mem_ref);
 	    dbug_printf("(R) RFL cout=%08x RES=%08x\n",
 		RFL.cout,RFL.res);
 //	    if (debug_level('e')==9) dbug_printf("\n%s",e_print_regs());
@@ -2829,29 +2827,33 @@ static unsigned char *CodeGen_sim(unsigned char *CodePtr, unsigned char *BaseGen
 	return CodePtr + sizeof(*IG);
 }
 
-static unsigned Exec_sim(unsigned *mem_ref, unsigned long *flg,
+static unsigned Exec_sim(unsigned *pmem_ref, unsigned long *flg,
 			 unsigned char *ecpu, void *SeqStart,
 			 unsigned short seqflg)
 {
 	IGen *IG = SeqStart;
 	unsigned int P0;
+	dosaddr_t mem_ref = 0;
 
 	FlagSync_RFL(*flg);
 	do {
-		if (IG->op >= A_DI_0 && IG->op <= A_DI_2D) {
-			AR1.d = AddrGen_sim(IG);
+		if (IG->op <= O_MOVS_SetA) {
+			mem_ref = AddrGen_sim(IG);
 			if (TheCPU.err2 == EXCP0D_GPF) {
-				P0 =  FindPC((unsigned char *)IG);
+				if (IG->op == O_INT)
+					P0 = (dosaddr_t)IG->p1;
+				else
+					P0 =  FindPC((unsigned char *)IG);
 				break;
 			}
 			IG++;
 		} // no need for "else", a non-addr op always follows
 		currentIG = (unsigned char *)IG;
-		P0 = Gen_sim(IG);
+		P0 = Gen_sim(IG, mem_ref);
 		IG++;
 	} while (P0 == (unsigned int)-1);
 	currentIG = NULL;
-	*mem_ref = TheCPU.mem_ref;
+	*pmem_ref = mem_ref;
 	*flg = FlagSync_All();
 
 #ifdef DEBUG_MORE
@@ -2861,7 +2863,7 @@ static unsigned Exec_sim(unsigned *mem_ref, unsigned long *flg,
 #endif
 	{
 	    dbug_printf("(R) DR1=%08x AR1=%08x\n",
-		DR1.d,AR1.d);
+		DR1.d,mem_ref);
 	    dbug_printf("(R) RFL cout=%08x RES=%08x\n\n",
 		RFL.cout,RFL.res);
 	}

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -555,17 +555,15 @@ static unsigned int Gen_sim(const IGen *IG)
 		GTRACE1("L_LXS1",o);
 		if (mode&DATA16) {
 		    CPUWORD(o) = DR1.w.l = sim_read_word(AR1.d);
-		    AR1.d += 2;
 		}
 		else {
 		    CPULONG(o) = DR1.d = sim_read_dword(AR1.d);
-		    AR1.d += 4;
 		} }
 		break;
 	case L_LXS2: {	/* real mode segment base from segment value */
 		unsigned int o = IG->p0;
 		GTRACE1("L_LXS2",o);
-		DR1.d = sim_read_word(AR1.d);
+		DR1.d = sim_read_word(AR1.d + BT24(BitDATA16, mode));
 		SetSegReal(DR1.w.l, o);
 		}
 		break;

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -2232,16 +2232,6 @@ static unsigned int Gen_sim(const IGen *IG)
 		    }
 		}
 		} while (1);
-		AR2.d -= CPULONG(Ofs_XES);
-		if (mode&ADDR16) {
-		    CPUWORD(Ofs_DI) = AR2.w.l;
-		    if (mode&(MREP|MREPNE))
-			CPUWORD(Ofs_CX) = 0;
-		} else {
-		    CPULONG(Ofs_EDI) = AR2.d;
-		    if (mode&(MREP|MREPNE))
-			CPULONG(Ofs_ECX) = 0;
-		}
 		}
 		break;
 	case O_MOVS_LodD: {
@@ -2266,13 +2256,6 @@ static unsigned int Gen_sim(const IGen *IG)
 		else {
 		    while (i--) { DR1.d = sim_read_dword(addr); addr += 4*df; }
 		}
-		if (mode&(MREP|MREPNE)) {
-		    if (mode&ADDR16)
-			CPUWORD(Ofs_CX) = 0;
-		    else
-			CPULONG(Ofs_ECX) = 0;
-		}
-		AR1.d = addr;
 		// ! Warning DI,SI wrap	in 16-bit mode
 		}
 		break;
@@ -2333,86 +2316,79 @@ static unsigned int Gen_sim(const IGen *IG)
 		SR1.d = (df == -1 ? 0xffff : 0);
 		AR1.d -= 0x10000*df;
 		} while (1);
-		if (mode&(MREP|MREPNE)) {
-		    if (mode&ADDR16)
-			CPUWORD(Ofs_CX) = 0;
-		    else
-			CPULONG(Ofs_ECX) = 0;
-		}
 		}
 		break;
-	case O_MOVS_ScaD: {	// OSZAPC
+	case O_MOVS_ScaD: {	// OSZAPC, never called with rep
 		int df = (CPUWORD(Ofs_FLAGS) & EFLAGS_DF? -1:1);
 		dosaddr_t addr;
-		unsigned int i;
+		unsigned int i, di;
 		char k, z;
-		if (mode&ADDR16)
-		    i = (mode&(MREP|MREPNE)? CPUWORD(Ofs_CX) : 1);
-		else
-		    i = (mode&(MREP|MREPNE)? CPULONG(Ofs_ECX) : 1);
+		if (mode&ADDR16) {
+		    i = CPUWORD(Ofs_CX);
+		    di = CPUWORD(Ofs_DI);
+		} else {
+		    i = CPULONG(Ofs_ECX);
+		    di = CPULONG(Ofs_EDI);
+		}
 		GTRACE4("O_MOVS_ScaD",0xff,0xff,df,i);
 		if (i == 0) break; /* eCX = 0, no-op, no flags updated */
 		z = k = (mode&MREP? 1:0);
-		addr = AR1.d;
+		addr = AR1.d - di;
 		while (i && (z==k)) {
 		    if (mode&MBYTE) {
 			S1 = DR1.b.bl;
-			S2 = sim_read_byte(addr);
+			S2 = sim_read_byte(addr+di);
 			FlagHandleSub(S1, S2, (int8_t)(S1 - S2), 8);
-			addr += df;
+			di += df;
 		    }
 		    else if (mode&DATA16) {
 			S1 = DR1.w.l;
-			S2 = sim_read_word(addr);
+			S2 = sim_read_word(addr+di);
 			FlagHandleSub(S1, S2, (int16_t)(S1 - S2), 16);
-			addr += 2*df;
+			di += 2*df;
 		    }
 		    else {
 			S1 = DR1.d;
-			S2 = sim_read_dword(addr);
+			S2 = sim_read_dword(addr+di);
 			FlagHandleSub(S1, S2, S1 - S2, 32);
-			addr += 4*df;
+			di += 4*df;
 		    }
+		    if (mode&ADDR16) di &= 0xffff;
 		    z = (RFL.res==0);
 		    i--;
 		}
-		AR1.d = addr;
-		if (mode&(MREP|MREPNE)) {
-		    if (mode&ADDR16)
-			CPUWORD(Ofs_CX) = i;
-		    else
-			CPULONG(Ofs_ECX) = i;
+		if (mode&ADDR16) {
+		    CPUWORD(Ofs_CX) = i;
+		    CPUWORD(Ofs_DI) = di;
 		}
-		// ! Warning DI,SI wrap	in 16-bit mode
+		else {
+		    CPULONG(Ofs_ECX) = i;
+		    CPULONG(Ofs_EDI) = di;
+		}
 		}
 		break;
 	case O_MOVS_CmpD: {	// OSZAPC
-		wkreg AR2;
 		int df;
 		dosaddr_t addr1, addr2;
-		unsigned int i;
+		unsigned int i, si, di;
 		char k, z;
-		AR2.d = CPULONG(Ofs_XES);
-		if (mode&ADDR16)
-		    AR2.d += CPUWORD(Ofs_DI);
-		else
-		    AR2.d += CPULONG(Ofs_EDI);
 		df = (CPUWORD(Ofs_FLAGS) & EFLAGS_DF? -1:1);
-		addr1 = AR2.d;
+		addr1 = CPULONG(Ofs_XES);
+		di = (mode&ADDR16) ? CPUWORD(Ofs_DI) : CPULONG(Ofs_EDI);
 		if(!(mode & (MREP|MREPNE))) {
 			GTRACE4("O_MOVS_CmpD",0xff,0xff,df,1);
 			// assumes DR1=*AR1
 			if (mode&MBYTE) {
 				S1 = DR1.b.bl;
-				S2 = sim_read_byte(addr1);
+				S2 = sim_read_byte(addr1+di);
 				FlagHandleSub(S1, S2, (int8_t)(S1 - S2), 8);
 			} else if (mode&DATA16) {
 				S1 = DR1.w.l;
-				S2 = sim_read_word(addr1);
+				S2 = sim_read_word(addr1+di);
 				FlagHandleSub(S1, S2, (int16_t)(S1 - S2), 16);
 			} else {
 				S1 = DR1.d;
-				S2 = sim_read_dword(addr1);
+				S2 = sim_read_dword(addr1+di);
 				FlagHandleSub(S1, S2, S1 - S2, 32);
 			}
 			break;
@@ -2421,38 +2397,38 @@ static unsigned int Gen_sim(const IGen *IG)
 		GTRACE4("O_MOVS_CmpD",0xff,0xff,df,i);
 		if (i == 0) break; /* eCX = 0, no-op, no flags updated */
 		z = k = (mode&MREP? 1:0);
-		addr2 = AR1.d;
+		si = (mode&ADDR16) ? CPUWORD(Ofs_SI) : CPULONG(Ofs_ESI);
+		addr2 = AR1.d - si;
 		while (i && (z==k)) {
 		    if (mode&MBYTE) {
-			S1 = sim_read_byte(addr2);
-			S2 = sim_read_byte(addr1);
+			S1 = sim_read_byte(addr2+si);
+			S2 = sim_read_byte(addr1+di);
 			FlagHandleSub(S1, S2, (int8_t)(S1 - S2), 8);
-			addr1 += df; addr2 += df;
+			si += df; di += df;
 		    }
 		    else if (mode&DATA16) {
-			S1 = sim_read_word(addr2);
-			S2 = sim_read_word(addr1);
+			S1 = sim_read_word(addr2+si);
+			S2 = sim_read_word(addr1+di);
 			FlagHandleSub(S1, S2, (int16_t)(S1 - S2), 16);
-			addr1 += 2*df; addr2 += 2*df;
+			si += 2*df; di += 2*df;
 		    }
 		    else {
-			S1 = sim_read_dword(addr2);
-			S2 = sim_read_dword(addr1);
+			S1 = sim_read_dword(addr2+si);
+			S2 = sim_read_dword(addr1+di);
 			FlagHandleSub(S1, S2, S1 - S2, 32);
-			addr1 += 4*df; addr2 += 4*df;
+			si += 4*df; di += 4*df;
 		    }
+		    if (mode&ADDR16) {si &= 0xffff; di &= 0xffff;}
 		    z = (RFL.res==0);
 		    i--;
 		}
-		AR2.d = addr1;
-		AR1.d = addr2;
-		// ! Warning DI,SI wrap	in 16-bit mode
-		AR2.d -= CPULONG(Ofs_XES);
 		if (mode&ADDR16) {
-		    CPUWORD(Ofs_DI) = AR2.w.l;
+		    CPUWORD(Ofs_SI) = si;
+		    CPUWORD(Ofs_DI) = di;
 		    CPUWORD(Ofs_CX) = i;
 		} else {
-		    CPULONG(Ofs_EDI) = AR2.d;
+		    CPULONG(Ofs_ESI) = si;
+		    CPULONG(Ofs_EDI) = di;
 		    CPULONG(Ofs_ECX) = i;
 		}
 		}
@@ -2461,39 +2437,28 @@ static unsigned int Gen_sim(const IGen *IG)
 	case O_MOVS_SavA: {
 		unsigned int ofs = IG->p0;
 		GTRACE1("O_MOVS_SavA",ofs);
-		if (!(mode&(MREP|MREPNE))) {
+		if (!(mode&(MREP|MREPNE)) || !(mode&MREPCOND)) {
+		    unsigned int count = (mode&(MREP|MREPNE)) ? CPULONG(Ofs_ECX):1;
 		    wkreg DR2;
 		    // %%edx set to DF's increment
 		    DR2.d = (signed char)CPUBYTE(Ofs_DF_INCREMENTS+OPSIZEBIT(mode));
 		    if(mode & MOVSSRC) {
 			if (mode & ADDR16)
-			    CPUWORD(Ofs_SI) += DR2.w.l;
+			    CPUWORD(Ofs_SI) += DR2.w.l * (count & 0xffff);
 			else
-			    CPULONG(Ofs_SI) += DR2.d;
+			    CPULONG(Ofs_ESI) += DR2.d * count;
 		    }
 		    if(mode & MOVSDST) {
 			if (mode & ADDR16)
-			    CPUWORD(Ofs_DI) += DR2.w.l;
+			    CPUWORD(Ofs_DI) += DR2.w.l * (count & 0xffff);
 			else
-			    CPULONG(Ofs_DI) += DR2.d;
+			    CPULONG(Ofs_EDI) += DR2.d * count;
 		    }
-		}
-		else if (mode&ADDR16) {
-		    if (mode&MOVSSRC) {
-			AR1.d -= CPULONG(ofs);
-			CPUWORD(Ofs_SI) = AR1.w.l;
-		    } else {
-	    		AR1.d -= CPULONG(Ofs_XES);
-			CPUWORD(Ofs_DI) = AR1.w.l;
-		    }
-		}
-		else {
-		    if (mode&MOVSSRC) {
-			AR1.d -= CPULONG(ofs);
-			CPULONG(Ofs_ESI) = AR1.d;
-		    } else {
-	    		AR1.d -= CPULONG(Ofs_XES);
-			CPULONG(Ofs_EDI) = AR1.d;
+		    if(mode&(MREP|MREPNE)) {
+			if (mode & ADDR16)
+			    CPUWORD(Ofs_CX) = 0;
+			else
+			    CPULONG(Ofs_ECX) = 0;
 		    }
 		}
 		}

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -2084,23 +2084,28 @@ shrot0:
 				// movl offs(%%ebx),%%edx
 				G3M(0x8b,0x53,IG->p1,Cp);
 			}
-			if (mode & RM_REG) {
-				// OP{wl} %%{e}dx,%%{e}ax
-				Gen66(mode,Cp);	G3M(0x0f,(n+0xa0),0xd0,Cp);
-			}
-			else {
+			if (!(mode & RM_REG)) {
 				/* add bit offset to effective address */
+				// movl %%edx, %%eax
+				G2M(0x89,0xd0,Cp);
 				if (mode&DATA16) {
-					// shrl $4, %%edx
-					G3M(0xc1,0xea,0x04,Cp);
-					// leal (%%edi,%%edx,2), %%edi
-					G3M(0x8d,0x3c,0x57,Cp);
+					// shrl $4, %%eax
+					G3M(0xc1,0xe8,0x04,Cp);
+					// leal (%%edi,%%eax,2), %%edi
+					G3M(0x8d,0x3c,0x47,Cp);
 				} else {
-					// shrl $5, %%edx
-					G3M(0xc1,0xea,0x05,Cp);
-					// leal (%%edi,%%edx,4), %%edi
-					G3M(0x8d,0x3c,0x97,Cp);
+					// shrl $5, %%eax
+					G3M(0xc1,0xe8,0x05,Cp);
+					// leal (%%edi,%%eax,4), %%edi
+					G3M(0x8d,0x3c,0x87,Cp);
 				}
+				// mov (%%edi,%%ebp,1), %%{e}ax
+				Gen66(mode,Cp); G3M(0x8b,0x04,0x2f,Cp);
+			}
+			// OP{wl} %%{e}dx,%%{e}ax
+			Gen66(mode,Cp);	G3M(0x0f,(n+0xa0),0xd0,Cp);
+			if (!(mode & RM_REG) && n != 0x03) {
+				STD_WRITE_WL(mode);
 			}
 			break;
 		case 0x1c: /* BSF */

--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -43,15 +43,18 @@
 
 /////////////////////////////////////////////////////////////////////////////
 
-#define L_NOP		0
-
 /* #define LEA_DI_R	1 */
 #define A_DI_0		2
 #define A_DI_1		3
 #define A_DI_2		4
 #define A_DI_2D		5
-#define A_SR_SH4	6
-#define O_FOP		7
+#define O_XLAT		6
+#define O_INT		7
+#define O_MOVS_SetA	8
+/* The above all generate an address, the below only consume it
+   (except for string instructions O_MOVS_* in the JIT only) */
+
+#define A_SR_SH4	9
 
 #define L_REG		10
 #define S_REG		11
@@ -67,6 +70,7 @@
 #define L_CR0		21
 #define L_DI_R1		22
 #define S_DI		23
+#define L_NOP		24
 
 #define O_ADD_R		30
 #define O_OR_R		31
@@ -100,7 +104,7 @@
 #define O_SHR		59
 #define O_SAR		60
 #define O_OPAX		61
-#define O_XLAT		62
+#define O_FOP		62
 #define O_CJMP		63	// unused
 #define O_SLAHF		64
 #define O_SETFL		65
@@ -130,9 +134,7 @@
 #define O_POP2		90
 #define O_POP3		91
 #define O_LEAVE		92
-#define O_INT		93
 
-#define O_MOVS_SetA	100
 #define O_MOVS_MovD	101
 #define O_MOVS_SavA	102
 #define O_MOVS_LodD	103

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -3273,18 +3273,11 @@ repag0:
 				if (TheCPU.mode & RM_REG) {
 				    Gen(L_REG, _mode, REG3);
 				}
-				else {
-				    /* add bit offset to effective address,
-				       then load and store from there */
-				    Gen(O_BITOP, _mode, (opc2-0xa0), REG1);
-				    Gen(L_DI_R1, _mode);
-				}
-				Gen(O_BITOP, _mode|RM_REG, (opc2-0xa0), REG1);
+				Gen(O_BITOP, _mode | (TheCPU.mode & RM_REG),
+				    (opc2-0xa0), REG1);
 				if (opc2 != 0xa3) {
 				    if (TheCPU.mode & RM_REG)
 					Gen(S_REG, _mode, REG3);
-				    else
-					Gen(S_DI, _mode);
 				}
 				break;
 			case 0xbc: /* BSF */

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -359,10 +359,11 @@ static unsigned int _JumpGen(unsigned int P2, int mode, int opc,
 	case LOOP: case LOOPZ_LOOPE: case LOOPNZ_LOOPNE:
 		Gen(JLOOP_LINK, mode, opc, j_t, j_nt);
 		break;
-	case RETl: case RETlisp: case JMPli: case CALLli: // far ret, indirect
-	case INT:
+	case RETl: case RETlisp: // far ret, indirect
 		Gen(S_REG, mode|DATA16, Ofs_CS);
 		AddrGen(A_SR_SH4, mode, Ofs_CS, Ofs_XCS);
+		/* fall through */
+	case JMPli: case CALLli: case INT: // far jmp/call, indirect
 		Gen(L_REG, mode, Ofs_EIP);
 		/* fall through */
 	case RET: case RETisp: case JMPi: case CALLi: // ret, indirect
@@ -1996,7 +1997,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 				Gen(O_PUSHI, _mode, PC + 2 - LONG_CS);
 				Gen(O_SETFL, _mode, INT);
 				Gen(L_LXS1, _mode, Ofs_EIP);
-				Gen(L_DI_R1, _mode);
+				Gen(L_LXS2, _mode, Ofs_CS, Ofs_XCS);
 				PC = JumpGen(PC, _mode, opc, 2, P0, _flags);
 				if (debug_level('e')>1)
 					dbug_printf("EMU86: directly called int %#x ax=%#x at %#x:%#x\n",
@@ -2658,7 +2659,7 @@ repag0:
 					    Gen(O_PUSHI, _mode, oip);
 					}
 					Gen(L_LXS1, _mode, Ofs_EIP);
-					Gen(L_DI_R1, _mode);
+					Gen(L_LXS2, _mode, Ofs_CS, Ofs_XCS);
 					PC = JumpGen(PC, _mode, (opc<<8)|REG1, len,
 						P0, _flags);
 					if (debug_level('e')>2) {


### PR DESCRIPTION
Follow up to #2556 .

This one was a bit trickier: I separated the intermediate ops into ones that were producing an address and ones that were only using it, and eliminated the ones that were modifying it for later use, and then moved them together for quick classification in codegen.h

This affected O_XLAT (produces (E)BX+AL), O_INT (produces 4*intno), O_MOVS_SetA (overrideDS:eSI or ES:eDI), O_BITOP (which was called twice from interp.c, once to compute the offset, now does the work all inside), and L_LXS1/L_LXS2 (L_LXS2 no longer depends on L_LXS1 modifying the address). The rep-string instructions in the simulator now compute DI/SI directly without involving AR1.d, which also got overflow handling fixed in rep-cmps and rep-scas (the lazy way, by masking di/si every loop iteration)

The goal is here to make Gen_sim easier to optimize for a compiler and to make it easier to follow how mem_ref is used.
