### PR TITLE
simx86: split push from jmp in CALL

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -2713,17 +2713,11 @@ static unsigned int Gen_sim(const IGen *IG, dosaddr_t mem_ref)
 			dbug_printf("** Jump taken to %08x\n",P0);
 		break;
 
-	case JMP_LINK: {	// opc, dspt, retaddr, link
-		int opc = IG->p0;
-		P0 = (unsigned int)IG->p1;
-		unsigned int d_nt = (unsigned int)IG->p2;
-		if (opc == CALLd || opc == CALLl)
-			PUSH(mode, d_nt);
+	case JMP_LINK:		// dspt
+		P0 = (unsigned int)IG->p0;
 		if (debug_level('e')>2) {
-			if(opc == CALLd || opc == CALLl)
-				dbug_printf("CALL: ret=%08x\n",d_nt);
 			dbug_printf("** Jump taken to %08x\n",P0);
-		} }
+		}
 		break;
 
 	case JF_LINK:

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -2261,80 +2261,9 @@ shrot0:
 		}
 		break;
 
-	case JMP_LINK: {	// opc, dspt, retaddr, link
-		const unsigned char pseq16[] = {
-			// movw $RA,%%ax
-/*00*/			0xb8,0,0,0,0,
-			// movl Ofs_XSS(%%ebx),%%esi
-			0x8b,0x73,Ofs_XSS,
-			// movl Ofs_ESP(%%ebx),%%ecx
-			0x8b,0x4b,Ofs_ESP,
-			// leal -2(%%ecx),%%ecx
-			0x8d,0x49,0xfe,
-			// andl StackMask(%%ebx),%%ecx
-			0x23,0x4b,Ofs_STACKM,
-			// leal (%%esi,%%ecx,1),%%edi
-			0x8d,0x14,0x0e,
-			// movw %%ax,(%%edx,%%ebp,1)
-			0x66,0x89,0x04,0x2a,
-#ifdef KEEP_ESP	/* keep high 16-bits of ESP in small-stack mode */
-			// movl StackMask(%%ebx),%%edx
-			0x8b,0x53,Ofs_STACKM,
-			// notl %%edx
-			0xf7,0xd2,
-			// andl Ofs_ESP(%%ebx),%%edx
-			0x23,0x53,Ofs_ESP,
-			// orl %%edx,%%ecx
-			0x09,0xd1,
-#endif
-			// movl %%ecx,Ofs_ESP(%%ebx)
-			0x89,0x4b,Ofs_ESP
-		};
-		const unsigned char pseq32[] = {
-			// movl $RA,%%eax
-/*00*/			0xb8,0,0,0,0,
-			// movl Ofs_XSS(%%ebx),%%esi
-			0x8b,0x73,Ofs_XSS,
-			// movl Ofs_ESP(%%ebx),%%ecx
-			0x8b,0x4b,Ofs_ESP,
-			// leal -4(%%ecx),%%ecx
-			0x8d,0x49,0xfc,
-			// andl StackMask(%%ebx),%%ecx
-			0x23,0x4b,Ofs_STACKM,
-			// leal (%%esi,%%ecx,1),%%edi
-			0x8d,0x14,0x0e,
-			// movl %%eax,(%%edx,%%ebp,1)
-			0x89,0x04,0x2a,
-#ifdef KEEP_ESP	/* keep high 16-bits of ESP in small-stack mode */
-			// movl StackMask(%%ebx),%%edx
-			0x8b,0x53,Ofs_STACKM,
-			// notl %%edx
-			0xf7,0xd2,
-			// andl Ofs_ESP(%%ebx),%%edx
-			0x23,0x53,Ofs_ESP,
-			// orl %%edx,%%ecx
-			0x09,0xd1,
-#endif
-			// movl %%ecx,Ofs_ESP(%%ebx)
-			0x89,0x4b,Ofs_ESP
-		};
-		unsigned char opc = IG->p0;
-		int dspt = IG->p1;
-		int dspnt = IG->p2;
-		if (opc == CALLd || opc == CALLl) {
-			const unsigned char *p;
-			unsigned char *q;
-			int sz;
-			if (mode&DATA16) {
-				p=pseq16,sz=sizeof(pseq16);
-			}
-			else {
-				p=pseq32,sz=sizeof(pseq32);
-			}
-			q = Cp; GNX(Cp, p, sz);
-			*((int *)(q+1)) = dspnt;
-			if (debug_level('e')>1) e_printf("CALL: ret=%08x\n",dspnt);
-		} else if (mode & CKSIGN) {
+	case JMP_LINK: {	// dspt
+		int dspt = IG->p0;
+		if (mode & CKSIGN) {
 		    // check signal on TAKEN branch
 		    // for backjmp-after-jcc:
 		    // movzwl Ofs_EXITPEND(%%ebx),%%ecx
@@ -2347,8 +2276,7 @@ shrot0:
 		// t:	b8 [exit_pc] 5a c3
 		G1(0xb8,Cp);
 		G4(dspt,Cp); G2(0xc35a,Cp); PADJMP;
-		if (debug_level('e')>2) e_printf("JMP_Link %08x:%08x lk=%d\n",
-			dspt,dspnt,IG->op);
+		if (debug_level('e')>2) e_printf("JMP_Link %08x\n", dspt);
 		}
 		break;
 

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -369,7 +369,10 @@ void Gen(int op, int mode, ...)
 	case JMP_INDIRECT:
 		break;
 
-	case JMP_LINK:		// opc, dspt, retaddr, link
+	case JMP_LINK:		// dspt
+		IG->p0 = va_arg(ap,unsigned int);	// dspt
+		break;
+
 	case JLOOP_LINK:
 	case JF_LINK:
 	case JB_LINK: {		// opc, dspt, dspnt, link

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -299,7 +299,7 @@ static unsigned int JumpGen(unsigned int P2, unsigned int Interp_LONG_CS,
 		    leavedos_main(0xebfe);
 		}
 		if (dsp <= 0) mode |= CKSIGN;
-		Gen(JMP_LINK, mode, opc, j_t, d_nt);
+		Gen(JMP_LINK, mode, j_t);
 		break;
 	case CALLl: {   /* call far */
 		unsigned short jcs = FetchW(P2 + pskip - 2);
@@ -321,7 +321,8 @@ static unsigned int JumpGen(unsigned int P2, unsigned int Interp_LONG_CS,
 	}
 	/* no break for realaddr call */
 	case CALLd:    /* call, unfortunately also uses JMP_LINK */
-		Gen(JMP_LINK, mode, opc, j_t, d_nt);
+		Gen(O_PUSHI, mode, d_nt);
+		Gen(JMP_LINK, mode, j_t);
 		break;
 	case LOOP: case LOOPZ_LOOPE: case LOOPNZ_LOOPNE:
 		Gen(JLOOP_LINK, mode, opc, j_t, j_nt);
@@ -347,8 +348,12 @@ static int can_speculate(void)
 	IGen *IG = &GL->gen[GL->ngen-1];
 	int opc = IG->op;
 	/* With uncond JMP or RET nothing to speculate. */
-	if (opc < JMP_LINK ||
-	    (opc == JMP_LINK && IG->p0 != CALLd && IG->p0 != CALLl))
+	if (opc == JMP_LINK && GL->ngen > 1) {
+		IG = &GL->gen[GL->ngen-2];
+		if (IG->op == O_PUSHI) // PUSHI before means CALL
+			return F_SPEC;
+	}
+	if (opc <= JMP_LINK)
 		return 0;
 	return F_SPEC;
 }


### PR DESCRIPTION
Indirect calls already used O_PUSHI to push the return (e)ip. This makes it more consistent and removes duplicate code (vs O_PUSHI) in JMP_LINK.