### PR TITLE
simx86: reorganize pop/push a little

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -1958,14 +1958,14 @@ static unsigned int Gen_sim(const IGen *IG, dosaddr_t mem_ref)
 			SR1.d &= stackm;
 			sim_write_dword(AR2.d + SR1.d, DR1.d);
 		}
-#ifdef KEEP_ESP	/* keep high 16-bits of ESP in small-stack mode */
-		SR1.d |= (CPULONG(Ofs_ESP) & ~stackm);
-#endif
 		if (debug_level('e')>3) dbug_printf("(V) %08x\n",DR1.d);
 		} break;
 
 	case O_PUSH3:
 		GTRACE0("O_PUSH3");
+#ifdef KEEP_ESP	/* keep high 16-bits of ESP in small-stack mode */
+		SR1.d |= (CPULONG(Ofs_ESP) & ~CPULONG(Ofs_STACKM));
+#endif
 		CPULONG(Ofs_ESP) = SR1.d;
 		break;
 
@@ -2080,14 +2080,14 @@ static unsigned int Gen_sim(const IGen *IG, dosaddr_t mem_ref)
 				CPULONG(o) = DR1.d;
 			SR1.d += 4;
 		}
-#ifdef KEEP_ESP	/* keep high 16-bits of ESP in small-stack mode */
-		SR1.d |= (CPULONG(Ofs_ESP) & ~stackm);
-#endif
 		if (debug_level('e')>3) dbug_printf("(V) %08x\n",DR1.d);
 		} break;
 
 	case O_POP3:
 		GTRACE0("O_POP3");
+#ifdef KEEP_ESP	/* keep high 16-bits of ESP in small-stack mode */
+		SR1.d |= (CPULONG(Ofs_ESP) & ~CPULONG(Ofs_STACKM));
+#endif
 		CPULONG(Ofs_ESP) = SR1.d;
 		break;
 

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -2064,21 +2064,22 @@ static unsigned int Gen_sim(const IGen *IG, dosaddr_t mem_ref)
 		wkreg AR2;
 		unsigned int o = (mode & MNOREG) ? 0 : IG->p0;
 		long stackm = CPULONG(Ofs_STACKM);
-		GTRACE1("O_POP2",o);
+		int imm16 = (mode&MRETISP) ? IG->p0 : 0;
+		GTRACE2("O_POP2",o,imm16);
 		AR2.d = CPULONG(Ofs_XSS);
 		if (mode & DATA16) {
 			SR1.d &= stackm;
 			DR1.w.l = sim_read_word(AR2.d + SR1.d);
 			if (!(mode & MNOREG))
 				CPUWORD(o) = DR1.w.l;
-			SR1.d += 2;
+			SR1.d += 2 + imm16;
 		}
 		else {
 			SR1.d &= stackm;
 			DR1.d = sim_read_dword(AR2.d + SR1.d);
 			if (!(mode & MNOREG))
 				CPULONG(o) = DR1.d;
-			SR1.d += 4;
+			SR1.d += 4 + imm16;
 		}
 		if (debug_level('e')>3) dbug_printf("(V) %08x\n",DR1.d);
 		} break;

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -2085,6 +2085,9 @@ static unsigned int Gen_sim(const IGen *IG, dosaddr_t mem_ref)
 
 	case O_POP3:
 		GTRACE0("O_POP3");
+#ifdef STACK_WRAP_MP	/* mask after incrementing */
+		SR1.d &= CPULONG(Ofs_STACKM);
+#endif
 #ifdef KEEP_ESP	/* keep high 16-bits of ESP in small-stack mode */
 		SR1.d |= (CPULONG(Ofs_ESP) & ~CPULONG(Ofs_STACKM));
 #endif

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -2062,21 +2062,21 @@ static unsigned int Gen_sim(const IGen *IG, dosaddr_t mem_ref)
 
 	case O_POP2: {
 		wkreg AR2;
-		unsigned int o = IG->p0;
+		unsigned int o = (mode & MNOREG) ? 0 : IG->p0;
 		long stackm = CPULONG(Ofs_STACKM);
 		GTRACE1("O_POP2",o);
 		AR2.d = CPULONG(Ofs_XSS);
 		if (mode & DATA16) {
 			SR1.d &= stackm;
 			DR1.w.l = sim_read_word(AR2.d + SR1.d);
-			if (o != Ofs_RZERO)
+			if (!(mode & MNOREG))
 				CPUWORD(o) = DR1.w.l;
 			SR1.d += 2;
 		}
 		else {
 			SR1.d &= stackm;
 			DR1.d = sim_read_dword(AR2.d + SR1.d);
-			if (o != Ofs_RZERO)
+			if (!(mode & MNOREG))
 				CPULONG(o) = DR1.d;
 			SR1.d += 4;
 		}

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -1516,7 +1516,7 @@ shrot0:
 		//	first do address calculation, then pop,
 		//	then store data, and last adjust stack
 		GNX(Cp, p, sz);
-		if (IG->p0 != Ofs_RZERO) {
+		if (!(mode & MNOREG)) {
 			// mov{wl} %%{e}ax,offs(%%ebx)
 			Gen66(mode, Cp); G3M(0x89,0x43,IG->p0,Cp);
 		}

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -1495,7 +1495,7 @@ shrot0:
 			0x8d,0x14,0x0e,
 			// movw (%%edx,%%ebp,1),%%ax
 			0x66,0x8b,0x04,0x2a,
-/*0a*/			// leal 2(%%esi),%%esi
+			// leal 2(%%esi),%%esi
 			0x8d,0x76,0x02,
 		};
 		const unsigned char pseq32[] = {
@@ -1505,7 +1505,7 @@ shrot0:
 			0x8d,0x14,0x0e,
 			// movl (%%edx,%%ebp,1),%%eax
 			0x90,0x8b,0x04,0x2a,
-/*0a*/			// leal 4(%%esi),%%esi
+			// leal 4(%%esi),%%esi
 			0x8d,0x76,0x04,
 		};
 		const unsigned char *p;
@@ -1516,6 +1516,10 @@ shrot0:
 		//	first do address calculation, then pop,
 		//	then store data, and last adjust stack
 		GNX(Cp, p, sz);
+		if (mode & MRETISP) {
+			// leal IG->p0(%%esi),%%esi
+			G2M(0x8d,0xb6,Cp); G4(IG->p0,Cp);
+		}
 		if (!(mode & MNOREG)) {
 			// mov{wl} %%{e}ax,offs(%%ebx)
 			Gen66(mode, Cp); G3M(0x89,0x43,IG->p0,Cp);

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -1479,60 +1479,53 @@ shrot0:
 /* POP derived (sub-)sequences: */
 	case O_POP1: {
 		const unsigned char pseq[] = {
-			// movl Ofs_XSS(%%ebx),%%esi
-			0x8b,0x73,Ofs_XSS,
-			// movl Ofs_ESP(%%ebx),%%ecx
-			0x8b,0x4b,Ofs_ESP
+			// movl Ofs_XSS(%%ebx),%%ecx
+			0x8b,0x4b,Ofs_XSS,
+			// movl Ofs_ESP(%%ebx),%%esi
+			0x8b,0x73,Ofs_ESP,
 		};
 		GNX(Cp, pseq, sizeof(pseq));
 		} break;
 
 	case O_POP2: {
 		const unsigned char pseq16[] = {
-			// andl StackMask(%%ebx),%%ecx
-			0x23,0x4b,Ofs_STACKM,
+			// andl StackMask(%%ebx),%%esi
+			0x23,0x73,Ofs_STACKM,
 			// leal (%%esi,%%ecx,1),%%edx
 			0x8d,0x14,0x0e,
 			// movw (%%edx,%%ebp,1),%%ax
 			0x66,0x8b,0x04,0x2a,
-/*0a*/			// leal 2(%%ecx),%%ecx
-			0x8d,0x49,0x02,
+/*0a*/			// leal 2(%%esi),%%esi
+			0x8d,0x76,0x02,
 		};
 		const unsigned char pseq32[] = {
-			// andl StackMask(%%ebx),%%ecx
-			0x23,0x4b,Ofs_STACKM,
+			// andl StackMask(%%ebx),%%esi
+			0x23,0x73,Ofs_STACKM,
 			// leal (%%esi,%%ecx,1),%%edx
 			0x8d,0x14,0x0e,
 			// movl (%%edx,%%ebp,1),%%eax
 			0x90,0x8b,0x04,0x2a,
-/*0a*/			// leal 4(%%ecx),%%ecx
-			0x8d,0x49,0x04,
+/*0a*/			// leal 4(%%esi),%%esi
+			0x8d,0x76,0x04,
 		};
 		const unsigned char *p;
-		unsigned char *q;
 		int sz;
 		if (mode&DATA16) p=pseq16,sz=sizeof(pseq16);
 			else p=pseq32,sz=sizeof(pseq32);
 		// for popping into memory the sequence is:
 		//	first do address calculation, then pop,
 		//	then store data, and last adjust stack
-		q=Cp; GNX(Cp, p, sz);
+		GNX(Cp, p, sz);
 		if (IG->p0 != Ofs_RZERO) {
 			// mov{wl} %%{e}ax,offs(%%ebx)
 			Gen66(mode, Cp); G3M(0x89,0x43,IG->p0,Cp);
-		}
-		if (mode&MPOPRM) {
-			// save ecx into esi
-			// which is preserved in CPatches
-			// Use leal {2|4}(%%ecx),%%esi
-			q[0x0b] = 0x71;
 		}
 		} break;
 
 	case O_POP3: {
 #ifdef STACK_WRAP_MP	/* mask after incrementing */
-		// andl StackMask(%%ebx),%%ecx
-		G3M(0x23,0x4b,Ofs_STACKM,Cp);
+		// andl StackMask(%%ebx),%%esi
+		G3M(0x23,0x73,Ofs_STACKM,Cp);
 #endif
 #ifdef KEEP_ESP	/* keep high 16-bits of ESP in small-stack mode */
 		const unsigned char pseq[] = {
@@ -1542,15 +1535,13 @@ shrot0:
 			0xf7,0xd2,
 			// andl Ofs_ESP(%%ebx),%%edx
 			0x23,0x53,Ofs_ESP,
-			// orl %%edx,%%ecx
-			0x09,0xd1,
+			// orl %%edx,%%esi
+			0x09,0xd6,
 		};
 		GNX(Cp, pseq, sizeof(pseq));
-		// use orl %%edx,%%esi
-		if (mode&MPOPRM) Cp[-1] = 0xd6;
 #endif
-		// movl %%e{si|cx},Ofs_ESP(%%ebx)
-		G3M(0x89,(mode&MPOPRM)?0x73:0x4b,Ofs_ESP,Cp);
+		// movl %%esi,Ofs_ESP(%%ebx)
+		G3M(0x89,0x73,Ofs_ESP,Cp);
 		} break;
 
 	case O_LEAVE: {

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -1207,16 +1207,6 @@ shrot0:
 			0x8d,0x14,0x0e,
 			// movw %%ax,(%%edx,%%ebp,1)
 			0x66,0x89,0x04,0x2a,
-#ifdef KEEP_ESP	/* keep high 16-bits of ESP in small-stack mode */
-			// movl StackMask(%%ebx),%%edx
-			0x8b,0x53,Ofs_STACKM,
-			// notl %%edx
-			0xf7,0xd2,
-			// andl Ofs_ESP(%%ebx),%%edx
-			0x23,0x53,Ofs_ESP,
-			// orl %%edx,%%ecx
-			0x09,0xd1,
-#endif
 		};
 		const unsigned char pseq32[] = {
 			// nop; movl offs(%%ebx),%%eax
@@ -1229,16 +1219,6 @@ shrot0:
 			0x8d,0x14,0x0e,
 			// movl %%eax,(%%edx,%%ebp,1)
 			0x89,0x04,0x2a,
-#ifdef KEEP_ESP	/* keep high 16-bits of ESP in small-stack mode */
-			// movl StackMask(%%ebx),%%edx
-			0x8b,0x53,Ofs_STACKM,
-			// notl %%edx
-			0xf7,0xd2,
-			// andl Ofs_ESP(%%ebx),%%edx
-			0x23,0x53,Ofs_ESP,
-			// orl %%edx,%%ecx
-			0x09,0xd1,
-#endif
 		};
 		const unsigned char *p;
 		unsigned char *q;
@@ -1254,10 +1234,23 @@ shrot0:
 		}
 		} break;
 
-	case O_PUSH3:
+	case O_PUSH3: {
+#ifdef KEEP_ESP	/* keep high 16-bits of ESP in small-stack mode */
+		const unsigned char pseq[] = {
+			// movl StackMask(%%ebx),%%edx
+			0x8b,0x53,Ofs_STACKM,
+			// notl %%edx
+			0xf7,0xd2,
+			// andl Ofs_ESP(%%ebx),%%edx
+			0x23,0x53,Ofs_ESP,
+			// orl %%edx,%%ecx
+			0x09,0xd1,
+		};
+		GNX(Cp, pseq, sizeof(pseq));
+#endif
 		// movl %%ecx,Ofs_ESP(%%ebx)
 		G3M(0x89,0x4b,Ofs_ESP,Cp);
-		break;
+		} break;
 
 	case O_PUSH2F: {
 		const unsigned char pseqpre[] = {
@@ -1504,16 +1497,6 @@ shrot0:
 			0x66,0x8b,0x04,0x2a,
 /*0a*/			// leal 2(%%ecx),%%ecx
 			0x8d,0x49,0x02,
-#ifdef KEEP_ESP	/* keep high 16-bits of ESP in small-stack mode */
-			// movl StackMask(%%ebx),%%edx
-			0x8b,0x53,Ofs_STACKM,
-			// notl %%edx
-			0xf7,0xd2,
-			// andl Ofs_ESP(%%ebx),%%edx
-			0x23,0x53,Ofs_ESP,
-			// orl %%edx,%%ecx
-			0x09,0xd1,
-#endif
 		};
 		const unsigned char pseq32[] = {
 			// andl StackMask(%%ebx),%%ecx
@@ -1524,16 +1507,6 @@ shrot0:
 			0x90,0x8b,0x04,0x2a,
 /*0a*/			// leal 4(%%ecx),%%ecx
 			0x8d,0x49,0x04,
-#ifdef KEEP_ESP	/* keep high 16-bits of ESP in small-stack mode */
-			// movl StackMask(%%ebx),%%edx
-			0x8b,0x53,Ofs_STACKM,
-			// notl %%edx
-			0xf7,0xd2,
-			// andl Ofs_ESP(%%ebx),%%edx
-			0x23,0x53,Ofs_ESP,
-			// orl %%edx,%%ecx
-			0x09,0xd1,
-#endif
 		};
 		const unsigned char *p;
 		unsigned char *q;
@@ -1553,17 +1526,28 @@ shrot0:
 			// which is preserved in CPatches
 			// Use leal {2|4}(%%ecx),%%esi
 			q[0x0b] = 0x71;
-#ifdef KEEP_ESP	/* keep high 16-bits of ESP in small-stack mode */
-			// use orl %%edx,%%esi
-			q[sz-1] = 0xd6;
-#endif
 		}
 		} break;
 
-	case O_POP3:
+	case O_POP3: {
+#ifdef KEEP_ESP	/* keep high 16-bits of ESP in small-stack mode */
+		const unsigned char pseq[] = {
+			// movl StackMask(%%ebx),%%edx
+			0x8b,0x53,Ofs_STACKM,
+			// notl %%edx
+			0xf7,0xd2,
+			// andl Ofs_ESP(%%ebx),%%edx
+			0x23,0x53,Ofs_ESP,
+			// orl %%edx,%%ecx
+			0x09,0xd1,
+		};
+		GNX(Cp, pseq, sizeof(pseq));
+		// use orl %%edx,%%esi
+		if (mode&MPOPRM) Cp[-1] = 0xd6;
+#endif
 		// movl %%e{si|cx},Ofs_ESP(%%ebx)
 		G3M(0x89,(mode&MPOPRM)?0x73:0x4b,Ofs_ESP,Cp);
-		break;
+		} break;
 
 	case O_LEAVE: {
 		const unsigned char pseq16[] = {

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -1530,6 +1530,10 @@ shrot0:
 		} break;
 
 	case O_POP3: {
+#ifdef STACK_WRAP_MP	/* mask after incrementing */
+		// andl StackMask(%%ebx),%%ecx
+		G3M(0x23,0x4b,Ofs_STACKM,Cp);
+#endif
 #ifdef KEEP_ESP	/* keep high 16-bits of ESP in small-stack mode */
 		const unsigned char pseq[] = {
 			// movl StackMask(%%ebx),%%edx

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -269,7 +269,7 @@ void Gen(int op, int mode, ...)
 		break;
 
 	case O_POP2:
-		if (!(mode & MNOREG))
+		if (!(mode & MNOREG) || (mode && MRETISP))
 			IG->p0 = va_arg(ap,unsigned int);
 		break;
 

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -264,9 +264,13 @@ void Gen(int op, int mode, ...)
 	case O_IDIV:
 	case O_PUSHI:
 	case O_PUSH2:
-	case O_POP2:
 	case JMP_TAILCODE:
 		IG->p0 = va_arg(ap,unsigned int);
+		break;
+
+	case O_POP2:
+		if (!(mode & MNOREG))
+			IG->p0 = va_arg(ap,unsigned int);
 		break;
 
 	case L_REG2REG:

--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -185,6 +185,7 @@
 #define MBIGCS	0x00080000
 
 #define CKSIGN	0x00100000	// check signal: for jumps
+#define MNOREG  0x00200000
 // for HOST_ARCH_X86
 #define MREPCOND 0x01000000	// this is SCASx or CMPSx, REP can be terminated
 				// by flags

--- a/src/base/emu-i386/simx86/cpatch.c
+++ b/src/base/emu-i386/simx86/cpatch.c
@@ -634,11 +634,12 @@ int Cpatch(sigcontext_t *scp)
 	    JSRPATCH(p,Ofs_stub_stk_32);
 	}
 	p+=3;
-#ifdef KEEP_ESP
-	p += 10;
-#endif
 	/* check for optimized multiple register push */
+#ifdef KEEP_ESP
+	if (p[10]==0x89) return 1; //O_PUSH3
+#else
 	if (p[0]==0x89) return 1; //O_PUSH3
+#endif
 	p += 13;
 	if (p[0]==0xff) return 1; // already JSRPATCH'ed
 	if (*p==0x66) w16=1,p++; else w16=0;

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -1010,12 +1010,12 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			    AddrGen(A_SR_SH4, _mode, Ofs_ES, Ofs_XES);
 			} else { /* restartable */
 			    Gen(O_POP1, _mode);
-			    Gen(O_POP2, _mode|MPOPRM, Ofs_RZERO);
+			    Gen(O_POP2, _mode|MNOREG);
 			    /* same principle applies as for POPrm: this
 			       segment load may fault, above pops into
 			       temporary storage without adjusting (E)SP */
 			    AddrGen(A_SR_PROT, _mode, Ofs_ES, P0);
-			    Gen(O_POP3, _mode|MPOPRM);
+			    Gen(O_POP3, _mode);
 			}
 			PC++;
 			break;
@@ -1024,9 +1024,9 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			    AddrGen(A_SR_SH4, _mode, Ofs_SS, Ofs_XSS);
 			} else { /* restartable */
 			    Gen(O_POP1, _mode);
-			    Gen(O_POP2, _mode|MPOPRM, Ofs_RZERO);
+			    Gen(O_POP2, _mode|MNOREG);
 			    AddrGen(A_SR_PROT, _mode, Ofs_SS, P0);
-			    Gen(O_POP3, _mode|MPOPRM);
+			    Gen(O_POP3, _mode);
 			}
 			InstrMeta[CurrIMeta].flags |= F_INHI;
 			PC++;
@@ -1036,9 +1036,9 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			    AddrGen(A_SR_SH4, _mode, Ofs_DS, Ofs_XDS);
 			} else { /* restartable */
 			    Gen(O_POP1, _mode);
-			    Gen(O_POP2, _mode|MPOPRM, Ofs_RZERO);
+			    Gen(O_POP2, _mode|MNOREG);
 			    AddrGen(A_SR_PROT, _mode, Ofs_DS, P0);
-			    Gen(O_POP3, _mode|MPOPRM);
+			    Gen(O_POP3, _mode);
 			}
 			PC++;
 			break;
@@ -1259,13 +1259,13 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			} else {
 				// read data into temporary storage
 				Gen(O_POP1, _mode);
-				Gen(O_POP2, _mode|MPOPRM, Ofs_RZERO);
+				Gen(O_POP2, _mode|MNOREG);
 				// store data
 				// S_DI may fault, in which case the instruction
 				// may need to be restarted with the original
 				// value of ESP!
 				Gen(S_DI, _mode);	// mov [edi],{e}ax
-				Gen(O_POP3, _mode|MPOPRM);
+				Gen(O_POP3, _mode);
 			}
 			break;
 
@@ -1864,8 +1864,8 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			if (!REALADDR()) {
 				/* pop from stack without adjusting esp */
 				Gen(O_POP1, _mode);
-				Gen(O_POP2, _mode, Ofs_RZERO);
-				Gen(O_POP2, _mode, Ofs_RZERO);
+				Gen(O_POP2, _mode|MNOREG);
+				Gen(O_POP2, _mode|MNOREG);
 				AddrGen(A_SR_PROT, _mode, Ofs_CS, P0);
 			}
 			{
@@ -1966,8 +1966,8 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			if (!REALADDR()) {
 			    /* pop from stack without adjusting esp */
 			    Gen(O_POP1, _mode);
-			    Gen(O_POP2, _mode, Ofs_RZERO);
-			    Gen(O_POP2, _mode, Ofs_RZERO);
+			    Gen(O_POP2, _mode|MNOREG);
+			    Gen(O_POP2, _mode|MNOREG);
 			    AddrGen(A_SR_PROT, _mode, Ofs_CS, P0);
 			}
 			Gen(O_POP, _mode);
@@ -3109,9 +3109,9 @@ repag0:
 				    AddrGen(A_SR_SH4, _mode, Ofs_FS, Ofs_XFS);
 				} else { /* restartable */
 				    Gen(O_POP1, _mode);
-				    Gen(O_POP2, _mode|MPOPRM, Ofs_RZERO);
+				    Gen(O_POP2, _mode|MNOREG);
 				    AddrGen(A_SR_PROT, _mode, Ofs_FS, P0);
-				    Gen(O_POP3, _mode|MPOPRM);
+				    Gen(O_POP3, _mode);
 				}
 				PC+=2;
 				break;
@@ -3213,9 +3213,9 @@ repag0:
 				    AddrGen(A_SR_SH4, _mode, Ofs_GS, Ofs_XGS);
 				} else { /* restartable */
 				    Gen(O_POP1, _mode);
-				    Gen(O_POP2, _mode|MPOPRM, Ofs_RZERO);
+				    Gen(O_POP2, _mode|MNOREG);
 				    AddrGen(A_SR_PROT, _mode, Ofs_GS, P0);
-				    Gen(O_POP3, _mode|MPOPRM);
+				    Gen(O_POP3, _mode);
 				}
 				PC+=2;
 				break;

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -388,8 +388,6 @@ static unsigned int _JumpGen(unsigned int P2, int mode, int opc,
 		Gen(JLOOP_LINK, mode, opc, j_t, j_nt);
 		break;
 	case RETl: case RETlisp: // far ret, indirect
-		if (REALADDR()) AddrGen(A_SR_SH4, mode, Ofs_CS, Ofs_XCS);
-		/* fall through */
 	case JMPli: case CALLli: case INT: // far jmp/call, indirect
 		Gen(L_REG, mode, Ofs_EIP);
 		/* fall through */
@@ -1860,23 +1858,21 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 /*c9*/	case LEAVE:
 			Gen(O_LEAVE, _mode); PC++;
 			break;
-/*ca*/	case RETlisp:	/* restartable */
-			if (!REALADDR()) {
-				/* pop from stack without adjusting esp */
-				Gen(O_POP1, _mode);
-				Gen(O_POP2, _mode|MNOREG);
-				Gen(O_POP2, _mode|MNOREG);
+/*ca*/	case RETlisp: {	/* restartable */
+			/* pop from stack without adjusting esp before A_SR_* */
+			int dr = (signed short)FetchW(PC+1);
+			Gen(O_POP1, _mode);
+			Gen(O_POP2, _mode, Ofs_EIP);
+			Gen(O_POP2, _mode|MNOREG|MRETISP, dr);
+			if (REALADDR())
+				AddrGen(A_SR_SH4, _mode, Ofs_CS, Ofs_XCS);
+			else
 				AddrGen(A_SR_PROT, _mode, Ofs_CS, P0);
-			}
-			{
-				int dr = (signed short)FetchW(PC+1);
-				Gen(O_POP, _mode);
-				Gen(S_REG, _mode, Ofs_EIP);
-				Gen(O_POP, _mode|MRETISP, dr);
-				PC = JumpGen(PC, _mode, opc, 3, P0, _flags);
-				if (debug_level('e')>2)
-					e_printf("RET_%d: ret=%08x\n",dr,TheCPU.eip);
-				if (TheCPU.err) return PC;
+			Gen(O_POP3, _mode);
+			PC = JumpGen(PC, _mode, opc, 3, P0, _flags);
+			if (debug_level('e')>2)
+				e_printf("RET_%d: ret=%08x\n",dr,TheCPU.eip);
+			if (TheCPU.err) return PC;
 			}
 			break;
 /*cc*/	case INT3:
@@ -1963,16 +1959,15 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 		}
 
 /*cb*/	case RETl:
-			if (!REALADDR()) {
-			    /* pop from stack without adjusting esp */
-			    Gen(O_POP1, _mode);
-			    Gen(O_POP2, _mode|MNOREG);
-			    Gen(O_POP2, _mode|MNOREG);
-			    AddrGen(A_SR_PROT, _mode, Ofs_CS, P0);
-			}
-			Gen(O_POP, _mode);
-			Gen(S_REG, _mode, Ofs_EIP);
-			Gen(O_POP, _mode);
+			/* pop from stack without adjusting esp before A_SR_* */
+			Gen(O_POP1, _mode);
+			Gen(O_POP2, _mode, Ofs_EIP);
+			Gen(O_POP2, _mode|MNOREG);
+			if (REALADDR())
+				AddrGen(A_SR_SH4, _mode, Ofs_CS, Ofs_XCS);
+			else
+				AddrGen(A_SR_PROT, _mode, Ofs_CS, P0);
+			Gen(O_POP3, _mode);
 			PC = JumpGen(PC, _mode, opc, 1, P0, _flags);
 			if (debug_level('e')>1)
 			    e_printf("RET_FAR: ret=%04x:%08x\n",TheCPU.cs,TheCPU.eip);


### PR DESCRIPTION
To address https://github.com/dosemu2/dosemu2/pull/2572#discussion_r2331246722 I reorganized a little:
* switch role of ecx/esi in O_POP1/O_POP2/O_POP3 to avoid special changes for MPOPRM
* STACK_WRAP_MP (recently enabled) now also applies the same way to the split up POPs
* KEEP_ESP can be done more efficiently in O_POP3, as O_POP2 doesn't modify ESP. Also did O_PUSH2/O_PUSH3 here as it's similar.
* Use MNOREG instead of Ofs_RZERO
* POP into TheCPU.eip as that's safe for pm with faults