### PR TITLE
mapfile: stop checking cap [fixes #2567]

### DIFF
--- a/src/base/lib/mapping/mapfile.c
+++ b/src/base/lib/mapping/mapfile.c
@@ -257,42 +257,39 @@ static void free_mapping_file(int cap, void *addr, size_t mapsize)
  * This is the simplest design. */
 static void *resize_mapping_file(int cap, void *addr, size_t oldsize, size_t newsize)
 {
+  struct file_mapping *p = find_file_mapping(addr);
+  int size = p->size;
   Q__printf("MAPPING: realloc, cap=%s, addr=%p, oldsize=%zx, newsize=%zx\n",
 	cap, addr, oldsize, newsize);
-  if (cap & (MAPPING_EMS | MAPPING_DPMI)) {
-    struct file_mapping *p = find_file_mapping(addr);
-    int size = p->size;
 
-    if (!size || size != oldsize || addr != p->addr) return (void *)-1;
-    if (size == newsize) return addr;
-    if (newsize < size) {
-      p->size = newsize;
+  if (!size || size != oldsize || addr != p->addr) return (void *)-1;
+  if (size == newsize) return addr;
+  if (newsize < size) {
+    p->size = newsize;
 #ifdef HAVE_MREMAP
-      p->addr = mremap(addr, oldsize, newsize, 0);
-      assert(p->addr == addr);
+    p->addr = mremap(addr, oldsize, newsize, 0);
+    assert(p->addr == addr);
 #else
-      /* ensure page-aligned */
-      assert(!(oldsize & (PAGE_SIZE - 1)));
-      assert(!(newsize & (PAGE_SIZE - 1)));
-      munmap(addr + newsize, oldsize - newsize);
+    /* ensure page-aligned */
+    assert(!(oldsize & (PAGE_SIZE - 1)));
+    assert(!(newsize & (PAGE_SIZE - 1)));
+    munmap(addr + newsize, oldsize - newsize);
 #endif
-    } else {
-      if (newsize > p->fsize) {
-        int rc = ftruncate(p->fd, newsize);
-        assert(rc != -1);
-        p->fsize = newsize;
-      }
-      p->size = newsize;
-#if HAVE_DECL_MREMAP_MAYMOVE
-      p->addr = mremap(addr, oldsize, newsize, MREMAP_MAYMOVE);
-#else
-      p->addr = mmap(NULL, newsize, p->prot, MAP_SHARED, p->fd, 0);
-      munmap(addr, oldsize);
-#endif
+  } else {
+    if (newsize > p->fsize) {
+      int rc = ftruncate(p->fd, newsize);
+      assert(rc != -1);
+      p->fsize = newsize;
     }
-    return p->addr;
+    p->size = newsize;
+#if HAVE_DECL_MREMAP_MAYMOVE
+    p->addr = mremap(addr, oldsize, newsize, MREMAP_MAYMOVE);
+#else
+    p->addr = mmap(NULL, newsize, p->prot, MAP_SHARED, p->fd, 0);
+    munmap(addr, oldsize);
+#endif
   }
-  return (void *)-1;
+  return p->addr;
 }
 
 #ifdef HAVE_SHM_OPEN


### PR DESCRIPTION
It was checking for (MAPPING_EMS | MAPPING_DPMI), but XMS also uses realloc_mapping(MAPPING_OTHER), so it didn't work.