### PR TITLE
simx86: use one single step for STI hold off

### DIFF
--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -598,6 +598,11 @@ static void Exec_post(unsigned long flg, unsigned int mem_ref)
 {
 	EFLAGS = (EFLAGS & ~EFLAGS_CC) | (flg &	EFLAGS_CC);
 	TheCPU.mem_ref = mem_ref;
+	CEmuStat &= ~CeS_STI;
+	if (TheCPU.err2 == EXCP_STISHADOW) {
+		CEmuStat |= CeS_STI;
+		TheCPU.err2 = 0;
+	}
 }
 
 unsigned int DoExec(TNode *G)
@@ -648,14 +653,15 @@ unsigned int DoExec(TNode *G)
 	/* signal_pending at this point is 1 if there was ANY signal,
 	 * not just a SIGALRM
 	 */
-	if ((G->flags & F_INHI) && !(G->seqnum == 1 && (CEmuStat & CeS_INHI))) {
+	if (((G->flags & F_INHI) || (CEmuStat & CeS_STI)) &&
+	    !(G->seqnum == 1 && (CEmuStat & CeS_INHI))) {
 		/* ignore signals and traps for movss/popss; if there is just
 		   one compiled instruction it should be ignored unconditionally
 		   if signals and traps were already ignored */
 		CEmuStat |= CeS_INHI;
 		CEmuStat &= ~CeS_TRAP;
 	} else {
-		CEmuStat &= ~CeS_INHI;
+		CEmuStat &= ~(CeS_INHI|CeS_STI);
 		CEmuStat |= exit_pending_xchg(0);
 	}
 
@@ -704,6 +710,13 @@ unsigned int DoExec_fast(TNode *G)
 			     LastXNode->clink_nt.target == G->key))
 				NodeLinker(LastXNode, G);
 			LastXNode = G;
+		}
+		if (TheCPU.err2 == EXCP_STISHADOW) {
+			/* as STI can exit here as well from the middle
+			   of a block we must mirror DoExec here */
+			CEmuStat |= CeS_INHI;
+			CEmuStat &= ~CeS_TRAP;
+			break;
 		}
 		e = exit_pending_xchg(0);
 		if (e) {

--- a/src/base/emu-i386/simx86/emu86.h
+++ b/src/base/emu-i386/simx86/emu86.h
@@ -682,6 +682,7 @@ extern int SpecPrejits;
 #define EXCP_EMULEAVE	69
 #define EXCP_RETRY	70
 #define EXCP_TFSET	71
+#define EXCP_STISHADOW	72
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -461,7 +461,7 @@ static unsigned int FindExecCode(unsigned int PC)
 	 * any signal processing. Jumps are defined as
 	 * a 'descheduling point' for checking signals.
 	 */
-	while (!(CEmuStat & (CeS_TRAP|CeS_DRTRAP|CeS_SIGPEND|CeS_RPIC)) &&
+	while (!(CEmuStat & (CeS_TRAP|CeS_DRTRAP|CeS_SIGPEND|CeS_RPIC|CeS_STI)) &&
 	       (G=FindTree(PC))) {
 		if (!GoodNode(G)) {
 			InvalidateNodeRange(G->seqbase, G->seqlen, NULL);
@@ -639,7 +639,7 @@ static unsigned int interp_post(unsigned int PC, const int mode, unsigned P0,
 		}
 #endif
 
-		if (CurrIMeta>=0 && (CEmuStat & CeS_TRAP)) {
+		if (CurrIMeta>=0 && (CEmuStat & (CeS_TRAP|CeS_STI))) {
 			P0 = PC;
 			CODE_FLUSH2(mode);
 		}
@@ -675,7 +675,7 @@ static unsigned int _Interp86(unsigned int PC)
 	}
 
 	TheCPU.err = 0;
-	CEmuStat &= ~CeS_TRAP;
+	CEmuStat &= ~(CeS_TRAP|CeS_STI);
 
 #ifndef __clang__
 #pragma GCC diagnostic push
@@ -970,6 +970,7 @@ stack_return_from_vm86:
 					    EFLAGS);
 				/* force exit after next compiled block execution */
 				exit_pending_or(CeS_RPIC);
+				TheCPU.err2 = EXCP_STISHADOW;
 			    }
 			}
 			break;

--- a/src/include/cpu-emu.h
+++ b/src/include/cpu-emu.h
@@ -50,6 +50,7 @@ extern void e_priv_iopl(int);
 #define CeS_SIGPEND	0x01	/* signal pending mask */
 #define CeS_SIGACT	0x02	/* signal active mask */
 #define CeS_RPIC	0x04	/* pic asks for interruption */
+#define CeS_STI		0x08	/* STI shadow active */
 #define CeS_INHI	0x800	/* inhibit interrupts(pop ss; pop sp et sim.) */
 #define CeS_TRAP	0x1000	/* INT01 Sstep active */
 #define CeS_DRTRAP	0x2000	/* Debug Registers active */


### PR DESCRIPTION
We can use the same mechanism as used for the trap flag to force executing just one instruction past STI and only then exiting for PIC if needed. We need this only for STI, not for POPSS/MOVSS. This reintroduces CeS_STI though it doesn't directly cause CeS_RPIC to be set in HandleEmuSignals(), it just forces one single step, and to ignore signals/pic at the end of DoExec().

Tested with win31 and Warcraft2.