### PR TITLE
simx86: Generate code for data segment loads in protected mode, by calling a C helper to `SetSegProt()`

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -447,7 +447,7 @@ static unsigned int Gen_sim(const IGen *IG, dosaddr_t mem_ref)
 	case A_SR_SH4: {	// real mode make base addr from seg
 		unsigned int o = IG->p0;
 		GTRACE1("A_SR_SH4",o);
-		SetSegReal(CPUWORD(o), o);
+		SetSegReal(DR1.w.l, o);
 		}
 		break;
 	case A_SR_PROT: {	// protected mode make base addr from seg

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -450,6 +450,15 @@ static unsigned int Gen_sim(const IGen *IG, dosaddr_t mem_ref)
 		SetSegReal(CPUWORD(o), o);
 		}
 		break;
+	case A_SR_PROT: {	// protected mode make base addr from seg
+		unsigned int o = IG->p0;
+		int e;
+		GTRACE1("A_SR_PROT",o);
+		e = SetDataSegProt(DR1.w.l, o);
+		if (e)
+			P0 = IG->p1;
+		}
+		break;
 	case L_NOP:
 		GTRACE0("L_NOP");
 		break;

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -613,12 +613,9 @@ static unsigned int Gen_sim(const IGen *IG, dosaddr_t mem_ref)
 		    CPULONG(o) = DR1.d = sim_read_dword(mem_ref);
 		} }
 		break;
-	case L_LXS2: {	/* real mode segment base from segment value */
-		unsigned int o = IG->p0;
-		GTRACE1("L_LXS2",o);
+	case L_LXS2:	/* real mode segment base from segment value */
+		GTRACE0("L_LXS2");
 		DR1.d = sim_read_word(mem_ref + BT24(BitDATA16, mode));
-		SetSegReal(DR1.w.l, o);
-		}
 		break;
 	case L_ZXAX:
 		GTRACE0("L_ZXAX");

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -272,6 +272,32 @@ static unsigned char *CodeGen_x86(unsigned char *CodePtr, unsigned char *BaseGen
 		G3M(0x89,0x43,IG->p1+4,Cp);
 		}
 		break;
+	case A_SR_PROT: {	// prot mode make base addr from seg
+		// pushb Ofs
+		G2M(0x6a,IG->p0,Cp)
+#ifdef __x86_64__
+		// popq %%rsi
+		G1(0x5e,Cp);
+		// movq %%rax,%%rdi
+		G2M(0x89,0xc7,Cp);
+#else
+		// pushl %eax
+		G1(0x50,Cp);
+#endif
+		// call Ofs_SetSegProt(%%ebx)
+		G3M(0xff,0x53,Ofs_SetSegProt(),Cp);
+#ifndef __x86_64__
+		// popl %edx; popl %edx
+		G2M(0x5a,0x5a,Cp);
+#endif
+		// or %%eax,%%eax
+		G2M(0x09,0xc0,Cp);
+		// jz skip
+		G2M(0x74,TAILSIZE,Cp);
+		// movl {exit_addr},%%eax; pop %%edx; ret
+		G1(0xb8,Cp); G4(IG->p1,Cp); G2M(0x5a,0xc3,Cp);
+		}
+		break;
 	case L_NOP:
 		G1(0x90,Cp);
 		break;

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -260,8 +260,10 @@ static unsigned char *CodeGen_x86(unsigned char *CodePtr, unsigned char *BaseGen
 		} }
 		break;
 	case A_SR_SH4: {	// real mode make base addr from seg
-		// movzwl ofs(%%ebx),%%eax
-		G4M(0x0f,0xb7,0x43,IG->p0,Cp);
+		// movw %%ax,offs(%%ebx)
+		G4M(0x66,0x89,0x43,IG->p0,Cp);
+		// movzwl %%ax,%%eax
+		G3(0xc0b70f,Cp);
 		// shll $4,%%eax
 		G3M(0xc1,0xe0,0x04,Cp);
 		// movl %%eax,ofs(%%ebx)

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -432,23 +432,15 @@ static unsigned char *CodeGen_x86(unsigned char *CodePtr, unsigned char *BaseGen
 		Gen66(mode,Cp); G3M(0x8b,0x04,0x2f,Cp);
 		// mov{wl} %%{e}ax,offs(%%ebx)
 		Gen66(mode,Cp);	G3M(0x89,0x43,IG->p0,Cp);
-		// leal {2|4}(%%edi),%%edi
-		G2M(0x8d,0x7f,Cp); G1((mode&DATA16? 2:4),Cp);
 		}
 		break;
-	case L_LXS2: {	/* real mode segment base from segment value */
+	case L_LXS2: {	/* load segment from memory + 2/4 */
+		// leal {2|4}(%%edi),%%edi
+		G2M(0x8d,0x7f,Cp); G1((mode&DATA16? 2:4),Cp);
 		// movzwl (%%edi,%%ebp,1),%%eax
 		G4M(0x0f,0xb7,0x04,0x2f,Cp);
-		// movw %%ax,ofs(%%ebx)
-		G4M(0x66,0x89,0x43,IG->p0,Cp);
-		// shll $4,%%eax
-		G3M(0xc1,0xe0,0x04,Cp);
-		// movl %%eax,ofs(%%ebx)
-		G3M(0x89,0x43,IG->p1,Cp);
-		// addl $0xffff,%eax
-		G1(0x05,Cp); G4(0x0000ffff,Cp);
-		// movl %%eax,ofs(%%ebx)
-		G3M(0x89,0x43,IG->p1+4,Cp);
+		// leal {-2|-4}(%%edi),%%edi
+		G2M(0x8d,0x7f,Cp); G1((mode&DATA16? -2:-4),Cp);
 		}
 		break;
 	case L_ZXAX:

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -275,6 +275,12 @@ static unsigned char *CodeGen_x86(unsigned char *CodePtr, unsigned char *BaseGen
 		}
 		break;
 	case A_SR_PROT: {	// prot mode make base addr from seg
+#ifdef __x86_64__
+		// pushq %rdi: save memory address for LDS etc.
+		G1(0x57,Cp);
+		// pushq %rsi: save stack address for O_POP3
+		G1(0x56,Cp);
+#endif
 		// pushb Ofs
 		G2M(0x6a,IG->p0,Cp)
 #ifdef __x86_64__
@@ -288,7 +294,10 @@ static unsigned char *CodeGen_x86(unsigned char *CodePtr, unsigned char *BaseGen
 #endif
 		// call Ofs_SetSegProt(%%ebx)
 		G3M(0xff,0x53,Ofs_SetSegProt(),Cp);
-#ifndef __x86_64__
+#ifdef __x86_64__
+		// popq %rsi; popq %rdi
+		G2M(0x5e,0x5f,Cp);
+#else
 		// popl %edx; popl %edx
 		G2M(0x5a,0x5a,Cp);
 #endif

--- a/src/base/emu-i386/simx86/codegen-x86.h
+++ b/src/base/emu-i386/simx86/codegen-x86.h
@@ -124,5 +124,6 @@ void NodeUnlinker(TNode *G);
 int Cpatch(sigcontext_t *scp);
 int UnCpatch(unsigned char *eip);
 void Cpatch_init(void);
+int Ofs_SetSegProt(void);
 
 #endif

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -647,7 +647,7 @@ unsigned int DoExec(TNode *G)
 		CEmuStat |= CeS_INHI;
 		CEmuStat &= ~CeS_TRAP;
 	} else {
-		CEmuStat &= ~(CeS_INHI|CeS_MOVSS);
+		CEmuStat &= ~CeS_INHI;
 		if (sigalrm_pending()) {
 			CEmuStat|=CeS_SIGPEND;
 			sigalrm_pending_w(0);

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -168,6 +168,7 @@ void AddrGen(int op, int mode, ...)
 		IG->p3 = sh;
 		}
 		break;
+	case A_SR_PROT:		// prot mode make base addr from seg
 	case A_SR_SH4: {	// real mode make base addr from seg
 		IG->p0 = va_arg(ap,unsigned int);
 		IG->p1 = va_arg(ap,unsigned int);

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -169,12 +169,9 @@ void AddrGen(int op, int mode, ...)
 		}
 		break;
 	case A_SR_PROT:		// prot mode make base addr from seg
-	case A_SR_SH4: {	// real mode make base addr from seg
+	case A_SR_SH4:		// real mode make base addr from seg
 		IG->p0 = va_arg(ap,unsigned int);
 		IG->p1 = va_arg(ap,unsigned int);
-		if (IG->p0 == Ofs_SS)
-			I->flags |= F_INHI;
-		}
 		break;
 	}
 	va_end(ap);
@@ -213,6 +210,7 @@ void Gen(int op, int mode, ...)
 	case L_CR0:
 	case L_ZXAX:
 	case L_DI_R1:
+	case L_LXS2:	/* load segment value from mem +2/4 */
 	case S_DI:
 	case O_NOT:
 	case O_NEG:
@@ -272,7 +270,6 @@ void Gen(int op, int mode, ...)
 		break;
 
 	case L_REG2REG:
-	case L_LXS2:	/* real mode segment base from segment value */
 	case O_XCHG_R:
 	case L_IMM:
 	case L_MOVZS:

--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -43,18 +43,19 @@
 
 /////////////////////////////////////////////////////////////////////////////
 
-/* #define LEA_DI_R	1 */
-#define A_DI_0		2
-#define A_DI_1		3
-#define A_DI_2		4
-#define A_DI_2D		5
-#define O_XLAT		6
-#define O_INT		7
-#define O_MOVS_SetA	8
+/* #define LEA_DI_R	0 */
+#define A_DI_0		1
+#define A_DI_1		2
+#define A_DI_2		3
+#define A_DI_2D		4
+#define O_XLAT		5
+#define O_INT		6
+#define O_MOVS_SetA	7
 /* The above all generate an address, the below only consume it
    (except for string instructions O_MOVS_* in the JIT only) */
 
-#define A_SR_SH4	9
+#define A_SR_SH4	8
+#define A_SR_PROT	9
 
 #define L_REG		10
 #define S_REG		11

--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -251,12 +251,6 @@ static __inline__ void POP(int m, uint32_t *w)
 	TheCPU.esp = (sp&TheCPU.StackMask) | (TheCPU.esp&~TheCPU.StackMask);
 }
 
-static __inline__ void TOS_WORD(int m, uint16_t *w)		// for segments
-{
-	unsigned int sp = TheCPU.esp & TheCPU.StackMask;
-	GetSWord(w);
-}
-
 static __inline__ void NOS_WORD(int m, uint16_t *w)		// for segments
 {
 	unsigned int sp = (TheCPU.esp+(m&DATA16? 2:4)) & TheCPU.StackMask;

--- a/src/base/emu-i386/simx86/cpatch.c
+++ b/src/base/emu-i386/simx86/cpatch.c
@@ -559,6 +559,7 @@ enum {
 	STUB_READ_8,
 	STUB_READ_16,
 	STUB_READ_32,
+	STUB_SETSEGPROT,
 	STUBS_LEN
 };
 static_assert(STUBS_LEN <= STUBS_LEN_MAX);
@@ -575,6 +576,12 @@ static_assert(STUBS_LEN <= STUBS_LEN_MAX);
 #define Ofs_stub_read_8 Ofs_stub(STUB_READ_8)
 #define Ofs_stub_read_16 Ofs_stub(STUB_READ_16)
 #define Ofs_stub_read_32 Ofs_stub(STUB_READ_32)
+typedef void (*stubfunc_t)(void);
+
+int Ofs_SetSegProt(void)
+{
+	return Ofs_stub(STUB_SETSEGPROT);
+}
 
 /* call N(%ebx) */
 #define JSRPATCH(p,N) *((short *)(p))=0x53ff;p[2]=N;
@@ -754,6 +761,7 @@ void Cpatch_init(void)
     TheCPU_struct.stub_func[STUB_READ_8] = stub_read_8;
     TheCPU_struct.stub_func[STUB_READ_16] = stub_read_16;
     TheCPU_struct.stub_func[STUB_READ_32] = stub_read_32;
+    TheCPU_struct.stub_func[STUB_SETSEGPROT] = (stubfunc_t)SetDataSegProt;
 }
 
 /* ======================================================================= */

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -1415,50 +1415,30 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			    CODE_FLUSH();
 			    goto illegal_op;
 			}
+			PC += ModRM(opc, PC, _mode);
+			Gen(L_LXS2, _mode);
 			if (REALADDR()) {
-			    PC += ModRM(opc, PC, _mode);
-			    Gen(L_LXS2, _mode);
 			    AddrGen(A_SR_SH4, _mode, Ofs_ES, Ofs_XES);
-			    Gen(L_LXS1, _mode, REG1);
 			}
 			else {
-			    unsigned short sv = 0;
-			    unsigned long rv;
-			    CODE_FLUSH();
-			    PC += ModRMSim(PC, _mode, OVERR_DS, OVERR_SS);
-			    rv = DataGetWL_U(_mode,TheCPU.mem_ref);
-			    TheCPU.mem_ref += BT24(BitDATA16, _mode);
-			    sv = GetDWord(TheCPU.mem_ref);
-			    TheCPU.err = MAKESEG(_mode, Ofs_ES, sv);
-			    if (TheCPU.err) return P0;
-			    SetCPU_WL(_mode, REG1, rv);
-			    TheCPU.es = sv;
+			    AddrGen(A_SR_PROT, _mode, Ofs_ES, P0);
 			}
+			Gen(L_LXS1, _mode, REG1);
 			break;
 /*c5*/	case LDS:
 			if (Fetch(PC+1) >= 0xc0) {
 			    CODE_FLUSH();
 			    goto illegal_op;
 			}
+			PC += ModRM(opc, PC, _mode);
+			Gen(L_LXS2, _mode);
 			if (REALADDR()) {
-			    PC += ModRM(opc, PC, _mode);
-			    Gen(L_LXS2, _mode);
 			    AddrGen(A_SR_SH4, _mode, Ofs_DS, Ofs_XDS);
-			    Gen(L_LXS1, _mode, REG1);
 			}
 			else {
-			    unsigned short sv = 0;
-			    unsigned long rv;
-			    CODE_FLUSH();
-			    PC += ModRMSim(PC, _mode, OVERR_DS, OVERR_SS);
-			    rv = DataGetWL_U(_mode,TheCPU.mem_ref);
-			    TheCPU.mem_ref += BT24(BitDATA16, _mode);
-			    sv = GetDWord(TheCPU.mem_ref);
-			    TheCPU.err = MAKESEG(_mode, Ofs_DS, sv);
-			    if (TheCPU.err) return P0;
-			    SetCPU_WL(_mode, REG1, rv);
-			    TheCPU.ds = sv;
+			    AddrGen(A_SR_PROT, _mode, Ofs_DS, P0);
 			}
+			Gen(L_LXS1, _mode, REG1);
 			break;
 /*8e*/	case MOVsrfrm:
 			PC += ModRM(opc, PC, _mode|SEGREG|DATA16|MLOAD);
@@ -3348,75 +3328,45 @@ repag0:
 				    CODE_FLUSH();
 				    goto illegal_op;
 				}
+				PC++; PC += ModRM(opc, PC, _mode);
+				Gen(L_LXS2, _mode);
 				if (REALADDR()) {
-				    PC++; PC += ModRM(opc, PC, _mode);
-				    Gen(L_LXS2, _mode);
 				    AddrGen(A_SR_SH4, _mode, Ofs_SS, Ofs_XSS);
-				    Gen(L_LXS1, _mode, REG1);
 				}
 				else {
-				    unsigned short sv = 0;
-				    unsigned long rv;
-				    CODE_FLUSH();
-				    PC++; PC += ModRMSim(PC, _mode, OVERR_DS, OVERR_SS);
-				    rv = DataGetWL_U(_mode,TheCPU.mem_ref);
-				    TheCPU.mem_ref += BT24(BitDATA16,_mode);
-				    sv = GetDWord(TheCPU.mem_ref);
-				    TheCPU.err = MAKESEG(_mode, Ofs_SS, sv);
-				    if (TheCPU.err) return P0;
-				    SetCPU_WL(_mode, REG1, rv);
-				    TheCPU.ss = sv;
+				    AddrGen(A_SR_PROT, _mode, Ofs_SS, P0);
 				}
+				Gen(L_LXS1, _mode, REG1);
 				break;
 			case 0xb4: /* LFS */
 				if (Fetch(PC+2) >= 0xc0) {
 				    CODE_FLUSH();
 				    goto illegal_op;
 				}
+				PC++; PC += ModRM(opc, PC, _mode);
+				Gen(L_LXS2, _mode);
 				if (REALADDR()) {
-				    PC++; PC += ModRM(opc, PC, _mode);
-				    Gen(L_LXS2, _mode);
 				    AddrGen(A_SR_SH4, _mode, Ofs_FS, Ofs_XFS);
-				    Gen(L_LXS1, _mode, REG1);
 				}
 				else {
-				    unsigned short sv = 0;
-				    unsigned long rv;
-				    CODE_FLUSH();
-				    PC++; PC += ModRMSim(PC, _mode, OVERR_DS, OVERR_SS);
-				    rv = DataGetWL_U(_mode,TheCPU.mem_ref);
-				    TheCPU.mem_ref += BT24(BitDATA16,_mode);
-				    sv = GetDWord(TheCPU.mem_ref);
-				    TheCPU.err = MAKESEG(_mode, Ofs_FS, sv);
-				    if (TheCPU.err) return P0;
-				    SetCPU_WL(_mode, REG1, rv);
-				    TheCPU.fs = sv;
+				    AddrGen(A_SR_PROT, _mode, Ofs_FS, P0);
 				}
+				Gen(L_LXS1, _mode, REG1);
 				break;
 			case 0xb5: /* LGS */
 				if (Fetch(PC+2) >= 0xc0) {
 				    CODE_FLUSH();
 				    goto illegal_op;
 				}
+				PC++; PC += ModRM(opc, PC, _mode);
+				Gen(L_LXS2, _mode);
 				if (REALADDR()) {
-				    PC++; PC += ModRM(opc, PC, _mode);
-				    Gen(L_LXS2, _mode);
 				    AddrGen(A_SR_SH4, _mode, Ofs_GS, Ofs_XGS);
-				    Gen(L_LXS1, _mode, REG1);
 				}
 				else {
-				    unsigned short sv = 0;
-				    unsigned long rv;
-				    CODE_FLUSH();
-				    PC++; PC += ModRMSim(PC, _mode, OVERR_DS, OVERR_SS);
-				    rv = DataGetWL_U(_mode,TheCPU.mem_ref);
-				    TheCPU.mem_ref += BT24(BitDATA16,_mode);
-				    sv = GetDWord(TheCPU.mem_ref);
-				    TheCPU.err = MAKESEG(_mode, Ofs_GS, sv);
-				    if (TheCPU.err) return P0;
-				    SetCPU_WL(_mode, REG1, rv);
-				    TheCPU.gs = sv;
+				    AddrGen(A_SR_PROT, _mode, Ofs_GS, P0);
 				}
+				Gen(L_LXS1, _mode, REG1);
 				break;
 			case 0xb6: /* MOVZXb */
 				PC++; PC += ModRM(opc, PC, _mode|MBYTX|MLOAD);

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -479,7 +479,7 @@ static unsigned int FindExecCode(unsigned int PC)
 		TotalNodesExecd++;
 #elif !defined(ASM_DUMP)
 		/* try fast inner loop if nothing special is going on */
-		if (!(EFLAGS & TF) && !(CEmuStat & (CeS_INHI|CeS_MOVSS)) &&
+		if (!(EFLAGS & TF) && !(CEmuStat & (CeS_INHI)) &&
 		    !debug_level('e') &&
 		    GoodNode(G, mode) && !(G->flags & (F_FPOP|F_INHI)))
 			PC = DoExec_fast(G);
@@ -644,19 +644,6 @@ static unsigned int interp_post(unsigned int PC, const int mode, unsigned P0,
 		if (CurrIMeta>=0 && (CEmuStat & CeS_TRAP)) {
 			P0 = PC;
 			CODE_FLUSH2(mode);
-		}
-		if (CEmuStat & CeS_MOVSS) {
-			/* following non-compiled (sim or protected mode)
-			   mov ss / pop ss only */
-			if (!(CEmuStat & CeS_INHI)) {
-				// directly following mov ss / pop ss
-				CEmuStat |= CeS_INHI;
-				CEmuStat &= ~CeS_TRAP;
-			} else {
-				// instruction after clear unconditionally
-				// even if it's another mov ss / pop ss
-				CEmuStat &= ~(CeS_INHI|CeS_MOVSS);
-			}
 		}
 		if (CEmuStat & CeS_INSTREMUx(PROTMODE())) {
 			if (debug_level('e')>1)

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -1481,39 +1481,21 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			    TheCPU.ds = sv;
 			}
 			break;
-/*8e*/	case MOVsrfrm:
+/*8e*/	case MOVsrfrm:	{
+			int seg;
+			PC += ModRM(opc, PC, _mode|SEGREG|DATA16|MLOAD);
+			seg = e_ofsseg(REG1);
+			if (seg == Ofs_XCS) {
+			    CODE_FLUSH();
+			    goto illegal_op;
+			}
 			if (REALADDR()) {
-			    int seg;
-			    PC += ModRM(opc, PC, _mode|SEGREG|DATA16|MLOAD);
-			    seg = e_ofsseg(REG1);
-			    if (seg == Ofs_XCS) {
-				CODE_FLUSH();
-				goto illegal_op;
-			    }
 			    Gen(S_REG, _mode|DATA16, REG1);
 			    AddrGen(A_SR_SH4, _mode, REG1, seg);
 			}
 			else {
-			    unsigned short sv = 0;
-			    CODE_FLUSH();
-			    PC += ModRMSim(PC, _mode|SEGREG, OVERR_DS, OVERR_SS);
-			    if (TheCPU.mode & RM_REG) {
-				sv = CPUWORD(REG3);
-			    } else {
-				sv = GetDWord(TheCPU.mem_ref);
-			    }
-			    TheCPU.err = MAKESEG(_mode, REG1, sv);
-			    if (TheCPU.err) return P0;
-			    switch (REG1) {
-				case Ofs_DS: TheCPU.ds=sv; break;
-				case Ofs_SS: TheCPU.ss=sv;
-				    CEmuStat |= CeS_MOVSS;
-				    break;
-				case Ofs_ES: TheCPU.es=sv; break;
-				case Ofs_FS: TheCPU.fs=sv; break;
-				case Ofs_GS: TheCPU.gs=sv; break;
-				default: goto illegal_op;
-			    }
+			    AddrGen(A_SR_PROT, _mode, REG1, P0);
+			}
 			}
 			break;
 

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -1017,6 +1017,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			    AddrGen(A_SR_PROT, _mode, Ofs_SS, P0);
 			    Gen(O_POP3, _mode|MPOPRM);
 			}
+			InstrMeta[CurrIMeta].flags |= F_INHI;
 			PC++;
 			break;
 /*1f*/	case POPds:	if (REALADDR()) {
@@ -1429,8 +1430,9 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			}
 			if (REALADDR()) {
 			    PC += ModRM(opc, PC, _mode);
+			    Gen(L_LXS2, _mode);
+			    AddrGen(A_SR_SH4, _mode, Ofs_ES, Ofs_XES);
 			    Gen(L_LXS1, _mode, REG1);
-			    Gen(L_LXS2, _mode, Ofs_ES, Ofs_XES);
 			}
 			else {
 			    unsigned short sv = 0;
@@ -1453,8 +1455,9 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			}
 			if (REALADDR()) {
 			    PC += ModRM(opc, PC, _mode);
+			    Gen(L_LXS2, _mode);
+			    AddrGen(A_SR_SH4, _mode, Ofs_DS, Ofs_XDS);
 			    Gen(L_LXS1, _mode, REG1);
-			    Gen(L_LXS2, _mode, Ofs_DS, Ofs_XDS);
 			}
 			else {
 			    unsigned short sv = 0;
@@ -1482,6 +1485,8 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			else {
 			    AddrGen(A_SR_PROT, _mode, REG1, P0);
 			}
+			if (REG1 == Ofs_SS)
+			    InstrMeta[CurrIMeta].flags |= F_INHI;
 			break;
 
 /*9b*/	case oWAIT:
@@ -1963,8 +1968,9 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 				Gen(O_PUSH, _mode);
 				Gen(O_PUSHI, _mode, PC + 2 - LONG_CS);
 				Gen(O_SETFL, _mode, INT);
+				Gen(L_LXS2, _mode);
+				AddrGen(A_SR_SH4, _mode, Ofs_CS, Ofs_XCS);
 				Gen(L_LXS1, _mode, Ofs_EIP);
-				Gen(L_LXS2, _mode, Ofs_CS, Ofs_XCS);
 				PC = JumpGen(PC, _mode, opc, 2, P0, _flags);
 				if (debug_level('e')>1)
 					dbug_printf("EMU86: directly called int %#x ax=%#x at %#x:%#x\n",
@@ -2625,8 +2631,9 @@ repag0:
 					    Gen(O_PUSH, _mode);
 					    Gen(O_PUSHI, _mode, oip);
 					}
+					Gen(L_LXS2, _mode);
+					AddrGen(A_SR_SH4, _mode, Ofs_CS, Ofs_XCS);
 					Gen(L_LXS1, _mode, Ofs_EIP);
-					Gen(L_LXS2, _mode, Ofs_CS, Ofs_XCS);
 					PC = JumpGen(PC, _mode, (opc<<8)|REG1, len,
 						P0, _flags);
 					if (debug_level('e')>2) {
@@ -3356,8 +3363,9 @@ repag0:
 				}
 				if (REALADDR()) {
 				    PC++; PC += ModRM(opc, PC, _mode);
+				    Gen(L_LXS2, _mode);
+				    AddrGen(A_SR_SH4, _mode, Ofs_SS, Ofs_XSS);
 				    Gen(L_LXS1, _mode, REG1);
-				    Gen(L_LXS2, _mode, Ofs_SS, Ofs_XSS);
 				}
 				else {
 				    unsigned short sv = 0;
@@ -3380,8 +3388,9 @@ repag0:
 				}
 				if (REALADDR()) {
 				    PC++; PC += ModRM(opc, PC, _mode);
+				    Gen(L_LXS2, _mode);
+				    AddrGen(A_SR_SH4, _mode, Ofs_FS, Ofs_XFS);
 				    Gen(L_LXS1, _mode, REG1);
-				    Gen(L_LXS2, _mode, Ofs_FS, Ofs_XFS);
 				}
 				else {
 				    unsigned short sv = 0;
@@ -3404,8 +3413,9 @@ repag0:
 				}
 				if (REALADDR()) {
 				    PC++; PC += ModRM(opc, PC, _mode);
+				    Gen(L_LXS2, _mode);
+				    AddrGen(A_SR_SH4, _mode, Ofs_GS, Ofs_XGS);
 				    Gen(L_LXS1, _mode, REG1);
-				    Gen(L_LXS2, _mode, Ofs_GS, Ofs_XGS);
 				}
 				else {
 				    unsigned short sv = 0;

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -998,13 +998,13 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			    Gen(O_POP, _mode);
 			    AddrGen(A_SR_SH4, _mode, Ofs_ES, Ofs_XES);
 			} else { /* restartable */
-			    unsigned short sv = 0;
-			    CODE_FLUSH();
-			    TOS_WORD(_mode, &sv);
-			    TheCPU.err = MAKESEG(_mode, Ofs_ES, sv);
-			    if (TheCPU.err) return P0;
-			    POP_ONLY(_mode);
-			    TheCPU.es = sv;
+			    Gen(O_POP1, _mode);
+			    Gen(O_POP2, _mode|MPOPRM, 0);
+			    /* same principle applies as for POPrm: this
+			       segment load may fault, above pops into
+			       temporary storage without adjusting (E)SP */
+			    AddrGen(A_SR_PROT, _mode, Ofs_ES, P0);
+			    Gen(O_POP3, _mode|MPOPRM);
 			}
 			PC++;
 			break;
@@ -1012,14 +1012,10 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			    Gen(O_POP, _mode);
 			    AddrGen(A_SR_SH4, _mode, Ofs_SS, Ofs_XSS);
 			} else { /* restartable */
-			    unsigned short sv = 0;
-			    CODE_FLUSH();
-			    TOS_WORD(_mode, &sv);
-			    TheCPU.err = MAKESEG(_mode, Ofs_SS, sv);
-			    if (TheCPU.err) return P0;
-			    POP_ONLY(_mode);
-			    TheCPU.ss = sv;
-			    CEmuStat |= CeS_MOVSS;
+			    Gen(O_POP1, _mode);
+			    Gen(O_POP2, _mode|MPOPRM, 0);
+			    AddrGen(A_SR_PROT, _mode, Ofs_SS, P0);
+			    Gen(O_POP3, _mode|MPOPRM);
 			}
 			PC++;
 			break;
@@ -1027,13 +1023,10 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			    Gen(O_POP, _mode);
 			    AddrGen(A_SR_SH4, _mode, Ofs_DS, Ofs_XDS);
 			} else { /* restartable */
-			    unsigned short sv = 0;
-			    CODE_FLUSH();
-			    TOS_WORD(_mode, &sv);
-			    TheCPU.err = MAKESEG(_mode, Ofs_DS, sv);
-			    if (TheCPU.err) return P0;
-			    POP_ONLY(_mode);
-			    TheCPU.ds = sv;
+			    Gen(O_POP1, _mode);
+			    Gen(O_POP2, _mode|MPOPRM, 0);
+			    AddrGen(A_SR_PROT, _mode, Ofs_DS, P0);
+			    Gen(O_POP3, _mode|MPOPRM);
 			}
 			PC++;
 			break;
@@ -3215,13 +3208,10 @@ repag0:
 				    Gen(O_POP, _mode);
 				    AddrGen(A_SR_SH4, _mode, Ofs_FS, Ofs_XFS);
 				} else { /* restartable */
-				    unsigned short sv = 0;
-				    CODE_FLUSH();
-				    TOS_WORD(_mode, &sv);
-				    TheCPU.err = MAKESEG(_mode, Ofs_FS, sv);
-				    if (TheCPU.err) return P0;
-				    POP_ONLY(_mode);
-				    TheCPU.fs = sv;
+				    Gen(O_POP1, _mode);
+				    Gen(O_POP2, _mode|MPOPRM, 0);
+				    AddrGen(A_SR_PROT, _mode, Ofs_FS, P0);
+				    Gen(O_POP3, _mode|MPOPRM);
 				}
 				PC+=2;
 				break;
@@ -3324,13 +3314,10 @@ repag0:
 				    Gen(O_POP, _mode);
 				    AddrGen(A_SR_SH4, _mode, Ofs_GS, Ofs_XGS);
 				} else { /* restartable */
-				    unsigned short sv = 0;
-				    CODE_FLUSH();
-				    TOS_WORD(_mode, &sv);
-				    TheCPU.err = MAKESEG(_mode, Ofs_GS, sv);
-				    if (TheCPU.err) return P0;
-				    POP_ONLY(_mode);
-				    TheCPU.gs = sv;
+				    Gen(O_POP1, _mode);
+				    Gen(O_POP2, _mode|MPOPRM, 0);
+				    AddrGen(A_SR_PROT, _mode, Ofs_GS, P0);
+				    Gen(O_POP3, _mode|MPOPRM);
 				}
 				PC+=2;
 				break;

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -331,7 +331,7 @@ static unsigned int _JumpGen(unsigned int P2, int mode, int opc,
 		break;
 	case JMPld: {   /* uncond jmp far */
 		unsigned short jcs = FetchW(P2 + pskip - 2);
-		Gen(L_IMM, mode|DATA16, Ofs_CS, jcs);
+		Gen(L_IMM_R1, mode|DATA16, jcs);
 		AddrGen(A_SR_SH4, mode, Ofs_CS, Ofs_XCS);
 	}
 	/* no break */
@@ -349,7 +349,7 @@ static unsigned int _JumpGen(unsigned int P2, int mode, int opc,
 		if (!(mode & DATA16)) // 32-bit segreg padding
 		    Gen(L_ZXAX, mode);
 		Gen(O_PUSH, mode);
-		Gen(L_IMM, mode|DATA16, Ofs_CS, jcs);
+		Gen(L_IMM_R1, mode|DATA16, jcs);
 		AddrGen(A_SR_SH4, mode, Ofs_CS, Ofs_XCS);
 	}
 	/* no break */
@@ -360,7 +360,6 @@ static unsigned int _JumpGen(unsigned int P2, int mode, int opc,
 		Gen(JLOOP_LINK, mode, opc, j_t, j_nt);
 		break;
 	case RETl: case RETlisp: // far ret, indirect
-		Gen(S_REG, mode|DATA16, Ofs_CS);
 		AddrGen(A_SR_SH4, mode, Ofs_CS, Ofs_XCS);
 		/* fall through */
 	case JMPli: case CALLli: case INT: // far jmp/call, indirect
@@ -997,7 +996,6 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 
 /*07*/	case POPes:	if (REALADDR()) {
 			    Gen(O_POP, _mode);
-			    Gen(S_REG, _mode, Ofs_ES);
 			    AddrGen(A_SR_SH4, _mode, Ofs_ES, Ofs_XES);
 			} else { /* restartable */
 			    unsigned short sv = 0;
@@ -1012,7 +1010,6 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			break;
 /*17*/	case POPss:	if (REALADDR()) {
 			    Gen(O_POP, _mode);
-			    Gen(S_REG, _mode, Ofs_SS);
 			    AddrGen(A_SR_SH4, _mode, Ofs_SS, Ofs_XSS);
 			} else { /* restartable */
 			    unsigned short sv = 0;
@@ -1028,7 +1025,6 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			break;
 /*1f*/	case POPds:	if (REALADDR()) {
 			    Gen(O_POP, _mode);
-			    Gen(S_REG, _mode, Ofs_DS);
 			    AddrGen(A_SR_SH4, _mode, Ofs_DS, Ofs_XDS);
 			} else { /* restartable */
 			    unsigned short sv = 0;
@@ -1481,21 +1477,17 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			    TheCPU.ds = sv;
 			}
 			break;
-/*8e*/	case MOVsrfrm:	{
-			int seg;
+/*8e*/	case MOVsrfrm:
 			PC += ModRM(opc, PC, _mode|SEGREG|DATA16|MLOAD);
-			seg = e_ofsseg(REG1);
-			if (seg == Ofs_XCS) {
+			if (REG1 == Ofs_CS) {
 			    CODE_FLUSH();
 			    goto illegal_op;
 			}
 			if (REALADDR()) {
-			    Gen(S_REG, _mode|DATA16, REG1);
-			    AddrGen(A_SR_SH4, _mode, REG1, seg);
+			    AddrGen(A_SR_SH4, _mode, REG1, e_ofsseg(REG1));
 			}
 			else {
 			    AddrGen(A_SR_PROT, _mode, REG1, P0);
-			}
 			}
 			break;
 
@@ -3221,7 +3213,6 @@ repag0:
 			case 0xa1: /* POPfs */
 				if (REALADDR()) {
 				    Gen(O_POP, _mode);
-				    Gen(S_REG, _mode, Ofs_FS);
 				    AddrGen(A_SR_SH4, _mode, Ofs_FS, Ofs_XFS);
 				} else { /* restartable */
 				    unsigned short sv = 0;
@@ -3331,7 +3322,6 @@ repag0:
 			case 0xa9: /* POPgs */
 				if (REALADDR()) {
 				    Gen(O_POP, _mode);
-				    Gen(S_REG, _mode, Ofs_GS);
 				    AddrGen(A_SR_SH4, _mode, Ofs_GS, Ofs_XGS);
 				} else { /* restartable */
 				    unsigned short sv = 0;

--- a/src/base/emu-i386/simx86/protmode.c
+++ b/src/base/emu-i386/simx86/protmode.c
@@ -93,6 +93,19 @@ int SetSegReal(unsigned short sel, int ofs)
 	return 0;
 }
 
+// not for CS; this function is called from JIT-generated code
+int SetDataSegProt(unsigned short sel, int ofs)
+{
+	unsigned char big;
+	int e = SetSegProt(TheCPU.basemode&ADDR16, ofs, &big, sel);
+	if (e) {
+		TheCPU.err2 = e;
+	} else if (ofs==Ofs_SS) {
+		TheCPU.StackMask = (big? 0xffffffff : 0x0000ffff);
+		if (debug_level('e')>1) e_printf("MAKESEG SS: big=%d basemode=%04x\n",big&1,TheCPU.basemode);
+	}
+	return e;
+}
 
 int SetSegProt(int a16, int ofs, unsigned char *big, unsigned long sel)
 {

--- a/src/base/emu-i386/simx86/protmode.h
+++ b/src/base/emu-i386/simx86/protmode.h
@@ -229,6 +229,7 @@ typedef struct {
 extern unsigned char e_ofsseg(int ofs);
 //
 int SetSegProt(int a16, int ofs, unsigned char *big, unsigned long sel);
+int SetDataSegProt(unsigned short sv, int ofs);
 int SetSegReal(unsigned short sel, int ofs);
 int e_larlsl(int mode, unsigned short sel);
 int hsw_verr(unsigned short sel);

--- a/src/include/cpu-emu.h
+++ b/src/include/cpu-emu.h
@@ -61,7 +61,6 @@ extern void e_priv_iopl(int);
 #define CeS_SIGACT	0x02	/* signal active mask */
 #define CeS_RPIC	0x04	/* pic asks for interruption */
 #define CeS_STI		0x08	/* IF active was popped */
-#define CeS_MOVSS	0x10	/* mov ss or pop ss interpreted */
 #define CeS_INHI	0x800	/* inhibit interrupts(pop ss; pop sp et sim.) */
 #define CeS_TRAP	0x1000	/* INT01 Sstep active */
 #define CeS_DRTRAP	0x2000	/* Debug Registers active */


### PR DESCRIPTION
These were some of the most common simulated instructions in `interp.c`: `pop segreg`/`mov segreg`/LDS...LSS. Ideally we could all handle them with Gen, but it's a little more complex for the ones that use CS, so so far it's just for DS,ES,FS,GS, and SS loads.