### PR TITLE
simx86: sigalrm_pending -> exit_pending also handles PIC, STI w/ PVI, CKSIGN improvement

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -2729,10 +2729,8 @@ static unsigned int Gen_sim(const IGen *IG, dosaddr_t mem_ref)
 	case JF_LINK:
 	case JB_LINK: {		// opc, PC, dspt, dspnt, link
 		int opc = IG->p0;
-		unsigned int PC = (unsigned int)IG->p1;
-		unsigned int j_t = (unsigned int)IG->p2;
-		unsigned int j_nt = (unsigned int)IG->p3;
-		(void)PC;
+		unsigned int j_t = (unsigned int)IG->p1;
+		unsigned int j_nt = (unsigned int)IG->p2;
 		switch(opc) {
 		case JO:      P0 = is_of_set() ? j_t : j_nt; break;
 		case JNO:     P0 = !is_of_set() ? j_t : j_nt; break;

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -2355,16 +2355,15 @@ shrot0:
 	case JF_LINK:
 	case JB_LINK: {		// opc, PC, dspt, dspnt, link
 		unsigned char opc = IG->p0;
-		int jpc = IG->p1;
-		int dspt = IG->p2;
-		int dspnt = IG->p3;
+		int dspt = IG->p1;
+		int dspnt = IG->p2;
 		int sz;
 		//	JCXZ:	8b 4b Ofs_ECX e3 07 or 0f b7 4b Ofs_ECX e3 07
 		//	JCC:	7x 07
 		// nt:	b8 [nt_pc] 5a c3
-		// t:	0f b7 4f [sig] e3 07
-		//	b8 [sig_pc] 5a c3
+		// t:	0f b7 4b [sig] e3 07
 		//	b8 [t_pc] 5a c3
+		//	b8 [t_pc] 5a c3 (can be patched by node linker)
 		sz = JMPTAILSIZE + (mode & CKSIGN? CKSIGNSIZE:0);
 		if (opc==JCXZ) {
 			if (mode&ADDR16) {
@@ -2389,7 +2388,7 @@ shrot0:
 		    // jecxz {continue}: exit if exitpend not 0
 		    G2M(0xe3,TAILSIZE,Cp);
 		    // movl {exit_addr},%%eax; pop %%edx; ret
-		    G1(0xb8,Cp); G4(jpc,Cp); G2(0xc35a,Cp);
+		    G1(0xb8,Cp); G4(dspnt,Cp); G2(0xc35a,Cp);
 	        }
 		// not taken: continue with next instr
 		G1(0xb8,Cp);
@@ -2399,7 +2398,7 @@ shrot0:
 		    // check signal on TAKEN branch for back jumps
 		    G4M(0x0f,0xb7,0x4b,Ofs_EXITPEND,Cp);
 		    G2M(0xe3,TAILSIZE,Cp);
-		    G1(0xb8,Cp); G4(jpc,Cp); G2(0xc35a,Cp);
+		    G1(0xb8,Cp); G4(dspt,Cp); G2(0xc35a,Cp);
 	        }
 		G1(0xb8,Cp);
 		G4(dspt,Cp); G2(0xc35a,Cp); PADJMP;

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -2337,9 +2337,9 @@ shrot0:
 		} else if (mode & CKSIGN) {
 		    // check signal on TAKEN branch
 		    // for backjmp-after-jcc:
-		    // movzwl Ofs_SIGAPEND(%%ebx),%%ecx
-		    G4M(0x0f,0xb7,0x4b,Ofs_SIGAPEND,Cp);
-		    // jecxz {continue}: exit if sigpend not 0
+		    // movzwl Ofs_EXITPEND(%%ebx),%%ecx
+		    G4M(0x0f,0xb7,0x4b,Ofs_EXITPEND,Cp);
+		    // jecxz {continue}: exit if exitpend not 0
 		    G2M(0xe3,TAILSIZE,Cp);
 		    // movl {exit_addr},%%eax; pop %%edx; ret
 		    G1(0xb8,Cp); G4(dspt,Cp); G2(0xc35a,Cp);
@@ -2384,9 +2384,9 @@ shrot0:
 		if (mode & CKSIGN) {
 		    // check signal on NOT TAKEN branch
 		    // for backjmp-after-jcc:
-		    // movzwl Ofs_SIGAPEND(%%ebx),%%ecx
-		    G4M(0x0f,0xb7,0x4b,Ofs_SIGAPEND,Cp);
-		    // jecxz {continue}: exit if sigpend not 0
+		    // movzwl Ofs_EXITPEND(%%ebx),%%ecx
+		    G4M(0x0f,0xb7,0x4b,Ofs_EXITPEND,Cp);
+		    // jecxz {continue}: exit if exitpend not 0
 		    G2M(0xe3,TAILSIZE,Cp);
 		    // movl {exit_addr},%%eax; pop %%edx; ret
 		    G1(0xb8,Cp); G4(jpc,Cp); G2(0xc35a,Cp);
@@ -2397,7 +2397,7 @@ shrot0:
 		// taken
 		if (IG->op==JB_LINK) {
 		    // check signal on TAKEN branch for back jumps
-		    G4M(0x0f,0xb7,0x4b,Ofs_SIGAPEND,Cp);
+		    G4M(0x0f,0xb7,0x4b,Ofs_EXITPEND,Cp);
 		    G2M(0xe3,TAILSIZE,Cp);
 		    G1(0xb8,Cp); G4(jpc,Cp); G2(0xc35a,Cp);
 	        }
@@ -2456,9 +2456,9 @@ shrot0:
 		if (mode & CKSIGN) {
 		    // check signal on TAKEN branch
 		    // for backjmp-after-jcc:
-		    // movzwl Ofs_SIGAPEND(%%ebx),%%ecx
-		    G4M(0x0f,0xb7,0x4b,Ofs_SIGAPEND,Cp);
-		    // jecxz {continue}: exit if sigpend not 0
+		    // movzwl Ofs_EXITPEND(%%ebx),%%ecx
+		    G4M(0x0f,0xb7,0x4b,Ofs_EXITPEND,Cp);
+		    // jecxz {continue}: exit if exitpend not 0
 		    G2M(0xe3,TAILSIZE,Cp);
 		    // movl {exit_addr},%%eax; pop %%edx; ret
 		    G1(0xb8,Cp); G4(dspt,Cp); G2(0xc35a,Cp);

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -376,24 +376,15 @@ void Gen(int op, int mode, ...)
 		break;
 
 	case JMP_LINK:		// opc, dspt, retaddr, link
-	case JLOOP_LINK: {
+	case JLOOP_LINK:
+	case JF_LINK:
+	case JB_LINK: {		// opc, dspt, dspnt, link
 		unsigned char opc = (unsigned char)va_arg(ap,unsigned int);
 		IG->p0 = opc;
 		IG->p1 = va_arg(ap,unsigned int);	// dspt
 		IG->p2 = va_arg(ap,unsigned int);	// dspnt
 		}
 		break;
-
-	case JF_LINK:
-	case JB_LINK: {		// opc, PC, dspt, dspnt, link
-		unsigned char opc = (unsigned char)va_arg(ap,unsigned int);
-		IG->p0 = opc;
-		IG->p1 = va_arg(ap,unsigned int);	// jpc
-		IG->p2 = va_arg(ap,unsigned int);	// dspt
-		IG->p3 = va_arg(ap,unsigned int);	// dspnt
-		}
-		break;
-
 	}
 
 	va_end(ap);

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -610,7 +610,9 @@ unsigned int DoExec(TNode *G)
 
 	ecpu = CPUOFFS(0);
 	if (debug_level('e')>1) {
-		if (sigalrm_pending()>0) e_printf("** SIGALRM is pending\n");
+		unsigned e = exit_pending();
+		if (e & CeS_SIGPEND) e_printf("** SIGALRM is pending\n");
+		if (e & CeS_RPIC) e_printf("** PIC is pending\n");
 		e_printf("==== Executing code at %p flg=%04x\n",
 			SeqStart,seqflg);
 	}
@@ -631,7 +633,7 @@ unsigned int DoExec(TNode *G)
 #endif
 	    if (debug_level('e')>1) {
 		e_printf("** End code, PC=%08x sig=%x\n",ePC,
-		    sigalrm_pending());
+		    exit_pending());
 		if ((debug_level('e')>3) && (seqflg & F_FPOP)) {
 		    e_printf("  %s\n", e_trace_fp());
 		}
@@ -653,10 +655,7 @@ unsigned int DoExec(TNode *G)
 		CEmuStat &= ~CeS_TRAP;
 	} else {
 		CEmuStat &= ~CeS_INHI;
-		if (sigalrm_pending()) {
-			CEmuStat|=CeS_SIGPEND;
-			sigalrm_pending_w(0);
-		}
+		CEmuStat |= exit_pending_xchg(0);
 	}
 
 #if defined(SINGLESTEP)
@@ -694,7 +693,7 @@ unsigned int DoExec_fast(TNode *G)
 {
 	unsigned char *ecpu = CPUOFFS(0);
 	unsigned long flg = Exec_pre(ecpu);
-	unsigned int ePC, mem_ref;
+	unsigned int ePC, mem_ref, e;
 
 	do {
 		ePC = Exec(&mem_ref, &flg, ecpu, G->addr, 0);
@@ -705,15 +704,15 @@ unsigned int DoExec_fast(TNode *G)
 				NodeLinker(LastXNode, G);
 			LastXNode = G;
 		}
-		if (sigalrm_pending()) {
-			CEmuStat|=CeS_SIGPEND;
+		e = exit_pending_xchg(0);
+		if (e) {
+			CEmuStat |= e;
 			break;
 		}
 	} while (!TheCPU.err2 && (G=FindTree(ePC)) &&
 		 GoodNode(G) && !(G->flags & (F_FPOP|F_INHI)));
 
 	Exec_post(flg, mem_ref);
-	sigalrm_pending_w(0);
 	return ePC;
 }
 

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -814,12 +814,12 @@ void e_gen_sigalrm(void)
 	/* here we come from the kernel with cs==UCODESEL, as
 	 * the passed context is that of dosemu, NOT that of the
 	 * emulated CPU! */
-	sigalrm_pending_w(1);
+	exit_pending_or(CeS_SIGPEND);
 }
 
 void e_gen_sigalrm_from_thread(void)
 {
-	__atomic_store_n(&TheCPU.sigalrm_pending, 1, __ATOMIC_RELAXED);
+	exit_pending_or(CeS_SIGPEND);
 }
 
 static void enter_cpu_emu(void)
@@ -978,7 +978,7 @@ int e_vm86(struct vm86_struct *info)
 #if PREJIT_TEST
   prejit_vm86(info);
 #endif
-  sigalrm_pending_w(0);
+  exit_pending_w(0);
 
   e_sigpa_count = 0;
 #ifdef SKIP_VM86_TRACE
@@ -1089,7 +1089,7 @@ int e_dpmi(cpuctx_t *scp)
 #if PREJIT_TEST
   prejit_dpmi(scp);
 #endif
-  sigalrm_pending_w(0);
+  exit_pending_w(0);
 
   e_sigpa_count = 0;
 

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -336,14 +336,14 @@ static unsigned int _JumpGen(unsigned int P2, int mode, int opc,
 			     * condition changing a flag */
 			    e_printf("### dsp=0 jmp=%x pskip=%d\n",opc,pskip);
 		    }
-		    Gen(JB_LINK, mode, opc, P2, j_t, j_nt);
+		    Gen(JB_LINK, mode, opc, j_t, j_nt);
 		}
 		else {
 		    if (dsp == pskip) {
 			e_printf("### jmp %x 00\n",opc);
 		    }
 		    /* forward jump or backward jump >=256 bytes */
-		    Gen(JF_LINK, mode, opc, P2, j_t, j_nt);
+		    Gen(JF_LINK, mode, opc, j_t, j_nt);
 		}
 		break;
 	case JMPld: {   /* uncond jmp far */

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -463,8 +463,6 @@ static unsigned int JumpGen(unsigned int P2, int mode, int opc, int pskip,
 			Interp_LONG_CS = LONG_CS;
 		}
 	}
-	if (sigalrm_pending())
-		CEmuStat |= CeS_SIGPEND;
 	return _P1;
 }
 
@@ -498,7 +496,7 @@ static unsigned int FindExecCode(unsigned int PC)
 	 * any signal processing. Jumps are defined as
 	 * a 'descheduling point' for checking signals.
 	 */
-	while (!(CEmuStat & (CeS_TRAP|CeS_DRTRAP|CeS_SIGPEND)) &&
+	while (!(CEmuStat & (CeS_TRAP|CeS_DRTRAP|CeS_SIGPEND|CeS_RPIC)) &&
 	       (G=FindTree(PC))) {
 		if (!GoodNode(G)) {
 			InvalidateNodeRange(G->seqbase, G->seqlen, NULL);
@@ -579,16 +577,10 @@ static void HandleEmuSignals(void)
 		if (EFLAGS & EFLAGS_IF)
 			TheCPU.err=EXCP_PICSIGNAL;
 	}
-	else if (CEmuStat & CeS_STI) {
-		/* force exit after next instruction */
-		CEmuStat &= ~CeS_STI;
-		if (pic_pending())
-			CEmuStat |= CeS_RPIC;
-	}
 	/* clear optional exit conditions */
 	CEmuStat &= ~CeS_TRAP;
 	if (TheCPU.err)
-		CEmuStat &= ~(CeS_SIGPEND | CeS_RPIC | CeS_STI);
+		CEmuStat &= ~(CeS_SIGPEND | CeS_RPIC);
 }
 
 static unsigned int _Interp86(unsigned int PC);
@@ -608,7 +600,7 @@ void Interp86(void)
 static unsigned int interp_pre(unsigned int PC, const int mode, int _flags)
 {
 		if (CurrIMeta<0) {
-			if (CEmuStat & (CeS_TRAP|CeS_DRTRAP|CeS_SIGPEND|CeS_RPIC|CeS_STI)) {
+			if (CEmuStat & (CeS_TRAP|CeS_DRTRAP|CeS_SIGPEND|CeS_RPIC)) {
 				HandleEmuSignals();
 				if (TheCPU.err) return PC;
 			}
@@ -634,7 +626,7 @@ static unsigned int interp_pre(unsigned int PC, const int mode, int _flags)
 			if (!(EFLAGS & TF)) {
 				P2 = FindExecCode(PC);
 				if (TheCPU.err) return P2;
-				if (CEmuStat & (CeS_TRAP|CeS_DRTRAP|CeS_SIGPEND|CeS_RPIC|CeS_STI)) {
+				if (CEmuStat & (CeS_TRAP|CeS_DRTRAP|CeS_SIGPEND|CeS_RPIC)) {
 					HandleEmuSignals();
 					if (TheCPU.err) return P2;
 					if (EFLAGS & TF)
@@ -2375,11 +2367,12 @@ stack_return_from_vm86:
 			    if (debug_level('e')>1)
 				e_printf("Popped flags %08x->{r=%08x v=%08x}\n",temp,EFLAGS,_EFLAGS);
 			    TheCPU.df_increments = (EFLAGS&DF)?0xfcfeff:0x040201;
-			    if (opc == POPF && (EFLAGS & EFLAGS_IF)) {
+			    if (opc == POPF && (EFLAGS & EFLAGS_IF) && isset_VIP()) {
 				if (debug_level('e')>1)
 				    e_printf("Return for STI fl=%08x\n",
 					    EFLAGS);
-				CEmuStat |= CeS_STI;
+				TheCPU.err = EXCP_STISIGNAL;
+				return PC+1;
 			    }
 			}
 			if (opc==POPF) PC++;
@@ -2710,10 +2703,13 @@ repag0:
 				if (debug_level('e')>2) e_printf("Virtual DPMI STI\n");
 				EFLAGS |= EFLAGS_VIF;
 			    }
-			    if (debug_level('e')>1)
-				    e_printf("Return for STI fl=%08x\n",
-					    EFLAGS);
-			    CEmuStat |= CeS_STI;
+			    if (isset_VIP()) {
+				if (debug_level('e')>1)
+				    e_printf("Return for STI ASAP fl=%08x\n",
+					     EFLAGS);
+				/* force exit after next compiled block execution */
+				exit_pending_or(CeS_RPIC);
+			    }
 			}
 			break;
 /*fc*/	case CLD:	PC++;

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -2348,6 +2348,7 @@ stack_return_from_vm86:
 			    }
 			}
 			else {
+			    int is_tf = !!(EFLAGS & TF);
 			    int amask = (CPL==0? 0:EFLAGS_IOPL_MASK) |
 					(CPL<=IOPL? 0:EFLAGS_IF) |
 					(EFLAGS_VM|EFLAGS_RF);
@@ -2371,7 +2372,7 @@ stack_return_from_vm86:
 				if (debug_level('e')>1)
 				    e_printf("Return for STI fl=%08x\n",
 					    EFLAGS);
-				TheCPU.err = EXCP_STISIGNAL;
+				TheCPU.err = (is_tf ? EXCP01_SSTP : EXCP_STISIGNAL);
 				return PC+1;
 			    }
 			}

--- a/src/base/emu-i386/simx86/syncpu.h
+++ b/src/base/emu-i386/simx86/syncpu.h
@@ -68,7 +68,7 @@ typedef struct {
 /* ------------------------------------------------ */
 /*70*/	unsigned short fpuc;
 /* ------------------------------------------------ */
-/*72*/	/*sig_atomic_t*/unsigned short sigalrm_pending;
+/*72*/	/*sig_atomic_t*/unsigned short exit_pending;
 /*74*/	unsigned int StackMask;
 /*78*/ 	unsigned int df_increments; /* either 0x040201 or 0xfcfeff */
 	/* begin of cr array */
@@ -184,7 +184,7 @@ extern struct _SynCPU TheCPU_struct;
 #define Ofs_STACKM	(offsetof(SynCPU,StackMask))
 //#define Ofs_ETIME	(offsetof(SynCPU,EMUtime))
 #define Ofs_RZERO	(offsetof(SynCPU,rzero))
-#define Ofs_SIGAPEND	(offsetof(SynCPU,sigalrm_pending))
+#define Ofs_EXITPEND	(offsetof(SynCPU,exit_pending))
 #define Ofs_DF_INCREMENTS (offsetof(SynCPU,df_increments))
 
 #define Ofs_FPUC	(offsetof(SynCPU,fpuc))
@@ -257,9 +257,13 @@ extern struct _SynCPU TheCPU_struct;
 #define LONG_FS		TheCPU.fs_cache.BoundL
 #define LONG_GS		TheCPU.gs_cache.BoundL
 
-#define sigalrm_pending() __atomic_load_n(&TheCPU.sigalrm_pending, \
+#define exit_pending() __atomic_load_n(&TheCPU.exit_pending, \
   __ATOMIC_RELAXED)
-#define sigalrm_pending_w(v) __atomic_store_n(&TheCPU.sigalrm_pending, v, \
+#define exit_pending_w(v) __atomic_store_n(&TheCPU.exit_pending, v, \
+  __ATOMIC_RELAXED)
+#define exit_pending_or(v) __atomic_fetch_or(&TheCPU.exit_pending, v, \
+  __ATOMIC_RELAXED)
+#define exit_pending_xchg(v) __atomic_exchange_n(&TheCPU.exit_pending, v, \
   __ATOMIC_RELAXED)
 
 #endif

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -619,8 +619,13 @@ static void dpmi_pic_run(cpuctx_t *scp)
 {
   int inum;
 
-  if (!_isset_IF() || !pic_pending())
+  clear_VIP();
+  if (!pic_pending())
     return;
+  if (!_isset_IF()) {
+    set_VIP();
+    return;
+  }
   inum = pic_get_inum();
   do_pm_int(scp, inum);
 }

--- a/src/include/cpu-emu.h
+++ b/src/include/cpu-emu.h
@@ -50,7 +50,6 @@ extern void e_priv_iopl(int);
 #define CeS_SIGPEND	0x01	/* signal pending mask */
 #define CeS_SIGACT	0x02	/* signal active mask */
 #define CeS_RPIC	0x04	/* pic asks for interruption */
-#define CeS_STI		0x08	/* IF active was popped */
 #define CeS_INHI	0x800	/* inhibit interrupts(pop ss; pop sp et sim.) */
 #define CeS_TRAP	0x1000	/* INT01 Sstep active */
 #define CeS_DRTRAP	0x2000	/* Debug Registers active */


### PR DESCRIPTION
I thought it may be better to address the comments in #2595 in a more easy to follow PR (without moving code), where I can keep EXCP_PICSIGNAL by renaming signal_pending to a more general exit_pending with the same bitmask values as CEmuStat, for CeS_RPIC and CeS_SIGPEND. #2595 could then be rebased after.

In doing so I observed that conditional jumps are interrupted at the original PC after a signal, which messes up the JIT a little, as that PC is at the end of a block, so that block would then be invalidated when re-entering. It's better to use the new PC (unconditional jumps already used the new PC for signals at backjmps, since fb04f78fd).

The sigalrm/exit_pending check in JumpGen is gone because JumpGen now always implies a DoExec and it's already checked there.


