### PR TITLE
simx86: make emu_pagefault_handler work again with JIT

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -2128,7 +2128,7 @@ static unsigned int Gen_sim(const IGen *IG, dosaddr_t mem_ref)
 	case O_SIM: {
 		uint32_t flags = FlagSync_All();
 		DR1.d = Sim_helper(mem_ref, DR1.d, mode,
-				   &flags, IG->p0, IG->p1);
+				   &flags, IG->p0, IG->p1, IG->p2);
 		FlagSync_RFL(flags);
 		if (TheCPU.err)
 			P0 = IG->p2;
@@ -2863,8 +2863,10 @@ static void emu_pagefault_handler(dosaddr_t addr, int err, uint32_t op, int len)
 	/* err = -1 is special, hitting a page with code that's been converted
 	   to intermediate ops */
 	if (err == -1) {
+		/* currentIG==NULL in JIT, where this is called via Sim_helper */
+		unsigned int P0 = currentIG ? (unsigned)-1: LONG_CS + TheCPU.eip;
 		if (e_querymark(addr, len))
-			InvalidateNodeRange(addr, len, currentIG);
+			InvalidateNodeRangeP0(addr, len, currentIG, P0);
 		return;
 	}
 	if ((err & 2) && msdos_ldt_access(addr)) {
@@ -2872,8 +2874,7 @@ static void emu_pagefault_handler(dosaddr_t addr, int err, uint32_t op, int len)
 		return;
 	}
 	/* trigger an exception in DPMI */
-	/* Need to shutdown prejitter to touch TheCPU.err
-	   to return to _Interp86() */
+	/* Need to shutdown prejitter to return to _Interp86() */
 	prejit_sync();
 	TheCPU.err = EXCP0E_PAGE;
 	TheCPU.scp_err = err;
@@ -2882,10 +2883,8 @@ static void emu_pagefault_handler(dosaddr_t addr, int err, uint32_t op, int len)
 		unsigned int P0 = FindPC(currentIG);
 		TheCPU.eip = P0 - LONG_CS;
 		EFLAGS = (EFLAGS & ~EFLAGS_CC) | FlagSync_All();
-		longjmp(jmp_env, 2);
-	} else
-		/* for faulting sim_read/write directly from interp.c */
-		longjmp(jmp_env, 1);
+	} // else Sim_helper sets these
+	longjmp(jmp_env, 1);
 }
 
 uint8_t sim_read_byte(dosaddr_t x)

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -1650,11 +1650,15 @@ shrot0:
 		G2M(0x41,0xb8,Cp); G4(IG->p0,Cp);
 		// mov $arg, %%r9d
 		G2M(0x41,0xb9,Cp); G4(IG->p1,Cp);
-		// push %%rdi // keep mem_ref (2x for alignment)
-		G2M(PUSHdi,PUSHdi,Cp);
+		// push %%rdi // keep mem_ref
+		G1(PUSHdi,Cp);
+		// push $P0
+		G1(PUSHwi,Cp); G4(IG->p2,Cp);
 #else
 		// mov %esp, %ecx // flags
 		G2M(0x89,0xe1,Cp);
+		// push $P0
+		G1(PUSHwi,Cp); G4(IG->p2,Cp);
 		// push $arg
 		G1(PUSHwi,Cp); G4(IG->p1,Cp);
 		// push $opc
@@ -1674,8 +1678,8 @@ shrot0:
 		// pop %%rdi // mem_ref
 		G2M(POPdi,POPdi,Cp);
 #else
-		// addl $24,%%esp
-		G3M(0x83,0xc4,24,Cp)
+		// addl $28,%%esp
+		G3M(0x83,0xc4,28,Cp)
 #endif
 		// cmpl $0x0,Ofs_ERR(%rbx)
 		G4M(0x83,0x7b,Ofs_ERR,0x00,Cp);

--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -198,10 +198,6 @@
 
 /////////////////////////////////////////////////////////////////////////////
 
-/* x386 */
-#define GetSWord(w)	((*w) = read_word(LONG_SS+sp))
-#define GetSLong(w)	((*w) = read_dword(LONG_SS+sp))
-
 // returns 1(16 bit), 0(32 bit)
 #define BTA(bpos, mode) (((mode) >> (bpos)) & 1)
 
@@ -214,55 +210,6 @@ static __inline__ int FastLog2(int v)
 }
 
 /////////////////////////////////////////////////////////////////////////////
-
-static __inline__ void PUSH(int m, uint32_t w)
-{
-	unsigned int sp;
-	unsigned int addr;
-
-	sp = (TheCPU.esp-BT24(BitDATA16, m)) & TheCPU.StackMask;
-	addr = LONG_SS + sp;
-	if (m&DATA16) {
-		e_invalidate(addr, 2);
-		WRITE_WORD(addr, w);
-	} else {
-		e_invalidate(addr, 4);
-		WRITE_DWORD(addr, w);
-	}
-#ifdef KEEP_ESP
-	TheCPU.esp = (sp&TheCPU.StackMask) | (TheCPU.esp&~TheCPU.StackMask);
-#else
-	TheCPU.esp = sp;
-#endif
-}
-
-/////////////////////////////////////////////////////////////////////////////
-
-static __inline__ void POP(int m, uint32_t *w)
-{
-	unsigned int sp = TheCPU.esp & TheCPU.StackMask;
-	if (m&DATA16) {
-		uint16_t w16;
-		GetSWord(&w16);
-		*w = (*w & 0xffff0000) | w16; sp+=2;
-	}
-	else {
-		GetSLong(w); sp+=4;
-	}
-	TheCPU.esp = (sp&TheCPU.StackMask) | (TheCPU.esp&~TheCPU.StackMask);
-}
-
-static __inline__ void NOS_WORD(int m, uint16_t *w)		// for segments
-{
-	unsigned int sp = (TheCPU.esp+(m&DATA16? 2:4)) & TheCPU.StackMask;
-	GetSWord(w);
-}
-
-static __inline__ void POP_ONLY(int m)
-{
-	unsigned int sp = TheCPU.esp + (m&DATA16? 2:4);
-	TheCPU.esp = (sp&TheCPU.StackMask) | (TheCPU.esp&~TheCPU.StackMask);
-}
 
 void InitGen(void);
 int NewIMeta(int npc);

--- a/src/base/emu-i386/simx86/emu86.h
+++ b/src/base/emu-i386/simx86/emu86.h
@@ -766,7 +766,8 @@ void prejit_sync(void);
 void init_emu_npu(void);
 
 unsigned int Sim_helper(unsigned int mem_ref, unsigned int data, int mode,
-			uint32_t *flags, unsigned int opc, unsigned int arg);
+			uint32_t *flags, unsigned int opc, unsigned int arg,
+			unsigned int P0);
 
 void e_VgaMovs(dosaddr_t edi, dosaddr_t esi, unsigned int rep,
 	       int dp, unsigned int access);

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -576,14 +576,13 @@ static TNode *interp_post(unsigned int PC, unsigned int Interp_LONG_CS,
 
 static unsigned int _Interp86(unsigned int PC)
 {
-	volatile unsigned int P0 = PC; /* volatile because of setjmp */
 	int val;
 	TNode *G;
 
 	if (PROTMODE() && (val = setjmp(jmp_env))) {
 		/* long jump to here from simulated page fault
-		   val == 2 comes from Gen_Sim, with different cs:eip */
-		return val == 2 ? LONG_CS + TheCPU.eip : P0;
+		   from Gen_Sim, with different cs:eip */
+		return LONG_CS + TheCPU.eip;
 	}
 
 	CEmuStat &= ~(CeS_TRAP|CeS_STI);
@@ -598,7 +597,6 @@ static unsigned int _Interp86(unsigned int PC)
 		if (TheCPU.err)
 			return PC;
 		do {
-			P0 = PC;
 			PC = InterpOne(PC, LONG_CS, TheCPU.mode);
 			G = interp_post(PC, LONG_CS, TheCPU.mode, 1);
 		} while (!G);
@@ -622,9 +620,17 @@ static unsigned int _Interp86(unsigned int PC)
  * returns data (could be modified), so compiled code can write it back
  */
 unsigned int Sim_helper(unsigned int mem_ref, unsigned int data, int mode,
-			uint32_t *flags, unsigned int opc, unsigned int arg)
+			uint32_t *flags, unsigned int opc, unsigned int arg,
+			unsigned int P0)
 {
 	unsigned int temp;
+	if (opc != IRET) {
+			// save for emu_pagefault_handler(),
+			// except for IRET where it's not used from
+			// here and TheCPU.eip contains the popped eip.
+			TheCPU.eip = P0 - LONG_CS;
+			EFLAGS = (EFLAGS & ~EFLAGS_CC) | (*flags & EFLAGS_CC);
+	}
 	switch (opc) {
 /*9c*/	case PUSHF:    { /* flag handling for VME-case only,
 			    not used presently with IOPL==3 */
@@ -762,7 +768,7 @@ unsigned int Sim_helper(unsigned int mem_ref, unsigned int data, int mode,
 			    if (debug_level('e')>1)
 				e_printf("Popped flags %08x->{r=%08x v=%08x}\n",temp,EFLAGS,get_FLAGS(EFLAGS));
 			}
-			*flags = EFLAGS & EFLAGS_CC;
+			*flags = (*flags & ~EFLAGS_CC) | (EFLAGS & EFLAGS_CC);
 			} break;
 /*9d*/	case POPF: {
 			/* GPF handled in interpreter */
@@ -838,7 +844,7 @@ stack_return_from_vm86:
 				TheCPU.err = (is_tf ? EXCP01_SSTP : EXCP_STISIGNAL);
 			    }
 			}
-			*flags = EFLAGS & EFLAGS_CC;
+			*flags = (*flags & ~EFLAGS_CC) | (EFLAGS & EFLAGS_CC);
 			} break;
 /*fa*/	case CLI:
 			/* only for PVI/VME IOPL<3 CLI, not used presently */

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -673,7 +673,7 @@ unsigned int Sim_helper(unsigned int mem_ref, unsigned int data, int mode,
 			}
 /*c8*/	case ENTER: {
 			// This simulates only the middle part for level >=2
-			unsigned int bp;
+			unsigned int bp, sp, val;
 			int level, ds;
 			level = arg;
 			assert(level > 1); // level 0 and 1 are compiled
@@ -682,9 +682,15 @@ unsigned int Sim_helper(unsigned int mem_ref, unsigned int data, int mode,
 			while (--level) {
 				bp -= ds;
 				bp &= TheCPU.StackMask;
-				PUSH(mode, (mode&DATA16) ?
+				val = (mode&DATA16) ?
 				     sim_read_word(LONG_SS + bp) :
-				     sim_read_dword(LONG_SS + bp));
+				     sim_read_dword(LONG_SS + bp);
+				sp = (rESP - ds) & TheCPU.StackMask;
+				if (mode&DATA16)
+					sim_write_word(LONG_SS + sp, val);
+				else
+					sim_write_dword(LONG_SS + sp, val);
+				rESP = sp | (rESP&~TheCPU.StackMask);
 			}
 			}
 			break;

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -1165,7 +1165,7 @@ static void BreakNode(TNode *G, unsigned char *eip)
 
   ebase = eip - G->addr;
   for (i=0; i<G->seqnum; i++) {
-    if (A->daddr >= ebase) {		// found following instr
+    if (A->daddr > ebase) {		// found following instr
 	IGen IG = (IGen){.op = JMP_TAILCODE, .p0 = G->key + A->dnpc};
 	p = G->addr + A->daddr;		// translated IP of following instr
 	CodeGen(p, G->addr, &IG);
@@ -1187,7 +1187,7 @@ static TNode *DoDelNode(TNode *G)
   return CollectTree.root.link[0];
 }
 
-int InvalidateNodeRange(int al, int len, unsigned char *eip)
+int InvalidateNodeRangeP0(int al, int len, unsigned char *eip, unsigned int P0)
 {
   TNode *G;
   int ah;
@@ -1258,6 +1258,20 @@ int InvalidateNodeRange(int al, int len, unsigned char *eip)
 	    */
 	    /* Exclude last instruction, as there is no need to break
 	     * node after last instruction (it ends there anyway). */
+	    if (!eip && P0 != (unsigned)-1) {
+	      ahG = G->key + G->pmeta[G->seqnum - 1].dnpc;
+	      if (ADDR_IN_RANGE(P0,G->seqbase,ahG)) {
+		int i;
+		Addr2Pc *A;
+		for (i=0, A=G->pmeta; i<G->seqnum; i++, A++) {
+		  if (G->key + A->dnpc == P0) {
+		    /* Find corresponding eip if only P0 is given */
+		    eip = G->addr + A->daddr;
+		    break;
+		  }
+		}
+	      }
+	    }
 	    ahE = G->addr + G->pmeta[G->seqnum - 1].daddr;
 	    if (eip && ADDR_IN_RANGE(eip,G->addr,ahE)) {
 		if (debug_level('e')>1)
@@ -1280,6 +1294,10 @@ quit:
   return cleaned;
 }
 
+int InvalidateNodeRange(int al, int len, unsigned char *eip)
+{
+  return InvalidateNodeRangeP0(al, len, eip, (unsigned)-1);
+}
 
 /////////////////////////////////////////////////////////////////////////////
 static void do_invalidate(unsigned data, int cnt)

--- a/src/base/emu-i386/simx86/trees.h
+++ b/src/base/emu-i386/simx86/trees.h
@@ -155,6 +155,7 @@ TNode *Move2Tree(IMeta *I0, CodeBuf *GenCodeBuf);
 void InitTrees(void);
 
 unsigned int FindPC(const unsigned char *addr);
+int InvalidateNodeRangeP0(int addr, int len, unsigned char *eip, unsigned int P0);
 int InvalidateNodeRange(int addr, int len, unsigned char *eip);
 void avltr_delete(const int key);
 


### PR DESCRIPTION
Alternative to #2609 

We can avoid using `currentIG` in the JIT by setting TheCPU.eip in Sim_helper, based on `P0`, which is now passed.

`InvalidateNodeRange` (via `InvalidateNodeRangeP0`) can now be passed either the `eip` pointer of compiled code, or the `P0` of the original code.

I can just use #2609 for it cleanups then, which I left out here mostly.