### PR TITLE
Revert "flatpak: disable ncurses"

### DIFF
--- a/io.github.dosemu2.dosemu2.yml
+++ b/io.github.dosemu2.dosemu2.yml
@@ -86,8 +86,6 @@ modules:
     buildsystem: autotools
     build-options:
       env: ['CROSS_PREFIX=i686-unknown-linux-gnu-']
-    config-opts:
-      - --disable-ncurses
     sources:
       - type: git
         url: https://github.com/stsp/dj64dev.git


### PR DESCRIPTION
This reverts commit 74b2951bbda35635382927b20c7aa0a00d3dbb53.

@ThomasDickey fixed the problem, see
https://github.com/stsp/dj64dev/issues/33#issuecomment-3289871510