### PR TITLE
simx86: Handle x87 FPU illegal ops properly

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -477,10 +477,7 @@ static unsigned int Gen_sim(const IGen *IG, dosaddr_t mem_ref)
 		unsigned char exop = (unsigned char)IG->p0;
 		int reg = IG->p1;
 		GTRACE2("O_FPOP",exop,reg);
-		if (Fp87_op(exop, reg, mem_ref)) {
-		    TheCPU.err2 = -96;
-		    P0 = FindPC((const unsigned char *)IG);
-		}
+		Fp87_op(exop, reg, mem_ref);
 		int exs = TheCPU.fpus & 0x7f;
 		if (debug_level('e')>3) {
 		    e_printf("  %s\n", e_trace_fp());

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -327,12 +327,8 @@ static unsigned char *CodeGen_x86(unsigned char *CodePtr, unsigned char *BaseGen
 		// andl $0x3f,%%eax
 		G3(0x3fe083,Cp);
 		break;
-	case O_FOP: {
-		unsigned char *p = Fp87_op_x86(CodePtr, IG->p0, IG->p1);
-		if (p == NULL)
-		    TheCPU.err = -96;
-		else Cp = p;
-		}
+	case O_FOP:
+		Cp = Fp87_op_x86(Cp, IG->p0, IG->p1);
 		break;
 
 	case L_REG: {

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -537,9 +537,6 @@ TNode *Close(unsigned int PC, unsigned int Interp_LONG_CS, int mode)
 	}
 
 	GenCodeBuf = ProduceCode(PC, I0);
-	/* check for fatal error */
-	if (TheCPU.err < 0)
-		return NULL;
 
 	NodesParsed++;
 #if PROFILE

--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -269,7 +269,8 @@ int NewIMeta(int npc, int *rc);
 extern int CurrIMeta;
 extern void Gen(int op, int mode, ...);
 extern void AddrGen(int op, int mode, ...);
-extern int  (*Fp87_op)(int exop, int reg, unsigned mem_ref);
+extern void (*Fp87_op)(int exop, int reg, unsigned mem_ref);
+extern int Fp87_illegal_op(int exop, int reg);
 TNode *Close(unsigned int PC, unsigned int Interp_LONGCS, int mode);
 extern unsigned char * (*CodeGen)(unsigned char *CodePtr,
 				  unsigned char *BaseGenBuf, const IGen *IG);

--- a/src/base/emu-i386/simx86/fp87-sim.c
+++ b/src/base/emu-i386/simx86/fp87-sim.c
@@ -37,6 +37,7 @@
 #include <math.h>
 #include "dos2linux.h"
 #include "emu86.h"
+#include "utilities.h"
 #include "codegen.h"
 #include "codegen-sim.h"
 #ifndef HAVE___FLOAT80
@@ -74,8 +75,8 @@
 #define M_LOG2El 1.442695040888963407359924681001892137L
 #endif
 
-int (*Fp87_op)(int exop, int reg, unsigned mem_ref);
-static int Fp87_op_sim(int exop, int reg, unsigned mem_ref);
+void (*Fp87_op)(int exop, int reg, unsigned mem_ref);
+static void Fp87_op_sim(int exop, int reg, unsigned mem_ref);
 
 static long double WFR0, WFR1;
 
@@ -256,7 +257,7 @@ static void write_long_double(dosaddr_t addr, long double ld)
 	sim_write_word(addr+8, x.u32[2]);
 }
 
-static int Fp87_op_sim(int exop, int reg, unsigned mem_ref)
+static void Fp87_op_sim(int exop, int reg, unsigned mem_ref)
 {
 //	42	DA 11000nnn	FCMOVB	st(0),st(n)
 //	43	DB 11000nnn	FCMOVNB	st(0),st(n)
@@ -1176,9 +1177,116 @@ fcom00:			TheCPU.fpus &= ~(FPUS_C0 | FPUS_C2 | FPUS_C3);
 
 /*xx*/	default:
 fp_notok:
-	return -1;
+	// should be caught by Fp87_illegal_op
+	dosemu_error("Unknown FPop %x.%d\n", exop, reg);
 	}
 fp_ok:
-	return 0;
 }
 
+int Fp87_illegal_op(int exop, int reg)
+{
+	e_printf("FPop %x.%d\n", exop, reg);
+
+	switch(exop) {
+//	09	D9 xx001nnn	undefined
+/*09*/	case 0x09:
+
+//	0B	DB xx001nnn	FISTTP	dw // SSE3 capable CPUs
+//	0D	DD xx001nnn	FISTTP	qw // SSE3 capable CPUs
+//	0F	DF xx001nnn	FISTTP	w  // SSE3 capable CPUs
+	case 0x0b: case 0x0d: case 0x0f:
+
+//	23	DB xx100nnn	undefined
+//	2D	DD xx101nnn	undefined
+//	33	DB xx110nnn	undefined
+	case 0x23: case 0x2d: case 0x33:
+
+//	42	DA 11000nnn	FCMOVB	st(0),st(n) (CPUID)
+//	43	DB 11000nnn	FCMOVNB	st(0),st(n) (CPUID)
+//	4A	DA 11001nnn	FCMOVE	st(0),st(n) (CPUID)
+//	4B	DB 11001nnn	FCMOVNE	st(0),st(n) (CPUID)
+	case 0x42: case 0x43: case 0x4a: case 0x4b:
+		break;
+
+//	51	D9 11010nnn	51.0=FNOP, others undefined
+/*51*/	case 0x51:
+		if (reg==0) goto fp_ok;
+		break;
+
+//	52	DA 11010nnn	FCMOVBE	st(0),st(n) (CPUID)
+//	53	DB 11010nnn	FCMOVNBE st(0),st(n) (CPUID)
+//	5A	DA 11011nnn	FCMOVU	st(0),st(n) (CPUID)
+//	5B	DB 11011nnn	FCMOVNU	st(0),st(n) (CPUID)
+	case 0x52: case 0x53: case 0x5a: case 0x5b:
+		break;
+
+//	5E	DE 11011nnn	5E.1 = FCOMPP, others undefined
+		if (reg==1) goto fp_ok;
+		break;
+
+	case 0x5e:
+
+//	61	D9 11100nnn     0,1,4,5 valid, others undefined
+	case 0x61:
+		switch(reg) {
+		   case 0:		/* FCHS */
+		   case 1:		/* FABS */
+		   case 4:		/* FTST */
+		   case 5:		/* FXAM */
+			goto fp_ok;
+		   default:
+			break;
+		}
+		break;
+
+//	62	DA 11100nnn	invalid
+	case 0x62:
+
+//	63	DB 11000nnn	63.5, 63.6, 63.7 are invalid
+/*63*/	case 0x63:
+		if (reg < 5) goto fp_ok;
+		break;
+
+//	67	DF 11100nnn	67.0=FNSTSW AX, others undefined
+	case 0x67:
+		if (reg==0) goto fp_ok;
+		break;
+
+//	69	D9 11101nnn	<7 defined, 7 invalid
+	case 0x69:
+		if (reg!=7) goto fp_ok;
+	        break;
+
+//	6A	DA 11101nnn	6A.1=FUCOMPP, others undefined
+	case 0x6a:
+		if (reg==1) goto fp_ok;
+		break;
+
+//	6B	DB 11101nnn	FUCOMI (CPUID)
+//	6F	DF 11101nnn	FUCOMIP (CPUID)
+	case 0x6b: case 0x6f:
+
+//	72	DA 11110nnn	undefined
+/*72*/	case 0x72:
+
+//	73	DB 11110nnn	FCOMI (CPUID)
+/*73*/	case 0x73:
+
+//	75	DD 11110nnn	undefined
+/*75*/	case 0x75:
+
+//	77	DF 11110nnn	FCOMIP (CPUID)
+/*77*/	case 0x77:
+
+//	7A	DA 11111nnn	undefined
+//	7B	DB 11111nnn	undefined
+//	7D	DD 11111nnn	undefined
+//	7F	DF 11111nnn	undefined
+	case 0x7a: case 0x7b: case 0x7d: case 0x7f:
+		break;
+
+	default:
+fp_ok:	return 0;
+	}
+	return 1;
+}

--- a/src/base/emu-i386/simx86/fp87-sim.c
+++ b/src/base/emu-i386/simx86/fp87-sim.c
@@ -577,9 +577,15 @@ fcom00:			TheCPU.fpus &= ~(FPUS_C0 | FPUS_C2 | FPUS_C3);
 		break;
 
 /*50*/	case 0x50:
+/*54*/	case 0x54:
+/*56*/	case 0x56:
 /*58*/	case 0x58:
+/*5c*/	case 0x5c:
 //*	50	D8 11010nnn	FCOM	st,st(n)
+//*	54	DC 11010nnn	FCOM2*	st,st(n) (alias)
+//*	56	DE 11010nnn	FCOMP5*	st,st(n) (alias)
 //*	58	D8 11011nnn	FCOMP	st,st(n)
+//*	5C	DC 11011nnn	FCOMP3*	st,st(n) (alias)
 		WFR0 = *ST0;
 		WFR1 = *STn(reg);
 		TheCPU.fpus &= ~(FPUS_C0 | FPUS_C2 | FPUS_C3);
@@ -590,7 +596,7 @@ fcom00:			TheCPU.fpus &= ~(FPUS_C0 | FPUS_C2 | FPUS_C3);
 			else if (WFR0 > WFR1); /* do nothing */
 			else /* not comparable */
 			    TheCPU.fpus |= FPUS_C0 | FPUS_C2 | FPUS_C3;
-		if (exop&8) INCFSPP;
+		if (exop>=0x56) INCFSPP;
 		break;
 
 /*6a*/	case 0x6a: if (reg!=1) goto fp_notok;
@@ -695,11 +701,13 @@ fcom00:			TheCPU.fpus &= ~(FPUS_C0 | FPUS_C2 | FPUS_C3);
 		break;
 
 /*45*/	case 0x45:
+/*45*/	case 0x47:
 //	45	DD 11000nnn	FFREE	st(n)		set tag(n) empty
+//	47	DF 11000nnn	FFREEP6*	st(n) (semi-alias)
 		FREETAG(reg);
+		if (exop==0x47) INCFSPP;
 		break;
 /*51*/	case 0x51:
-/*59*/	case 0x59:
 		 if (reg==0) {
 //*	51.0	D9 11010000	FNOP
 			break;		// nop
@@ -708,7 +716,11 @@ fcom00:			TheCPU.fpus &= ~(FPUS_C0 | FPUS_C2 | FPUS_C3);
 		   break;
 
 /*49*/	case 0x49:
+/*4d*/	case 0x4d:
+/*4f*/	case 0x4f:
 //*	49	D9 11001nnn	FXCH	st,st(n)
+//*	4D	DD 11001nnn	FXCH4*	st,st(n) (alias)
+//*	4F	DF 11001nnn	FXCH7*	st,st(n) (alias)
 		{ long double t;
 		  memcpy(&t, ST0, sizeof t);
 		  memcpy(ST0, STn(reg), sizeof t);
@@ -716,13 +728,27 @@ fcom00:			TheCPU.fpus &= ~(FPUS_C0 | FPUS_C2 | FPUS_C3);
 		}
 		break;
 
+/*59*/	case 0x59:
+//	59	D9 11011nnn	FSTPNCE1* st(n) (semi-alias)
+		// https://en.wikipedia.org/wiki/X86_instruction_listings#cite_note-339
+		// If the top-of-stack register st(0) is Empty, then the FSTPNCE
+		// instruction will behave like FINCSTP, incrementing the stack pointer
+		// with no data movement and no exceptions reported.
+		if (((TheCPU.fptag >> 2*S_reg(TheCPU.fpstt,0)) & 3) == 3) {
+			INCFSP;
+			break;
+		} // else fall through
 /*55*/	case 0x55:
+/*57*/	case 0x57:
 /*5d*/	case 0x5d:
+/*5f*/	case 0x5f:
 //	55	DD 11010nnn	FST	st(n)
+//	57	DF 11010nnn	FSTP8*	st(n) (alias)
 //	5D	DD 11011nnn	FSTP	st(n)
+//	5F	DF 11011nnn	FSTP9*	st(n) (alias)
 		*STn(reg) = *ST0;
 		UNFREETAG(reg);
-		if (exop==0x5d) INCFSPP;
+		if (exop>=0x57) INCFSPP;
 		break;
 
 /*61*/	case 0x61:
@@ -771,6 +797,10 @@ fcom00:			TheCPU.fpus &= ~(FPUS_C0 | FPUS_C2 | FPUS_C3);
 			feclearexcept(FE_ALL_EXCEPT);
 			WFR0 = WFR1 = 0.0;
 			break;
+		   case 5:
+		   case 6:
+		   case 7:
+			goto fp_notok;
 		   default: /* FNENI,FNDISI: 8087 */
 			    /* FSETPM,FRSTPM: 80287 */
 			goto fp_ok;	// do nothing

--- a/src/base/emu-i386/simx86/fp87-x86.c
+++ b/src/base/emu-i386/simx86/fp87-x86.c
@@ -249,11 +249,21 @@ fp_mem:
 //*	68	D8 11101nnn	FSUBR	st,st(n)
 //*	70	D8 11110nnn	FDIV	st,st(n)
 //*	78	D8 11111nnn	FDIVR	st,st(n)
+		goto fp_op;
 
 /*50*/	case 0x50:
-/*58*/	case 0x58:
+/*54*/	case 0x54:
 //*	50	D8 11010nnn	FCOM	st,st(n)
+//*	54	DC 11010nnn	FCOM2*	st,st(n) (alias)
+		exop = 0x50;
+		goto fp_op;
+/*56*/	case 0x56:
+/*58*/	case 0x58:
+/*58*/	case 0x5c:
+//*	56	DE 11010nnn	FCOMP5*	st,st(n) (alias)
 //*	58	D8 11011nnn	FCOMP	st,st(n)
+//*	5C	DC 11011nnn	FCOMP3*	st,st(n) (alias)
+		exop = 0x58;
 		goto fp_op;
 
 /*6a*/	case 0x6a: if (reg!=1) goto fp_notok;
@@ -307,7 +317,6 @@ fp_mem:
 
 /*45*/	case 0x45: goto fp_op;
 /*51*/	case 0x51:
-/*59*/	case 0x59:
 		if (reg==0) {
 //	45	DD 11000nnn	FFREE	st(n)		set tag(n) empty
 //*	51.0	D9 11010000	FNOP
@@ -316,14 +325,59 @@ fp_mem:
 		   else goto fp_notok;
 		   break;
 
+/*47*/	case 0x47:
+//	47	DF 11000nnn	FFREEP*6	st(n) (semi-alias)
+		// ffree %st(reg)
+		G2M(0xdd,0xc0|reg,Cp);
+		// fstp %st(0)
+		G2M(0xdd,0xd8,Cp);
+		break;
+
 /*49*/	case 0x49:
+/*4D*/	case 0x4d:
+/*4F*/	case 0x4f:
 //*	49	D9 11001nnn	FXCH	st,st(n)
+//*	4D	DD 11001nnn	FXCH4*	st,st(n) (alias)
+//*	4F	DF 11001nnn	FXCH7*	st,st(n) (alias)
+		exop = 0x49;
+		goto fp_op;
 
 /*55*/	case 0x55:
-/*5d*/	case 0x5d:
 //	55	DD 11010nnn	FST	st(n)
-//	5D	DD 11011nnn	FSTP	st(n)
 		goto fp_op;
+
+/*57*/	case 0x57:
+/*5d*/	case 0x5d:
+/*5f*/	case 0x5f:
+//	57	DF 11010nnn	FSTP8*	st(n) (alias)
+//	5D	DD 11011nnn	FSTP	st(n)
+//	5F	DF 11011nnn	FSTP9*	st(n) (alias)
+		exop = 0x5d;
+		goto fp_op;
+
+/*59*/	case 0x59:
+//	59	D9 11011nnn	FSTPNCE1* st(n) (semi-alias)
+		// https://en.wikipedia.org/wiki/X86_instruction_listings#cite_note-339
+		// If the top-of-stack register st(0) is Empty, then the FSTPNCE
+		// instruction will behave like FINCSTP, incrementing the stack pointer
+		// with no data movement and no exceptions reported.
+		// fxam
+		G2M(0xd9,0xe5,Cp);
+		// fnstsw %ax
+		G2M(0xdf,0xe0,Cp);
+		// andb $0x45,%ah
+		G3M(0x80,0xe4,0x45,Cp);
+		// cmpb $0x41,%ah tests for empty st(0)
+		G3M(0x80,0xfc,0x41,Cp);
+		// jne 1f:
+		G2M(0x75,0x04,Cp);
+		// fincstp
+		G2M(0xd9,0xf7,Cp);
+		// jmp 2f
+		G2M(0xeb,0x02,Cp);
+		// 1: fstp %st(reg)
+		G2M(0xdd,0xd8|reg,Cp);
+		break;
 
 /*61*/	case 0x61:
 //*	61.0	D9 11100000	FCHS
@@ -350,6 +404,10 @@ fp_mem:
 			// movw	0x37f,FPUC(ebx)
 			G3M(0x66,0xc7,0x43,Cp); G1(Ofs_FPUC,Cp); G2(0x37f,Cp);
 			goto fp_op;
+		   case 5:
+		   case 6:
+		   case 7:
+			goto fp_notok;
 		   default: /* FNENI,FNDISI: 8087 */
 			    /* FSETPM,FRSTPM: 80287 */
 			goto fp_ok;	// do nothing

--- a/src/base/emu-i386/simx86/fp87-x86.c
+++ b/src/base/emu-i386/simx86/fp87-x86.c
@@ -36,8 +36,9 @@
 #include "emu86.h"
 
 #include "codegen-x86.h"
+#include "utilities.h"
 
-static int Fp87_op_x86_sim(int exop, int reg, unsigned mem_ref);
+static void Fp87_op_x86_sim(int exop, int reg, unsigned mem_ref);
 
 /*
  * Only mask bits 0-5 of the control word (fpuc),
@@ -451,13 +452,14 @@ fp_mem:
 
 /*xx*/	default:
 fp_notok:
-	return NULL;
+	// should be caught by Fp87_illegal_op
+	dosemu_error("Unknown FPop %x.%d\n", exop, reg);
 	}
 fp_ok:
 	return Cp;
 }
 
-static int Fp87_op_x86_sim(int exop, int reg, unsigned mem_ref)
+static void Fp87_op_x86_sim(int exop, int reg, unsigned mem_ref)
 {
 	e_printf("FPop %x.%d\n", exop, reg);
 	if (TheCPU.fpstate) {
@@ -570,7 +572,7 @@ static int Fp87_op_x86_sim(int exop, int reg, unsigned mem_ref)
 		   break;
 
 /*xx*/	default:
-	return -1;
+	// should be caught by Fp87_illegal_op
+	dosemu_error("Unknown FPop %x.%d\n", exop, reg);
 	}
-	return 0;
 }

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -2831,11 +2831,12 @@ repag0:
 				}
 			}
 			b &= 7;
+			if (Fp87_illegal_op(exop, b)) {
+				CODE_FLUSH();
+				goto illegal_op;
+			}
 			if (sim) {
-			    if (Fp87_op(exop,b,TheCPU.mem_ref)) {
-				TheCPU.err = -96;
-				return P0;
-			    }
+			    Fp87_op(exop,b,TheCPU.mem_ref);
 			}
 			else
 			    Gen(O_FOP, _mode, exop, b);


### PR DESCRIPTION
When an undefined FPU instruction was encountered, we got TheCPU.err=-96 and a fatal exit. Moreover, this meant Close() could return NULL, which is not always checked. Handle this properly by checking in advance for illegal FPU instructions. Now dosemu2 no longer exits but DOS can report a SIGILL via int6.

I also went through various references to check which exact instructions are illegal and noticed some alias and semi-alias instructions; those now all work. I still should cross check if #1472 still works, since as a result the opcode D9 D8 was implemented as FNOP even if it really isn't according to docs (it's `FSTPNCE ST0`, which doesn't do much except pop the FPU stack).