### PR TITLE
simx86: remove seqbase fields in IMeta and TNode

### DIFF
--- a/src/base/emu-i386/simx86/Makefile
+++ b/src/base/emu-i386/simx86/Makefile
@@ -18,8 +18,6 @@ CFILES = interp.c cpu-emu.c modrm-gen.c $(JITFILES) \
 	codegen.c trees.c memory.c
 ALL_CPPFLAGS +=-I$(EM86DIR) $(EM86FLG)
 
-#ALL_CPPFLAGS +=-DNOJUMPS
-
 SFILES=
 ALL=$(CFILES) $(SFILES)
 

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -398,7 +398,6 @@ void Gen(int op, int mode, ...)
 static CodeBuf *ProduceCode(unsigned int PC, IMeta *I0)
 {
 	int i,j,nap,mall_req;
-	unsigned int adr_lo=0, adr_hi=0;
 	unsigned char *cp, *cp1, *BaseGenBuf, *CodePtr;
 	size_t GenBufSize;
 	CodeBuf *GenCodeBuf;
@@ -439,13 +438,6 @@ static CodeBuf *ProduceCode(unsigned int PC, IMeta *I0)
 
 	for (i=0; i<=CurrIMeta; i++) {
 	    IMeta *I = &I0[i];
-	    if (i==0) {
-		adr_lo = adr_hi = I->npc;
-	    }
-	    else {
-		if (I->npc < adr_lo) adr_lo = I->npc;
-		    else if (I->npc > adr_hi) adr_hi = I->npc;
-	    }
 	    cp = cp1 = CodePtr;
 	    I->daddr = cp - BaseGenBuf;
 	    for (j=0; j<I->ngen; j++) {
@@ -487,10 +479,7 @@ static CodeBuf *ProduceCode(unsigned int PC, IMeta *I0)
 	if (debug_level('e')>1)
 	    e_printf("Size=%td guess=%zd\n",(CodePtr-BaseGenBuf),GenBufSize);
 /**/ if ((CodePtr-BaseGenBuf) > GenBufSize) leavedos_main(0x535347);
-	if (PC < adr_lo) adr_lo = PC;
-	    else if (PC > adr_hi) adr_hi = PC;
-	I0->seqbase = adr_lo;
-	I0->seqlen  = adr_hi - adr_lo;
+	I0->seqlen  = PC - I0->npc;
 
 	if (debug_level('e')>1)
 	    e_printf("---------------------------------------------\n");
@@ -556,7 +545,7 @@ TNode *Close(unsigned int PC, unsigned int Interp_LONG_CS, int mode)
 	/* mprotect the page here; a page fault will be triggered
 	 * if some other code tries to write over the page including
 	 * this node */
-	e_markpage(G->seqbase, G->seqlen);
+	e_markpage(G->key, G->seqlen);
 	G->cs = Interp_LONG_CS;
 	G->mode = mode;
 	/* check links INSIDE current node */

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -386,28 +386,28 @@ static unsigned int FindExecCode(unsigned int PC)
 	 */
 	while ((G=FindTree(PC))) {
 		if (!GoodNode(G)) {
-			InvalidateNodeRange(G->seqbase, G->seqlen, NULL);
+			InvalidateNodeRange(G->key, G->seqlen, NULL);
 			return PC;
 		}
 		if (debug_level('e')>2)
 			e_printf("** Found compiled code at %08x\n",PC);
 		if (debug_level('e') &&
 				/* check for codemarks inconsistency */
-				e_querymark_all(G->seqbase, G->seqlen) == 0) {
+				e_querymark_all(G->key, G->seqlen) == 0) {
 			int i, j;
 			error("no mark at %x (%i)\n",
-					G->seqbase,
-					e_querymark(G->seqbase, G->seqlen));
+					G->key,
+					e_querymark(G->key, G->seqlen));
 			j = -1;
 			for (i = 0; i < G->seqlen; i++) {
-				int mrk = e_querymark(G->seqbase + i, 1);
+				int mrk = e_querymark(G->key + i, 1);
 				error("@%i ", mrk);
 				if (!mrk && j == -1)
 					j = i;
 			}
 			error("@\n");
 			if (j != -1)
-				error("@corrupted at %x\n", G->seqbase + j);
+				error("@corrupted at %x\n", G->key + j);
 		}
 		/* ---- this is the MAIN EXECUTE point ---- */
 		NodesExecd++;
@@ -3266,7 +3266,7 @@ static void *prejit_thread(void *arg)
   while (1) {
     sem_wait(&prejit_sem);
     TNode *G = __atomic_load_n(&prejit_G, __ATOMIC_RELAXED);
-    _PreJit86(G->seqbase + G->seqlen, G->cs, G->mode,
+    _PreJit86(G->key + G->seqlen, G->cs, G->mode,
 	    SAFE_PRJ_GAP);
     pthread_mutex_lock(&run_mtx);
     prejit_running = 0;
@@ -3279,7 +3279,7 @@ static void *prejit_thread(void *arg)
 #if SPEC_PREJIT
 static void prejit_run(TNode *G)
 {
-  unsigned int PC = G->seqbase + G->seqlen;
+  unsigned int PC = G->key + G->seqlen;
   if (debug_level('e')) {
     char *ds;
     unsigned short ocs = TheCPU.cs;

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -735,10 +735,6 @@ static void CheckLinks(void)
 	e_printf("DEBUG: node link check ok\n");
 	return;
     }
-    if (G->key<=0) {
-	error("Invalid key %08x\n",G->key);
-	goto nquit;
-    }
     if (G->alive <= 0) {
 	e_printf("Node %p invalidated\n",G);
 	continue;
@@ -785,7 +781,7 @@ static void DumpTree (FILE *fd)
 	continue;
     }
     fprintf(fd,"%04d Node %p at %08x..%08x mblock=%p flags=%#x\n",
-	nn,G,G->key,(G->seqbase+G->seqlen-1),G->mblock,G->flags);
+	nn,G,G->key,(G->key+G->seqlen-1),G->mblock,G->flags);
     fprintf(fd,"     AVL (%p:%p),%d,%d,%d,%d\n",G->link[0],G->link[1],
 		G->bal,G->cache,G->pad,G->rtag);
     fprintf(fd,"     source:     instr=%d, len=%#x\n",G->seqnum,G->seqlen);
@@ -870,7 +866,7 @@ static int TraverseAndClean(void)
       G->alive -= AGENODE;
       if (G->alive <= 0) {
 	if (debug_level('e')>2) e_printf("TraverseAndClean: node at %08x decayed\n",G->key);
-	e_unmarkpage(G->seqbase, G->seqlen);
+	e_unmarkpage(G->key, G->seqlen);
 	NodeUnlinker(G);
       }
   }
@@ -951,7 +947,6 @@ TNode *Move2Tree(IMeta *I0, CodeBuf *GenCodeBuf)
   pthread_mutex_unlock(&trees_mtx);
 
   /* transfer info from first node of the Meta list to our new node */
-  nG->seqbase = I0->seqbase;
   nG->seqlen = I0->seqlen;
   nG->seqnum = I0->ncount;
 #if PROFILE
@@ -1239,13 +1234,13 @@ int InvalidateNodeRange(int al, int len, unsigned char *eip)
       if (G == &CollectTree.root || G->key >= ah)
         break;
       if (G->addr && (G->alive>0)) {
-	int ahG = G->seqbase + G->seqlen;
-	if (RANGE_INTERSECT(G->seqbase,ahG,al,ah)) {
+	int ahG = G->key + G->seqlen;
+	if (RANGE_INTERSECT(G->key,ahG,al,ah)) {
 	    unsigned char *ahE;
 	    if (debug_level('e')>1)
 		dbug_printf("Invalidated node %p at %08x\n",G,G->key);
 	    G->alive = 0;
-	    e_unmarkpage(G->seqbase, G->seqlen);
+	    e_unmarkpage(G->key, G->seqlen);
 	    NodeUnlinker(G);
 	    cleaned++;
 	    NodesCleaned++;

--- a/src/base/emu-i386/simx86/trees.h
+++ b/src/base/emu-i386/simx86/trees.h
@@ -75,7 +75,7 @@ typedef struct _ianpc {
 } Addr2Pc;
 
 typedef struct _imeta {
-	int seqbase, npc;
+	int npc;
 	unsigned short ncount, flags, seqlen;
 	unsigned int len, totlen, daddr;
 	int ngen;
@@ -121,7 +121,6 @@ typedef struct avltr_node
 	unsigned char *addr;
 	Addr2Pc *pmeta;
 	unsigned short len, flags, seqlen, seqnum __attribute__ ((packed));
-	int seqbase;
 	unsigned short nrefs;
 	linkdesc clink_t;
 	linkdesc clink_nt;


### PR DESCRIPTION
Once upon a time before 9aa2b21 (2014), with NOJUMPS G->seqbase could be different from G->key but it's much easier to deal with cpuemu with those two being the same; similar for I0->npc vs. I0->seqbase for IMeta. Hence seqbase is now redundant and can go away.