### PR TITLE
mfs: support lredir up to LASTDRIVE=32 in MS-DOS v7 and lDOS

### DIFF
--- a/src/dosext/mfs/mfs.h
+++ b/src/dosext/mfs/mfs.h
@@ -15,7 +15,7 @@ Andrew.Tridgell@anu.edu.au 30th March 1993
 #define d_namlen d_reclen
 #endif
 
-#define MAX_DRIVE 26
+#define MAX_DRIVE 32
 #define PRINTER_BASE_DRIVE MAX_DRIVE
 #define MAX_PRINTER 9
 

--- a/src/dosext/mfs/util.c
+++ b/src/dosext/mfs/util.c
@@ -223,7 +223,7 @@ int get_drive_from_path(char *path, int *drive)
     return 0;
 
   c = toupper(path[0]);
-  if (c < 'A' || c > 'Z' || path[1] != ':')
+  if (c < 'A' || c > '`' || path[1] != ':')
     return 0;
 
   *drive = c - 'A';


### PR DESCRIPTION
lredir actually already worked to create or delete drives up to and including drive \`: but beyond [: they were inaccessible. [: itself worked only partially (probably no int 2Fh function 110Ch). Now mfs supports all possible drives as desired.

This requires setting eg LASTDRIVE=32 in config.sys or ldos.ini, or for lDOS only running with `append lastdrive 32` in the kernel command line.

Test cases:

```
C:\>type testmfs.bat
lredir %1: /home/[user]/proj/devload
lredir
dir %1:
lredir -d %1:
```

The DIR command in this batch file requires the FreeCOM patch in https://github.com/FDOS/freecom/pull/180

Different test case:

```
ldebug
ext extlib.eld dosspace `:
```

This runs DOS interrupt 21h function 36h, which in turn calls int 2Fh function 110Ch.

Some uses of the very last drive letter, \`:, require a patch for working under MS-DOS v7: https://pushbx.org/ecm/test/20250926.3/