### PR TITLE
simx86: generate code (with helper call) for protected mode long jmp/call/ret instructions

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -447,17 +447,21 @@ static unsigned int Gen_sim(const IGen *IG, dosaddr_t mem_ref)
 	switch(op) {
 	case A_SR_SH4: {	// real mode make base addr from seg
 		unsigned int o = IG->p0;
+		unsigned int v = CPUWORD(o);
 		GTRACE1("A_SR_SH4",o);
 		SetSegReal(DR1.w.l, o);
+		DR1.d = v; // only needed for pushing old CS
 		}
 		break;
 	case A_SR_PROT: {	// protected mode make base addr from seg
 		unsigned int o = IG->p0;
 		int e;
 		GTRACE1("A_SR_PROT",o);
-		e = SetDataSegProt(DR1.w.l, o);
-		if (e)
+		e = SetSegProt_helper(DR1.w.l, o);
+		if (e < 0)
 			P0 = IG->p1;
+		else
+			DR1.d = e;
 		}
 		break;
 	case L_NOP:

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -2069,14 +2069,14 @@ static unsigned int Gen_sim(const IGen *IG, dosaddr_t mem_ref)
 		if (mode & DATA16) {
 			SR1.d &= stackm;
 			DR1.w.l = sim_read_word(AR2.d + SR1.d);
-			if (!(mode & MPOPRM))
+			if (o != Ofs_RZERO)
 				CPUWORD(o) = DR1.w.l;
 			SR1.d += 2;
 		}
 		else {
 			SR1.d &= stackm;
 			DR1.d = sim_read_dword(AR2.d + SR1.d);
-			if (!(mode & MPOPRM))
+			if (o != Ofs_RZERO)
 				CPULONG(o) = DR1.d;
 			SR1.d += 4;
 		}

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -1502,9 +1502,7 @@ shrot0:
 			0x8d,0x14,0x0e,
 			// movw (%%edx,%%ebp,1),%%ax
 			0x66,0x8b,0x04,0x2a,
-			// movw %%ax,offs(%%ebx)
-/*0a*/			0x66,0x89,0x43,0x00,
-			// leal 2(%%ecx),%%ecx
+/*0a*/			// leal 2(%%ecx),%%ecx
 			0x8d,0x49,0x02,
 #ifdef KEEP_ESP	/* keep high 16-bits of ESP in small-stack mode */
 			// movl StackMask(%%ebx),%%edx
@@ -1524,9 +1522,7 @@ shrot0:
 			0x8d,0x14,0x0e,
 			// movl (%%edx,%%ebp,1),%%eax
 			0x90,0x8b,0x04,0x2a,
-			// movl %%eax,offs(%%ebx)
-/*0a*/			0x90,0x89,0x43,0x00,
-			// leal 4(%%ecx),%%ecx
+/*0a*/			// leal 4(%%ecx),%%ecx
 			0x8d,0x49,0x04,
 #ifdef KEEP_ESP	/* keep high 16-bits of ESP in small-stack mode */
 			// movl StackMask(%%ebx),%%edx
@@ -1548,13 +1544,15 @@ shrot0:
 		//	first do address calculation, then pop,
 		//	then store data, and last adjust stack
 		q=Cp; GNX(Cp, p, sz);
-		q[0x0d] = IG->p0;
+		if (IG->p0 != Ofs_RZERO) {
+			// mov{wl} %%{e}ax,offs(%%ebx)
+			Gen66(mode, Cp); G3M(0x89,0x43,IG->p0,Cp);
+		}
 		if (mode&MPOPRM) {
-			// NOP the register write, save ecx into esi
+			// save ecx into esi
 			// which is preserved in CPatches
-			*(uint32_t *)(q+0x0a) = 0x90909090;
 			// Use leal {2|4}(%%ecx),%%esi
-			q[0x0f] = 0x71;
+			q[0x0b] = 0x71;
 #ifdef KEEP_ESP	/* keep high 16-bits of ESP in small-stack mode */
 			// use orl %%edx,%%esi
 			q[sz-1] = 0xd6;

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -260,6 +260,10 @@ static unsigned char *CodeGen_x86(unsigned char *CodePtr, unsigned char *BaseGen
 		} }
 		break;
 	case A_SR_SH4: {	// real mode make base addr from seg
+		if (IG->p0 == Ofs_CS) {
+			// movzwl offs(%%ebx),%%edx
+			G4M(0x0f,0xb7,0x53,IG->p0,Cp);
+		}
 		// movw %%ax,offs(%%ebx)
 		G4M(0x66,0x89,0x43,IG->p0,Cp);
 		// movzwl %%ax,%%eax
@@ -272,6 +276,10 @@ static unsigned char *CodeGen_x86(unsigned char *CodePtr, unsigned char *BaseGen
 		G1(0x05,Cp); G4(0x0000ffff,Cp);
 		// movl %%eax,ofs(%%ebx)
 		G3M(0x89,0x43,IG->p1+4,Cp);
+		if (IG->p0 == Ofs_CS) {
+			// movl %%edx,%%eax : old cs in eax
+			G2M(0x89,0xd0,Cp);
+		}
 		}
 		break;
 	case A_SR_PROT: {	// prot mode make base addr from seg
@@ -303,8 +311,8 @@ static unsigned char *CodeGen_x86(unsigned char *CodePtr, unsigned char *BaseGen
 #endif
 		// or %%eax,%%eax
 		G2M(0x09,0xc0,Cp);
-		// jz skip
-		G2M(0x74,TAILSIZE,Cp);
+		// jns skip
+		G2M(0x79,TAILSIZE,Cp);
 		// movl {exit_addr},%%eax; pop %%edx; ret
 		G1(0xb8,Cp); G4(IG->p1,Cp); G2M(0x5a,0xc3,Cp);
 		}

--- a/src/base/emu-i386/simx86/cpatch.c
+++ b/src/base/emu-i386/simx86/cpatch.c
@@ -761,7 +761,7 @@ void Cpatch_init(void)
     TheCPU_struct.stub_func[STUB_READ_8] = stub_read_8;
     TheCPU_struct.stub_func[STUB_READ_16] = stub_read_16;
     TheCPU_struct.stub_func[STUB_READ_32] = stub_read_32;
-    TheCPU_struct.stub_func[STUB_SETSEGPROT] = (stubfunc_t)SetDataSegProt;
+    TheCPU_struct.stub_func[STUB_SETSEGPROT] = (stubfunc_t)SetSegProt_helper;
 }
 
 /* ======================================================================= */

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -388,7 +388,7 @@ static unsigned int _JumpGen(unsigned int P2, int mode, int opc,
 		Gen(JLOOP_LINK, mode, opc, j_t, j_nt);
 		break;
 	case RETl: case RETlisp: // far ret, indirect
-		AddrGen(A_SR_SH4, mode, Ofs_CS, Ofs_XCS);
+		if (REALADDR()) AddrGen(A_SR_SH4, mode, Ofs_CS, Ofs_XCS);
 		/* fall through */
 	case JMPli: case CALLli: case INT: // far jmp/call, indirect
 		Gen(L_REG, mode, Ofs_EIP);
@@ -1010,7 +1010,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			    AddrGen(A_SR_SH4, _mode, Ofs_ES, Ofs_XES);
 			} else { /* restartable */
 			    Gen(O_POP1, _mode);
-			    Gen(O_POP2, _mode|MPOPRM, 0);
+			    Gen(O_POP2, _mode|MPOPRM, Ofs_RZERO);
 			    /* same principle applies as for POPrm: this
 			       segment load may fault, above pops into
 			       temporary storage without adjusting (E)SP */
@@ -1024,7 +1024,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			    AddrGen(A_SR_SH4, _mode, Ofs_SS, Ofs_XSS);
 			} else { /* restartable */
 			    Gen(O_POP1, _mode);
-			    Gen(O_POP2, _mode|MPOPRM, 0);
+			    Gen(O_POP2, _mode|MPOPRM, Ofs_RZERO);
 			    AddrGen(A_SR_PROT, _mode, Ofs_SS, P0);
 			    Gen(O_POP3, _mode|MPOPRM);
 			}
@@ -1036,7 +1036,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			    AddrGen(A_SR_SH4, _mode, Ofs_DS, Ofs_XDS);
 			} else { /* restartable */
 			    Gen(O_POP1, _mode);
-			    Gen(O_POP2, _mode|MPOPRM, 0);
+			    Gen(O_POP2, _mode|MPOPRM, Ofs_RZERO);
 			    AddrGen(A_SR_PROT, _mode, Ofs_DS, P0);
 			    Gen(O_POP3, _mode|MPOPRM);
 			}
@@ -1259,7 +1259,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			} else {
 				// read data into temporary storage
 				Gen(O_POP1, _mode);
-				Gen(O_POP2, _mode|MPOPRM, 0);
+				Gen(O_POP2, _mode|MPOPRM, Ofs_RZERO);
 				// store data
 				// S_DI may fault, in which case the instruction
 				// may need to be restarted with the original
@@ -1972,7 +1972,13 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 		}
 
 /*cb*/	case RETl:
-		   if (REALADDR()) {
+			if (!REALADDR()) {
+			    /* pop from stack without adjusting esp */
+			    Gen(O_POP1, _mode);
+			    Gen(O_POP2, _mode, Ofs_RZERO);
+			    Gen(O_POP2, _mode, Ofs_RZERO);
+			    AddrGen(A_SR_PROT, _mode, Ofs_CS, P0);
+			}
 			Gen(O_POP, _mode);
 			Gen(S_REG, _mode, Ofs_EIP);
 			Gen(O_POP, _mode);
@@ -1980,9 +1986,8 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			if (debug_level('e')>1)
 			    e_printf("RET_FAR: ret=%04x:%08x\n",TheCPU.cs,TheCPU.eip);
 			if (TheCPU.err) return PC;
-			break;	/* un-fall */
-		   }
-		   /* fall through */
+			break;
+
 /*cf*/	case IRET: {	/* restartable */
 			uint16_t sv=0;
 			int m = _mode;
@@ -1993,11 +1998,6 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			TheCPU.eip=0; POP(m, &TheCPU.eip);
 			POP_ONLY(m);
 			PC = Interp_LONG_CS + TheCPU.eip;
-			if (opc==RETl) {
-			    if (debug_level('e')>1)
-				e_printf("RET_FAR: ret=%04x:%08x\n",sv,TheCPU.eip);
-			    break;	/* un-fall */
-			}
 			if (debug_level('e')>1) {
 				e_printf("IRET: ret=%04x:%08x\n",sv,TheCPU.eip);
 			}
@@ -3118,7 +3118,7 @@ repag0:
 				    AddrGen(A_SR_SH4, _mode, Ofs_FS, Ofs_XFS);
 				} else { /* restartable */
 				    Gen(O_POP1, _mode);
-				    Gen(O_POP2, _mode|MPOPRM, 0);
+				    Gen(O_POP2, _mode|MPOPRM, Ofs_RZERO);
 				    AddrGen(A_SR_PROT, _mode, Ofs_FS, P0);
 				    Gen(O_POP3, _mode|MPOPRM);
 				}
@@ -3222,7 +3222,7 @@ repag0:
 				    AddrGen(A_SR_SH4, _mode, Ofs_GS, Ofs_XGS);
 				} else { /* restartable */
 				    Gen(O_POP1, _mode);
-				    Gen(O_POP2, _mode|MPOPRM, 0);
+				    Gen(O_POP2, _mode|MPOPRM, Ofs_RZERO);
 				    AddrGen(A_SR_PROT, _mode, Ofs_GS, P0);
 				    Gen(O_POP3, _mode|MPOPRM);
 				}

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -174,6 +174,7 @@ static unsigned int do_flush(unsigned P0, unsigned _P0,
 			    TheCPU.err = EXCP_RETRY; /* BreakNode */ \
 			    return P2; \
 			  } \
+			  basemode = TheCPU.mode; \
 			}
 
 static inline unsigned int UNPREFIX(unsigned int m)
@@ -541,7 +542,7 @@ static void HandleEmuSignals(void)
 		CEmuStat &= ~(CeS_SIGPEND | CeS_RPIC | CeS_STI);
 }
 
-static unsigned int _Interp86(unsigned int PC, int mod0);
+static unsigned int _Interp86(unsigned int PC);
 static unsigned int InterpOne(unsigned int PC, int basemode, int _flags);
 
 void Interp86(void)
@@ -550,7 +551,7 @@ void Interp86(void)
 
     TheCPU.err2 = 0;
     Interp_LONG_CS = LONG_CS;
-    ret = _Interp86(Interp_LONG_CS + TheCPU.eip, TheCPU.mode);
+    ret = _Interp86(Interp_LONG_CS + TheCPU.eip);
     assert(CurrIMeta<0);
     TheCPU.eip = ret - Interp_LONG_CS;
 }
@@ -665,7 +666,7 @@ static unsigned int interp_post(unsigned int PC, const int mode, unsigned P0,
 		return PC;
 }
 
-static unsigned int _Interp86(unsigned int PC, int basemode)
+static unsigned int _Interp86(unsigned int PC)
 {
 	volatile unsigned int P0 = PC; /* volatile because of setjmp */
 	int val;
@@ -684,14 +685,11 @@ static unsigned int _Interp86(unsigned int PC, int basemode)
 #pragma GCC diagnostic ignored "-Wdiscarded-qualifiers"
 #endif
 	while (1) {
-		PC = interp_pre(PC, basemode, 0);
+		PC = interp_pre(PC, TheCPU.mode, 0);
 		if (TheCPU.err)
 			return PC;
 		P0 = PC;
-		PC = InterpOne(PC, basemode, 0);
-		/* InterpOne can change CS */
-		Interp_LONG_CS = LONG_CS;
-		basemode = TheCPU.mode;
+		PC = InterpOne(PC, TheCPU.mode, 0);
 		if (TheCPU.err) {
 			if (TheCPU.err == EXCP_RETRY) {
 				TheCPU.err = 0;
@@ -699,7 +697,7 @@ static unsigned int _Interp86(unsigned int PC, int basemode)
 			}
 			return PC;
 		}
-		PC = interp_post(PC, basemode, P0, 0);
+		PC = interp_post(PC, TheCPU.mode, P0, 0);
 		if (TheCPU.err)
 			return PC;
 	}

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -2565,21 +2565,21 @@ repag0:
 					CODE_FLUSH();
 					goto illegal_op;
 				}
-				if (REALADDR()) {
+				{
 					dosaddr_t oip = 0;
 					int len = ModRM(opc, PC, _mode|NOFLDR);
 					ocs = TheCPU.cs;
+					Gen(L_LXS2, _mode);
+					if (REALADDR())
+					    AddrGen(A_SR_SH4, _mode, Ofs_CS, Ofs_XCS);
+					else
+					    AddrGen(A_SR_PROT, _mode, Ofs_CS, P0);
 					if (REG1==Ofs_BX) {
 					    /* ok, now push old cs:eip */
 					    oip = PC + len - Interp_LONG_CS;
-					    Gen(L_REG, _mode|DATA16, Ofs_CS);
-					    if (!(_mode & DATA16)) // padding
-						Gen(L_ZXAX, _mode);
 					    Gen(O_PUSH, _mode);
 					    Gen(O_PUSHI, _mode, oip);
 					}
-					Gen(L_LXS2, _mode);
-					AddrGen(A_SR_SH4, _mode, Ofs_CS, Ofs_XCS);
 					Gen(L_LXS1, _mode, Ofs_EIP);
 					PC = JumpGen(PC, _mode, (opc<<8)|REG1, len,
 						P0, _flags);
@@ -2599,41 +2599,6 @@ repag0:
 					}
 #endif
 					if (TheCPU.err) return PC;
-				}
-				else {
-					unsigned short jcs;
-					unsigned long oip,xcs,jip=0;
-					CODE_FLUSH();
-					PC += ModRMSim(PC, _mode|NOFLDR, OVERR_DS, OVERR_SS);
-					TheCPU.eip = PC - Interp_LONG_CS;
-					/* get new cs:ip */
-					jip = DataGetWL_U(_mode, TheCPU.mem_ref);
-					jcs = GetDWord(TheCPU.mem_ref+BT24(BitDATA16,_mode));
-					/* check if new cs is valid, save old for error */
-					ocs = TheCPU.cs;
-					xcs = Interp_LONG_CS;
-					TheCPU.err = MAKESEG(_mode, Ofs_CS, jcs);
-					if (TheCPU.err) {
-					    TheCPU.cs = ocs;
-					    TheCPU.cs_cache.BoundL = xcs;
-					    // should not change
-					    return P0;
-					}
-					if (REG1==Ofs_BX) {
-					    /* ok, now push old cs:eip */
-					    oip = PC - xcs;
-					    PUSH(_mode, ocs);
-					    PUSH(_mode, oip);
-					    if (debug_level('e')>2)
-						e_printf("CALL_FAR indirect: ret=%04x:%08lx\n\tcalling: %04x:%08lx\n",
-							ocs,oip,jcs,jip);
-					}
-					else {
-					    if (debug_level('e')>2)
-						e_printf("JMP_FAR indirect: %04x:%08lx\n",jcs,jip);
-					}
-					TheCPU.eip = jip;
-					PC = Interp_LONG_CS + jip;
 				}
 				break;
 			case Ofs_SI:	/*6*/	 // PUSH

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -240,14 +240,15 @@ static unsigned int _JumpGen(unsigned int P2, int mode, int opc,
 	 *	eb ff	dsp=1	illegal or tricky
 	 *	eb fe	dsp=0	loop forever
 	 */
-	if ((opc>>8) == GRP2wrm || opc == INT) {	// indirect jump
+	switch(opc) {
+	case RET: case RETisp: case JMPi: case CALLi:
+	case RETl: case RETlisp: case JMPli: case CALLli:
+	case INT: // indirect jumps
 		dsp = 0;
 		j_t = 0;
-		j_nt = 0;
 		d_t = 0;
-		d_nt = 0;
-	}
-	else if (opc == JMPld || opc == CALLl) { // far jmp/call
+		break;
+	case JMPld: case CALLl: // far jmp/call
 		d_t = DataFetchWL_U(mode, P2+1);
 		if (REALADDR()) {
 			j_t = SEGOFF2LINEAR(FetchW(P2 + pskip - 2), d_t);
@@ -256,8 +257,8 @@ static unsigned int _JumpGen(unsigned int P2, int mode, int opc,
 			j_t = 0;
 			dsp = 0;
 		}
-	}
-	else {
+		break;
+	default:
 		dsp = pskip;
 		if (pskip == 2)	// short branch (byte)
 			dsp += (signed char)Fetch(P2+1);
@@ -271,6 +272,7 @@ static unsigned int _JumpGen(unsigned int P2, int mode, int opc,
 
 		/* jump address for taken branch */
 		j_t = d_t + Interp_LONG_CS;
+		break;
 	}
 
 	/* displacement for not taken branch */

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -1860,8 +1860,15 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 /*c9*/	case LEAVE:
 			Gen(O_LEAVE, _mode); PC++;
 			break;
-/*ca*/	case RETlisp:
-			if (REALADDR()) {
+/*ca*/	case RETlisp:	/* restartable */
+			if (!REALADDR()) {
+				/* pop from stack without adjusting esp */
+				Gen(O_POP1, _mode);
+				Gen(O_POP2, _mode, Ofs_RZERO);
+				Gen(O_POP2, _mode, Ofs_RZERO);
+				AddrGen(A_SR_PROT, _mode, Ofs_CS, P0);
+			}
+			{
 				int dr = (signed short)FetchW(PC+1);
 				Gen(O_POP, _mode);
 				Gen(S_REG, _mode, Ofs_EIP);
@@ -1870,22 +1877,6 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 				if (debug_level('e')>2)
 					e_printf("RET_%d: ret=%08x\n",dr,TheCPU.eip);
 				if (TheCPU.err) return PC;
-			}
-			else { /* restartable */
-				int dr;
-				uint16_t sv=0;
-				CODE_FLUSH();
-				NOS_WORD(_mode, &sv);
-				dr = (signed short)FetchW(PC+1);
-				TheCPU.err = MAKESEG(_mode, Ofs_CS, sv);
-				if (TheCPU.err) return P0;
-				TheCPU.eip=0; POP(_mode, &TheCPU.eip);
-				POP_ONLY(_mode);
-				if (debug_level('e')>2)
-					e_printf("RET_%x: ret=%08x\n",dr,TheCPU.eip);
-				PC = Interp_LONG_CS + TheCPU.eip;
-				temp = rESP + dr;
-				rESP = (temp&TheCPU.StackMask) | (rESP&~TheCPU.StackMask);
 			}
 			break;
 /*cc*/	case INT3:

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -249,8 +249,13 @@ static unsigned int _JumpGen(unsigned int P2, int mode, int opc,
 	}
 	else if (opc == JMPld || opc == CALLl) { // far jmp/call
 		d_t = DataFetchWL_U(mode, P2+1);
-		j_t = SEGOFF2LINEAR(FetchW(P2 + pskip - 2), d_t);
-		dsp = j_t - P2;
+		if (REALADDR()) {
+			j_t = SEGOFF2LINEAR(FetchW(P2 + pskip - 2), d_t);
+			dsp = j_t - P2;
+		} else {
+			j_t = 0;
+			dsp = 0;
+		}
 	}
 	else {
 		dsp = pskip;
@@ -334,7 +339,17 @@ static unsigned int _JumpGen(unsigned int P2, int mode, int opc,
 	case JMPld: {   /* uncond jmp far */
 		unsigned short jcs = FetchW(P2 + pskip - 2);
 		Gen(L_IMM_R1, mode|DATA16, jcs);
-		AddrGen(A_SR_SH4, mode, Ofs_CS, Ofs_XCS);
+		if (REALADDR()) {
+		    AddrGen(A_SR_SH4, mode, Ofs_CS, Ofs_XCS);
+		}
+		else {
+		    AddrGen(A_SR_PROT, mode, Ofs_CS, P2);
+		    /* transfer to new PC
+		       (new cs base dynamic, so indirect jmp) */
+		    Gen(L_IMM_R1, mode, d_t);
+		    Gen(JMP_INDIRECT, mode);
+		    break;
+		}
 	}
 	/* no break */
 	case JMPsid: case JMPd:   /* uncond jmp */
@@ -347,14 +362,23 @@ static unsigned int _JumpGen(unsigned int P2, int mode, int opc,
 		break;
 	case CALLl: {   /* call far */
 		unsigned short jcs = FetchW(P2 + pskip - 2);
-		Gen(L_REG, mode|DATA16, Ofs_CS);
-		if (!(mode & DATA16)) // 32-bit segreg padding
-		    Gen(L_ZXAX, mode);
-		Gen(O_PUSH, mode);
 		Gen(L_IMM_R1, mode|DATA16, jcs);
-		AddrGen(A_SR_SH4, mode, Ofs_CS, Ofs_XCS);
+		if (REALADDR())
+		    AddrGen(A_SR_SH4, mode, Ofs_CS, Ofs_XCS);
+		else
+		    /* check if new cs is valid, load if so */
+		    AddrGen(A_SR_PROT, mode, Ofs_CS, P2);
+		/* ok, now push old cs (returned by A_SR_*):eip */
+		Gen(O_PUSH, mode);
+		if (!REALADDR()) {
+		    Gen(O_PUSHI, mode, d_nt);
+		    /* transfer to new PC (indirect jmp) */
+		    Gen(L_IMM_R1, mode, d_t);
+		    Gen(JMP_INDIRECT, mode);
+		    break;
+		}
 	}
-	/* no break */
+	/* no break for realaddr call */
 	case CALLd:    /* call, unfortunately also uses JMP_LINK */
 		Gen(JMP_LINK, mode, opc, j_t, d_nt);
 		break;
@@ -615,7 +639,7 @@ static unsigned int interp_pre(unsigned int PC, const int mode, int _flags)
 				dbug_printf("\n%s",e_print_regs(Interp_LONG_CS));
 			char *ds;
 			unsigned short ocs = TheCPU.cs;
-			ds = e_emu_disasm(EMU_BASE32(PC),mode&MBIGCS,ocs);
+			ds = e_emu_disasm(EMU_BASE32(PC),TheCPU.mode&MBIGCS,ocs);
 			e_printf("  %s\n", ds);
 		}
 		return PC;
@@ -1740,61 +1764,19 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 		    break;
 
 /*9a*/	case CALLl:
-/*ea*/	case JMPld:
-		    if (REALADDR()) {
-			int len = 3 + BT24(BitDATA16,_mode);
-			dosaddr_t oip = PC + len - Interp_LONG_CS;
-			ocs = TheCPU.cs;
-			PC = JumpGen(PC, _mode, opc, len, P0, _flags);
-			if (debug_level('e')>2) {
-			    if (opc==CALLl)
-				e_printf("CALL_FAR: ret=%04x:%08x\n  calling:	   %04x:%08x\n",
-					 ocs,oip,TheCPU.cs,PC-Interp_LONG_CS);
-			    else
-				e_printf("JMP_FAR: %04x:%08x\n",TheCPU.cs,PC-Interp_LONG_CS);
-			}
-			if (TheCPU.err) return PC;
+/*ea*/	case JMPld: {
+		    int len = 3 + BT24(BitDATA16,_mode);
+		    dosaddr_t oip = PC + len - LONG_CS;
+		    ocs = TheCPU.cs;
+		    PC = JumpGen(PC, _mode, opc, len, P0, _flags);
+		    if (debug_level('e')>2) {
+			if (opc==CALLl)
+			    e_printf("CALL_FAR: ret=%04x:%08x\n  calling:	   %04x:%08x\n",
+				     ocs,oip,TheCPU.cs,PC-LONG_CS);
+			else
+			    e_printf("JMP_FAR: %04x:%08x\n",TheCPU.cs,PC-LONG_CS);
 		    }
-		    else {
-			unsigned short jcs;
-			unsigned long oip,xcs,jip=0;
-			CODE_FLUSH();
-			/* get new cs:ip */
-			jip = DataFetchWL_U(_mode, PC+1);
-			INC_WL_PC(_mode,1);
-			jcs = FetchW(PC);
-			PC+=2;
-			/* check if new cs is valid, save old for error */
-			ocs = TheCPU.cs;
-			xcs = Interp_LONG_CS;
-			TheCPU.err = MAKESEG(_mode, Ofs_CS, jcs);
-			if (TheCPU.err) {
-			    TheCPU.cs = ocs;
-			    TheCPU.cs_cache.BoundL = xcs;
-			    // should not change
-			    return P0;
-			}
-			if (opc==CALLl) {
-			    /* ok, now push old cs:eip */
-			    oip = PC - xcs;
-			    PUSH(_mode, ocs);
-			    PUSH(_mode, oip);
-			    if (debug_level('e')>2)
-				e_printf("CALL_FAR: ret=%04x:%08lx\n  calling:      %04x:%08lx\n",
-					ocs,oip,jcs,jip);
-			}
-			else {
-			    if (debug_level('e')>2)
-				e_printf("JMP_FAR: %04x:%08lx\n",jcs,jip);
-			}
-			TheCPU.eip = jip;
-			PC = Interp_LONG_CS + jip;
-#ifdef SKIP_EMU_VBIOS
-			if ((jcs&0xf000)==config.vbios_seg) {
-			    /* return the new PC after the jump */
-			    TheCPU.err = EXCP_GOBACK; return PC;
-			}
-#endif
+		    if (TheCPU.err) return PC;
 		    }
 		    break;
 

--- a/src/base/emu-i386/simx86/protmode.c
+++ b/src/base/emu-i386/simx86/protmode.c
@@ -93,18 +93,25 @@ int SetSegReal(unsigned short sel, int ofs)
 	return 0;
 }
 
-// not for CS; this function is called from JIT-generated code
-int SetDataSegProt(unsigned short sel, int ofs)
+// this function is called from JIT-generated code
+int SetSegProt_helper(unsigned short sel, int ofs)
 {
 	unsigned char big;
+	int oldsel = CPUWORD(ofs);
 	int e = SetSegProt(TheCPU.mode&ADDR16, ofs, &big, sel);
 	if (e) {
 		TheCPU.err2 = e;
+		oldsel = -1; /* invalid old value flags error */
 	} else if (ofs==Ofs_SS) {
 		TheCPU.StackMask = (big? 0xffffffff : 0x0000ffff);
 		if (debug_level('e')>1) e_printf("MAKESEG SS: big=%d basemode=%04x\n",big&1,TheCPU.mode);
+	} else if (ofs==Ofs_CS) {
+		TheCPU.mode &= ~(ADDR16|DATA16|MBIGCS);
+		if (big) TheCPU.mode |= MBIGCS;
+		else TheCPU.mode |= (ADDR16|DATA16);
+		if (debug_level('e')>1) e_printf("MAKESEG CS: big=%d basemode=%04x\n",big&1,TheCPU.mode);
 	}
-	return e;
+	return oldsel;
 }
 
 int SetSegProt(int a16, int ofs, unsigned char *big, unsigned long sel)

--- a/src/base/emu-i386/simx86/protmode.h
+++ b/src/base/emu-i386/simx86/protmode.h
@@ -229,7 +229,7 @@ typedef struct {
 extern unsigned char e_ofsseg(int ofs);
 //
 int SetSegProt(int a16, int ofs, unsigned char *big, unsigned long sel);
-int SetDataSegProt(unsigned short sv, int ofs);
+int SetSegProt_helper(unsigned short sv, int ofs);
 int SetSegReal(unsigned short sel, int ofs);
 int e_larlsl(int mode, unsigned short sel);
 int hsw_verr(unsigned short sel);


### PR DESCRIPTION
Expands on #2559 to also include CS. Now that generated code can change `TheCPU.mode`, I also had to make sure it's read back into `basemode` after a `CODE_FLUSH()`.

The rest is quite similar to existing real mode generation but we need to be careful setting CS first before doing anything else in case of exceptions. So the helper now returns the old CS value so it can be pushed *after* the new CS was checked and set if ok. And for `RETl` we need to pop into temporary storage twice to obtain the new CS value, before `TheCPU.esp` can be adjusted etc.

The remaining callers of `MAKESEG` also do so for vm86 (INT and IRET). They are a little harder to deal with.

