### PR TITLE
kvm: re-enable on kernel 6.12.44+ (but not 6.13)

### DIFF
--- a/src/base/emu-i386/kvm.c
+++ b/src/base/emu-i386/kvm.c
@@ -506,9 +506,11 @@ int init_kvm_cpu(void)
   int ret;
   int nent = 512;
 
-  if (kernel_version_code >= KERNEL_VERSION(6, 11, 0) &&
-      kernel_version_code < KERNEL_VERSION(6, 14, 0)) {
-    error("disabling KVM for kernels 6.11 .. 6.13\n");
+  if ((kernel_version_code >= KERNEL_VERSION(6, 11, 0) &&
+       kernel_version_code < KERNEL_VERSION(6, 12, 44)) ||
+      (kernel_version_code >= KERNEL_VERSION(6, 13, 0) &&
+       kernel_version_code < KERNEL_VERSION(6, 14, 0))) {
+    error("disabling KVM for kernels 6.11 .. 6.13 except 6.12.44+\n");
     error("See https://github.com/dosemu2/dosemu2/issues/2471\n");
     return 0;
   }


### PR DESCRIPTION
The fix in 6.14 was backported to 6.12.44.
See 408add15, #2472 and #2471.