### PR TITLE
simx86: separate interpreter from execution a bit more

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -2842,6 +2842,10 @@ static unsigned Exec_sim(unsigned *pmem_ref, unsigned long *flg,
 	unsigned int P0;
 	dosaddr_t mem_ref = 0;
 
+	if (seqflg & F_FPOP)
+		/* mask all exceptions, and set rounding properly */
+		fp87_mask_except();
+
 	FlagSync_RFL(*flg);
 	do {
 		if (IG->op <= O_MOVS_SetA) {

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -1478,7 +1478,7 @@ static unsigned int Gen_sim(const IGen *IG, dosaddr_t mem_ref)
 			}
 		}
 		if (TheCPU.err2 == EXCP00_DIVZ)
-			P0 = _LONG_CS + (dosaddr_t)IG->p0;
+			P0 = LONG_CS + (dosaddr_t)IG->p0;
 		break;
 	case O_IDIV:		// no flags
 		GTRACE0("O_IDIV");
@@ -1537,7 +1537,7 @@ static unsigned int Gen_sim(const IGen *IG, dosaddr_t mem_ref)
 			}
 		}
 		if (TheCPU.err2 == EXCP00_DIVZ)
-			P0 = _LONG_CS + (dosaddr_t)IG->p0;
+			P0 = LONG_CS + (dosaddr_t)IG->p0;
 		break;
 	case O_CBWD:
 		GTRACE0("O_CBWD");
@@ -2728,7 +2728,7 @@ static unsigned int Gen_sim(const IGen *IG, dosaddr_t mem_ref)
 		break;
 
 	case JMP_INDIRECT:
-		P0 = _LONG_CS + ((mode & DATA16) ? DR1.w.l : DR1.d);
+		P0 = LONG_CS + ((mode & DATA16) ? DR1.w.l : DR1.d);
 		if (debug_level('e')>2)
 			dbug_printf("** Jump taken to %08x\n",P0);
 		break;
@@ -2900,14 +2900,13 @@ static void emu_pagefault_handler(dosaddr_t addr, int err, uint32_t op, int len)
 		return;
 	}
 	/* trigger an exception in DPMI */
-	/* Need to shutdown prejitter to touch LONG_CS and TheCPU.err
+	/* Need to shutdown prejitter to touch TheCPU.err
 	   to return to _Interp86() */
 	prejit_sync();
 	TheCPU.err = EXCP0E_PAGE;
 	TheCPU.scp_err = err;
 	TheCPU.cr[2] = addr;
 	if (currentIG) {
-		LONG_CS = _LONG_CS;
 		unsigned int P0 = FindPC(currentIG);
 		TheCPU.eip = P0 - LONG_CS;
 		EFLAGS = (EFLAGS & ~EFLAGS_CC) | FlagSync_All();

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -690,7 +690,6 @@ unsigned int DoExec_fast(TNode *G)
 	unsigned char *ecpu = CPUOFFS(0);
 	unsigned long flg = Exec_pre(ecpu);
 	unsigned int ePC, mem_ref;
-	unsigned mode = G->mode;
 
 	do {
 		ePC = Exec(&mem_ref, &flg, ecpu, G->addr, 0);
@@ -706,7 +705,7 @@ unsigned int DoExec_fast(TNode *G)
 			break;
 		}
 	} while (!TheCPU.err2 && (G=FindTree(ePC)) &&
-		 GoodNode(G, mode) && !(G->flags & (F_FPOP|F_INHI)));
+		 GoodNode(G) && !(G->flags & (F_FPOP|F_INHI)));
 
 	Exec_post(flg, mem_ref);
 	sigalrm_pending_w(0);

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -518,7 +518,7 @@ static CodeBuf *ProduceCode(unsigned int PC, IMeta *I0)
  *
  */
 
-TNode *Close(unsigned int PC, int mode)
+TNode *Close(unsigned int PC, unsigned int Interp_LONG_CS, int mode)
 {
 	IMeta *I0;
 	TNode *G;
@@ -551,7 +551,7 @@ TNode *Close(unsigned int PC, int mode)
 	 * if some other code tries to write over the page including
 	 * this node */
 	e_markpage(G->seqbase, G->seqlen);
-	G->cs = LONG_CS;
+	G->cs = Interp_LONG_CS;
 	G->mode = mode;
 	/* check links INSIDE current node */
 	if (0 == (EFLAGS & EFLAGS_TF) ) {

--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -182,6 +182,7 @@
 #define MPOPRM	0x00010000
 #define MRETISP	0x00020000
 #define MREALA	0x00040000
+#define MBIGCS	0x00080000
 
 #define CKSIGN	0x00100000	// check signal: for jumps
 // for HOST_ARCH_X86
@@ -281,7 +282,7 @@ void EndGen(void);
 extern void fp87_mask_except(void);
 extern void fp87_save_except(void);
 //
-static __inline__ int GoodNode(TNode *G, int mode)
+static __inline__ int GoodNode(TNode *G)
 {
 	if (G->cs != LONG_CS) {
 		/* CS mismatch can confuse relative jump/call */
@@ -289,10 +290,10 @@ static __inline__ int GoodNode(TNode *G, int mode)
 					G->key, G->cs, LONG_CS);
 		return 0;
 	}
-	if (G->mode != mode) {
-		/* mode mismatch can be 32/16 or MREALA */
+	if (G->mode != TheCPU.mode) {
+		/* mode mismatch can be 32/16(MBIGCS) or MREALA */
 		e_printf("mode mismatch at %08x: old=%x new=%x\n",
-					G->key, G->mode, mode);
+					G->key, G->mode, TheCPU.mode);
 		return 0;
 	}
 	return 1;

--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -278,7 +278,7 @@ extern unsigned (*Exec)(unsigned *mem_ref, unsigned long *flg,
 unsigned int DoExec(TNode *G);
 unsigned int DoExec_fast(TNode *G);
 void EndGen(void);
-extern void fp87_set_rounding(void);
+extern void fp87_mask_except(void);
 extern void fp87_save_except(void);
 //
 static __inline__ int GoodNode(TNode *G, int mode)

--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -270,7 +270,7 @@ extern int CurrIMeta;
 extern void Gen(int op, int mode, ...);
 extern void AddrGen(int op, int mode, ...);
 extern int  (*Fp87_op)(int exop, int reg, unsigned mem_ref);
-TNode *Close(unsigned int PC, int mode);
+TNode *Close(unsigned int PC, unsigned int Interp_LONGCS, int mode);
 extern unsigned char * (*CodeGen)(unsigned char *CodePtr,
 				  unsigned char *BaseGenBuf, const IGen *IG);
 extern unsigned (*Exec)(unsigned *mem_ref, unsigned long *flg,

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -235,7 +235,7 @@ static inline void exprintb(unsigned char val,char *bf,unsigned int pos)
 	while (v) { *p-- = ehextab[v&15]; v>>=4; }
 }
 
-char *e_print_regs(void)
+char *e_print_regs(unsigned int Interp_LONG_CS)
 {
 	static char buf[sizeof(eregbuf) + 300];
 	char *p = buf;
@@ -261,7 +261,7 @@ char *e_print_regs(void)
 	exprintl(TheCPU.eip,buf,(ERB_L4+ERB_LEFTM)+39);
 	{
 		int i;
-		dosaddr_t csp = LONG_CS+TheCPU.eip;
+		dosaddr_t csp = Interp_LONG_CS+TheCPU.eip;
 		dosaddr_t st = LONG_SS+TheCPU.esp;
 		if (csp < 0xa0000 - 256 || dpmi_is_valid_range(csp, 256)) {
 			unsigned char *op = EMU_BASE32(csp);
@@ -548,11 +548,10 @@ static void Reg2Cpu(struct vm86_struct *info)
 
   /* FPU state is loaded later on demand for JIT, not used for simulator */
   TheCPU.fpstate = &vm86_fpu_state;
-  LONG_CS = _LONG_CS;
   if (debug_level('e')>1) {
 	if (debug_level('e')==9) e_printf("Reg2Cpu< vm86=%08x dpm=%08x emu=%08x\n%s\n",
 		regs->eflags,get_FLAGS(TheCPU.eflags),TheCPU.eflags,
-		e_print_regs());
+		e_print_regs(LONG_CS));
 	else e_printf("Reg2Cpu< vm86=%08x dpm=%08x emu=%08x\n",
 		regs->eflags,get_FLAGS(TheCPU.eflags),TheCPU.eflags);
   }
@@ -725,10 +724,9 @@ erseg:
 	e_printf("Scp2CpuD%s: CS:IP=%08x:%08x\n%s\n",
 			(TheCPU.err? " ERR":""),
 			LONG_CS, _eip,
-			e_print_regs());
+			e_print_regs(LONG_CS));
   }
   TheCPU.mode = mode;
-  LONG_CS = _LONG_CS;
 }
 
 
@@ -1131,7 +1129,7 @@ static int e_dpmi_tail(cpuctx_t *scp)
       /* 0 if ok, else exception code+1 or negative if dosemu err */
       if (xval < 0) {
         error("DPM86: error %d\n", -xval);
-        error("@\n%s",e_print_regs());
+        error("@\n%s",e_print_regs(LONG_CS));
         leavedos_main(0);
         return -1;
       }

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -708,7 +708,7 @@ static void Scp2CpuD(cpuctx_t *scp)
   InvalidateSegs(); // makes sure real mode segs aren't confused with PM sels
   TheCPU.err = SetSegProt(mode&ADDR16,Ofs_CS,&big,_cs);
   if (TheCPU.err) goto erseg;
-  if (big) mode=0; else mode |= DATA16;
+  if (big) mode=MBIGCS; else mode |= DATA16;
 
   TheCPU.err = SetSegProt(mode&ADDR16,Ofs_DS,&big,_ds);
   if (TheCPU.err) goto erseg;

--- a/src/base/emu-i386/simx86/emu86.h
+++ b/src/base/emu-i386/simx86/emu86.h
@@ -743,7 +743,7 @@ int _ModRMSim(unsigned int PC, int mode, signed char overr_ds, signed char overr
 int ModGetReg1(unsigned int PC, int mode);
 //
 char *e_emu_disasm(unsigned char *org, int is32, unsigned int refseg);
-char *e_print_regs(void);
+char *e_print_regs(unsigned int Interp_LONGCS);
 char *e_print_scp_regs(cpuctx_t *scp, int pmode);
 const char *e_trace_fp(void);
 void GCPrint(unsigned char *cp, unsigned char *cbase, int len);

--- a/src/base/emu-i386/simx86/fp87-sim.c
+++ b/src/base/emu-i386/simx86/fp87-sim.c
@@ -116,7 +116,7 @@ void init_emu_npu (void)
 	WFR0 = WFR1 = 0.0;
 }
 
-void fp87_set_rounding(void)
+static void fp87_set_rounding(void)
 {
 	switch (TheCPU.fpuc & 0xc00) {
 	case 0x000: fesetround(FE_TONEAREST); break;
@@ -184,6 +184,17 @@ void fp87_save_except(void)
 #warning FPU exceptions unsupported
 #endif
 	TheCPU.fpus = (fps&~FPUS_TOP)|(TheCPU.fpstt<<FPUS_TOP_BIT);
+}
+
+void fp87_mask_except(void)
+{
+	if (TheCPU.fpstate) {
+		/* For simulator, only need to mask all
+		   exceptions, and set rounding properly */
+		fesetenv(FE_DFL_ENV);
+		fp87_set_rounding();
+	}
+	TheCPU.fpstate = NULL;
 }
 
 static float read_float(dosaddr_t addr)
@@ -1008,6 +1019,7 @@ fcom00:			TheCPU.fpus &= ~(FPUS_C0 | FPUS_C2 | FPUS_C3);
 //	25	DD xx100nnn	FRSTOR	94/108byte
 		    dosaddr_t p = mem_ref, q;
 		    TheCPU.fpuc = sim_read_word(p) | 0x40;
+		    fp87_mask_except();
 		    feclearexcept(FE_ALL_EXCEPT);
 		    fp87_set_rounding();
 		    if (reg&DATA16) {
@@ -1080,6 +1092,7 @@ fcom00:			TheCPU.fpus &= ~(FPUS_C0 | FPUS_C2 | FPUS_C3);
 		    unsigned fptag, ntag;
 //*	31	D9 xx110nnn	FSTENV	14/28byte
 //	35	DD xx110nnn	FSAVE	94/108byte
+		    fp87_mask_except();
 		    fp87_save_except();
 		    TheCPU.fpus = (TheCPU.fpus & ~FPUS_TOP) | (TheCPU.fpstt<<FPUS_TOP_BIT);
 //

--- a/src/base/emu-i386/simx86/fp87-x86.c
+++ b/src/base/emu-i386/simx86/fp87-x86.c
@@ -402,6 +402,12 @@ fp_ok:
 static int Fp87_op_x86_sim(int exop, int reg, unsigned mem_ref)
 {
 	e_printf("FPop %x.%d\n", exop, reg);
+	if (TheCPU.fpstate) {
+		/* load emulated FPU state into real FPU, if not already
+		   done so by Exec_x86 */
+		loadfpstate(*TheCPU.fpstate);
+		TheCPU.fpstate = NULL;
+	}
 
 	switch(exop) {
 /*21*/	case 0x21:

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -758,7 +758,7 @@ override:
 /*38*/	case CMPbfrm:
 intop28:		{ int m = _mode | MBYTE;
 			PC += ModRM(opc, PC, m);	// DI=mem
-			if (TheCPU.mode & RM_REG) {
+			if (REG3) {
 			    int op = ArOpsFR[D_MO(opc)];
 			    Gen(L_REG, m, REG1);	// mov al,[ebx+reg]
 			    Gen(op, m, REG3);		// op [ebx+rmreg],al	rmreg=rmreg op reg
@@ -813,7 +813,7 @@ intop3a:		{ int m = _mode | MBYTE;
 /*11*/	case ADCwfrm:
 /*39*/	case CMPwfrm:
 intop29:		PC += ModRM(opc, PC, _mode);	// DI=mem
-			if (TheCPU.mode & RM_REG) {
+			if (REG3) {
 			    int op = ArOpsFR[D_MO(opc)];
 			    Gen(L_REG, _mode, REG1);	// mov (e)ax,[ebx+reg]
 			    Gen(op, _mode, REG3);	// op [ebx+rmreg],(e)ax	rmreg=rmreg op reg
@@ -952,7 +952,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			unsigned short dest, src;
 			CODE_FLUSH();
 			PC += ModRMSim(PC, _mode, OVERR_DS, OVERR_SS);
-			if (TheCPU.mode & RM_REG) {
+			if (REG3) {
 				dest = CPUWORD(REG3);
 			} else {
 				dest = GetDWord(TheCPU.mem_ref);
@@ -961,7 +961,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			if ((dest & 3) < (src & 3)) {
 				EFLAGS |= EFLAGS_ZF;
 				dest = (dest & ~3) | (src & 3);
-				if (TheCPU.mode & RM_REG) {
+				if (REG3) {
 					CPUWORD(REG3) = dest;
 				} else {
 					WRITE_WORD(TheCPU.mem_ref, dest);
@@ -1227,7 +1227,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			// now calculate address. This way when using %esp
 			//	as index we use the value AFTER the pop
 			PC += ModRM(opc, PC, _mode|MPOPRM);
-			if (TheCPU.mode & RM_REG) {
+			if (REG3) {
 				// pop data into temporary storage and adjust esp
 				Gen(O_POP, _mode);
 				// store data
@@ -1276,7 +1276,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			int m = _mode | MBYTE;
 			int op = D_MO(Fetch(PC+1));
 			PC += ModRM(opc, PC, m);
-			if (TheCPU.mode & RM_REG) {
+			if (REG3) {
 				op = ArOpsFR[op];
 				// op [ebx+reg],#imm
 				Gen(op, m|IMMED, REG3, Fetch(PC));
@@ -1293,7 +1293,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 /*81*/	case IMMEDwrm: {
 			int op = D_MO(Fetch(PC+1));
 			PC += ModRM(opc, PC, _mode);
-			if (TheCPU.mode & RM_REG) {
+			if (REG3) {
 				op = ArOpsFR[op];
 				// op [ebx+reg],#imm
 				Gen(op, _mode|IMMED, REG3, DataFetchWL_U(_mode,PC));
@@ -1313,7 +1313,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			long v;
 			PC += ModRM(opc, PC, _mode);
 			v = (signed char)Fetch(PC);
-			if (TheCPU.mode & RM_REG) {
+			if (REG3) {
 				op = ArOpsFR[op];
 				// op [ebx+reg],#imm
 				Gen(op, _mode|IMMED, REG3, v);
@@ -1333,7 +1333,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			}
 			else {
 			    PC += ModRM(opc, PC, _mode|MBYTE|MLOAD);// al=[rm]
-			    if (TheCPU.mode & RM_REG) {
+			    if (REG3) {
 				Gen(O_XCHG, _mode|MBYTE, REG1);
 				Gen(S_REG, _mode|MBYTE, REG3);
 			    }
@@ -1349,7 +1349,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			}
 			else {
 			    PC += ModRM(opc, PC, _mode|MLOAD);	// (e)ax=[rm]
-			    if (TheCPU.mode & RM_REG) {
+			    if (REG3) {
 				Gen(O_XCHG, _mode, REG1);
 				Gen(S_REG, _mode, REG3);
 			    }
@@ -1394,7 +1394,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 /*8c*/	case MOVsrtrm:
 			PC += ModRM(opc, PC, _mode|SEGREG);
 			Gen(L_REG, _mode|DATA16, REG1);
-			if (TheCPU.mode & RM_REG) {
+			if (REG3) {
 			    if (!(_mode & DATA16))
 				Gen(L_ZXAX, _mode);
 			    Gen(S_REG, _mode, REG3);
@@ -1683,7 +1683,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 				Gen(O_SAR, m, count);
 				break;
 			}
-			if (TheCPU.mode & RM_REG)
+			if (REG3)
 				Gen(S_REG, m, REG3);
 			else
 				Gen(S_DI, m);
@@ -1727,7 +1727,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 				Gen(O_SAR, m, count);
 				break;
 			}
-			if (TheCPU.mode & RM_REG)
+			if (REG3)
 				Gen(S_REG, m, REG3);
 			else
 				Gen(S_DI, m);
@@ -1816,14 +1816,14 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			break;
 /*c6*/	case MOVbirm:
 			PC += ModRM(opc, PC, _mode|MBYTE);
-			if (TheCPU.mode & RM_REG)
+			if (REG3)
 			    Gen(L_IMM, _mode|MBYTE, REG3, Fetch(PC));
 			else
 			    Gen(S_DI_IMM, _mode|MBYTE, Fetch(PC));
 			PC++; break;
 /*c7*/	case MOVwirm:
 			PC += ModRM(opc, PC, _mode);
-			if (TheCPU.mode & RM_REG)
+			if (REG3)
 			    Gen(L_IMM, _mode, REG3, DataFetchWL_U(_mode,PC));
 			else
 			    Gen(S_DI_IMM, _mode, DataFetchWL_U(_mode,PC));
@@ -2340,14 +2340,14 @@ repag0:
 				break;
 			case Ofs_DL:	/*2*/	/* NOT */
 				Gen(O_NOT, _mode|MBYTE);			// not al
-				if (TheCPU.mode & RM_REG)
+				if (REG3)
 					Gen(S_REG, _mode|MBYTE, REG3);
 				else
 					Gen(S_DI, _mode|MBYTE);
 				break;
 			case Ofs_BL:	/*3*/	/* NEG */
 				Gen(O_NEG, _mode|MBYTE);			// neg al
-				if (TheCPU.mode & RM_REG)
+				if (REG3)
 					Gen(S_REG, _mode|MBYTE, REG3);
 				else
 					Gen(S_DI, _mode|MBYTE);
@@ -2376,14 +2376,14 @@ repag0:
 				break;
 			case Ofs_DX:	/*2*/	/* NOT */
 				Gen(O_NOT, _mode);			// not (e)ax
-				if (TheCPU.mode & RM_REG)
+				if (REG3)
 					Gen(S_REG, _mode, REG3);
 				else
 					Gen(S_DI, _mode);
 				break;
 			case Ofs_BX:	/*3*/	/* NEG */
 				Gen(O_NEG, _mode);			// neg (e)ax
-				if (TheCPU.mode & RM_REG)
+				if (REG3)
 					Gen(S_REG, _mode, REG3);
 				else
 					Gen(S_DI, _mode);
@@ -2567,7 +2567,7 @@ repag0:
 				int len = ModRM(opc, PC, _mode|NOFLDR);
 				dosaddr_t ret = PC + len - LONG_CS;
 				Gen(O_PUSHI, _mode, ret);
-				if (TheCPU.mode & RM_REG)
+				if (REG3)
 					Gen(L_REG, _mode, REG3);
 				else
 					Gen(L_DI_R1, _mode);
@@ -2935,7 +2935,7 @@ repag0:
 				    CODE_FLUSH();
 				    if (REALMODE()) goto illegal_op;
 				    PC += ModRMSim(PC+1, _mode, OVERR_DS, OVERR_SS) + 1;
-				    if (TheCPU.mode & RM_REG) {
+				    if (REG3) {
 					sv = CPUWORD(REG3);
 				    } else {
 					sv = GetDWord(TheCPU.mem_ref);
@@ -2951,7 +2951,7 @@ repag0:
 				    CODE_FLUSH();
 				    if (REALMODE()) goto illegal_op;
 				    PC += ModRMSim(PC+1, _mode, OVERR_DS, OVERR_SS) + 1;
-				    if (TheCPU.mode & RM_REG) {
+				    if (REG3) {
 					sv = CPUWORD(REG3);
 				    } else {
 					sv = GetDWord(TheCPU.mem_ref);
@@ -3007,7 +3007,7 @@ repag0:
 				CODE_FLUSH();
 				if (REALMODE()) goto illegal_op;
 				PC += ModRMSim(PC+1, _mode, OVERR_DS, OVERR_SS) + 1;
-				if (TheCPU.mode & RM_REG) {
+				if (REG3) {
 				    sv = CPUWORD(REG3);
 				} else {
 				    sv = GetDWord(TheCPU.mem_ref);
@@ -3195,20 +3195,19 @@ repag0:
 			case 0xb3: /* BTR */
 			case 0xbb: /* BTC */
 				PC++; PC += ModRM(opc, PC, _mode);
-				if (TheCPU.mode & RM_REG) {
+				if (REG3) {
 				    Gen(L_REG, _mode, REG3);
 				}
-				Gen(O_BITOP, _mode | (TheCPU.mode & RM_REG),
+				Gen(O_BITOP, _mode | (REG3 ? RM_REG : 0),
 				    (opc2-0xa0), REG1);
 				if (opc2 != 0xa3) {
-				    if (TheCPU.mode & RM_REG)
+				    if (REG3)
 					Gen(S_REG, _mode, REG3);
 				}
 				break;
 			case 0xbc: /* BSF */
 			case 0xbd: /* BSR */
 				PC++; PC += ModRM(opc, PC, _mode|MLOAD);
-				_mode |= (TheCPU.mode & RM_REG);
 				Gen(O_BITOP, _mode, (opc2-0xa0), REG1);
 				break;
 			case 0xba: { /* GRP8 - Code Extension 22 */
@@ -3225,10 +3224,9 @@ repag0:
 				case 0x30: /* BTR imm8 */
 				case 0x38: /* BTC imm8 */
 					PC++; PC += ModRM(opc, PC, _mode|MLOAD);
-					_mode |= (TheCPU.mode & RM_REG);
 					Gen(O_BITOP, _mode, opm, Fetch(PC));
 					if (opm != 0x20) {
-					    if (TheCPU.mode & RM_REG) {
+					    if (REG3) {
 						Gen(S_REG, _mode, REG3);
 					    }
 					    else {
@@ -3256,7 +3254,7 @@ repag0:
 					Gen(O_SHFD, _mode|IMMED, (opc2&8), REG1, Fetch(PC));
 					PC++;
 				}
-				if (TheCPU.mode & RM_REG)
+				if (REG3)
 					Gen(S_REG, _mode, REG3);
 				else
 					Gen(S_DI, _mode);
@@ -3294,18 +3292,16 @@ repag0:
 				break;
 			case 0xb0:		/* CMPXCHGb */
 				PC++; PC += ModRM(opc, PC, _mode|MBYTE|MLOAD);
-				_mode |= (TheCPU.mode & RM_REG);
 				Gen(O_CMPXCHG, _mode | MBYTE, REG1);
-				if (TheCPU.mode & RM_REG)
+				if (REG3)
 				    Gen(S_REG, _mode | MBYTE, REG3);
 				else
 				    Gen(S_DI, _mode | MBYTE);
 				break;
 			case 0xb1:		/* CMPXCHGw */
 				PC++; PC += ModRM(opc, PC, _mode|MLOAD);
-				_mode |= (TheCPU.mode & RM_REG);
 				Gen(O_CMPXCHG, _mode, REG1);
-				if (TheCPU.mode & RM_REG)
+				if (REG3)
 				    Gen(S_REG, _mode, REG3);
 				else
 				    Gen(S_DI, _mode);
@@ -3381,7 +3377,7 @@ repag0:
 				PC++; PC += ModRM(opc, PC, _mode|MBYTE|MLOAD);
 				Gen(O_XCHG, _mode | MBYTE, REG1);
 				Gen(O_ADD_R, _mode | MBYTE, REG1);
-				if (TheCPU.mode & RM_REG)
+				if (REG3)
 				    Gen(S_REG, _mode|MBYTE, REG3);
 				else
 				    Gen(S_DI, _mode|MBYTE);
@@ -3390,7 +3386,7 @@ repag0:
 				PC++; PC += ModRM(opc, PC, _mode|MLOAD);
 				Gen(O_XCHG, _mode, REG1);
 				Gen(O_ADD_R, _mode, REG1);
-				if (TheCPU.mode & RM_REG)
+				if (REG3)
 				    Gen(S_REG, _mode, REG3);
 				else
 				    Gen(S_DI, _mode);

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -69,7 +69,7 @@ int SpecPrejits;
 /* countdown to exit after handling VGAEMU faults, reset by
    planar VGA reads and writes */
 static int interp_inst_emu_count;
-unsigned int LONG_CS;
+static unsigned int Interp_LONG_CS;
 
 static int ArOpsR[] =
 	{ O_ADD_R, O_OR_R, O_ADC_R, O_SBB_R, O_AND_R, O_SUB_R, O_XOR_R, O_CMP_R };
@@ -119,7 +119,7 @@ static TNode *DoClose(unsigned int PC, int mode, unsigned int P0)
 			Fetch(abeg);
 	    }
 	}
-	return Close(PC, mode);
+	return Close(PC, Interp_LONG_CS, mode);
 }
 
 static unsigned int DoCloseAndExec(unsigned int PC, int mode, unsigned _P0)
@@ -130,7 +130,7 @@ static unsigned int DoCloseAndExec(unsigned int PC, int mode, unsigned _P0)
 	    return _P0;
 	ret = DoExec(G);
 	TheCPU.err = TheCPU.err2;
-	LONG_CS = _LONG_CS;
+	Interp_LONG_CS = LONG_CS;
 	return ret;
 }
 
@@ -194,7 +194,7 @@ static int MAKESEG(int mode, int ofs, unsigned short sv)
 	if (REALADDR()) {
 		e = SetSegReal(sv,ofs);
 		if (ofs == Ofs_CS)
-			LONG_CS = _LONG_CS;
+			Interp_LONG_CS = LONG_CS;
 		return e;
 	}
 
@@ -206,7 +206,7 @@ static int MAKESEG(int mode, int ofs, unsigned short sv)
 		if (big) TheCPU.mode |= MBIGCS;
 		else TheCPU.mode |= (ADDR16|DATA16);
 		if (debug_level('e')>1) e_printf("MAKESEG CS: big=%d basemode=%04x\n",big&1,TheCPU.mode);
-		LONG_CS = _LONG_CS;
+		Interp_LONG_CS = LONG_CS;
 	}
 	if (ofs==Ofs_SS) {
 		TheCPU.StackMask = (big? 0xffffffff : 0x0000ffff);
@@ -260,19 +260,19 @@ static unsigned int _JumpGen(unsigned int P2, int mode, int opc,
 				P2+pskip-BT24(BitDATA16,mode));
 
 		/* displacement for taken branch */
-		d_t = P2 - LONG_CS + dsp;
+		d_t = P2 - Interp_LONG_CS + dsp;
 		if (mode&DATA16) d_t &= 0xffff;
 
 		/* jump address for taken branch */
-		j_t = d_t + LONG_CS;
+		j_t = d_t + Interp_LONG_CS;
 	}
 
 	/* displacement for not taken branch */
-	d_nt = P2 - LONG_CS + pskip;
+	d_nt = P2 - Interp_LONG_CS + pskip;
 	if (mode&DATA16) d_nt &= 0xffff;
 
 	/* jump address for not taken branch, usually next instruction */
-	j_nt = d_nt + LONG_CS;
+	j_nt = d_nt + Interp_LONG_CS;
 	assert(j_nt > P2);
 	*r_P0 = j_nt;
 
@@ -289,9 +289,9 @@ static unsigned int _JumpGen(unsigned int P2, int mode, int opc,
 		  if (Fetch(P1)==JMPsid) {	/* eb xx */
 		    int dsp2 = (signed char)Fetch(P1+1) + 2;
 	    	    if (dsp2 < 0) mode |= CKSIGN;
-		    d_nt = P1 - LONG_CS + dsp2;
+		    d_nt = P1 - Interp_LONG_CS + dsp2;
 		    if (mode&DATA16) d_nt &= 0xffff;
-		    j_nt = d_nt + LONG_CS;
+		    j_nt = d_nt + Interp_LONG_CS;
 		    if (debug_level('e')>1)
 			e_printf("JMPs (%02x,%d) at %08x after Jcc: t=%08x nt=%08x\n",
 				 Fetch(P1),dsp2,P1,j_t,j_nt);
@@ -300,9 +300,9 @@ static unsigned int _JumpGen(unsigned int P2, int mode, int opc,
 		    int skp2 = BT24(BitDATA16,mode) + 1;
 		    int dsp2 = skp2 + (int)DataFetchWL_S(mode, P1+1);
 	    	    if (dsp2 < 0) mode |= CKSIGN;
-		    d_nt = P1 - LONG_CS + dsp2;
+		    d_nt = P1 - Interp_LONG_CS + dsp2;
 		    if (mode&DATA16) d_nt &= 0xffff;
-		    j_nt = d_nt + LONG_CS;
+		    j_nt = d_nt + Interp_LONG_CS;
 		    if (debug_level('e')>1)
 			e_printf("JMPl (%02x,%d) at %08x after Jcc: t=%08x nt=%08x\n",
 				 Fetch(P1),dsp2,P1,j_t,j_nt);
@@ -427,7 +427,7 @@ static unsigned int JumpGen(unsigned int P2, int mode, int opc, int pskip,
 				prejit_sync();
 #endif
 			TheCPU.err = TheCPU.err2;
-			LONG_CS = _LONG_CS;
+			Interp_LONG_CS = LONG_CS;
 		}
 	}
 	if (sigalrm_pending())
@@ -488,7 +488,7 @@ static unsigned int FindExecCode(unsigned int PC)
 #endif
 			PC = DoExec(G);
 		TheCPU.err = TheCPU.err2;
-		LONG_CS = _LONG_CS;
+		Interp_LONG_CS = LONG_CS;
 #if PROFILE
 		if (G->flags & F_PREJ)
 			PrejitNodesExecd++;
@@ -549,10 +549,10 @@ void Interp86(void)
     unsigned int ret;
 
     TheCPU.err2 = 0;
-    LONG_CS = _LONG_CS;
-    ret = _Interp86(LONG_CS + TheCPU.eip, TheCPU.mode);
+    Interp_LONG_CS = LONG_CS;
+    ret = _Interp86(Interp_LONG_CS + TheCPU.eip, TheCPU.mode);
     assert(CurrIMeta<0);
-    TheCPU.eip = ret - LONG_CS;
+    TheCPU.eip = ret - Interp_LONG_CS;
 }
 
 static unsigned int interp_pre(unsigned int PC, const int mode, int _flags)
@@ -611,7 +611,7 @@ static unsigned int interp_pre(unsigned int PC, const int mode, int _flags)
 		if (debug_level('e')>2) {
 			if (debug_level('e')>=9 && CurrIMeta<0)
 				/* if CurrIMeta was already >= 0, the registers are outdated */
-				dbug_printf("\n%s",e_print_regs());
+				dbug_printf("\n%s",e_print_regs(Interp_LONG_CS));
 			char *ds;
 			unsigned short ocs = TheCPU.cs;
 			ds = e_emu_disasm(EMU_BASE32(PC),mode&MBIGCS,ocs);
@@ -690,6 +690,7 @@ static unsigned int _Interp86(unsigned int PC, int basemode)
 		P0 = PC;
 		PC = InterpOne(PC, basemode, 0);
 		/* InterpOne can change CS */
+		Interp_LONG_CS = LONG_CS;
 		basemode = TheCPU.mode;
 		if (TheCPU.err) {
 			if (TheCPU.err == EXCP_RETRY) {
@@ -1744,15 +1745,15 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 /*ea*/	case JMPld:
 		    if (REALADDR()) {
 			int len = 3 + BT24(BitDATA16,_mode);
-			dosaddr_t oip = PC + len - LONG_CS;
+			dosaddr_t oip = PC + len - Interp_LONG_CS;
 			ocs = TheCPU.cs;
 			PC = JumpGen(PC, _mode, opc, len, P0, _flags);
 			if (debug_level('e')>2) {
 			    if (opc==CALLl)
 				e_printf("CALL_FAR: ret=%04x:%08x\n  calling:	   %04x:%08x\n",
-					 ocs,oip,TheCPU.cs,PC-LONG_CS);
+					 ocs,oip,TheCPU.cs,PC-Interp_LONG_CS);
 			    else
-				e_printf("JMP_FAR: %04x:%08x\n",TheCPU.cs,PC-LONG_CS);
+				e_printf("JMP_FAR: %04x:%08x\n",TheCPU.cs,PC-Interp_LONG_CS);
 			}
 			if (TheCPU.err) return PC;
 		    }
@@ -1767,7 +1768,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			PC+=2;
 			/* check if new cs is valid, save old for error */
 			ocs = TheCPU.cs;
-			xcs = LONG_CS;
+			xcs = Interp_LONG_CS;
 			TheCPU.err = MAKESEG(_mode, Ofs_CS, jcs);
 			if (TheCPU.err) {
 			    TheCPU.cs = ocs;
@@ -1789,7 +1790,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 				e_printf("JMP_FAR: %04x:%08lx\n",jcs,jip);
 			}
 			TheCPU.eip = jip;
-			PC = LONG_CS + jip;
+			PC = Interp_LONG_CS + jip;
 #ifdef SKIP_EMU_VBIOS
 			if ((jcs&0xf000)==config.vbios_seg) {
 			    /* return the new PC after the jump */
@@ -1804,13 +1805,13 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			Gen(O_POP, _mode|MRETISP, dr);
 			PC = JumpGen(PC, _mode, opc, 3, P0, _flags);
 			if (debug_level('e')>2)
-				e_printf("RET: ret=%08x inc_sp=%d\n",PC-LONG_CS,dr);
+				e_printf("RET: ret=%08x inc_sp=%d\n",PC-Interp_LONG_CS,dr);
 			if (TheCPU.err) return PC; }
 			break;
 /*c3*/	case RET:
 			Gen(O_POP, _mode);
 			PC = JumpGen(PC, _mode, opc, 1, P0, _flags);
-			if (debug_level('e')>2) e_printf("RET: ret=%08x\n",PC-LONG_CS);
+			if (debug_level('e')>2) e_printf("RET: ret=%08x\n",PC-Interp_LONG_CS);
 			if (TheCPU.err) return PC;
 			break;
 /*c6*/	case MOVbirm:
@@ -1900,7 +1901,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 				POP_ONLY(_mode);
 				if (debug_level('e')>2)
 					e_printf("RET_%x: ret=%08x\n",dr,TheCPU.eip);
-				PC = LONG_CS + TheCPU.eip;
+				PC = Interp_LONG_CS + TheCPU.eip;
 				temp = rESP + dr;
 				rESP = (temp&TheCPU.StackMask) | (rESP&~TheCPU.StackMask);
 			}
@@ -1932,7 +1933,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 				Gen(O_PUSH2F, _mode);
 				Gen(L_REG, _mode, Ofs_CS);
 				Gen(O_PUSH, _mode);
-				Gen(O_PUSHI, _mode, PC + 2 - LONG_CS);
+				Gen(O_PUSHI, _mode, PC + 2 - Interp_LONG_CS);
 				Gen(O_SETFL, _mode, INT);
 				Gen(L_LXS2, _mode);
 				AddrGen(A_SR_SH4, _mode, Ofs_CS, Ofs_XCS);
@@ -1940,7 +1941,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 				PC = JumpGen(PC, _mode, opc, 2, P0, _flags);
 				if (debug_level('e')>1)
 					dbug_printf("EMU86: directly called int %#x ax=%#x at %#x:%#x\n",
-						    inum, TheCPU.eax, TheCPU.cs, PC - LONG_CS);
+						    inum, TheCPU.eax, TheCPU.cs, PC - Interp_LONG_CS);
 				if (TheCPU.err) return PC;
 				break;
 			}
@@ -1960,11 +1961,11 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 				}
 				PUSH(_mode, temp);
 				PUSH(_mode, TheCPU.cs);
-				PUSH(_mode, PC + 2 - LONG_CS);
+				PUSH(_mode, PC + 2 - Interp_LONG_CS);
 				TheCPU.err = MAKESEG(_mode, Ofs_CS, segoffs >> 16);
 				if (TheCPU.err) return P0;
 				TheCPU.eip = segoffs & 0xffff;
-				PC = LONG_CS + TheCPU.eip;
+				PC = Interp_LONG_CS + TheCPU.eip;
 				EFLAGS &= ~(TF|RF|AC|NT);
 				EFLAGS &= ~(IOPL==3 ? EFLAGS_IF : EFLAGS_VIF);
 				if (debug_level('e')>1)
@@ -2009,7 +2010,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			if (TheCPU.err) return P0;
 			TheCPU.eip=0; POP(m, &TheCPU.eip);
 			POP_ONLY(m);
-			PC = LONG_CS + TheCPU.eip;
+			PC = Interp_LONG_CS + TheCPU.eip;
 			if (opc==RETl) {
 			    if (debug_level('e')>1)
 				e_printf("RET_FAR: ret=%04x:%08x\n",sv,TheCPU.eip);
@@ -2358,10 +2359,10 @@ repag0:
 				Gen(O_IMUL, _mode|MBYTE);		// al*[edi]->AX signed
 				break;
 			case Ofs_DH:	/*6*/	/* DIV AL */
-				Gen(O_DIV, _mode|MBYTE, P0 - LONG_CS);			// ah:al/[edi]->AH:AL unsigned
+				Gen(O_DIV, _mode|MBYTE, P0 - Interp_LONG_CS);			// ah:al/[edi]->AH:AL unsigned
 				break;
 			case Ofs_BH:	/*7*/	/* IDIV AL */
-				Gen(O_IDIV, _mode|MBYTE, P0 - LONG_CS);		// ah:al/[edi]->AH:AL signed
+				Gen(O_IDIV, _mode|MBYTE, P0 - Interp_LONG_CS);		// ah:al/[edi]->AH:AL signed
 				break;
 			} }
 			break;
@@ -2394,10 +2395,10 @@ repag0:
 				Gen(O_IMUL, _mode);			// (e)ax*[edi]->(E)DX:(E)AX signed
 				break;
 			case Ofs_SI:	/*6*/	/* DIV AX+DX */
-				Gen(O_DIV, _mode, P0 - LONG_CS);		// (e)ax:(e)dx/[edi]->(E)AX:(E)DX unsigned
+				Gen(O_DIV, _mode, P0 - Interp_LONG_CS);		// (e)ax:(e)dx/[edi]->(E)AX:(E)DX unsigned
 				break;
 			case Ofs_DI:	/*7*/	/* IDIV AX+DX */
-				Gen(O_IDIV, _mode, P0 - LONG_CS);		// (e)ax:(e)dx/[edi]->(E)AX:(E)DX signed
+				Gen(O_IDIV, _mode, P0 - Interp_LONG_CS);		// (e)ax:(e)dx/[edi]->(E)AX:(E)DX signed
 				break;
 			} }
 			break;
@@ -2564,7 +2565,7 @@ repag0:
 			case Ofs_DX: {	/*2*/	 // CALL near indirect
 				/* don't use MLOAD as O_PUSHI clobbers eax */
 				int len = ModRM(opc, PC, _mode|NOFLDR);
-				dosaddr_t ret = PC + len - LONG_CS;
+				dosaddr_t ret = PC + len - Interp_LONG_CS;
 				Gen(O_PUSHI, _mode, ret);
 				if (REG3)
 					Gen(L_REG, _mode, REG3);
@@ -2574,7 +2575,7 @@ repag0:
 					P0, _flags);
 				if (debug_level('e')>2)
 					e_printf("CALL indirect: ret=%08x\n\tcalling: %08x\n",
-						 ret,PC-LONG_CS);
+						 ret,PC-Interp_LONG_CS);
 				if (TheCPU.err) return PC;
 				}
 				break;
@@ -2590,7 +2591,7 @@ repag0:
 					ocs = TheCPU.cs;
 					if (REG1==Ofs_BX) {
 					    /* ok, now push old cs:eip */
-					    oip = PC + len - LONG_CS;
+					    oip = PC + len - Interp_LONG_CS;
 					    Gen(L_REG, _mode|DATA16, Ofs_CS);
 					    if (!(_mode & DATA16)) // padding
 						Gen(L_ZXAX, _mode);
@@ -2604,7 +2605,7 @@ repag0:
 						P0, _flags);
 					if (debug_level('e')>2) {
 					    unsigned short jcs = TheCPU.cs;
-					    dosaddr_t jip = PC - LONG_CS;
+					    dosaddr_t jip = PC - Interp_LONG_CS;
 					    if (REG1==Ofs_BX)
 						e_printf("CALL_FAR indirect: ret=%04x:%08x\n\tcalling: %04x:%08x\n",
 							 ocs,oip,jcs,jip);
@@ -2624,13 +2625,13 @@ repag0:
 					unsigned long oip,xcs,jip=0;
 					CODE_FLUSH();
 					PC += ModRMSim(PC, _mode|NOFLDR, OVERR_DS, OVERR_SS);
-					TheCPU.eip = PC - LONG_CS;
+					TheCPU.eip = PC - Interp_LONG_CS;
 					/* get new cs:ip */
 					jip = DataGetWL_U(_mode, TheCPU.mem_ref);
 					jcs = GetDWord(TheCPU.mem_ref+BT24(BitDATA16,_mode));
 					/* check if new cs is valid, save old for error */
 					ocs = TheCPU.cs;
-					xcs = LONG_CS;
+					xcs = Interp_LONG_CS;
 					TheCPU.err = MAKESEG(_mode, Ofs_CS, jcs);
 					if (TheCPU.err) {
 					    TheCPU.cs = ocs;
@@ -2652,7 +2653,7 @@ repag0:
 						e_printf("JMP_FAR indirect: %04x:%08lx\n",jcs,jip);
 					}
 					TheCPU.eip = jip;
-					PC = LONG_CS + jip;
+					PC = Interp_LONG_CS + jip;
 				}
 				break;
 			case Ofs_SI:	/*6*/	 // PUSH
@@ -3454,8 +3455,8 @@ repag0:
 			return P0;
 
 		/* check segment boundaries. TODO for prot _mode */
-		if (REALADDR() && (PC - LONG_CS > 0xffff)) {
-			e_printf("PC out of bounds, %x\n", PC - LONG_CS);
+		if (REALADDR() && (PC - Interp_LONG_CS > 0xffff)) {
+			e_printf("PC out of bounds, %x\n", PC - Interp_LONG_CS);
 			CODE_FLUSH();
 			goto not_permitted;
 		}
@@ -3525,7 +3526,7 @@ void PreJit86(unsigned int PC, int basemode)
 	if (e_querymark(PC, 1))
 		return;
 	TheCPU.err = 0;
-	LONG_CS = _LONG_CS;
+	Interp_LONG_CS = LONG_CS;
 	_PreJit86(PC, basemode, FLG_PREJIT);
 	e_mdrop();
 }

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -59,9 +59,9 @@ static pthread_t prejit_thr;
 static sem_t prejit_sem;
 static void *prejit_thread(void *arg);
 #if SPEC_PREJIT
-static void prejit_run(unsigned int PC);
+static void prejit_run(unsigned int PC, unsigned int basemode);
 #endif
-static unsigned int prejit_PC;
+static unsigned int prejit_PC, prejit_mode;
 #if PROFILE
 int SpecPrejits;
 #endif
@@ -176,7 +176,10 @@ static unsigned int do_flush(unsigned P0, unsigned _P0,
 			  } \
 			}
 
-#define UNPREFIX(m)	((m)&~(DATA16|ADDR16))|(basemode&(DATA16|ADDR16))
+static inline unsigned int UNPREFIX(unsigned int m)
+{
+	return (m&~(DATA16|ADDR16))|((m&MBIGCS)?0:(DATA16|ADDR16));
+}
 
 /////////////////////////////////////////////////////////////////////////////
 
@@ -199,7 +202,8 @@ static int MAKESEG(int mode, int ofs, unsigned short sv)
 	if (e)
 		return e;
 	if (ofs==Ofs_CS) {
-		if (big) TheCPU.mode &= ~(ADDR16|DATA16);
+		TheCPU.mode &= ~(ADDR16|DATA16|MBIGCS);
+		if (big) TheCPU.mode |= MBIGCS;
 		else TheCPU.mode |= (ADDR16|DATA16);
 		if (debug_level('e')>1) e_printf("MAKESEG CS: big=%d basemode=%04x\n",big&1,TheCPU.mode);
 		LONG_CS = _LONG_CS;
@@ -382,6 +386,7 @@ static unsigned int JumpGen(unsigned int P2, int mode, int opc, int pskip,
 #if SPEC_PREJIT
 		int can_speculate = 1;
 #endif
+		unsigned int basemode = UNPREFIX(mode);
 		TNode *G;
 		NewIMeta(P0, &_rc);
 #if SPEC_PREJIT
@@ -395,7 +400,7 @@ static unsigned int JumpGen(unsigned int P2, int mode, int opc, int pskip,
 			break;
 		}
 #endif
-		G = DoClose(_P0, TheCPU.basemode, InstrMeta[0].npc);
+		G = DoClose(_P0, basemode, InstrMeta[0].npc);
 		if (!G)
 			return P0;
 		if (_flags & FLG_PREJIT) {
@@ -408,12 +413,12 @@ static unsigned int JumpGen(unsigned int P2, int mode, int opc, int pskip,
 				if (debug_level('e')) {
 					char *ds;
 					unsigned short ocs = TheCPU.cs;
-					ds = e_emu_disasm(EMU_BASE32(P2),(~TheCPU.basemode&3),ocs);
+					ds = e_emu_disasm(EMU_BASE32(P2),mode&MBIGCS,ocs);
 					e_printf("prejit after  %s\n", ds);
-					ds = e_emu_disasm(EMU_BASE32(_P0),(~TheCPU.basemode&3),ocs);
+					ds = e_emu_disasm(EMU_BASE32(_P0),mode&MBIGCS,ocs);
 					e_printf("prejit at  %s\n", ds);
 				}
-				prejit_run(_P0);
+				prejit_run(_P0, basemode);
 			}
 #endif
 			_P1 = DoExec(G);
@@ -435,7 +440,6 @@ static unsigned int JumpGen(unsigned int P2, int mode, int opc, int pskip,
 #if !defined(SINGLESTEP)
 static unsigned int FindExecCode(unsigned int PC)
 {
-	int mode = TheCPU.mode;
 	TNode *G;
 
 	/* for a sequence to be found, it must begin with
@@ -446,7 +450,7 @@ static unsigned int FindExecCode(unsigned int PC)
 	 */
 	while (!(CEmuStat & (CeS_TRAP|CeS_DRTRAP|CeS_SIGPEND)) &&
 	       (G=FindTree(PC))) {
-		if (!GoodNode(G, mode)) {
+		if (!GoodNode(G)) {
 			InvalidateNodeRange(G->seqbase, G->seqlen, NULL);
 			return PC;
 		}
@@ -478,7 +482,7 @@ static unsigned int FindExecCode(unsigned int PC)
 		/* try fast inner loop if nothing special is going on */
 		if (!(EFLAGS & TF) && !(CEmuStat & (CeS_INHI)) &&
 		    !debug_level('e') &&
-		    GoodNode(G, mode) && !(G->flags & (F_FPOP|F_INHI)))
+		    GoodNode(G) && !(G->flags & (F_FPOP|F_INHI)))
 			PC = DoExec_fast(G);
 		else
 #endif
@@ -544,7 +548,6 @@ void Interp86(void)
 {
     unsigned int ret;
 
-    TheCPU.basemode = TheCPU.mode;
     TheCPU.err2 = 0;
     LONG_CS = _LONG_CS;
     ret = _Interp86(LONG_CS + TheCPU.eip, TheCPU.mode);
@@ -611,7 +614,7 @@ static unsigned int interp_pre(unsigned int PC, const int mode, int _flags)
 				dbug_printf("\n%s",e_print_regs());
 			char *ds;
 			unsigned short ocs = TheCPU.cs;
-			ds = e_emu_disasm(EMU_BASE32(PC),(~mode&3),ocs);
+			ds = e_emu_disasm(EMU_BASE32(PC),mode&MBIGCS,ocs);
 			e_printf("  %s\n", ds);
 		}
 		return PC;
@@ -687,7 +690,7 @@ static unsigned int _Interp86(unsigned int PC, int basemode)
 		P0 = PC;
 		PC = InterpOne(PC, basemode, 0);
 		/* InterpOne can change CS */
-		TheCPU.basemode = basemode = TheCPU.mode;
+		basemode = TheCPU.mode;
 		if (TheCPU.err) {
 			if (TheCPU.err == EXCP_RETRY) {
 				TheCPU.err = 0;
@@ -3495,10 +3498,12 @@ static void _PreJit86(unsigned int PC, int basemode, int flags)
 		if (debug_level('e')) {
 			char *ds;
 			unsigned short ocs = TheCPU.cs;
-			ds = e_emu_disasm(EMU_BASE32(PC),(~basemode&3),ocs);
+			ds = e_emu_disasm(EMU_BASE32(PC),basemode&MBIGCS,ocs);
 			e_printf("  %s\n", ds);
 		}
 		PC = InterpOne(PC, basemode, flags);
+		/* InterpOne can NOT change CS with PreJit, basemode
+		   stays the same */
 		if (TheCPU.err)
 			return;
 		PC = interp_post(PC, basemode, P0, flags);
@@ -3519,7 +3524,6 @@ void PreJit86(unsigned int PC, int basemode)
 {
 	if (e_querymark(PC, 1))
 		return;
-	TheCPU.basemode = basemode;
 	TheCPU.err = 0;
 	LONG_CS = _LONG_CS;
 	_PreJit86(PC, basemode, FLG_PREJIT);
@@ -3530,7 +3534,8 @@ static void *prejit_thread(void *arg)
 {
   while (1) {
     sem_wait(&prejit_sem);
-    _PreJit86(__atomic_load_n(&prejit_PC, __ATOMIC_RELAXED), TheCPU.basemode,
+    _PreJit86(__atomic_load_n(&prejit_PC, __ATOMIC_RELAXED),
+	    __atomic_load_n(&prejit_mode, __ATOMIC_RELAXED),
 	    FLG_PREJIT | FLG_SPECULATIVE);
     pthread_mutex_lock(&run_mtx);
     prejit_running = 0;
@@ -3541,7 +3546,7 @@ static void *prejit_thread(void *arg)
 }
 
 #if SPEC_PREJIT
-static void prejit_run(unsigned int PC)
+static void prejit_run(unsigned int PC, unsigned int basemode)
 {
   if (e_querymark(PC, SAFE_PRJ_GAP))
     return;
@@ -3549,6 +3554,7 @@ static void prejit_run(unsigned int PC)
   SpecPrejits++;
 #endif
   __atomic_store_n(&prejit_PC, PC, __ATOMIC_RELAXED);
+  __atomic_store_n(&prejit_mode, basemode, __ATOMIC_RELAXED);
   pthread_mutex_lock(&run_mtx);
   assert(!prejit_running);
   prejit_running = 1;

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -181,7 +181,7 @@ static unsigned int do_flush(unsigned P0, unsigned _P0,
 /////////////////////////////////////////////////////////////////////////////
 
 
-static int _MAKESEG(int mode, int *basemode, int ofs, unsigned short sv)
+static int MAKESEG(int mode, int ofs, unsigned short sv)
 {
 	int e;
 	unsigned char big;
@@ -189,30 +189,27 @@ static int _MAKESEG(int mode, int *basemode, int ofs, unsigned short sv)
 //	if ((ofs<0)||(ofs>=0x60)) return EXCP06_ILLOP;
 
 	if (REALADDR()) {
-		return SetSegReal(sv,ofs);
+		e = SetSegReal(sv,ofs);
+		if (ofs == Ofs_CS)
+			LONG_CS = _LONG_CS;
+		return e;
 	}
 
 	e = SetSegProt(mode&ADDR16, ofs, &big, sv);
 	if (e)
 		return e;
 	if (ofs==Ofs_CS) {
-		if (big) *basemode &= ~(ADDR16|DATA16);
-		else *basemode |= (ADDR16|DATA16);
-		if (debug_level('e')>1) e_printf("MAKESEG CS: big=%d basemode=%04x\n",big&1,*basemode);
+		if (big) TheCPU.mode &= ~(ADDR16|DATA16);
+		else TheCPU.mode |= (ADDR16|DATA16);
+		if (debug_level('e')>1) e_printf("MAKESEG CS: big=%d basemode=%04x\n",big&1,TheCPU.mode);
+		LONG_CS = _LONG_CS;
 	}
 	if (ofs==Ofs_SS) {
 		TheCPU.StackMask = (big? 0xffffffff : 0x0000ffff);
-		if (debug_level('e')>1) e_printf("MAKESEG SS: big=%d basemode=%04x\n",big&1,*basemode);
+		if (debug_level('e')>1) e_printf("MAKESEG SS: big=%d basemode=%04x\n",big&1,TheCPU.mode);
 	}
 	return 0;
 }
-
-#define MAKESEG(mode, ofs, sv) ({ \
-    int _rv = _MAKESEG(mode, &basemode, ofs, sv); \
-    if (ofs == Ofs_CS) \
-      LONG_CS = _LONG_CS; \
-    _rv; \
-})
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -541,7 +538,7 @@ static void HandleEmuSignals(void)
 }
 
 static unsigned int _Interp86(unsigned int PC, int mod0);
-static unsigned int InterpOne(unsigned int PC, int *_basemode, int _flags);
+static unsigned int InterpOne(unsigned int PC, int basemode, int _flags);
 
 void Interp86(void)
 {
@@ -684,13 +681,13 @@ static unsigned int _Interp86(unsigned int PC, int basemode)
 #pragma GCC diagnostic ignored "-Wdiscarded-qualifiers"
 #endif
 	while (1) {
-		TheCPU.mode = basemode;
-		TheCPU.basemode = basemode;
 		PC = interp_pre(PC, basemode, 0);
 		if (TheCPU.err)
 			return PC;
 		P0 = PC;
-		PC = InterpOne(PC, &basemode, 0);
+		PC = InterpOne(PC, basemode, 0);
+		/* InterpOne can change CS */
+		TheCPU.basemode = basemode = TheCPU.mode;
 		if (TheCPU.err) {
 			if (TheCPU.err == EXCP_RETRY) {
 				TheCPU.err = 0;
@@ -708,13 +705,12 @@ static unsigned int _Interp86(unsigned int PC, int basemode)
 	return 0;
 }
 
-static unsigned int InterpOne(unsigned int PC, int *_basemode, int _flags)
+static unsigned int InterpOne(unsigned int PC, int basemode, int _flags)
 {
 	unsigned int P0 = PC;
 	unsigned char opc;
 	unsigned int temp;
 	unsigned short ocs;
-	#define basemode (*_basemode)
 	int _mode = basemode;
 	/* WARNING - these are signed char offsets, NOT pointers! */
 	signed char OVERR_DS = Ofs_XDS;
@@ -3476,7 +3472,6 @@ illegal_op:
 	dbug_printf("!!! Illegal op %02x %02x %02x\n",opc,
 		    Fetch(PC+1),Fetch(PC+2));
 	TheCPU.err = EXCP06_ILLOP; return P0;
-#undef basemode
 }
 
 /* reset for VGA reads and writes */
@@ -3496,8 +3491,6 @@ static void _PreJit86(unsigned int PC, int basemode, int flags)
 	int gap = ((flags & FLG_SPECULATIVE) ? SAFE_PRJ_GAP : 1);
 
 	while (1) {
-		TheCPU.mode = basemode;
-		TheCPU.basemode = basemode;
 		P0 = PC;
 		if (debug_level('e')) {
 			char *ds;
@@ -3505,7 +3498,7 @@ static void _PreJit86(unsigned int PC, int basemode, int flags)
 			ds = e_emu_disasm(EMU_BASE32(PC),(~basemode&3),ocs);
 			e_printf("  %s\n", ds);
 		}
-		PC = InterpOne(PC, &basemode, flags);
+		PC = InterpOne(PC, basemode, flags);
 		if (TheCPU.err)
 			return;
 		PC = interp_post(PC, basemode, P0, flags);

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -2893,18 +2893,6 @@ repag0:
 				}
 			}
 			b &= 7;
-			if (TheCPU.fpstate) {
-				/* For simulator, only need to mask all
-				   exceptions, and set rounding properly;
-				   for JIT, load emulated FPU state
-				   into real FPU */
-				if (CONFIG_CPUSIM) {
-					fesetenv(FE_DFL_ENV);
-					fp87_set_rounding();
-				} else
-					loadfpstate(*TheCPU.fpstate);
-				TheCPU.fpstate = NULL;
-			}
 			if (sim) {
 			    if (Fp87_op(exop,b,TheCPU.mem_ref)) {
 				TheCPU.err = -96;

--- a/src/base/emu-i386/simx86/modrm-gen.c
+++ b/src/base/emu-i386/simx86/modrm-gen.c
@@ -84,8 +84,8 @@ int _ModRM(unsigned char opc, unsigned int PC, int mode, signed char overr_ds, s
 			REG1 = (mode&ADDR16? R1Tab_w[mod]:R1Tab_l[mod]);
 	}
 	mod = D_HO(cab);
+	REG3 = 0;
 	if (mod == 3) {
-		TheCPU.mode |= RM_REG;
 		if (mode & (MBYTE|MBYTX))
 			REG3 = R1Tab_b[cab&7];
 		else if (mode & ADDR16)
@@ -165,8 +165,8 @@ int ModGetReg1(unsigned int PC, int mode)
 	else
 		REG1 = (mode&ADDR16? R1Tab_w[mod]:R1Tab_l[mod]);
 	mod = D_HO(cab);
+	REG3 = 0;
 	if (mod==3) {
-		TheCPU.mode |= RM_REG;
 		if (mode & MBYTE)
 			REG3 = R1Tab_b[cab&7];
 		else if (mode & ADDR16)

--- a/src/base/emu-i386/simx86/protmode.c
+++ b/src/base/emu-i386/simx86/protmode.c
@@ -97,12 +97,12 @@ int SetSegReal(unsigned short sel, int ofs)
 int SetDataSegProt(unsigned short sel, int ofs)
 {
 	unsigned char big;
-	int e = SetSegProt(TheCPU.basemode&ADDR16, ofs, &big, sel);
+	int e = SetSegProt(TheCPU.mode&ADDR16, ofs, &big, sel);
 	if (e) {
 		TheCPU.err2 = e;
 	} else if (ofs==Ofs_SS) {
 		TheCPU.StackMask = (big? 0xffffffff : 0x0000ffff);
-		if (debug_level('e')>1) e_printf("MAKESEG SS: big=%d basemode=%04x\n",big&1,TheCPU.basemode);
+		if (debug_level('e')>1) e_printf("MAKESEG SS: big=%d basemode=%04x\n",big&1,TheCPU.mode);
 	}
 	return e;
 }

--- a/src/base/emu-i386/simx86/sigsegv.c
+++ b/src/base/emu-i386/simx86/sigsegv.c
@@ -410,7 +410,7 @@ int e_handle_fault(sigcontext_t *scp)
 		return 0;
 	}
 	TheCPU.err2 = EXCP00_DIVZ + _scp_trapno;
-	_scp_eax = _LONG_CS + TheCPU.eip;
+	_scp_eax = LONG_CS + TheCPU.eip;
 	_scp_edx = _scp_eflags;
 	_scp_rip = *(long *)_scp_rsp;
 	_scp_rsp += sizeof(long);

--- a/src/base/emu-i386/simx86/syncpu.h
+++ b/src/base/emu-i386/simx86/syncpu.h
@@ -250,14 +250,12 @@ extern struct _SynCPU TheCPU_struct;
 #define FS_DTR		TheCPU.fs_cache
 #define GS_DTR		TheCPU.gs_cache
 
-#define _LONG_CS	TheCPU.cs_cache.BoundL
+#define LONG_CS		TheCPU.cs_cache.BoundL
 #define LONG_DS		TheCPU.ds_cache.BoundL
 #define LONG_ES		TheCPU.es_cache.BoundL
 #define LONG_SS		TheCPU.ss_cache.BoundL
 #define LONG_FS		TheCPU.fs_cache.BoundL
 #define LONG_GS		TheCPU.gs_cache.BoundL
-
-extern unsigned int LONG_CS;
 
 #define sigalrm_pending() __atomic_load_n(&TheCPU.sigalrm_pending, \
   __ATOMIC_RELAXED)

--- a/src/base/emu-i386/simx86/syncpu.h
+++ b/src/base/emu-i386/simx86/syncpu.h
@@ -80,7 +80,6 @@ typedef struct {
 	int err2;
 	int err;
 	unsigned int mode;
-	unsigned int basemode;
 	unsigned int sreg1;
 	unsigned int dreg1;
 	unsigned int xreg1;


### PR DESCRIPTION
To be able to set CS in protected mode generated code (via the helper) I need to make some changes to the general code.
* I was confused between `_LONG_CS` and `LONG_CS`; I renamed `_LONG_CS` back to `LONG_CS`, whereas the newer `LONG_CS` global is now a static `Interp_LONG_CS` in `interp.c`. One user of `LONG_CS` was wrong (in `GoodNode()`) and now correct. I think it's safe to use `LONG_CS` from `TheCPU` in `cpu-emu.c` as `PREJIT_ASYNC`/`PREJIT` don't care with them only running concurrently with native/kvm execution (as opposed to `SPEC_PREJIT`) but please tell me if I'm wrong!
* Eliminated `TheCPU.basemode`: add a flag `MBIGCS`, that is not changed by prefixes. This we can use to `UNPREFIX()` the current mode as seen by the interpreter, and get what used to be in `TheCPU.basemode`. `TheCPU.mode` can now change in `MAKESEG()` and is used by the execution, not by `SPEC_PREJIT`.
* While I tested `SPEC_PREJIT` there would sometimes be an FPU exception in sim mode. I moved the FPU masking down where the prejit code can't reach it.