### PR TITLE
simx86: generate code for SALC, illegal instruction, GPF, some ints 3 and 4.

### DIFF
--- a/src/base/emu-i386/simx86/emu86.h
+++ b/src/base/emu-i386/simx86/emu86.h
@@ -723,6 +723,7 @@ int _ModRM(unsigned char opc, unsigned int PC, int mode, signed char overr_ds, s
 #define ModRM(o, p, m) ({ \
     int __l = _ModRM(o, p, m, OVERR_DS, OVERR_SS); \
     if (REG1 == 0xff) { \
+        PC += __l; \
         goto illegal_op; \
     } \
     __l; \

--- a/src/base/emu-i386/simx86/emu86.h
+++ b/src/base/emu-i386/simx86/emu86.h
@@ -732,9 +732,6 @@ int _ModRMSim(unsigned int PC, int mode, signed char overr_ds, signed char overr
 /* always already after a CODE_FLUSH() */
 #define ModRMSim(p, m, ods, oss) ({ \
     int __l = _ModRMSim(p, m, ods, oss); \
-    if (REG1 == 0xff) { \
-        goto illegal_op; \
-    } \
     if (TheCPU.err2 == EXCP0D_GPF) { \
         goto not_permitted; \
     } \

--- a/src/base/emu-i386/simx86/emu86.h
+++ b/src/base/emu-i386/simx86/emu86.h
@@ -723,7 +723,6 @@ int _ModRM(unsigned char opc, unsigned int PC, int mode, signed char overr_ds, s
 #define ModRM(o, p, m) ({ \
     int __l = _ModRM(o, p, m, OVERR_DS, OVERR_SS); \
     if (REG1 == 0xff) { \
-        CODE_FLUSH(); \
         goto illegal_op; \
     } \
     __l; \

--- a/src/base/emu-i386/simx86/emu86.h
+++ b/src/base/emu-i386/simx86/emu86.h
@@ -733,7 +733,7 @@ int _ModRMSim(unsigned int PC, int mode, signed char overr_ds, signed char overr
 #define ModRMSim(p, m, ods, oss) ({ \
     int __l = _ModRMSim(p, m, ods, oss); \
     if (TheCPU.err2 == EXCP0D_GPF) { \
-        goto not_permitted; \
+        goto not_permitted_sim; \
     } \
     __l; \
 })

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -101,7 +101,7 @@ static TNode *DoClose(unsigned int PC, int mode, unsigned int P0)
 	/* If the code doesn't terminate with a jump/loop instruction
 	 * it still lacks the tail code; add it here */
 	IMeta *GL = &InstrMeta[CurrIMeta-1];
-	if (GL->gen[GL->ngen-1].op < JMP_INDIRECT) {
+	if (GL->gen[GL->ngen-1].op < JMP_TAILCODE) {
 		int rc;
 		Gen(JMP_TAILCODE, mode, PC);
 		NewIMeta(PC, &rc);
@@ -473,6 +473,8 @@ static unsigned int ExceptionGen(unsigned int PC, int basemode, int trapno,
 {
 	int rc = 0;
 	Gen(L_IMM, basemode, Ofs_ERR, trapno);
+	if (trapno != EXCP03_INT3 && trapno != EXCP04_INTO)
+		Gen(JMP_TAILCODE, basemode, P0); // fault: use current instr
 	NewIMeta(P0, &rc);
 	P0 = PC;
 	CODE_FLUSH();
@@ -1129,7 +1131,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 					PC++; goto override;
 				}
 			}
-			goto illegal_op;
+			PC += i+1; goto illegal_op;
 			}
 /*40*/	case INCax:
 /*41*/	case INCcx:
@@ -1446,7 +1448,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			break;
 /*8d*/	case LEA:
 			if (Fetch(PC+1) >= 0xc0) {
-			    goto illegal_op;
+			    PC += 2; goto illegal_op;
 			}
 			PC += ModRM(opc, PC, _mode|MLEA);
 			Gen(S_DI_R, _mode, REG1);
@@ -1454,7 +1456,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 
 /*c4*/	case LES:
 			if (Fetch(PC+1) >= 0xc0) {
-			    goto illegal_op;
+			    PC += 2; goto illegal_op;
 			}
 			PC += ModRM(opc, PC, _mode);
 			Gen(L_LXS2, _mode);
@@ -1468,7 +1470,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			break;
 /*c5*/	case LDS:
 			if (Fetch(PC+1) >= 0xc0) {
-			    goto illegal_op;
+			    PC += 2; goto illegal_op;
 			}
 			PC += ModRM(opc, PC, _mode);
 			Gen(L_LXS2, _mode);
@@ -2492,7 +2494,7 @@ repag0:
 				Gen(S_DI, _mode|MBYTE);
 				break;
 			default:
-				goto illegal_op;
+				PC += 2; goto illegal_op;
 			}
 			break;
 /*ff*/	case GRP2wrm:
@@ -2550,7 +2552,7 @@ repag0:
 			case Ofs_BX:	/*3*/	 // CALL long indirect restartable
 			case Ofs_BP:	/*5*/	 // JMP long indirect restartable
 				if (Fetch(PC+1) >= 0xc0) {
-					goto illegal_op;
+					PC += 2; goto illegal_op;
 				}
 				{
 					dosaddr_t oip = 0;
@@ -2593,7 +2595,7 @@ repag0:
 				Gen(O_PUSH, _mode); break;	// push [rm]
 				break;
 			default:
-				goto illegal_op;
+				PC += 2; goto illegal_op;
 			}
 			break;
 
@@ -2844,7 +2846,7 @@ repag0:
 				switch (opm) {
 				case 0: /* SLDT */
 				    if (REALMODE()) {
-					goto illegal_op;
+					PC += 3; goto illegal_op;
 				    }
 				    CODE_FLUSH();
 				    PC += ModRMSim(PC+1, _mode, OVERR_DS, OVERR_SS) + 1;
@@ -2853,7 +2855,7 @@ repag0:
 				case 1: /* STR */
 				    /* Store Task Register */
 				    if (REALMODE()) {
-					goto illegal_op;
+					PC += 3; goto illegal_op;
 				    }
 				    CODE_FLUSH();
 				    PC += ModRMSim(PC+1, _mode, OVERR_DS, OVERR_SS) + 1;
@@ -2868,7 +2870,7 @@ repag0:
 				case 4: { /* VERR */
 				    unsigned short sv; int tmp;
 				    if (!PROTMODE()) {
-					goto illegal_op;
+					PC += 3; goto illegal_op;
 				    }
 				    CODE_FLUSH();
 				    PC += ModRMSim(PC+1, _mode, OVERR_DS, OVERR_SS) + 1;
@@ -2885,7 +2887,7 @@ repag0:
 				case 5: { /* VERW */
 				    unsigned short sv; int tmp;
 				    if (!PROTMODE()) {
-					goto illegal_op;
+					PC += 3; goto illegal_op;
 				    }
 				    CODE_FLUSH();
 				    PC += ModRMSim(PC+1, _mode, OVERR_DS, OVERR_SS) + 1;
@@ -2901,7 +2903,7 @@ repag0:
 				    break;
 				case 6: /* JMP indirect to IA64 code */
 				case 7: /* Illegal */
-				    goto illegal_op;
+				    PC += 3; goto illegal_op;
 				} }
 				break;
 			case 0x01: { /* GRP7 - Extended Opcode 21 */
@@ -2932,7 +2934,7 @@ repag0:
 				case 6: /* LMSW, 80286 compatibility, Privileged */
 				    /* Load Machine Status Word */
 				case 7: /* Illegal */
-				    goto illegal_op;
+				    PC += 3; goto illegal_op;
 				} }
 				break;
 
@@ -2940,7 +2942,7 @@ repag0:
 			case 0x03: { /* LSL */ /* Load Segment Limit */
 				unsigned short sv; int tmp;
 				if (REALMODE()) {
-				    goto illegal_op;
+				    PC += 3; goto illegal_op;
 				}
 				CODE_FLUSH();
 				PC += ModRMSim(PC+1, _mode, OVERR_DS, OVERR_SS) + 1;
@@ -3003,7 +3005,7 @@ repag0:
 				if (D_HO(b)!=3 ||
 				    ((opc2&4) && (reg<6)) ||
 				    (!(opc2&5) && ((reg==1)||(reg>4)))) {
-				    goto illegal_op;
+				    PC += 3; goto illegal_op;
 				}
 				CODE_FLUSH();
 				b = D_LO(b);
@@ -3161,7 +3163,7 @@ repag0:
 				case 0x08: /* Illegal */
 				case 0x10: /* Illegal */
 				case 0x18: /* Illegal */
-				    goto illegal_op;
+				    PC += 3; goto illegal_op;
 				case 0x20: /* BT imm8 */
 				case 0x28: /* BTS imm8 */
 				case 0x30: /* BTR imm8 */
@@ -3247,7 +3249,7 @@ repag0:
 ///
 			case 0xb2: /* LSS */
 				if (Fetch(PC+2) >= 0xc0) {
-				    goto illegal_op;
+				    PC += 3; goto illegal_op;
 				}
 				PC++; PC += ModRM(opc, PC, _mode);
 				Gen(L_LXS2, _mode);
@@ -3261,7 +3263,7 @@ repag0:
 				break;
 			case 0xb4: /* LFS */
 				if (Fetch(PC+2) >= 0xc0) {
-				    goto illegal_op;
+				    PC += 3; goto illegal_op;
 				}
 				PC++; PC += ModRM(opc, PC, _mode);
 				Gen(L_LXS2, _mode);
@@ -3275,7 +3277,7 @@ repag0:
 				break;
 			case 0xb5: /* LGS */
 				if (Fetch(PC+2) >= 0xc0) {
-				    goto illegal_op;
+				    PC += 3; goto illegal_op;
 				}
 				PC++; PC += ModRM(opc, PC, _mode);
 				Gen(L_LXS2, _mode);
@@ -3331,7 +3333,7 @@ repag0:
 				unsigned char modrm;
 				modrm = Fetch(PC+2);
 				if (D_MO(modrm) != 1 || D_HO(modrm) == 3) {
-					goto illegal_op;
+					PC += 3; goto illegal_op;
 				}
 				CODE_FLUSH();
 				PC++; PC += ModRMSim(PC, _mode, OVERR_DS, OVERR_SS);
@@ -3376,12 +3378,12 @@ repag0:
 			   modrm and cause #PF or #GP if they straddle the
 			   page or segment limit, instead of #UD */
 			default: /* MMX etc */
-			    goto illegal_op;
+			    PC += 2; goto illegal_op;
 			} }
 			break;
 
 /*xx*/	default:
-			goto illegal_op;
+			PC++; goto illegal_op;
 		}
 		if (TheCPU.err < 0)
 			return P0;
@@ -3401,10 +3403,9 @@ not_permitted:
 //	dbug_printf("!!! Div by 0 %02x\n",opc);
 //	TheCPU.err = -6; return P0;
 illegal_op:
-	CODE_FLUSH();
-	dbug_printf("!!! Illegal op %02x %02x %02x\n",opc,
-		    Fetch(PC+1),Fetch(PC+2));
-	TheCPU.err = EXCP06_ILLOP; return P0;
+	dbug_printf("!!! Illegal op %02x %02x %02x\n",Fetch(P0),
+		    Fetch(P0+1),Fetch(P0+2));
+	return ExceptionGen(PC, _mode, EXCP06_ILLOP, P0, _flags);
 }
 
 /* reset for VGA reads and writes */

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -469,10 +469,12 @@ static unsigned int JumpGen(unsigned int P2, int mode, int opc, int pskip,
 }
 
 static unsigned int ExceptionGen(unsigned int PC, int basemode, int trapno,
-	unsigned int P0, int _flags)
+	unsigned int scp_err, unsigned int P0, int _flags)
 {
 	int rc = 0;
 	Gen(L_IMM, basemode, Ofs_ERR, trapno);
+	if (trapno == EXCP0D_GPF)
+		Gen(L_IMM, basemode, Ofs_SCP_ERR, scp_err);
 	if (trapno != EXCP03_INT3 && trapno != EXCP04_INTO)
 		Gen(JMP_TAILCODE, basemode, P0); // fault: use current instr
 	NewIMeta(P0, &rc);
@@ -931,7 +933,8 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			PC++;
 			break;
 
-/*9c*/	case PUSHF: {
+/*9c*/	case PUSHF:
+			PC++;
 			if (V86MODE() && (IOPL<3)) {
 			    /* virtual-8086 monitor */
 			    if (!(TheCPU.cr[4] & CR4_VME))
@@ -947,7 +950,6 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			else {
 				Gen(O_PUSH2F, _mode);
 			}
-			PC++; }
 			break;
 /*9e*/	case SAHF:
 			Gen(O_SLAHF, _mode, 1);
@@ -978,7 +980,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 /*62*/	case BOUND:    {
 	  		signed int lo, hi, r;
 			if (Fetch(PC+1) >= 0xc0) {
-			    goto not_permitted;
+			    PC += 2; goto not_permitted;
 			}
 			CODE_FLUSH();
 			PC += ModRMSim(PC, _mode, OVERR_DS, OVERR_SS);
@@ -1894,8 +1896,8 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			break;
 /*cc*/	case INT3:
 			e_printf("Interrupt 03\n");
-			PC = P0 = ExceptionGen(PC+1, _mode, EXCP03_INT3, P0,
-					       _flags);
+			PC = P0 = ExceptionGen(PC+1, _mode, EXCP03_INT3, 0,
+					       P0, _flags);
 			break;
 /*ce*/	case INTO:
 			CODE_FLUSH();
@@ -1932,8 +1934,9 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 				break;
 			}
 			// V86: always #GP(0) if revectored or without VME
-			if (V86MODE() && !(TheCPU.cr[4] & CR4_VME) && IOPL<3)
-				goto not_permitted;
+			if (V86MODE() && !(TheCPU.cr[4] & CR4_VME) && IOPL<3) {
+				PC += 2; goto not_permitted;
+			}
 			if (V86MODE() && (TheCPU.cr[4] & CR4_VME) &&
 			    !test_bit(inum, &vm86s.int_revectored)) {
 				CODE_FLUSH();
@@ -1972,8 +1975,10 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 				PC += 2;
 				return PC;
 			}
-			TheCPU.scp_err = (inum << 3) | 2;
-			goto not_permitted;
+			if (debug_level('e')>1)
+			    e_printf("!!! Not permitted int %x\n",inum);
+			PC = P0 = ExceptionGen(PC+2, _mode, EXCP0D_GPF,
+					       (inum << 3) | 2, P0, _flags);
 			break;
 		}
 
@@ -1994,8 +1999,9 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			break;
 
 /*cf*/	case IRET: {	/* restartable */
-			if (V86MODE() && IOPL!=3 && !(TheCPU.cr[4] & CR4_VME))
-			    goto not_permitted;	/* GPF */
+			if (V86MODE() && IOPL!=3 && !(TheCPU.cr[4] & CR4_VME)) {
+			    PC++; goto not_permitted;	/* GPF */
+			}
 			uint16_t sv=0;
 			int m = _mode;
 			CODE_FLUSH();
@@ -2038,8 +2044,9 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			} break;
 
 /*9d*/	case POPF: {
-			if (V86MODE() && IOPL!=3 && !(TheCPU.cr[4] & CR4_VME))
-			    goto not_permitted;	/* GPF */
+			if (V86MODE() && IOPL!=3 && !(TheCPU.cr[4] & CR4_VME)) {
+			    PC++; goto not_permitted;	/* GPF */
+			}
 			CODE_FLUSH();
 			temp=0; POP(_mode, &temp);
 			if (V86MODE()) {
@@ -2129,7 +2136,7 @@ repag0:
 				case INSw:
 				case OUTSb:
 				case OUTSw:
-					goto not_permitted;
+					PC++; goto not_permitted;
 				case LODSb:
 					repmod |= (MBYTE|MOVSSRC);
 					Gen(O_MOVS_SetA, repmod, OVERR_DS);
@@ -2294,7 +2301,7 @@ repag0:
 			} }
 			break;
 /*f4*/	case HLT:
-			goto not_permitted;
+			PC++; goto not_permitted;
 /*f5*/	case CMC:	PC++;
 #if 0
 			if ((CurrIMeta<0)&&(InterOps[Fetch(PC)]&1))
@@ -2392,6 +2399,7 @@ repag0:
 				Gen(O_SETFL, _mode, STC);
 			break;
 /*fa*/	case CLI:
+			PC++;
 			if (REALMODE() || (CPL <= IOPL) || (IOPL==3)) {
 				Gen(O_SETFL, _mode, CLI);
 			}
@@ -2409,9 +2417,9 @@ repag0:
 			    CODE_FLUSH();
 			    EFLAGS &= ~EFLAGS_VIF;
 			}
-			PC++;
 			break;
 /*fb*/	case STI:
+			PC++;
 			if (debug_level('e')>2 && V86MODE())
 				e_printf("Virtual VM86 STI\n");
 			if (!(REALMODE() || (CPL <= IOPL) || (IOPL==3)) &&
@@ -2430,7 +2438,7 @@ repag0:
 					e_printf("Return for STI fl=%08x\n",
 					    EFLAGS);
 				    TheCPU.err=EXCP_STISIGNAL;
-				    return PC+1;
+				    return PC;
 				}
 			}
 			else {
@@ -2446,7 +2454,6 @@ repag0:
 					    EFLAGS);
 			    CEmuStat |= CeS_STI;
 			}
-			PC++;
 			break;
 /*fc*/	case CLD:	PC++;
 #if 0
@@ -2604,7 +2611,7 @@ repag0:
 			unsigned int rd;
 			CODE_FLUSH();
 			a = rDX;
-			if (!test_ioperm(a)) goto not_permitted_portio;
+			if (!test_ioperm(a)) goto not_permitted_sim;
 			rd = (_mode&ADDR16? rDI:rEDI);
 			WRITE_BYTE(LONG_ES+rd, port_inb(a));
 			if (EFLAGS & EFLAGS_DF) rd--; else rd++;
@@ -2678,7 +2685,7 @@ repag0:
 			    }
 			}
 #endif
-			if (!test_ioperm(a)) goto not_permitted_portio;
+			if (!test_ioperm(a)) goto not_permitted_sim;
 #ifdef CPUEMU_DIRECT_IO
 			Gen(O_INPDX, _mode|MBYTE);
 #else
@@ -2692,14 +2699,14 @@ repag0:
 			/* there's no reason to compile this, as most of
 			 * the ports under 0x100 are emulated by dosemu */
 			a = Fetch(PC+1);
-			if (!test_ioperm(a)) goto not_permitted_portio;
+			if (!test_ioperm(a)) goto not_permitted_sim;
 			rAL = port_inb(a);
 			PC += 2; } break;
 /*6d*/	case INSw: {
 			unsigned int rd;
 			int dp;
 			CODE_FLUSH();
-			if (!test_ioperm(rDX)) goto not_permitted_portio;
+			if (!test_ioperm(rDX)) goto not_permitted_sim;
 			rd = (_mode&ADDR16? rDI:rEDI);
 			if (_mode&DATA16) {
 				WRITE_WORD(LONG_ES+rd, port_inw(rDX)); dp=2;
@@ -2712,7 +2719,7 @@ repag0:
 			PC++; } break;
 /*ed*/	case INvw: {
 			CODE_FLUSH();
-			if (!test_ioperm(rDX)) goto not_permitted_portio;
+			if (!test_ioperm(rDX)) goto not_permitted_sim;
 			if (_mode&DATA16) rAX = port_inw(rDX);
 			else rEAX = port_ind(rDX);
 			} PC++; break;
@@ -2720,7 +2727,7 @@ repag0:
 			unsigned short a;
 			CODE_FLUSH();
 			a = Fetch(PC+1);
-			if (!test_ioperm(a)) goto not_permitted_portio;
+			if (!test_ioperm(a)) goto not_permitted_sim;
 			if (_mode&DATA16) rAX = port_inw(a);
 			else rEAX = port_ind(a);
 			PC += 2; } break;
@@ -2730,7 +2737,7 @@ repag0:
 			unsigned long rs;
 			CODE_FLUSH();
 			a = rDX;
-			if (!test_ioperm(a)) goto not_permitted_portio;
+			if (!test_ioperm(a)) goto not_permitted_sim;
 			rs = (_mode&ADDR16? rSI:rESI);
 			do {
 			    port_outb(a,Fetch(LONG_DS+rs));
@@ -2749,7 +2756,7 @@ repag0:
 				PC++;
 				break;
 			}
-			if (!test_ioperm(a)) goto not_permitted_portio;
+			if (!test_ioperm(a)) goto not_permitted_sim;
 #ifdef CPUEMU_DIRECT_IO
 			Gen(O_OUTPDX, _mode|MBYTE);
 #else
@@ -2763,11 +2770,11 @@ repag0:
 			a = Fetch(PC+1);
 			/* there's no reason to compile this, as most of
 			 * the ports under 0x100 are emulated by dosemu */
-			if (!test_ioperm(a)) goto not_permitted_portio;
+			if (!test_ioperm(a)) goto not_permitted_sim;
 			port_outb(a,rAL);
 			PC += 2; } break;
 /*6f*/	case OUTSw:
-			goto not_permitted;
+			PC++; goto not_permitted;
 /*ef*/	case OUTvw: {
 			unsigned short a;
 			CODE_FLUSH();
@@ -2778,7 +2785,7 @@ repag0:
 				PC++;
 				break;
 			}
-			if (!test_ioperm(a)) goto not_permitted_portio;
+			if (!test_ioperm(a)) goto not_permitted_sim;
 #ifdef CPUEMU_DIRECT_IO
 			Gen(O_OUTPDX, _mode);
 #else
@@ -2791,7 +2798,7 @@ repag0:
 			unsigned short a;
 			CODE_FLUSH();
 			a = Fetch(PC+1);
-			if (!test_ioperm(a)) goto not_permitted_portio;
+			if (!test_ioperm(a)) goto not_permitted_sim;
 			if (_mode&DATA16) port_outw(a,rAX); else port_outd(a,rEAX);
 			PC += 2; } break;
 
@@ -2864,7 +2871,7 @@ repag0:
 				    /* Load Local Descriptor Table Register */
 				case 3: /* LTR */
 				    /* Load Task Register */
-				    goto not_permitted;
+				    PC += 3; goto not_permitted;
 				case 4: { /* VERR */
 				    unsigned short sv; int tmp;
 				    if (!PROTMODE()) {
@@ -2921,7 +2928,7 @@ repag0:
 				    /* Load Global Descriptor Table Register */
 				case 3: /* LIDT */ /* PM privileged AND real _mode */
 				    /* Load Interrupt Descriptor Table Register */
-				    goto not_permitted;
+				    PC += 3; goto not_permitted;
 				case 4: /* SMSW, 80286 compatibility */
 				    /* Store Machine Status Word */
 				    Gen(L_CR0, _mode);
@@ -2970,7 +2977,7 @@ repag0:
 			/* case 0x05:	LOADALL(286) - SYSCALL(K6) */
 			case 0x06: /* CLTS */ /* Privileged */
 				/* Clear Task State Register */
-				if (CPL != 0) goto not_permitted;
+				if (CPL != 0) {PC += 2; goto not_permitted;}
 				CODE_FLUSH();
 				TheCPU.cr[0] &= ~8;
 				PC += 2; break;
@@ -2993,8 +3000,9 @@ repag0:
 			case 0x24:   /* MOVtdrd */ /* Privileged */
 			case 0x26: { /* MOVrdtd */ /* Privileged */
 				int *srg; int reg; unsigned char b,opd;
-				if (V86MODE())
-				    goto not_permitted;
+				if (V86MODE()) {
+				    PC += 3; goto not_permitted;
+				}
 				b = Fetch(PC+2);
 				reg = D_MO(b);
 				if (D_HO(b)!=3 ||
@@ -3031,13 +3039,13 @@ repag0:
 		    		}
 		    		} PC += 3; break;
 			case 0x30: /* WRMSR */
-			    goto not_permitted;
+			    PC += 2; goto not_permitted;
 
 			case 0x31: /* RDTSC */
 				Gen(O_RDTSC, _mode);
 				PC+=2; break;
 			case 0x32: /* RDMSR */
-			    goto not_permitted;
+			    PC += 2; goto not_permitted;
 
 			/* case 0x33:	RDPMC(P6) */
 			/* case 0x34:	SYSENTER(PII) */
@@ -3389,8 +3397,9 @@ repag0:
 	return PC;
 
 not_permitted:
-	CODE_FLUSH();
-not_permitted_portio:
+	if (debug_level('e')>1) e_printf("!!! Not permitted %02x\n",opc);
+	return ExceptionGen(PC, _mode, EXCP0D_GPF, 0, P0, _flags);
+not_permitted_sim:
 	if (debug_level('e')>1) e_printf("!!! Not permitted %02x\n",opc);
 	TheCPU.err = EXCP0D_GPF; return P0;
 //div_by_zero:
@@ -3399,7 +3408,7 @@ not_permitted_portio:
 illegal_op:
 	dbug_printf("!!! Illegal op %02x %02x %02x\n",Fetch(P0),
 		    Fetch(P0+1),Fetch(P0+2));
-	return ExceptionGen(PC, _mode, EXCP06_ILLOP, P0, _flags);
+	return ExceptionGen(PC, _mode, EXCP06_ILLOP, 0, P0, _flags);
 }
 
 /* reset for VGA reads and writes */

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -468,6 +468,19 @@ static unsigned int JumpGen(unsigned int P2, int mode, int opc, int pskip,
 	return _P1;
 }
 
+static unsigned int ExceptionGen(unsigned int PC, int basemode, int trapno,
+	unsigned int P0, int _flags)
+{
+	int rc = 0;
+	Gen(L_IMM, basemode, Ofs_ERR, trapno);
+	NewIMeta(P0, &rc);
+	P0 = PC;
+	CODE_FLUSH();
+	assert(TheCPU.err == trapno ||
+	       TheCPU.err == EXCP_GOBACK || TheCPU.err == EXCP_RETRY);
+	return PC;
+}
+
 /////////////////////////////////////////////////////////////////////////////
 
 #if !defined(SINGLESTEP)
@@ -1885,10 +1898,10 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			}
 			break;
 /*cc*/	case INT3:
-			CODE_FLUSH();
 			e_printf("Interrupt 03\n");
-			TheCPU.err=EXCP03_INT3; PC++;
-			return PC;
+			PC = P0 = ExceptionGen(PC+1, _mode, EXCP03_INT3, P0,
+					       _flags);
+			break;
 /*ce*/	case INTO:
 			CODE_FLUSH();
 			PC++;

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -1963,22 +1963,26 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 				break;
 			}
 			/* protected _mode INT or revectored V86 with IOPL=3 */
-			if (PROTMODE()) switch(inum) {
+			switch(inum) {
 			case 0x03:
-				CODE_FLUSH();
-				TheCPU.err=EXCP03_INT3;
-				PC += 2;
-				return PC;
+			    if (PROTMODE())
+				PC = P0 = ExceptionGen(PC+2, _mode,
+						       EXCP03_INT3, 0, P0,
+						       _flags);
+			    break;
 			case 0x04:
-				CODE_FLUSH();
-				TheCPU.err=EXCP04_INTO;
-				PC += 2;
-				return PC;
+			    if (PROTMODE())
+				PC = P0 = ExceptionGen(PC+2, _mode,
+						       EXCP04_INTO, 0, P0,
+						       _flags);
+			    break;
+			default:
+			    if (debug_level('e')>1)
+				e_printf("!!! Not permitted int %x\n",inum);
+			    PC = P0 = ExceptionGen(PC+2, _mode, EXCP0D_GPF,
+						   (inum << 3) | 2, P0, _flags);
+			    break;
 			}
-			if (debug_level('e')>1)
-			    e_printf("!!! Not permitted int %x\n",inum);
-			PC = P0 = ExceptionGen(PC+2, _mode, EXCP0D_GPF,
-					       (inum << 3) | 2, P0, _flags);
 			break;
 		}
 

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -955,9 +955,10 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			Gen(O_OPAX, _mode, 2, AAD, Fetch(PC+1)); PC+=2; break;
 
 /*d6*/	case 0xd6:	/* Undocumented */
-			CODE_FLUSH();
 			e_printf("Undocumented op 0xd6\n");
-			rAL = (EFLAGS & EFLAGS_CF? 0xff:0x00);
+			Gen(O_SETCC, _mode, 2);
+			Gen(O_NEG, _mode|MBYTE);
+			Gen(S_REG, _mode|MBYTE, Ofs_AL);
 			PC++; break;
 /*62*/	case BOUND:    {
 	  		signed int lo, hi, r;

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -1129,7 +1129,6 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 					PC++; goto override;
 				}
 			}
-			CODE_FLUSH();
 			goto illegal_op;
 			}
 /*40*/	case INCax:
@@ -1447,7 +1446,6 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			break;
 /*8d*/	case LEA:
 			if (Fetch(PC+1) >= 0xc0) {
-			    CODE_FLUSH();
 			    goto illegal_op;
 			}
 			PC += ModRM(opc, PC, _mode|MLEA);
@@ -1456,7 +1454,6 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 
 /*c4*/	case LES:
 			if (Fetch(PC+1) >= 0xc0) {
-			    CODE_FLUSH();
 			    goto illegal_op;
 			}
 			PC += ModRM(opc, PC, _mode);
@@ -1471,7 +1468,6 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			break;
 /*c5*/	case LDS:
 			if (Fetch(PC+1) >= 0xc0) {
-			    CODE_FLUSH();
 			    goto illegal_op;
 			}
 			PC += ModRM(opc, PC, _mode);
@@ -1487,7 +1483,6 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 /*8e*/	case MOVsrfrm:
 			PC += ModRM(opc, PC, _mode|SEGREG|DATA16|MLOAD);
 			if (REG1 == Ofs_CS) {
-			    CODE_FLUSH();
 			    goto illegal_op;
 			}
 			if (REALADDR()) {
@@ -1713,7 +1708,6 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 				break;
 			case Ofs_DH:	/*6*/	// undoc
 				if (opc==SHIFTbv) {
-					CODE_FLUSH();
 					goto illegal_op;
 				}
 				break;
@@ -1758,7 +1752,6 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 				break;
 			case Ofs_SI:	/*6*/	// undoc
 				if ((opc==SHIFTw)||(opc==SHIFTwv)) {
-					CODE_FLUSH();
 					goto illegal_op;
 				}
 			case Ofs_SP:	/*4*/	// SHL,SAL
@@ -2499,7 +2492,6 @@ repag0:
 				Gen(S_DI, _mode|MBYTE);
 				break;
 			default:
-				CODE_FLUSH();
 				goto illegal_op;
 			}
 			break;
@@ -2558,7 +2550,6 @@ repag0:
 			case Ofs_BX:	/*3*/	 // CALL long indirect restartable
 			case Ofs_BP:	/*5*/	 // JMP long indirect restartable
 				if (Fetch(PC+1) >= 0xc0) {
-					CODE_FLUSH();
 					goto illegal_op;
 				}
 				{
@@ -2602,7 +2593,6 @@ repag0:
 				Gen(O_PUSH, _mode); break;	// push [rm]
 				break;
 			default:
-				CODE_FLUSH();
 				goto illegal_op;
 			}
 			break;
@@ -2835,7 +2825,6 @@ repag0:
 			}
 			b &= 7;
 			if (Fp87_illegal_op(exop, b)) {
-				CODE_FLUSH();
 				goto illegal_op;
 			}
 			if (sim) {
@@ -2855,7 +2844,6 @@ repag0:
 				switch (opm) {
 				case 0: /* SLDT */
 				    if (REALMODE()) {
-					CODE_FLUSH();
 					goto illegal_op;
 				    }
 				    CODE_FLUSH();
@@ -2865,7 +2853,6 @@ repag0:
 				case 1: /* STR */
 				    /* Store Task Register */
 				    if (REALMODE()) {
-					CODE_FLUSH();
 					goto illegal_op;
 				    }
 				    CODE_FLUSH();
@@ -2881,7 +2868,6 @@ repag0:
 				case 4: { /* VERR */
 				    unsigned short sv; int tmp;
 				    if (!PROTMODE()) {
-					CODE_FLUSH();
 					goto illegal_op;
 				    }
 				    CODE_FLUSH();
@@ -2899,7 +2885,6 @@ repag0:
 				case 5: { /* VERW */
 				    unsigned short sv; int tmp;
 				    if (!PROTMODE()) {
-					CODE_FLUSH();
 					goto illegal_op;
 				    }
 				    CODE_FLUSH();
@@ -2916,7 +2901,6 @@ repag0:
 				    break;
 				case 6: /* JMP indirect to IA64 code */
 				case 7: /* Illegal */
-				    CODE_FLUSH();
 				    goto illegal_op;
 				} }
 				break;
@@ -2948,7 +2932,6 @@ repag0:
 				case 6: /* LMSW, 80286 compatibility, Privileged */
 				    /* Load Machine Status Word */
 				case 7: /* Illegal */
-				    CODE_FLUSH();
 				    goto illegal_op;
 				} }
 				break;
@@ -2957,7 +2940,6 @@ repag0:
 			case 0x03: { /* LSL */ /* Load Segment Limit */
 				unsigned short sv; int tmp;
 				if (REALMODE()) {
-				    CODE_FLUSH();
 				    goto illegal_op;
 				}
 				CODE_FLUSH();
@@ -3021,7 +3003,6 @@ repag0:
 				if (D_HO(b)!=3 ||
 				    ((opc2&4) && (reg<6)) ||
 				    (!(opc2&5) && ((reg==1)||(reg>4)))) {
-				    CODE_FLUSH();
 				    goto illegal_op;
 				}
 				CODE_FLUSH();
@@ -3180,7 +3161,6 @@ repag0:
 				case 0x08: /* Illegal */
 				case 0x10: /* Illegal */
 				case 0x18: /* Illegal */
-				    CODE_FLUSH();
 				    goto illegal_op;
 				case 0x20: /* BT imm8 */
 				case 0x28: /* BTS imm8 */
@@ -3267,7 +3247,6 @@ repag0:
 ///
 			case 0xb2: /* LSS */
 				if (Fetch(PC+2) >= 0xc0) {
-				    CODE_FLUSH();
 				    goto illegal_op;
 				}
 				PC++; PC += ModRM(opc, PC, _mode);
@@ -3282,7 +3261,6 @@ repag0:
 				break;
 			case 0xb4: /* LFS */
 				if (Fetch(PC+2) >= 0xc0) {
-				    CODE_FLUSH();
 				    goto illegal_op;
 				}
 				PC++; PC += ModRM(opc, PC, _mode);
@@ -3297,7 +3275,6 @@ repag0:
 				break;
 			case 0xb5: /* LGS */
 				if (Fetch(PC+2) >= 0xc0) {
-				    CODE_FLUSH();
 				    goto illegal_op;
 				}
 				PC++; PC += ModRM(opc, PC, _mode);
@@ -3354,7 +3331,6 @@ repag0:
 				unsigned char modrm;
 				modrm = Fetch(PC+2);
 				if (D_MO(modrm) != 1 || D_HO(modrm) == 3) {
-					CODE_FLUSH();
 					goto illegal_op;
 				}
 				CODE_FLUSH();
@@ -3400,13 +3376,11 @@ repag0:
 			   modrm and cause #PF or #GP if they straddle the
 			   page or segment limit, instead of #UD */
 			default: /* MMX etc */
-			    CODE_FLUSH();
 			    goto illegal_op;
 			} }
 			break;
 
 /*xx*/	default:
-			CODE_FLUSH();
 			goto illegal_op;
 		}
 		if (TheCPU.err < 0)
@@ -3427,6 +3401,7 @@ not_permitted:
 //	dbug_printf("!!! Div by 0 %02x\n",opc);
 //	TheCPU.err = -6; return P0;
 illegal_op:
+	CODE_FLUSH();
 	dbug_printf("!!! Illegal op %02x %02x %02x\n",opc,
 		    Fetch(PC+1),Fetch(PC+2));
 	TheCPU.err = EXCP06_ILLOP; return P0;

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -2854,15 +2854,21 @@ repag0:
 				unsigned char opm = D_MO(Fetch(PC+2));
 				switch (opm) {
 				case 0: /* SLDT */
+				    if (REALMODE()) {
+					CODE_FLUSH();
+					goto illegal_op;
+				    }
 				    CODE_FLUSH();
-				    if (REALMODE()) goto illegal_op;
 				    PC += ModRMSim(PC+1, _mode, OVERR_DS, OVERR_SS) + 1;
 				    error("SLDT not implemented\n");
 				    break;
 				case 1: /* STR */
 				    /* Store Task Register */
+				    if (REALMODE()) {
+					CODE_FLUSH();
+					goto illegal_op;
+				    }
 				    CODE_FLUSH();
-				    if (REALMODE()) goto illegal_op;
 				    PC += ModRMSim(PC+1, _mode, OVERR_DS, OVERR_SS) + 1;
 				    error("STR not implemented\n");
 				    break;
@@ -2874,8 +2880,11 @@ repag0:
 				    goto not_permitted;
 				case 4: { /* VERR */
 				    unsigned short sv; int tmp;
+				    if (!PROTMODE()) {
+					CODE_FLUSH();
+					goto illegal_op;
+				    }
 				    CODE_FLUSH();
-				    if (REALMODE()) goto illegal_op;
 				    PC += ModRMSim(PC+1, _mode, OVERR_DS, OVERR_SS) + 1;
 				    if (REG3) {
 					sv = CPUWORD(REG3);
@@ -2883,15 +2892,17 @@ repag0:
 					sv = GetDWord(TheCPU.mem_ref);
 				    }
 				    tmp = hsw_verr(sv);
-				    if (tmp < 0) goto illegal_op;
 				    EFLAGS &= ~EFLAGS_ZF;
 				    if (tmp) EFLAGS |= EFLAGS_ZF;
 				    }
 				    break;
 				case 5: { /* VERW */
 				    unsigned short sv; int tmp;
+				    if (!PROTMODE()) {
+					CODE_FLUSH();
+					goto illegal_op;
+				    }
 				    CODE_FLUSH();
-				    if (REALMODE()) goto illegal_op;
 				    PC += ModRMSim(PC+1, _mode, OVERR_DS, OVERR_SS) + 1;
 				    if (REG3) {
 					sv = CPUWORD(REG3);
@@ -2899,7 +2910,6 @@ repag0:
 					sv = GetDWord(TheCPU.mem_ref);
 				    }
 				    tmp = hsw_verw(sv);
-				    if (tmp < 0) goto illegal_op;
 				    EFLAGS &= ~EFLAGS_ZF;
 				    if (tmp) EFLAGS |= EFLAGS_ZF;
 				    }
@@ -2946,8 +2956,11 @@ repag0:
 			case 0x02:   /* LAR */ /* Load Access Rights Byte */
 			case 0x03: { /* LSL */ /* Load Segment Limit */
 				unsigned short sv; int tmp;
+				if (REALMODE()) {
+				    CODE_FLUSH();
+				    goto illegal_op;
+				}
 				CODE_FLUSH();
-				if (REALMODE()) goto illegal_op;
 				PC += ModRMSim(PC+1, _mode, OVERR_DS, OVERR_SS) + 1;
 				if (REG3) {
 				    sv = CPUWORD(REG3);
@@ -2999,11 +3012,20 @@ repag0:
 			case 0x24:   /* MOVtdrd */ /* Privileged */
 			case 0x26: { /* MOVrdtd */ /* Privileged */
 				int *srg; int reg; unsigned char b,opd;
-				CODE_FLUSH();
-				if (V86MODE()) goto not_permitted;
+				if (V86MODE()) {
+				    CODE_FLUSH();
+				    goto not_permitted;
+				}
 				b = Fetch(PC+2);
-				if (D_HO(b)!=3) goto illegal_op;
-				reg = D_MO(b); b = D_LO(b);
+				reg = D_MO(b);
+				if (D_HO(b)!=3 ||
+				    ((opc2&4) && (reg<6)) ||
+				    (!(opc2&5) && ((reg==1)||(reg>4)))) {
+				    CODE_FLUSH();
+				    goto illegal_op;
+				}
+				CODE_FLUSH();
+				b = D_LO(b);
 				srg = (int *)CPUOFFS(R1Tab_l[b]);
 				opd = Fetch(PC+1)&2;
 		    		if (opc2&1) {
@@ -3011,12 +3033,11 @@ repag0:
 					else *srg = TheCPU.dr[reg];
 		    		}
 		    		else if (opc2&4) {
-				    reg-=6; if (reg<0) goto illegal_op;
+				    reg-=6;
 				    if (opd) TheCPU.tr[reg] = *srg;
 					else *srg = TheCPU.tr[reg];
 		    		}
 		    		else {
-				    if ((reg==1)||(reg>4)) goto illegal_op;
 		    		    if (opd) {	/* write to CRs */
 					if (reg==0) {
 			    		    if ((TheCPU.cr[0] ^ *srg) & 1) {
@@ -3331,10 +3352,12 @@ repag0:
 			case 0xc7: { /*	Code Extension 23 - 01=CMPXCHG8B mem */
 				uint64_t edxeax, m;
 				unsigned char modrm;
-				CODE_FLUSH();
 				modrm = Fetch(PC+2);
-				if (D_MO(modrm) != 1 || D_HO(modrm) == 3)
+				if (D_MO(modrm) != 1 || D_HO(modrm) == 3) {
+					CODE_FLUSH();
 					goto illegal_op;
+				}
+				CODE_FLUSH();
 				PC++; PC += ModRMSim(PC, _mode, OVERR_DS, OVERR_SS);
 				edxeax = ((uint64_t)rEDX << 32) | rEAX;
 				m = sim_read_qword(TheCPU.mem_ref);

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -933,10 +933,12 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 
 /*9c*/	case PUSHF: {
 			if (V86MODE() && (IOPL<3)) {
-			    CODE_FLUSH();
 			    /* virtual-8086 monitor */
-			    if (!(TheCPU.cr[4] & CR4_VME))
+			    if (!(TheCPU.cr[4] & CR4_VME)) {
+				CODE_FLUSH();
 				goto not_permitted;	/* GPF */
+			    }
+			    CODE_FLUSH();
 			    temp = (EFLAGS|IOPL_MASK) & RETURN_MASK;
 			    if (EFLAGS & VIF) temp |= EFLAGS_IF;
 			    PUSH(_mode, temp);
@@ -977,10 +979,11 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			PC++; break;
 /*62*/	case BOUND:    {
 	  		signed int lo, hi, r;
-			CODE_FLUSH();
 			if (Fetch(PC+1) >= 0xc0) {
+			    CODE_FLUSH();
 			    goto not_permitted;
 			}
+			CODE_FLUSH();
 			PC += ModRMSim(PC, _mode, OVERR_DS, OVERR_SS);
 			r = GetCPU_WL(_mode, REG1);
 			lo = DataGetWL_S(_mode,TheCPU.mem_ref);
@@ -1931,12 +1934,14 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 				if (TheCPU.err) return PC;
 				break;
 			}
-			CODE_FLUSH();
 			// V86: always #GP(0) if revectored or without VME
-			if (V86MODE() && !(TheCPU.cr[4] & CR4_VME) && IOPL<3)
+			if (V86MODE() && !(TheCPU.cr[4] & CR4_VME) && IOPL<3) {
+				CODE_FLUSH();
 				goto not_permitted;
+			}
 			if (V86MODE() && (TheCPU.cr[4] & CR4_VME) &&
 			    !test_bit(inum, &vm86s.int_revectored)) {
+				CODE_FLUSH();
 				uint32_t segoffs;
 				segoffs = read_dword(inum << 2);
 				temp = (EFLAGS|IOPL_MASK) & (RETURN_MASK|EFLAGS_IF);
@@ -1962,15 +1967,18 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			/* protected _mode INT or revectored V86 with IOPL=3 */
 			if (PROTMODE()) switch(inum) {
 			case 0x03:
+				CODE_FLUSH();
 				TheCPU.err=EXCP03_INT3;
 				PC += 2;
 				return PC;
 			case 0x04:
+				CODE_FLUSH();
 				TheCPU.err=EXCP04_INTO;
 				PC += 2;
 				return PC;
 			}
 			TheCPU.scp_err = (inum << 3) | 2;
+			CODE_FLUSH();
 			goto not_permitted;
 			break;
 		}
@@ -1992,6 +2000,10 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			break;
 
 /*cf*/	case IRET: {	/* restartable */
+			if (V86MODE() && IOPL!=3 && !(TheCPU.cr[4] & CR4_VME)) {
+			    CODE_FLUSH();
+			    goto not_permitted;	/* GPF */
+			}
 			uint16_t sv=0;
 			int m = _mode;
 			CODE_FLUSH();
@@ -2034,6 +2046,10 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			} break;
 
 /*9d*/	case POPF: {
+			if (V86MODE() && IOPL!=3 && !(TheCPU.cr[4] & CR4_VME)) {
+			    CODE_FLUSH();
+			    goto not_permitted;	/* GPF */
+			}
 			CODE_FLUSH();
 			temp=0; POP(_mode, &temp);
 			if (V86MODE()) {
@@ -2053,8 +2069,6 @@ stack_return_from_vm86:
 			    }
 			    else {
 				/* virtual-8086 monitor */
-				if (!(TheCPU.cr[4] & CR4_VME))
-				    goto not_permitted;	/* GPF */
 				/* move mask from pop{e}flags to regs->eflags */
 				if (_mode & DATA16)
 				    FLAGS &= ~SAFE_MASK;
@@ -2394,35 +2408,39 @@ repag0:
 				Gen(O_SETFL, _mode, CLI);
 			}
 			else {
-			    CODE_FLUSH();
-			    /* virtual-8086 monitor */
-			    if (V86MODE()) {
-				if (debug_level('e')>2) e_printf("Virtual VM86 CLI\n");
-				if (TheCPU.cr[4] & CR4_VME)
-				    EFLAGS &= ~EFLAGS_VIF;
-				else
-				    goto not_permitted;	/* GPF */
-			    }
-			    else if (TheCPU.cr[4] & CR4_PVI) {
-				if (debug_level('e')>2) e_printf("Virtual DPMI CLI\n");
-				EFLAGS &= ~EFLAGS_VIF;
-			    }
-			    else
+			    if ((V86MODE() && !(TheCPU.cr[4] & CR4_VME)) ||
+				(!V86MODE() && !(TheCPU.cr[4] & CR4_PVI))) {
+				CODE_FLUSH();
 				goto not_permitted;	/* GPF */
+			    }
+			    /* virtual-8086 monitor */
+			    if (debug_level('e')>2) {
+				if (V86MODE())
+				    e_printf("Virtual VM86 CLI\n");
+				else
+				    e_printf("Virtual DPMI CLI\n");
+			    }
+			    CODE_FLUSH();
+			    EFLAGS &= ~EFLAGS_VIF;
 			}
 			PC++;
 			break;
 /*fb*/	case STI:
+			if (debug_level('e')>2 && V86MODE())
+				e_printf("Virtual VM86 STI\n");
+			if (!(REALMODE() || (CPL <= IOPL) || (IOPL==3)) &&
+			    ((V86MODE() && !(TheCPU.cr[4] & CR4_VME)) ||
+			     (!V86MODE() && !(TheCPU.cr[4] & CR4_PVI)))) {
+				CODE_FLUSH();
+				goto not_permitted;	/* GPF */
+			}
 			CODE_FLUSH();
 			if (V86MODE()) {    /* traps always (Intel man) */
 				/* virtual-8086 monitor */
-				if (debug_level('e')>2) e_printf("Virtual VM86 STI\n");
 				if (IOPL==3)
 				    EFLAGS |= EFLAGS_IF;
-				else if (TheCPU.cr[4]&CR4_VME)
-				    EFLAGS |= EFLAGS_VIF;
 				else
-				    goto not_permitted;	/* GPF */
+				    EFLAGS |= EFLAGS_VIF;
 				if (vm86s.regs.eflags & VIP) {
 				    if (debug_level('e')>1)
 					e_printf("Return for STI fl=%08x\n",
@@ -2435,12 +2453,10 @@ repag0:
 			    if (REALMODE() || (CPL <= IOPL) || (IOPL==3)) {
 				EFLAGS |= EFLAGS_IF;
 			    }
-			    else if (TheCPU.cr[4] & CR4_PVI) {
+			    else {
 				if (debug_level('e')>2) e_printf("Virtual DPMI STI\n");
 				EFLAGS |= EFLAGS_VIF;
 			    }
-			    else
-				goto not_permitted;	/* GPF */
 			    if (debug_level('e')>1)
 				    e_printf("Return for STI fl=%08x\n",
 					    EFLAGS);
@@ -2973,8 +2989,11 @@ repag0:
 			/* case 0x05:	LOADALL(286) - SYSCALL(K6) */
 			case 0x06: /* CLTS */ /* Privileged */
 				/* Clear Task State Register */
+				if (CPL != 0) {
+					CODE_FLUSH();
+					goto not_permitted;
+				}
 				CODE_FLUSH();
-				if (CPL != 0) goto not_permitted;
 				TheCPU.cr[0] &= ~8;
 				PC += 2; break;
 			/* case 0x07:	LOADALL(386) - SYSRET(K6) etc. */

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -934,10 +934,8 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 /*9c*/	case PUSHF: {
 			if (V86MODE() && (IOPL<3)) {
 			    /* virtual-8086 monitor */
-			    if (!(TheCPU.cr[4] & CR4_VME)) {
-				CODE_FLUSH();
+			    if (!(TheCPU.cr[4] & CR4_VME))
 				goto not_permitted;	/* GPF */
-			    }
 			    CODE_FLUSH();
 			    temp = (EFLAGS|IOPL_MASK) & RETURN_MASK;
 			    if (EFLAGS & VIF) temp |= EFLAGS_IF;
@@ -980,7 +978,6 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 /*62*/	case BOUND:    {
 	  		signed int lo, hi, r;
 			if (Fetch(PC+1) >= 0xc0) {
-			    CODE_FLUSH();
 			    goto not_permitted;
 			}
 			CODE_FLUSH();
@@ -1935,10 +1932,8 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 				break;
 			}
 			// V86: always #GP(0) if revectored or without VME
-			if (V86MODE() && !(TheCPU.cr[4] & CR4_VME) && IOPL<3) {
-				CODE_FLUSH();
+			if (V86MODE() && !(TheCPU.cr[4] & CR4_VME) && IOPL<3)
 				goto not_permitted;
-			}
 			if (V86MODE() && (TheCPU.cr[4] & CR4_VME) &&
 			    !test_bit(inum, &vm86s.int_revectored)) {
 				CODE_FLUSH();
@@ -1978,7 +1973,6 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 				return PC;
 			}
 			TheCPU.scp_err = (inum << 3) | 2;
-			CODE_FLUSH();
 			goto not_permitted;
 			break;
 		}
@@ -2000,10 +1994,8 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			break;
 
 /*cf*/	case IRET: {	/* restartable */
-			if (V86MODE() && IOPL!=3 && !(TheCPU.cr[4] & CR4_VME)) {
-			    CODE_FLUSH();
+			if (V86MODE() && IOPL!=3 && !(TheCPU.cr[4] & CR4_VME))
 			    goto not_permitted;	/* GPF */
-			}
 			uint16_t sv=0;
 			int m = _mode;
 			CODE_FLUSH();
@@ -2046,10 +2038,8 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			} break;
 
 /*9d*/	case POPF: {
-			if (V86MODE() && IOPL!=3 && !(TheCPU.cr[4] & CR4_VME)) {
-			    CODE_FLUSH();
+			if (V86MODE() && IOPL!=3 && !(TheCPU.cr[4] & CR4_VME))
 			    goto not_permitted;	/* GPF */
-			}
 			CODE_FLUSH();
 			temp=0; POP(_mode, &temp);
 			if (V86MODE()) {
@@ -2139,7 +2129,6 @@ repag0:
 				case INSw:
 				case OUTSb:
 				case OUTSw:
-					CODE_FLUSH();
 					goto not_permitted;
 				case LODSb:
 					repmod |= (MBYTE|MOVSSRC);
@@ -2305,7 +2294,6 @@ repag0:
 			} }
 			break;
 /*f4*/	case HLT:
-			CODE_FLUSH();
 			goto not_permitted;
 /*f5*/	case CMC:	PC++;
 #if 0
@@ -2409,10 +2397,8 @@ repag0:
 			}
 			else {
 			    if ((V86MODE() && !(TheCPU.cr[4] & CR4_VME)) ||
-				(!V86MODE() && !(TheCPU.cr[4] & CR4_PVI))) {
-				CODE_FLUSH();
+				(!V86MODE() && !(TheCPU.cr[4] & CR4_PVI)))
 				goto not_permitted;	/* GPF */
-			    }
 			    /* virtual-8086 monitor */
 			    if (debug_level('e')>2) {
 				if (V86MODE())
@@ -2430,10 +2416,8 @@ repag0:
 				e_printf("Virtual VM86 STI\n");
 			if (!(REALMODE() || (CPL <= IOPL) || (IOPL==3)) &&
 			    ((V86MODE() && !(TheCPU.cr[4] & CR4_VME)) ||
-			     (!V86MODE() && !(TheCPU.cr[4] & CR4_PVI)))) {
-				CODE_FLUSH();
+			     (!V86MODE() && !(TheCPU.cr[4] & CR4_PVI))))
 				goto not_permitted;	/* GPF */
-			}
 			CODE_FLUSH();
 			if (V86MODE()) {    /* traps always (Intel man) */
 				/* virtual-8086 monitor */
@@ -2620,7 +2604,7 @@ repag0:
 			unsigned int rd;
 			CODE_FLUSH();
 			a = rDX;
-			if (!test_ioperm(a)) goto not_permitted;
+			if (!test_ioperm(a)) goto not_permitted_portio;
 			rd = (_mode&ADDR16? rDI:rEDI);
 			WRITE_BYTE(LONG_ES+rd, port_inb(a));
 			if (EFLAGS & EFLAGS_DF) rd--; else rd++;
@@ -2694,7 +2678,7 @@ repag0:
 			    }
 			}
 #endif
-			if (!test_ioperm(a)) goto not_permitted;
+			if (!test_ioperm(a)) goto not_permitted_portio;
 #ifdef CPUEMU_DIRECT_IO
 			Gen(O_INPDX, _mode|MBYTE);
 #else
@@ -2708,14 +2692,14 @@ repag0:
 			/* there's no reason to compile this, as most of
 			 * the ports under 0x100 are emulated by dosemu */
 			a = Fetch(PC+1);
-			if (!test_ioperm(a)) goto not_permitted;
+			if (!test_ioperm(a)) goto not_permitted_portio;
 			rAL = port_inb(a);
 			PC += 2; } break;
 /*6d*/	case INSw: {
 			unsigned int rd;
 			int dp;
 			CODE_FLUSH();
-			if (!test_ioperm(rDX)) goto not_permitted;
+			if (!test_ioperm(rDX)) goto not_permitted_portio;
 			rd = (_mode&ADDR16? rDI:rEDI);
 			if (_mode&DATA16) {
 				WRITE_WORD(LONG_ES+rd, port_inw(rDX)); dp=2;
@@ -2728,7 +2712,7 @@ repag0:
 			PC++; } break;
 /*ed*/	case INvw: {
 			CODE_FLUSH();
-			if (!test_ioperm(rDX)) goto not_permitted;
+			if (!test_ioperm(rDX)) goto not_permitted_portio;
 			if (_mode&DATA16) rAX = port_inw(rDX);
 			else rEAX = port_ind(rDX);
 			} PC++; break;
@@ -2736,7 +2720,7 @@ repag0:
 			unsigned short a;
 			CODE_FLUSH();
 			a = Fetch(PC+1);
-			if (!test_ioperm(a)) goto not_permitted;
+			if (!test_ioperm(a)) goto not_permitted_portio;
 			if (_mode&DATA16) rAX = port_inw(a);
 			else rEAX = port_ind(a);
 			PC += 2; } break;
@@ -2746,7 +2730,7 @@ repag0:
 			unsigned long rs;
 			CODE_FLUSH();
 			a = rDX;
-			if (!test_ioperm(a)) goto not_permitted;
+			if (!test_ioperm(a)) goto not_permitted_portio;
 			rs = (_mode&ADDR16? rSI:rESI);
 			do {
 			    port_outb(a,Fetch(LONG_DS+rs));
@@ -2765,7 +2749,7 @@ repag0:
 				PC++;
 				break;
 			}
-			if (!test_ioperm(a)) goto not_permitted;
+			if (!test_ioperm(a)) goto not_permitted_portio;
 #ifdef CPUEMU_DIRECT_IO
 			Gen(O_OUTPDX, _mode|MBYTE);
 #else
@@ -2779,11 +2763,10 @@ repag0:
 			a = Fetch(PC+1);
 			/* there's no reason to compile this, as most of
 			 * the ports under 0x100 are emulated by dosemu */
-			if (!test_ioperm(a)) goto not_permitted;
+			if (!test_ioperm(a)) goto not_permitted_portio;
 			port_outb(a,rAL);
 			PC += 2; } break;
 /*6f*/	case OUTSw:
-			CODE_FLUSH();
 			goto not_permitted;
 /*ef*/	case OUTvw: {
 			unsigned short a;
@@ -2795,7 +2778,7 @@ repag0:
 				PC++;
 				break;
 			}
-			if (!test_ioperm(a)) goto not_permitted;
+			if (!test_ioperm(a)) goto not_permitted_portio;
 #ifdef CPUEMU_DIRECT_IO
 			Gen(O_OUTPDX, _mode);
 #else
@@ -2808,7 +2791,7 @@ repag0:
 			unsigned short a;
 			CODE_FLUSH();
 			a = Fetch(PC+1);
-			if (!test_ioperm(a)) goto not_permitted;
+			if (!test_ioperm(a)) goto not_permitted_portio;
 			if (_mode&DATA16) port_outw(a,rAX); else port_outd(a,rEAX);
 			PC += 2; } break;
 
@@ -2881,7 +2864,6 @@ repag0:
 				    /* Load Local Descriptor Table Register */
 				case 3: /* LTR */
 				    /* Load Task Register */
-				    CODE_FLUSH();
 				    goto not_permitted;
 				case 4: { /* VERR */
 				    unsigned short sv; int tmp;
@@ -2939,7 +2921,6 @@ repag0:
 				    /* Load Global Descriptor Table Register */
 				case 3: /* LIDT */ /* PM privileged AND real _mode */
 				    /* Load Interrupt Descriptor Table Register */
-				    CODE_FLUSH();
 				    goto not_permitted;
 				case 4: /* SMSW, 80286 compatibility */
 				    /* Store Machine Status Word */
@@ -2989,10 +2970,7 @@ repag0:
 			/* case 0x05:	LOADALL(286) - SYSCALL(K6) */
 			case 0x06: /* CLTS */ /* Privileged */
 				/* Clear Task State Register */
-				if (CPL != 0) {
-					CODE_FLUSH();
-					goto not_permitted;
-				}
+				if (CPL != 0) goto not_permitted;
 				CODE_FLUSH();
 				TheCPU.cr[0] &= ~8;
 				PC += 2; break;
@@ -3015,10 +2993,8 @@ repag0:
 			case 0x24:   /* MOVtdrd */ /* Privileged */
 			case 0x26: { /* MOVrdtd */ /* Privileged */
 				int *srg; int reg; unsigned char b,opd;
-				if (V86MODE()) {
-				    CODE_FLUSH();
+				if (V86MODE())
 				    goto not_permitted;
-				}
 				b = Fetch(PC+2);
 				reg = D_MO(b);
 				if (D_HO(b)!=3 ||
@@ -3055,14 +3031,12 @@ repag0:
 		    		}
 		    		} PC += 3; break;
 			case 0x30: /* WRMSR */
-			    CODE_FLUSH();
 			    goto not_permitted;
 
 			case 0x31: /* RDTSC */
 				Gen(O_RDTSC, _mode);
 				PC+=2; break;
 			case 0x32: /* RDMSR */
-			    CODE_FLUSH();
 			    goto not_permitted;
 
 			/* case 0x33:	RDPMC(P6) */
@@ -3410,12 +3384,13 @@ repag0:
 		/* check segment boundaries. TODO for prot _mode */
 		if (REALADDR() && (PC - Interp_LONG_CS > 0xffff)) {
 			e_printf("PC out of bounds, %x\n", PC - Interp_LONG_CS);
-			CODE_FLUSH();
 			goto not_permitted;
 		}
 	return PC;
 
 not_permitted:
+	CODE_FLUSH();
+not_permitted_portio:
 	if (debug_level('e')>1) e_printf("!!! Not permitted %02x\n",opc);
 	TheCPU.err = EXCP0D_GPF; return P0;
 //div_by_zero:

--- a/src/base/emu-i386/simx86/protmode.c
+++ b/src/base/emu-i386/simx86/protmode.c
@@ -305,7 +305,6 @@ unsigned short GetSelectorXfer(unsigned short w)
 int hsw_verr(unsigned short sel)
 {
 	unsigned short wFlags;
-	if (V86MODE()) return -1;	/* maybe error */
 	/* test for present && CPL>=DPL && readable */
 	wFlags = GetSelectorFlags(sel);
 	if (wFlags & DF_PRESENT) {
@@ -318,7 +317,6 @@ int hsw_verr(unsigned short sel)
 int hsw_verw(unsigned short sel)
 {
 	unsigned short wFlags;
-	if (V86MODE()) return -1;	/* maybe error */
 	/* test for present && CPL>=DPL && writeable */
 	wFlags = GetSelectorFlags(sel);
 	if (wFlags & DF_PRESENT) {

--- a/src/base/emu-i386/simx86/protmode.c
+++ b/src/base/emu-i386/simx86/protmode.c
@@ -121,6 +121,7 @@ int SetSegProt(int a16, int ofs, unsigned char *big, unsigned long sel)
 	unsigned char lbig;
 	Descriptor *dt;
 	SDTR *sd;
+	unsigned int orig_scp_err = TheCPU.scp_err;
 
 	sd = (SDTR *)CPUOFFS(e_ofsseg(ofs));
 
@@ -224,7 +225,7 @@ int SetSegProt(int a16, int ofs, unsigned char *big, unsigned long sel)
 		e_printf("PMSEL %#04lx bounds=%08x:%08x flg=%04x big=%d\n",
 			sel, sd->BoundL, sd->BoundH, wFlags, lbig&1);
 	}
-	TheCPU.scp_err = 0;
+	TheCPU.scp_err = orig_scp_err;
 	CPUWORD(ofs) = sel;
 	return 0;
 }

--- a/src/base/emu-i386/simx86/syncpu.h
+++ b/src/base/emu-i386/simx86/syncpu.h
@@ -46,7 +46,8 @@ typedef struct {
 /* offsets up to end_mark are 8-bit */
 #define FIELD0		rzero	/* field of SynCPU at offset 00 */
 /*00*/	unsigned int rzero;
-/*08*/	unsigned int reserved[2];
+/*04*/	int err2;
+/*08*/	unsigned int reserved[1];
 /*0c*/	unsigned int edi;
 /*10*/	unsigned int esi;
 /*14*/	unsigned int ebp;
@@ -77,7 +78,6 @@ typedef struct {
 	unsigned int tr[2];
 
 	unsigned int scp_err;
-	int err2;
 	int err;
 	unsigned int mode;
 	unsigned int sreg1;

--- a/src/base/emu-i386/simx86/syncpu.h
+++ b/src/base/emu-i386/simx86/syncpu.h
@@ -47,7 +47,7 @@ typedef struct {
 #define FIELD0		rzero	/* field of SynCPU at offset 00 */
 /*00*/	unsigned int rzero;
 /*04*/	int err2;
-/*08*/	unsigned int reserved[1];
+/*08*/	unsigned int scp_err;
 /*0c*/	unsigned int edi;
 /*10*/	unsigned int esi;
 /*14*/	unsigned int ebp;
@@ -77,7 +77,6 @@ typedef struct {
 /*80*/	//unsigned int end_mark[0] = cr[1]
 	unsigned int tr[2];
 
-	unsigned int scp_err;
 	int err;
 	unsigned int mode;
 	unsigned int sreg1;
@@ -199,6 +198,7 @@ extern struct _SynCPU TheCPU_struct;
 #define Ofs_XGS		(offsetof(SynCPU,gs_cache))
 
 #define Ofs_ERR		(offsetof(SynCPU,err2))
+#define Ofs_SCP_ERR		(offsetof(SynCPU,scp_err))
 #define Ofs_int_revectored	(offsetof(SynCPU,int_revectored))
 
 #define rAX		CPUWORD(Ofs_AX)


### PR DESCRIPTION
Next step in separating simulation from decoding.

It may seem a little strange to compile e.g. `HLT` but the idea is that when it gets executed it doesn't need to re-enter `InterpOne` to re-decode the `HLT`, with the GPF in `TheCPU.err2`, it'll exit straightaway, and let upper level code deal with it.