### PR TITLE
simx86: fix CODE_FLUSH2 for full instruction tab

### DIFF
--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -642,10 +642,14 @@ static unsigned int interp_post(unsigned int PC, const int mode, unsigned P0,
 			int rc=0;
 			NewIMeta(P0, &rc);
 			if (rc < 0) {
+				unsigned int Interp_P0 = P0, Interp_PC = PC;
 				if (debug_level('e')>2)
 					e_printf("============ Tab full:cannot close sequence\n");
+				P0 = PC;
 				CODE_FLUSH2(mode);
-				NewIMeta(P0, &rc);
+				/* this may return a different PC because of BreakNode */
+				if (PC == Interp_PC)
+					NewIMeta(Interp_P0, &rc);
 			}
 		}
 

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -1399,8 +1399,9 @@ int NewIMeta(int npc, int *rc)
 		if (debug_level('e')) AddTime += (GETTSC() - t0);
 #endif
 		CurrIMeta++;
-		/* provoke caller to flush if we are about to overflow */
-		*rc = (CurrIMeta >= MAXINODES-1 ? -1 : 1);
+		/* provoke caller to flush if we are about to overflow:
+		   we need space for one more instruction to close */
+		*rc = (CurrIMeta >= MAXINODES-2 ? -1 : 1);
 		I++;
 		I->ngen = 0;
 		I->flags = 0;


### PR DESCRIPTION
We need to leave space for one more instruction and use P0=PC before calling CODE_FLUSH2. Tested with MAXINODES=10.

(a lot of cleanups are possible now that all instructions are compiled, but let's get the bug fix in first)