### PR TITLE
vgaemu: populate BDA even in dumb mode [fixes #2576]

### DIFF
--- a/src/arch/linux/async/signal.c
+++ b/src/arch/linux/async/signal.c
@@ -704,7 +704,7 @@ static void SIGALRM_call(void *arg)
 
   if ((pic_sys_time-cnt10) >= (PIT_TICK_RATE/100) || dosemu_frozen) {
     cnt10 = pic_sys_time;
-    if (video_initialized && !config.vga)
+    if (video_initialized && !config.vga && !config.dumb_video)
       update_screen();
   }
 

--- a/src/base/bios/int10.c
+++ b/src/base/bios/int10.c
@@ -476,11 +476,6 @@ bool set_video_mode(int mode)
   int co, li, vga_font_height, orig_mode;
   ioport_t port;
 
-  if (config.dumb_video) {
-    i10_msg("set_video_mode: no video!\n");
-    return 0;
-  }
-
   i10_msg("set_video_mode: mode 0x%02x\n", mode);
 
   if((vmi = vga_emu_find_mode(mode, NULL)) == NULL) {
@@ -649,7 +644,7 @@ bool set_video_mode(int mode)
   WRITE_WORD(BIOS_FONT_HEIGHT, vga_font_height); // before set_cursor_shape()
   set_cursor_shape(vmi->type == TEXT_MONO ? 0x0b0d : 0x0607);
 
-  if (using_text_mode()) {
+  if (!config.dumb_video && using_text_mode()) {
     v_printf("INT10: X_set_video_mode: 8x%d ROM font -> bank 0\n",
              vga_font_height);
     vga_ROM_to_RAM(vga_font_height, 0); /* 0 is default bank */

--- a/src/base/dev/vga/vgaemu.c
+++ b/src/base/dev/vga/vgaemu.c
@@ -1591,6 +1591,7 @@ int vga_emu_pre_init(void)
   vga_mapping_type vmt = {0, 0, 0};
 
   if (config.dumb_video) {
+    vga_emu_setup_mode_table();
     vgaemu_register_ports();
     return 0;
   }


### PR DESCRIPTION
The game LORD regressed at 5b3e1af94 which switched virtual comport to dumb mode. We need to make sure BDA is correctly populated, to get it back to work.