### PR TITLE
simx86: reorganize NewIMeta/CurrIMeta

### DIFF
--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -128,9 +128,6 @@ void AddrGen(int op, int mode, ...)
 	if (debug_level('e')) t0 = GETTSC();
 #endif
 
-	if (CurrIMeta<0) {
-		CurrIMeta=0; InstrMeta[0].ngen=0; InstrMeta[0].flags=0;
-	}
 	I = &InstrMeta[CurrIMeta];
 	if (I->ngen >= NUMGENS) { leavedos_main(0xbac1); return; }
 	IG = &(I->gen[I->ngen]);
@@ -193,9 +190,6 @@ void Gen(int op, int mode, ...)
 	if (debug_level('e')) t0 = GETTSC();
 #endif
 
-	if (CurrIMeta<0) {
-		CurrIMeta=0; InstrMeta[0].ngen=0; InstrMeta[0].flags=0;
-	}
 	I = &InstrMeta[CurrIMeta];
 	if (I->ngen >= NUMGENS) leavedos_main(0xbac2);
 	IG = &(I->gen[I->ngen]);
@@ -430,7 +424,7 @@ static CodeBuf *ProduceCode(unsigned int PC, IMeta *I0)
 	 *
 	 */
 	GenBufSize = 0;
-	for (i=0; i<CurrIMeta; i++)
+	for (i=0; i<=CurrIMeta; i++)
 	    GenBufSize += I0[i].ngen * MAX_GEND_BYTES_PER_OP;
 	mall_req = GenBufSize + offsetof(CodeBuf, meta) + sizeof(Addr2Pc) * nap + 32;// 32 for tail
 	GenCodeBuf = dlmalloc(mall_req);
@@ -440,7 +434,7 @@ static CodeBuf *ProduceCode(unsigned int PC, IMeta *I0)
 	if (debug_level('e')>1)
 	    e_printf("CodeBuf=%p siz %zd CodePtr=%p\n",GenCodeBuf,GenBufSize,CodePtr);
 
-	for (i=0; i<CurrIMeta; i++) {
+	for (i=0; i<=CurrIMeta; i++) {
 	    IMeta *I = &I0[i];
 	    if (i==0) {
 		adr_lo = adr_hi = I->npc;
@@ -469,7 +463,23 @@ static CodeBuf *ProduceCode(unsigned int PC, IMeta *I0)
 		cp1 = CodePtr;
 	    }
 	    I->len = CodePtr - cp;
-	    if (debug_level('e')>3) GCPrint(cp, BaseGenBuf, I->len);
+	    if (i > 0) {
+		/* F_INHI (pop ss/mov ss) only applies to the last
+		   instruction in the sequence and not twice in
+		   a row */
+		if ((I->flags & F_INHI) && !(I0->flags & F_INHI))
+		    I0->flags |= F_INHI;
+		else
+		    I0->flags &= ~F_INHI;
+		I0->flags |= I->flags & ~F_INHI;
+	    }
+	    if (debug_level('e')>3) {
+		if (debug_level('e')>4) {
+		    e_printf("Metadata %03d PC=%08x flags=%x(%x) ng=%d\n",
+			     i,I->npc,I->flags,I0->flags,I->ngen);
+		}
+		GCPrint(cp, BaseGenBuf, I->len);
+	    }
 	}
 	if (debug_level('e')>1)
 	    e_printf("Size=%td guess=%zd\n",(CodePtr-BaseGenBuf),GenBufSize);
@@ -523,7 +533,7 @@ TNode *Close(unsigned int PC, unsigned int Interp_LONG_CS, int mode)
 	TNode *G;
 	CodeBuf *GenCodeBuf;
 
-	if (CurrIMeta <= 0) {
+	if (CurrIMeta < 0) {
 /**/		e_printf("(X) Nothing to exec at %08x\n",PC);
 		return NULL;
 	}

--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -263,7 +263,7 @@ static __inline__ void POP_ONLY(int m)
 }
 
 void InitGen(void);
-int NewIMeta(int npc, int *rc);
+int NewIMeta(int npc);
 extern int CurrIMeta;
 extern void Gen(int op, int mode, ...);
 extern void AddrGen(int op, int mode, ...);

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -100,11 +100,9 @@ static TNode *DoClose(unsigned int PC, int mode, unsigned int P0)
 {
 	/* If the code doesn't terminate with a jump/loop instruction
 	 * it still lacks the tail code; add it here */
-	IMeta *GL = &InstrMeta[CurrIMeta-1];
+	IMeta *GL = &InstrMeta[CurrIMeta];
 	if (GL->gen[GL->ngen-1].op < JMP_TAILCODE) {
-		int rc;
 		Gen(JMP_TAILCODE, mode, PC);
-		NewIMeta(PC, &rc);
 	}
 
 	assert(PC > P0);
@@ -149,15 +147,15 @@ static unsigned int do_flush(unsigned P0, unsigned _P0,
     unsigned mode, unsigned _flags)
 {
   if (_flags & FLG_PREJIT) {
-    if (CurrIMeta>0) {
+    if (CurrIMeta>=0) {
       TNode *G = DoClose(P0, mode, _P0);
       G->flags |= F_PREJ;
       NodesPrejitted++;
-    } else if (CurrIMeta == 0) CurrIMeta = -1;
+    }
     TheCPU.err = EXCP_GOBACK;
-  } else if (CurrIMeta>0) {
+  } else if (CurrIMeta>=0) {
     return DoCloseAndExec(P0, mode, _P0);
-  } else if (CurrIMeta == 0) CurrIMeta = -1;
+  }
   return P0;
 }
 
@@ -382,7 +380,6 @@ static unsigned int JumpGen(unsigned int P2, int mode, int opc, int pskip,
 	unsigned int P0, int _flags)
 {
 	unsigned int _P0, _P1;
-	int _rc;
 	_P1 = _JumpGen(P2, mode, opc, pskip, &_P0);
 	if (_P1 == (unsigned)-1) {
 #if SPEC_PREJIT
@@ -390,7 +387,6 @@ static unsigned int JumpGen(unsigned int P2, int mode, int opc, int pskip,
 #endif
 		unsigned int basemode = UNPREFIX(mode);
 		TNode *G;
-		NewIMeta(P0, &_rc);
 #if SPEC_PREJIT
 		switch (opc) {
 		/* With uncond JMP or RET nothing to speculate. */
@@ -440,13 +436,11 @@ static unsigned int JumpGen(unsigned int P2, int mode, int opc, int pskip,
 static unsigned int ExceptionGen(unsigned int PC, int basemode, int trapno,
 	unsigned int scp_err, unsigned int P0, int _flags)
 {
-	int rc = 0;
 	Gen(L_IMM, basemode, Ofs_ERR, trapno);
 	if (trapno == EXCP0D_GPF)
 		Gen(L_IMM, basemode, Ofs_SCP_ERR, scp_err);
 	if (trapno != EXCP03_INT3 && trapno != EXCP04_INTO)
 		Gen(JMP_TAILCODE, basemode, P0); // fault: use current instr
-	NewIMeta(P0, &rc);
 	P0 = PC;
 	CODE_FLUSH();
 	assert(TheCPU.err == trapno ||
@@ -638,21 +632,6 @@ static unsigned int interp_pre(unsigned int PC, const int mode, int _flags)
 static unsigned int interp_post(unsigned int PC, const int mode, unsigned P0,
 	int _flags)
 {
-		if (CurrIMeta>=0) {
-			int rc=0;
-			NewIMeta(P0, &rc);
-			if (rc < 0) {
-				unsigned int Interp_P0 = P0, Interp_PC = PC;
-				if (debug_level('e')>2)
-					e_printf("============ Tab full:cannot close sequence\n");
-				P0 = PC;
-				CODE_FLUSH2(mode);
-				/* this may return a different PC because of BreakNode */
-				if (PC == Interp_PC)
-					NewIMeta(Interp_P0, &rc);
-			}
-		}
-
 #ifdef SINGLEBLOCK
 		if (CurrIMeta>=0) {
 			P0 = PC;
@@ -1228,6 +1207,13 @@ static unsigned int InterpOne(unsigned int PC, int basemode, int _flags)
 	/* WARNING - these are signed char offsets, NOT pointers! */
 	signed char OVERR_DS = Ofs_XDS;
 	signed char OVERR_SS = Ofs_XSS;
+
+	if (!NewIMeta(P0)) {
+		if (debug_level('e')>2)
+			e_printf("============ Tab full:cannot close sequence\n");
+		CODE_FLUSH();
+		NewIMeta(P0);
+	}
 
 override:
 	switch ((opc=Fetch(PC))) {
@@ -3417,7 +3403,7 @@ static void _PreJit86(unsigned int PC, int basemode, int flags)
 		if (TheCPU.err)
 			return;
 		if (e_querymark(PC, gap)) {
-			if (CurrIMeta>0) {
+			if (CurrIMeta>=0) {
 				TNode *G = DoClose(PC, basemode,
 						InstrMeta[0].npc);
 				G->flags |= F_PREJ;

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -985,7 +985,7 @@ TNode *Move2Tree(IMeta *I0, CodeBuf *GenCodeBuf)
 
   /* setup structures for inter-node linking */
   nG->unlinked_jmp_targets = 0;
-  op = I0[CurrIMeta-1].gen[I0[CurrIMeta-1].ngen-1].op;
+  op = I0[CurrIMeta].gen[I0[CurrIMeta].ngen-1].op;
 #ifdef X86_JIT
   if (op >= JMP_LINK) {
     nG->clink_t.link = (unsigned int *)(nG->addr + nG->len - JMPTAILSIZE + TAILFIX);
@@ -1355,20 +1355,19 @@ int e_invalidate_page_full(unsigned data)
 
 /////////////////////////////////////////////////////////////////////////////
 
-int NewIMeta(int npc, int *rc)
+int NewIMeta(int npc)
 {
+	int ret = 0;
 #if PROFILE >= 2
 	hitimer_t t0 = 0;
 
 	if (debug_level('e')) t0 = GETTSC();
 #endif
-	if (CurrIMeta >= 0) {
+	if (CurrIMeta < MAXINODES-1) {
 		// add new opcode metadata
 		IMeta *I,*I0;
 
-		if (CurrIMeta>=MAXINODES-1) {
-			*rc = -1; goto quit;
-		}
+		CurrIMeta++;
 		I = &InstrMeta[CurrIMeta];
 		if (CurrIMeta==0) {		// no open code sequences
 			if (debug_level('e')>2) e_printf("============ Opening sequence at %08x\n",npc);
@@ -1381,38 +1380,15 @@ int NewIMeta(int npc, int *rc)
 		I0->ncount += 1;
 		I->npc = npc;
 
-		if (CurrIMeta>0 && I->gen[I->ngen-1].op != JMP_TAILCODE) {
-			/* F_INHI (pop ss/mov ss) only applies to the last
-			   instruction in the sequence and not twice in
-			   a row */
-			if ((I->flags & F_INHI) && !(I0->flags & F_INHI))
-				I0->flags |= F_INHI;
-			else
-				I0->flags &= ~F_INHI;
-			I0->flags |= I->flags & ~F_INHI;
-		}
-		if (debug_level('e')>4) {
-			e_printf("Metadata %03d PC=%08x flags=%x(%x) ng=%d\n",
-				CurrIMeta,I->npc,I->flags,I0->flags,I->ngen);
-		}
-#if PROFILE >= 2
-		if (debug_level('e')) AddTime += (GETTSC() - t0);
-#endif
-		CurrIMeta++;
-		/* provoke caller to flush if we are about to overflow:
-		   we need space for one more instruction to close */
-		*rc = (CurrIMeta >= MAXINODES-2 ? -1 : 1);
-		I++;
 		I->ngen = 0;
 		I->flags = 0;
-		return CurrIMeta;
+		ret = 1;
 	}
-	*rc = 0;
-quit:
+
 #if PROFILE >= 2
 	if (debug_level('e')) AddTime += (GETTSC() - t0);
 #endif
-	return -1;
+	return ret;
 }
 
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
As all instructions are compiled now we can call NewIMeta() unconditionally at the start of InterpOne(), instead of at multiple places when an instruction is ready. Then CurrIMeta==0 is no longer special, it's just the first instruction in the sequence being compiled.

Some postprocessing then needed to be moved to ProduceCode().

Unlike in #2521 the tail code no longer gives a new IMeta, to allow having only a single NewIMeta() call with overflow backup in InterpOne(). I tested overflow again with MAXINODES=10.