### PR TITLE
simx86: concentrate exec, eliminate err2 and static Interp_LONG_CS

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -294,7 +294,7 @@ void InitGen_sim(void)
 static inline void check_v86_address_overflow(int mode, dosaddr_t offset)
 {
 	if (V86MODE() && (0 == (mode & (ADDR16 | MLEA))) && offset > 0xffff)
-		TheCPU.err2 = EXCP0D_GPF;
+		TheCPU.err = EXCP0D_GPF;
 }
 
 dosaddr_t AddrGen_sim(const IGen *IG)
@@ -400,7 +400,7 @@ dosaddr_t AddrGen_sim(const IGen *IG)
 		unsigned char intno = IG->p0;
 		// Check bitmap, GPF if revectored
 		if (test_bit(intno, &TheCPU.int_revectored)) {
-			TheCPU.err2 = EXCP0D_GPF;
+			TheCPU.err = EXCP0D_GPF;
 			mem_ref = (dosaddr_t)-1;
 		}
 		else {
@@ -486,7 +486,7 @@ static unsigned int Gen_sim(const IGen *IG, dosaddr_t mem_ref)
 			e_printf("FPU: error status %02x\n",exs);
 			if ((exs & ~TheCPU.fpuc) & 0x3f) {
 				e_printf("FPU exception\n");
-				TheCPU.err2 = EXCP10_COPR;
+				TheCPU.err = EXCP10_COPR;
 				P0 = FindPC((const unsigned char *)IG);
 			}
 		}
@@ -1429,12 +1429,12 @@ static unsigned int Gen_sim(const IGen *IG, dosaddr_t mem_ref)
 			uint32_t v = CPUWORD(Ofs_AX);
 			S1 = DR1.b.bl;
 			if (S1==0)
-			    TheCPU.err2 = EXCP00_DIVZ;
+			    TheCPU.err = EXCP00_DIVZ;
 			else {
 			    uint32_t rem = v % S1;
 			    v /= S1;
 			    if (v > 0xff)
-				TheCPU.err2 = EXCP00_DIVZ;
+				TheCPU.err = EXCP00_DIVZ;
 			    else {
 				CPUBYTE(Ofs_AL) = v;
 				CPUBYTE(Ofs_AH) = rem;
@@ -1447,12 +1447,12 @@ static unsigned int Gen_sim(const IGen *IG, dosaddr_t mem_ref)
 				v = ((uint32_t)CPUWORD(Ofs_DX) << 16) | CPUWORD(Ofs_AX);
 				S1 = DR1.w.l;
 				if (S1==0)
-				    TheCPU.err2 = EXCP00_DIVZ;
+				    TheCPU.err = EXCP00_DIVZ;
 		    		else {
 				    uint32_t rem = v % S1;
 				    v /= S1;
 				    if (v > 0xffff)
-					TheCPU.err2 = EXCP00_DIVZ;
+					TheCPU.err = EXCP00_DIVZ;
 				    else {
 					CPUWORD(Ofs_AX) = v;
 					CPUWORD(Ofs_DX) = rem;
@@ -1465,12 +1465,12 @@ static unsigned int Gen_sim(const IGen *IG, dosaddr_t mem_ref)
 				v.t.th = CPULONG(Ofs_EDX);
 				S1 = DR1.d;
 				if (S1==0)
-				    TheCPU.err2 = EXCP00_DIVZ;
+				    TheCPU.err = EXCP00_DIVZ;
 		    		else {
 				    uint32_t rem = v.td % S1;
 				    v.td /= S1;
 				    if (v.t.th)
-					TheCPU.err2 = EXCP00_DIVZ;
+					TheCPU.err = EXCP00_DIVZ;
 				    else {
 					CPULONG(Ofs_EAX) = v.t.tl;
 					CPULONG(Ofs_EDX) = rem;
@@ -1478,7 +1478,7 @@ static unsigned int Gen_sim(const IGen *IG, dosaddr_t mem_ref)
 		    		}
 			}
 		}
-		if (TheCPU.err2 == EXCP00_DIVZ)
+		if (TheCPU.err == EXCP00_DIVZ)
 			P0 = LONG_CS + (dosaddr_t)IG->p0;
 		break;
 	case O_IDIV:		// no flags
@@ -1488,12 +1488,12 @@ static unsigned int Gen_sim(const IGen *IG, dosaddr_t mem_ref)
 			int32_t S = DR1.bs.bl;
 			v = (signed short)CPUWORD(Ofs_AX);
 			if (S==0)
-			    TheCPU.err2 = EXCP00_DIVZ;
+			    TheCPU.err = EXCP00_DIVZ;
 	    		else {
 			    int32_t rem = v % S;
 			    v /= S;
 			    if (v > 127 || v < -128)
-				TheCPU.err2 = EXCP00_DIVZ;
+				TheCPU.err = EXCP00_DIVZ;
 			    else {
 				CPUBYTE(Ofs_AL) = v;
 				CPUBYTE(Ofs_AH) = rem;
@@ -1506,12 +1506,12 @@ static unsigned int Gen_sim(const IGen *IG, dosaddr_t mem_ref)
 				int32_t S = DR1.ws.l;
 				v = ((uint32_t)CPUWORD(Ofs_DX) << 16) | CPUWORD(Ofs_AX);
 				if (S==0)
-				    TheCPU.err2 = EXCP00_DIVZ;
+				    TheCPU.err = EXCP00_DIVZ;
 		    		else {
 				    int32_t rem = v % S;
 				    v /= S;
 				    if (v > 32767 || v < -32768)
-					TheCPU.err2 = EXCP00_DIVZ;
+					TheCPU.err = EXCP00_DIVZ;
 				    else {
 					CPUWORD(Ofs_AX) = v;
 					CPUWORD(Ofs_DX) = rem;
@@ -1524,12 +1524,12 @@ static unsigned int Gen_sim(const IGen *IG, dosaddr_t mem_ref)
 				v = CPULONG(Ofs_EAX) |
 				  ((uint64_t)CPULONG(Ofs_EDX) << 32);
 				if (S==0)
-				    TheCPU.err2 = EXCP00_DIVZ;
+				    TheCPU.err = EXCP00_DIVZ;
 		    		else {
 				    int32_t rem = v % S;
 				    v /= S;
 				    if (v > 0x7fffffffLL || v < -0x80000000LL)
-					TheCPU.err2 = EXCP00_DIVZ;
+					TheCPU.err = EXCP00_DIVZ;
 				    else {
 					CPULONG(Ofs_EAX) = v & 0xffffffff;
 					CPULONG(Ofs_EDX) = rem;
@@ -1537,7 +1537,7 @@ static unsigned int Gen_sim(const IGen *IG, dosaddr_t mem_ref)
 		    		}
 			}
 		}
-		if (TheCPU.err2 == EXCP00_DIVZ)
+		if (TheCPU.err == EXCP00_DIVZ)
 			P0 = LONG_CS + (dosaddr_t)IG->p0;
 		break;
 	case O_CBWD:
@@ -2130,7 +2130,7 @@ static unsigned int Gen_sim(const IGen *IG, dosaddr_t mem_ref)
 		DR1.d = Sim_helper(mem_ref, DR1.d, mode,
 				   &flags, IG->p0, IG->p1);
 		FlagSync_RFL(flags);
-		if (TheCPU.err2)
+		if (TheCPU.err)
 			P0 = IG->p2;
 		break;
 		}
@@ -2171,7 +2171,7 @@ static unsigned int Gen_sim(const IGen *IG, dosaddr_t mem_ref)
 
 			/* misaligned overflow generates trap. */
 			if(minofs & (OPSIZE(mode)-1)) {
-			    TheCPU.err2 = EXCP0D_GPF;
+			    TheCPU.err = EXCP0D_GPF;
 			    P0 = FindPC((const unsigned char *)IG);
 			    break;
 			}
@@ -2309,7 +2309,7 @@ static unsigned int Gen_sim(const IGen *IG, dosaddr_t mem_ref)
 			if(AR1.d & (OPSIZE(mode)-1))
 			{
 				/* misaligned overflow generates trap. */
-				TheCPU.err2 = EXCP0D_GPF;
+				TheCPU.err = EXCP0D_GPF;
 				P0 = FindPC((const unsigned char *)IG);
 				break;
 			}
@@ -2828,7 +2828,7 @@ static unsigned Exec_sim(unsigned *pmem_ref, unsigned long *flg,
 	do {
 		if (IG->op <= O_MOVS_SetA) {
 			mem_ref = AddrGen_sim(IG);
-			if (TheCPU.err2 == EXCP0D_GPF) {
+			if (TheCPU.err == EXCP0D_GPF) {
 				if (IG->op == O_INT)
 					P0 = (dosaddr_t)IG->p1;
 				else

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -2854,7 +2854,7 @@ static unsigned Exec_x86(unsigned *mem_ref, unsigned long *flg,
 			if ((exs & ~TheCPU.fpuc) & 0x3f) {
 				__asm__ __volatile__ ("fnclex\n" ::: "memory");
 				e_printf("FPU exception\n");
-				TheCPU.err2 = EXCP10_COPR;
+				TheCPU.err = EXCP10_COPR;
 			}
 		}
 	}

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -596,9 +596,9 @@ static void Exec_post(unsigned long flg, unsigned int mem_ref)
 	EFLAGS = (EFLAGS & ~EFLAGS_CC) | (flg &	EFLAGS_CC);
 	TheCPU.mem_ref = mem_ref;
 	CEmuStat &= ~CeS_STI;
-	if (TheCPU.err2 == EXCP_STISHADOW) {
+	if (TheCPU.err == EXCP_STISHADOW) {
 		CEmuStat |= CeS_STI;
-		TheCPU.err2 = 0;
+		TheCPU.err = 0;
 	}
 }
 
@@ -631,8 +631,8 @@ unsigned int DoExec(TNode *G)
 	Exec_post(flg, mem_ref);
 
 #ifdef SKIP_EMU_VBIOS
-	if ((jcs&0xf000)==config.vbios_seg && !TheCPU.err2)
-		TheCPU.err2 = EXCP_GOBACK;
+	if ((jcs&0xf000)==config.vbios_seg && !TheCPU.err)
+		TheCPU.err = EXCP_GOBACK;
 #endif
 
 	if (debug_level('e')) {
@@ -713,7 +713,7 @@ unsigned int DoExec_fast(TNode *G)
 				NodeLinker(LastXNode, G);
 			LastXNode = G;
 		}
-		if (TheCPU.err2 == EXCP_STISHADOW) {
+		if (TheCPU.err == EXCP_STISHADOW) {
 			/* as STI can exit here as well from the middle
 			   of a block we must mirror DoExec here */
 			CEmuStat |= CeS_INHI;
@@ -726,10 +726,10 @@ unsigned int DoExec_fast(TNode *G)
 			break;
 		}
 #ifdef SKIP_EMU_VBIOS
-		if ((jcs&0xf000)==config.vbios_seg && !TheCPU.err2)
-			TheCPU.err2 = EXCP_GOBACK;
+		if ((jcs&0xf000)==config.vbios_seg && !TheCPU.err)
+			TheCPU.err = EXCP_GOBACK;
 #endif
-	} while (!TheCPU.err2 && (G=FindTree(ePC)) &&
+	} while (!TheCPU.err && (G=FindTree(ePC)) &&
 		 GoodNode(G) && !(G->flags & (F_FPOP|F_INHI)));
 
 	Exec_post(flg, mem_ref);

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -70,7 +70,6 @@ int SpecPrejits;
 /* countdown to exit after handling VGAEMU faults, reset by
    planar VGA reads and writes */
 static int interp_inst_emu_count;
-static unsigned int Interp_LONG_CS;
 
 static int ArOpsR[] =
 	{ O_ADD_R, O_OR_R, O_ADC_R, O_SBB_R, O_AND_R, O_SUB_R, O_XOR_R, O_CMP_R };
@@ -97,7 +96,7 @@ static __inline__ void SetCPU_WL(int m, signed char o, unsigned long v)
 	if (m&DATA16) CPUWORD(o)=v; else CPULONG(o)=v;
 }
 
-static TNode *DoClose(unsigned int PC, int mode)
+static TNode *DoClose(unsigned int PC, unsigned int Interp_LONG_CS, int mode)
 {
 	unsigned int P0 = InstrMeta[0].npc;
 
@@ -132,11 +131,11 @@ static TNode *DoClose(unsigned int PC, int mode)
  *	from P0, abort the current instruction and resume the parsing
  *	loop at P2.
  */
-static TNode *do_flush(unsigned P0, unsigned mode)
+static TNode *do_flush(unsigned P0, unsigned Interp_LONG_CS, unsigned mode)
 {
   assert (CurrIMeta>=0);
   unsigned int flags = can_speculate();
-  TNode *G = DoClose(P0, mode);
+  TNode *G = DoClose(P0, Interp_LONG_CS, mode);
   G->flags |= flags;
   return G;
 }
@@ -155,8 +154,8 @@ static inline unsigned int UNPREFIX(unsigned int m)
 //	link	7x 06 e9 l l l l -- -- e9 l l l l -- --
 //
 
-static unsigned int JumpGen(unsigned int P2, int mode, int opc,
-			    int pskip)
+static unsigned int JumpGen(unsigned int P2, unsigned int Interp_LONG_CS,
+			    int mode, int opc, int pskip)
 {
 #if !defined(SINGLESTEP)
 	unsigned int P1;
@@ -420,7 +419,6 @@ static unsigned int FindExecCode(unsigned int PC)
 		else
 #endif
 			PC = DoExec(G);
-		Interp_LONG_CS = LONG_CS;
 #if PROFILE
 		if (G->flags & F_PREJ)
 			PrejitNodesExecd++;
@@ -468,17 +466,17 @@ static void HandleEmuSignals(void)
 }
 
 static unsigned int _Interp86(unsigned int PC);
-static unsigned int InterpOne(unsigned int PC, int basemode);
+static unsigned int InterpOne(unsigned int PC, unsigned int Interp_LONG_CS,
+			      int basemode);
 
 void Interp86(void)
 {
     unsigned int ret;
 
     TheCPU.err = 0;
-    Interp_LONG_CS = LONG_CS;
-    ret = _Interp86(Interp_LONG_CS + TheCPU.eip);
+    ret = _Interp86(LONG_CS + TheCPU.eip);
     assert(CurrIMeta<0);
-    TheCPU.eip = ret - Interp_LONG_CS;
+    TheCPU.eip = ret - LONG_CS;
 }
 
 static unsigned int interp_pre(unsigned int PC, const int mode)
@@ -521,11 +519,12 @@ static unsigned int interp_pre(unsigned int PC, const int mode)
 		error("simx86: code nodes clashed at %x\n", PC);
 #endif
 	if (debug_level('e')>=9)
-		dbug_printf("\n%s",e_print_regs(Interp_LONG_CS));
+		dbug_printf("\n%s",e_print_regs(LONG_CS));
 	return PC;
 }
 
-static TNode *interp_post(unsigned int PC, const int mode, int gap)
+static TNode *interp_post(unsigned int PC, unsigned int Interp_LONG_CS,
+			  const int mode, int gap)
 {
 		TNode *G = NULL;
 		unsigned int flags = 0;
@@ -555,7 +554,7 @@ static TNode *interp_post(unsigned int PC, const int mode, int gap)
 		    e_querymark(PC, gap))
 #endif
 		{
-			G = do_flush(PC, mode);
+			G = do_flush(PC, Interp_LONG_CS, mode);
 			G->flags |= flags;
 		}
 
@@ -587,8 +586,8 @@ static unsigned int _Interp86(unsigned int PC)
 			return PC;
 		do {
 			P0 = PC;
-			PC = InterpOne(PC, TheCPU.mode);
-			G = interp_post(PC, TheCPU.mode, 1);
+			PC = InterpOne(PC, LONG_CS, TheCPU.mode);
+			G = interp_post(PC, LONG_CS, TheCPU.mode, 1);
 		} while (!G);
 #if SPEC_PREJIT
 		if (G->flags & F_SPEC)
@@ -607,7 +606,6 @@ static unsigned int _Interp86(unsigned int PC)
 		}
 		if (TheCPU.err == EXCP_TFSET)
 			TheCPU.err = 0;
-		Interp_LONG_CS = LONG_CS;
 
 		if (TheCPU.err)
 			return PC;
@@ -1113,7 +1111,8 @@ not_permitted_sim:
 	return data;
 }
 
-static unsigned int InterpOne(unsigned int PC, int basemode)
+static unsigned int InterpOne(unsigned int PC, unsigned int Interp_LONG_CS,
+			      int basemode)
 {
 	unsigned int P0 = PC;
 	unsigned char opc;
@@ -1651,7 +1650,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 /*e1*/	case LOOPZ_LOOPE:
 /*e2*/	case LOOP:
 /*e3*/	case JCXZ:
-			PC = JumpGen(PC, _mode, opc, 2);
+			PC = JumpGen(PC, Interp_LONG_CS, _mode, opc, 2);
 			break;
 
 /*82*/	case IMMEDbrm2:		// add mem8,signed imm8: no AND,OR,XOR
@@ -2113,7 +2112,8 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 
 /*e9*/	case JMPd:
 /*e8*/	case CALLd:
-		    PC = JumpGen(PC, _mode, opc, 1 + BT24(BitDATA16,_mode));
+		    PC = JumpGen(PC, Interp_LONG_CS, _mode, opc,
+				 1 + BT24(BitDATA16,_mode));
 		    break;
 
 /*9a*/	case CALLl:
@@ -2121,7 +2121,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 		    int len = 3 + BT24(BitDATA16,_mode);
 		    dosaddr_t oip = PC + len - LONG_CS;
 		    ocs = TheCPU.cs;
-		    PC = JumpGen(PC, _mode, opc, len);
+		    PC = JumpGen(PC, Interp_LONG_CS, _mode, opc, len);
 		    if (debug_level('e')>2) {
 			if (opc==CALLl)
 			    e_printf("CALL_FAR: ret=%04x:%08x\n  calling:	   %04x:%08x\n",
@@ -2135,14 +2135,14 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 /*c2*/	case RETisp: {
 			int dr = (signed short)FetchW(PC+1);
 			Gen(O_POP, _mode|MRETISP, dr);
-			PC = JumpGen(PC, _mode, opc, 3);
+			PC = JumpGen(PC, Interp_LONG_CS, _mode, opc, 3);
 			if (debug_level('e')>2)
 				e_printf("RET: ret=%08x inc_sp=%d\n",PC-Interp_LONG_CS,dr);
 			}
 			break;
 /*c3*/	case RET:
 			Gen(O_POP, _mode);
-			PC = JumpGen(PC, _mode, opc, 1);
+			PC = JumpGen(PC, Interp_LONG_CS, _mode, opc, 1);
 			if (debug_level('e')>2) e_printf("RET: ret=%08x\n",PC-Interp_LONG_CS);
 			break;
 /*c6*/	case MOVbirm:
@@ -2199,7 +2199,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			else
 				AddrGen(A_SR_PROT, _mode, Ofs_CS, P0);
 			Gen(O_POP3, _mode);
-			PC = JumpGen(PC, _mode, opc, 3);
+			PC = JumpGen(PC, Interp_LONG_CS, _mode, opc, 3);
 			if (debug_level('e')>2)
 				e_printf("RET_%d: ret=%08x\n",dr,TheCPU.eip);
 			}
@@ -2234,7 +2234,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 				Gen(L_LXS2, _mode);
 				AddrGen(A_SR_SH4, _mode, Ofs_CS, Ofs_XCS);
 				Gen(L_LXS1, _mode, Ofs_EIP);
-				PC = JumpGen(PC, _mode, opc, 2);
+				PC = JumpGen(PC, Interp_LONG_CS, _mode, opc, 2);
 				if (debug_level('e')>1)
 					dbug_printf("EMU86: directly called int %#x ax=%#x at %#x:%#x\n",
 						    inum, TheCPU.eax, TheCPU.cs, PC - Interp_LONG_CS);
@@ -2276,7 +2276,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			else
 				AddrGen(A_SR_PROT, _mode, Ofs_CS, P0);
 			Gen(O_POP3, _mode);
-			PC = JumpGen(PC, _mode, opc, 1);
+			PC = JumpGen(PC, Interp_LONG_CS, _mode, opc, 1);
 			if (debug_level('e')>1)
 			    e_printf("RET_FAR: ret=%04x:%08x\n",TheCPU.cs,TheCPU.eip);
 			break;
@@ -2298,7 +2298,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			Gen(O_SIM, _mode, opc, 0, P0);
 			/* to process EXCP_TFSET */
 			Gen(S_REG, _mode & ~DATA16, Ofs_ERR);
-			PC = JumpGen(PC, _mode, opc, 1);
+			PC = JumpGen(PC, Interp_LONG_CS, _mode, opc, 1);
 			if (debug_level('e')>1)
 			    e_printf("IRET: ret=%04x:%08x\n",TheCPU.cs,TheCPU.eip);
 			break;
@@ -2668,7 +2668,7 @@ repag0:
 				Gen(S_DI, _mode);
 				break;
 			case Ofs_SP:	/*4*/	 // JMP near indirect
-				PC = JumpGen(PC, _mode, (opc<<8)|REG1,
+				PC = JumpGen(PC, Interp_LONG_CS, _mode, (opc<<8)|REG1,
 					ModRM(opc, PC, _mode|NOFLDR|MLOAD));
 				break;
 			case Ofs_DX: {	/*2*/	 // CALL near indirect
@@ -2680,7 +2680,8 @@ repag0:
 					Gen(L_REG, _mode, REG3);
 				else
 					Gen(L_DI_R1, _mode);
-				PC = JumpGen(PC, _mode, (opc<<8)|REG1, len);
+				PC = JumpGen(PC, Interp_LONG_CS, _mode,
+					     (opc<<8)|REG1, len);
 				if (debug_level('e')>2)
 					e_printf("CALL indirect: ret=%08x\n\tcalling: %08x\n",
 						 ret,PC-Interp_LONG_CS);
@@ -2707,7 +2708,8 @@ repag0:
 					    Gen(O_PUSHI, _mode, oip);
 					}
 					Gen(L_LXS1, _mode, Ofs_EIP);
-					PC = JumpGen(PC, _mode, (opc<<8)|REG1, len);
+					PC = JumpGen(PC, Interp_LONG_CS, _mode,
+						     (opc<<8)|REG1, len);
 					if (debug_level('e')>2) {
 					    unsigned short jcs = TheCPU.cs;
 					    dosaddr_t jip = PC - Interp_LONG_CS;
@@ -2934,7 +2936,8 @@ repag0:
 			case JLEimmdisp:	/*8e*/
 			case JNLEimmdisp:	/*8f*/
 				{
-				  PC = JumpGen(PC, _mode, JO+(opc2-JOimmdisp),
+				  PC = JumpGen(PC, Interp_LONG_CS, _mode,
+					       JO+(opc2-JOimmdisp),
 					       2 + BT24(BitDATA16,_mode));
 				}
 				break;
@@ -3241,13 +3244,14 @@ void instr_emu_sim_reset_count(void)
 	interp_inst_emu_count = VGA_EMU_INST_EMU_COUNT;
 }
 
-static void _PreJit86(unsigned int PC, int basemode, int gap)
+static void _PreJit86(unsigned int PC, unsigned int Interp_LONG_CS,
+		      int basemode, int gap)
 {
 	TNode *G;
 
 	do {
-		PC = InterpOne(PC, basemode);
-	} while (!(G = interp_post(PC, basemode, gap)));
+		PC = InterpOne(PC, Interp_LONG_CS, basemode);
+	} while (!(G = interp_post(PC, Interp_LONG_CS, basemode, gap)));
 	G->flags |= F_PREJ;
 	NodesPrejitted++;
 }
@@ -3256,8 +3260,7 @@ void PreJit86(unsigned int PC, int basemode)
 {
 	if (e_querymark(PC, 1))
 		return;
-	Interp_LONG_CS = LONG_CS;
-	_PreJit86(PC, basemode, 1);
+	_PreJit86(PC, LONG_CS, basemode, 1);
 	e_mdrop();
 }
 
@@ -3269,7 +3272,7 @@ static void *prejit_thread(void *arg)
   while (1) {
     sem_wait(&prejit_sem);
     TNode *G = __atomic_load_n(&prejit_G, __ATOMIC_RELAXED);
-    _PreJit86(G->seqbase + G->seqlen, G->mode,
+    _PreJit86(G->seqbase + G->seqlen, G->cs, G->mode,
 	    SAFE_PRJ_GAP);
     pthread_mutex_lock(&run_mtx);
     prejit_running = 0;

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -369,7 +369,6 @@ static unsigned int ExceptionGen(unsigned int PC, int basemode, int trapno,
 
 /////////////////////////////////////////////////////////////////////////////
 
-#if !defined(SINGLESTEP)
 static unsigned int FindExecCode(unsigned int PC)
 {
 	TNode *G;
@@ -380,8 +379,7 @@ static unsigned int FindExecCode(unsigned int PC)
 	 * any signal processing. Jumps are defined as
 	 * a 'descheduling point' for checking signals.
 	 */
-	while (!(CEmuStat & (CeS_TRAP|CeS_DRTRAP|CeS_SIGPEND|CeS_RPIC|CeS_STI)) &&
-	       (G=FindTree(PC))) {
+	while ((G=FindTree(PC))) {
 		if (!GoodNode(G)) {
 			InvalidateNodeRange(G->seqbase, G->seqlen, NULL);
 			return PC;
@@ -410,15 +408,32 @@ static unsigned int FindExecCode(unsigned int PC)
 		NodesExecd++;
 #if PROFILE
 		TotalNodesExecd++;
-#elif !defined(ASM_DUMP)
+#endif
+#if !defined(ASM_DUMP) && !defined(SINGLESTEP)
 		/* try fast inner loop if nothing special is going on */
 		if (!(EFLAGS & TF) && !(CEmuStat & (CeS_INHI)) &&
 		    !debug_level('e') &&
-		    GoodNode(G) && !(G->flags & (F_FPOP|F_INHI)))
+		    GoodNode(G) && !(G->flags & (F_FPOP|F_INHI|F_SPEC|F_LEAV)))
 			PC = DoExec_fast(G);
 		else
 #endif
+		{
+#if SPEC_PREJIT
+			if (G->flags & F_SPEC)
+				prejit_run(G);
+#endif
 			PC = DoExec(G);
+#if SPEC_PREJIT
+			if (G->flags & F_SPEC) {
+				G->flags &= ~F_SPEC;
+				prejit_sync();
+			}
+#endif
+			if (G->flags & F_LEAV) {
+				G->flags &= ~F_LEAV;
+				TheCPU.err = EXCP_EMULEAVE;
+			}
+		}
 #if PROFILE
 		if (G->flags & F_PREJ)
 			PrejitNodesExecd++;
@@ -427,11 +442,16 @@ static unsigned int FindExecCode(unsigned int PC)
 			error("CPU-EMU: Zero-len code node?\n");
 			break;
 		}
+#ifdef SINGLESTEP
+		return PC;
+#else
 		if (TheCPU.err) return PC;
+		if (CEmuStat & (CeS_TRAP|CeS_DRTRAP|CeS_SIGPEND|CeS_RPIC|CeS_STI))
+			  return PC;
+#endif
 	}
 	return PC;
 }
-#endif
 
 static void HandleEmuSignals(void)
 {
@@ -479,30 +499,18 @@ void Interp86(void)
     TheCPU.eip = ret - LONG_CS;
 }
 
-static unsigned int interp_pre(unsigned int PC, const int mode)
+static unsigned int interp_pre(unsigned int PC)
 {
+	unsigned int P2 = FindExecCode(PC);
+	if (TheCPU.err == EXCP_TFSET)
+		TheCPU.err = 0;
+	if (TheCPU.err) return P2;
 	if (CEmuStat & (CeS_TRAP|CeS_DRTRAP|CeS_SIGPEND|CeS_RPIC)) {
 		HandleEmuSignals();
-		if (TheCPU.err) return PC;
+		if (TheCPU.err) return P2;
 	}
 	if (EFLAGS & TF)
 		CEmuStat |= CeS_TRAP;
-
-	unsigned int P2 = PC;
-#ifndef SINGLESTEP
-	if (!(EFLAGS & TF)) {
-		P2 = FindExecCode(PC);
-		if (TheCPU.err == EXCP_TFSET)
-			TheCPU.err = 0;
-		if (TheCPU.err) return P2;
-		if (CEmuStat & (CeS_TRAP|CeS_DRTRAP|CeS_SIGPEND|CeS_RPIC)) {
-			HandleEmuSignals();
-			if (TheCPU.err) return P2;
-		}
-		if (EFLAGS & TF)
-			CEmuStat |= CeS_TRAP;
-	}
-#endif
 	if (P2 == PC || e_querymark(P2, 1)) {
 		/* slow path */
 		InvalidateNodeRange(P2, 1, NULL);
@@ -581,7 +589,7 @@ static unsigned int _Interp86(unsigned int PC)
 #endif
 	while (1) {
 		assert(CurrIMeta < 0);
-		PC = interp_pre(PC, TheCPU.mode);
+		PC = interp_pre(PC);
 		if (TheCPU.err)
 			return PC;
 		do {
@@ -589,26 +597,7 @@ static unsigned int _Interp86(unsigned int PC)
 			PC = InterpOne(PC, LONG_CS, TheCPU.mode);
 			G = interp_post(PC, LONG_CS, TheCPU.mode, 1);
 		} while (!G);
-#if SPEC_PREJIT
-		if (G->flags & F_SPEC)
-			prejit_run(G);
-#endif
-		PC = DoExec(G);
-#if SPEC_PREJIT
-		if (G->flags & F_SPEC) {
-			G->flags &= ~F_SPEC;
-			prejit_sync();
-		}
-#endif
-		if (G->flags & F_LEAV) {
-			G->flags &= ~F_LEAV;
-			TheCPU.err = EXCP_EMULEAVE;
-		}
-		if (TheCPU.err == EXCP_TFSET)
-			TheCPU.err = 0;
-
-		if (TheCPU.err)
-			return PC;
+		PC = G->key;
 	}
 #ifndef __clang__
 #pragma GCC diagnostic pop

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -58,11 +58,11 @@ static sem_t prejit_sem;
 static void *prejit_thread(void *arg);
 #if SPEC_PREJIT
 static int can_speculate(void);
-static void prejit_run(unsigned int PC, unsigned int basemode);
+static void prejit_run(TNode *G);
 #else
 #define can_speculate() 0
 #endif
-static unsigned int prejit_PC, prejit_mode;
+static TNode *prejit_G;
 #if PROFILE
 int SpecPrejits;
 #endif
@@ -592,12 +592,14 @@ static unsigned int _Interp86(unsigned int PC)
 		} while (!G);
 #if SPEC_PREJIT
 		if (G->flags & F_SPEC)
-			prejit_run(PC, TheCPU.mode);
+			prejit_run(G);
 #endif
 		PC = DoExec(G);
 #if SPEC_PREJIT
-		if (G->flags & F_SPEC)
+		if (G->flags & F_SPEC) {
+			G->flags &= ~F_SPEC;
 			prejit_sync();
+		}
 #endif
 		if (G->flags & F_LEAV) {
 			G->flags &= ~F_LEAV;
@@ -3266,8 +3268,8 @@ static void *prejit_thread(void *arg)
 {
   while (1) {
     sem_wait(&prejit_sem);
-    _PreJit86(__atomic_load_n(&prejit_PC, __ATOMIC_RELAXED),
-	    __atomic_load_n(&prejit_mode, __ATOMIC_RELAXED),
+    TNode *G = __atomic_load_n(&prejit_G, __ATOMIC_RELAXED);
+    _PreJit86(G->seqbase + G->seqlen, G->mode,
 	    SAFE_PRJ_GAP);
     pthread_mutex_lock(&run_mtx);
     prejit_running = 0;
@@ -3278,12 +3280,14 @@ static void *prejit_thread(void *arg)
 }
 
 #if SPEC_PREJIT
-static void prejit_run(unsigned int PC, unsigned int basemode)
+static void prejit_run(TNode *G)
 {
+  unsigned int PC = G->seqbase + G->seqlen;
   if (debug_level('e')) {
     char *ds;
     unsigned short ocs = TheCPU.cs;
     unsigned int P2 = InstrMeta[CurrIMeta].npc;
+    unsigned int basemode = G->mode;
     ds = e_emu_disasm(EMU_BASE32(P2),basemode&MBIGCS,ocs);
     e_printf("prejit after  %s\n", ds);
     ds = e_emu_disasm(EMU_BASE32(PC),basemode&MBIGCS,ocs);
@@ -3294,8 +3298,7 @@ static void prejit_run(unsigned int PC, unsigned int basemode)
 #if PROFILE
   SpecPrejits++;
 #endif
-  __atomic_store_n(&prejit_PC, PC, __ATOMIC_RELAXED);
-  __atomic_store_n(&prejit_mode, basemode, __ATOMIC_RELAXED);
+  __atomic_store_n(&prejit_G, G, __ATOMIC_RELAXED);
   pthread_mutex_lock(&run_mtx);
   assert(!prejit_running);
   prejit_running = 1;

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -420,7 +420,6 @@ static unsigned int FindExecCode(unsigned int PC)
 		else
 #endif
 			PC = DoExec(G);
-		TheCPU.err = TheCPU.err2;
 		Interp_LONG_CS = LONG_CS;
 #if PROFILE
 		if (G->flags & F_PREJ)
@@ -475,7 +474,7 @@ void Interp86(void)
 {
     unsigned int ret;
 
-    TheCPU.err2 = 0;
+    TheCPU.err = 0;
     Interp_LONG_CS = LONG_CS;
     ret = _Interp86(Interp_LONG_CS + TheCPU.eip);
     assert(CurrIMeta<0);
@@ -496,7 +495,7 @@ static unsigned int interp_pre(unsigned int PC, const int mode)
 	if (!(EFLAGS & TF)) {
 		P2 = FindExecCode(PC);
 		if (TheCPU.err == EXCP_TFSET)
-			TheCPU.err = TheCPU.err2 = 0;
+			TheCPU.err = 0;
 		if (TheCPU.err) return P2;
 		if (CEmuStat & (CeS_TRAP|CeS_DRTRAP|CeS_SIGPEND|CeS_RPIC)) {
 			HandleEmuSignals();
@@ -575,7 +574,6 @@ static unsigned int _Interp86(unsigned int PC)
 		return val == 2 ? LONG_CS + TheCPU.eip : P0;
 	}
 
-	TheCPU.err = 0;
 	CEmuStat &= ~(CeS_TRAP|CeS_STI);
 
 #ifndef __clang__
@@ -603,11 +601,10 @@ static unsigned int _Interp86(unsigned int PC)
 #endif
 		if (G->flags & F_LEAV) {
 			G->flags &= ~F_LEAV;
-			TheCPU.err2 = EXCP_EMULEAVE;
+			TheCPU.err = EXCP_EMULEAVE;
 		}
-		if (TheCPU.err2 == EXCP_TFSET)
-			TheCPU.err2 = 0;
-		TheCPU.err = TheCPU.err2;
+		if (TheCPU.err == EXCP_TFSET)
+			TheCPU.err = 0;
 		Interp_LONG_CS = LONG_CS;
 
 		if (TheCPU.err)
@@ -655,7 +652,7 @@ unsigned int Sim_helper(unsigned int mem_ref, unsigned int data, int mode,
 			if(r < lo || r > hi)
 			{
 				e_printf("Bound interrupt 05\n");
-				TheCPU.err2=EXCP05_BOUND;
+				TheCPU.err=EXCP05_BOUND;
 			}
 			break;
 		       }
@@ -701,7 +698,7 @@ unsigned int Sim_helper(unsigned int mem_ref, unsigned int data, int mode,
 			if(*flags & EFLAGS_OF)
 			{
 				e_printf("Overflow interrupt 04\n");
-				TheCPU.err2=EXCP04_INTO;
+				TheCPU.err=EXCP04_INTO;
 			}
 			break;
 /*cd*/	case INT:      {
@@ -772,7 +769,7 @@ unsigned int Sim_helper(unsigned int mem_ref, unsigned int data, int mode,
 			assert(!(V86MODE() && IOPL!=3 && !(TheCPU.cr[4] & CR4_VME)));
 			temp = data;
 			if (temp & TF)
-			    TheCPU.err2 = EXCP_TFSET;
+			    TheCPU.err = EXCP_TFSET;
 			EFLAGS = (EFLAGS & ~EFLAGS_CC) | (*flags & EFLAGS_CC);
 			if (V86MODE()) {
 			    int is_tf;
@@ -807,7 +804,7 @@ stack_return_from_vm86:
 					e_printf("Return for STI fl=%08x\n",
 						 EFLAGS);
 				    if (opc == POPF)
-					TheCPU.err2 = (is_tf ? EXCP01_SSTP : EXCP_STISIGNAL);
+					TheCPU.err = (is_tf ? EXCP01_SSTP : EXCP_STISIGNAL);
 				    else
 					data = (is_tf ? EXCP01_SSTP : EXCP_STISIGNAL);
 				}
@@ -838,7 +835,7 @@ stack_return_from_vm86:
 				if (debug_level('e')>1)
 				    e_printf("Return for STI fl=%08x\n",
 					    EFLAGS);
-				TheCPU.err2 = (is_tf ? EXCP01_SSTP : EXCP_STISIGNAL);
+				TheCPU.err = (is_tf ? EXCP01_SSTP : EXCP_STISIGNAL);
 			    }
 			}
 			*flags = EFLAGS & EFLAGS_CC;
@@ -868,7 +865,7 @@ stack_return_from_vm86:
 				    if (debug_level('e')>1)
 					e_printf("Return for STI fl=%08x\n",
 					    EFLAGS);
-				    TheCPU.err2=EXCP_STISIGNAL;
+				    TheCPU.err=EXCP_STISIGNAL;
 				}
 			}
 			else {
@@ -885,7 +882,7 @@ stack_return_from_vm86:
 					    EFLAGS);
 				/* force exit after next compiled block execution */
 				exit_pending_or(CeS_RPIC);
-				TheCPU.err2 = EXCP_STISHADOW;
+				TheCPU.err = EXCP_STISHADOW;
 			    }
 			}
 			break;
@@ -1110,7 +1107,7 @@ stack_return_from_vm86:
 
 not_permitted_sim:
 	if (debug_level('e')>1) e_printf("!!! Not permitted %02x\n",opc);
-	TheCPU.err2 = EXCP0D_GPF;
+	TheCPU.err = EXCP0D_GPF;
 	return data;
 }
 
@@ -3257,7 +3254,6 @@ void PreJit86(unsigned int PC, int basemode)
 {
 	if (e_querymark(PC, 1))
 		return;
-	TheCPU.err = 0;
 	Interp_LONG_CS = LONG_CS;
 	_PreJit86(PC, basemode, 1);
 	e_mdrop();

--- a/src/base/emu-i386/simx86/protmode.c
+++ b/src/base/emu-i386/simx86/protmode.c
@@ -100,7 +100,7 @@ int SetSegProt_helper(unsigned short sel, int ofs)
 	int oldsel = CPUWORD(ofs);
 	int e = SetSegProt(TheCPU.mode&ADDR16, ofs, &big, sel);
 	if (e) {
-		TheCPU.err2 = e;
+		TheCPU.err = e;
 		oldsel = -1; /* invalid old value flags error */
 	} else if (ofs==Ofs_SS) {
 		TheCPU.StackMask = (big? 0xffffffff : 0x0000ffff);

--- a/src/base/emu-i386/simx86/sigsegv.c
+++ b/src/base/emu-i386/simx86/sigsegv.c
@@ -259,7 +259,7 @@ static int e_emu_pagefault(sigcontext_t *scp, int pmode)
 	    return 1;
 	TheCPU.scp_err = _scp_err;
 	/* save eip, eflags, and do a "ret" out of compiled code */
-	TheCPU.err2 = EXCP0E_PAGE;
+	TheCPU.err = EXCP0E_PAGE;
 	_scp_eax = FindPC((unsigned char *)_scp_rip);
 	e_printf("FindPC: found %x\n",_scp_eax);
 	_scp_edx = *(long *)_scp_rsp; // flags
@@ -409,7 +409,7 @@ int e_handle_fault(sigcontext_t *scp)
 		error("Fault %i in jit-compiled code\n", _scp_trapno);
 		return 0;
 	}
-	TheCPU.err2 = EXCP00_DIVZ + _scp_trapno;
+	TheCPU.err = EXCP00_DIVZ + _scp_trapno;
 	_scp_eax = LONG_CS + TheCPU.eip;
 	_scp_edx = _scp_eflags;
 	_scp_rip = *(long *)_scp_rsp;

--- a/src/base/emu-i386/simx86/syncpu.h
+++ b/src/base/emu-i386/simx86/syncpu.h
@@ -46,7 +46,7 @@ typedef struct {
 /* offsets up to end_mark are 8-bit */
 #define FIELD0		rzero	/* field of SynCPU at offset 00 */
 /*00*/	unsigned int rzero;
-/*04*/	int err2;
+/*04*/	int err;
 /*08*/	unsigned int scp_err;
 /*0c*/	unsigned int edi;
 /*10*/	unsigned int esi;
@@ -77,7 +77,6 @@ typedef struct {
 /*80*/	//unsigned int end_mark[0] = cr[1]
 	unsigned int tr[2];
 
-	int err;
 	unsigned int mode;
 	unsigned int sreg1;
 	unsigned int dreg1;
@@ -197,7 +196,7 @@ extern struct _SynCPU TheCPU_struct;
 #define Ofs_XFS		(offsetof(SynCPU,fs_cache))
 #define Ofs_XGS		(offsetof(SynCPU,gs_cache))
 
-#define Ofs_ERR		(offsetof(SynCPU,err2))
+#define Ofs_ERR		(offsetof(SynCPU,err))
 #define Ofs_SCP_ERR		(offsetof(SynCPU,scp_err))
 #define Ofs_int_revectored	(offsetof(SynCPU,int_revectored))
 


### PR DESCRIPTION
* as prejit no longer uses TheCPU.err, we can remerge it with err2
* Interp_LONG_CS is passed around; we can pass the closed node to the prejit thread to get the info instead of 3 fields
* all exec is now called from interp_pre (renamed to interp_exec) so duplicate code could be removed there