### PR TITLE
simx86: further interp/Sim_helper cleanups

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -3001,7 +3001,7 @@ unsigned int Sim_helper(unsigned int mem_ref, unsigned int data, int mode,
 			}
 /*c8*/	case ENTER: {
 			// This simulates only the middle part for level >=2
-			unsigned int bp;
+			unsigned int bp, sp, val;
 			int level, ds;
 			level = arg;
 			assert(level > 1); // level 0 and 1 are compiled
@@ -3010,9 +3010,15 @@ unsigned int Sim_helper(unsigned int mem_ref, unsigned int data, int mode,
 			while (--level) {
 				bp -= ds;
 				bp &= TheCPU.StackMask;
-				PUSH(mode, (mode&DATA16) ?
+				val = (mode&DATA16) ?
 				     sim_read_word(LONG_SS + bp) :
-				     sim_read_dword(LONG_SS + bp));
+				     sim_read_dword(LONG_SS + bp);
+				sp = (rESP - ds) & TheCPU.StackMask;
+				if (mode&DATA16)
+					sim_write_word(LONG_SS + sp, val);
+				else
+					sim_write_dword(LONG_SS + sp, val);
+				rESP = sp | (rESP&~TheCPU.StackMask);
 			}
 			}
 			break;

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -3249,15 +3249,16 @@ stack_return_from_vm86:
 			if (mode&DATA16) rAX = port_inw(a);
 			else rEAX = port_ind(a);
 			} break;
-
-/*6e*/	case OUTSb: {
+/*6e*/	case OUTSb:
+/*6f*/	case OUTSw: {
 			unsigned short a = rDX;
-			unsigned long rs;
 			if (!test_ioperm(a)) goto not_permitted_sim;
-			rs = (mode&ADDR16? rSI:rESI);
-			port_outb(a,sim_read_byte(LONG_DS+rs));
-			if (EFLAGS & EFLAGS_DF) rs--; else rs++;
-			if (mode&ADDR16) rSI=rs; else rESI=rs;
+			if (mode&MBYTE)
+				port_outb(a, data);
+			else if (mode&DATA16)
+				port_outw(a, data);
+			else
+				port_outd(a, data);
 			} break;
 /*ee*/	case OUTvb: {
 			unsigned short a = rDX;

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -2954,18 +2954,15 @@ unsigned int Sim_helper(unsigned int mem_ref, unsigned int data, int mode,
 
 	unsigned int temp;
 	switch (opc) {
-/*9c*/	case PUSHF:    { /* flag handling for VME-case only,
+/*9c*/	case PUSHF:	/* flag handling for VME-case only,
 			    not used presently with IOPL==3 */
-			unsigned int temp;
 			assert(V86MODE() && IOPL<3 && (TheCPU.cr[4] & CR4_VME));
-			temp = (EFLAGS & ~EFLAGS_CC) | (*flags & EFLAGS_CC);
-			data = (temp|IOPL_MASK) & RETURN_MASK;
-			if (temp & VIF) data |= EFLAGS_IF;
+			data = (EFLAGS|IOPL_MASK) & RETURN_MASK;
+			if (EFLAGS & VIF) data |= EFLAGS_IF;
 			if (debug_level('e')>1)
 				e_printf("Pushing flags %08x fl=%08x\n",
-					 data,temp);
+					 data,EFLAGS);
 			break;
-		       }
 /*62*/	case BOUND:    {
 			signed int lo, hi, r = data;
 			lo = DataGetWL_S(mode, mem_ref);
@@ -3063,7 +3060,6 @@ unsigned int Sim_helper(unsigned int mem_ref, unsigned int data, int mode,
 			if (debug_level('e')>1) {
 				e_printf("IRET: ret=%04x:%08x\n",TheCPU.cs,TheCPU.eip);
 			}
-			EFLAGS = (EFLAGS & ~EFLAGS_CC) | (*flags & EFLAGS_CC);
 			if (!(mode & DATA16)) {
 			    temp &= EFLAGS_ALL & ~(VM|VIF|VIP);
 			    temp |= EFLAGS & (VM|VIF|VIP);
@@ -3098,7 +3094,6 @@ unsigned int Sim_helper(unsigned int mem_ref, unsigned int data, int mode,
 			temp = data;
 			if (temp & TF)
 			    TheCPU.err = EXCP_TFSET;
-			EFLAGS = (EFLAGS & ~EFLAGS_CC) | (*flags & EFLAGS_CC);
 			if (V86MODE()) {
 			    int is_tf;
 stack_return_from_vm86:

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -3209,15 +3209,17 @@ stack_return_from_vm86:
 			    }
 			}
 			break;
-/*6c*/	case INSb: {
+/*6c*/	case INSb:
+/*6d*/	case INSw: {
 			unsigned short a;
-			unsigned int rd;
 			a = rDX;
 			if (!test_ioperm(a)) goto not_permitted_sim;
-			rd = (mode&ADDR16? rDI:rEDI);
-			sim_write_byte(LONG_ES+rd, port_inb(a));
-			if (EFLAGS & EFLAGS_DF) rd--; else rd++;
-			if (mode&ADDR16) rDI=rd; else rEDI=rd;
+			if (mode&MBYTE)
+				data = port_inb(a);
+			else if (mode&DATA16)
+				data = port_inw(a);
+			else
+				data = port_ind(a);
 			} break;
 /*ec*/	case INvb: {
 			unsigned short a = rDX;
@@ -3235,20 +3237,6 @@ stack_return_from_vm86:
 			unsigned short a = arg;
 			if (!test_ioperm(a)) goto not_permitted_sim;
 			rAL = port_inb(a);
-			} break;
-/*6d*/	case INSw: {
-			unsigned int rd;
-			int dp;
-			if (!test_ioperm(rDX)) goto not_permitted_sim;
-			rd = (mode&ADDR16? rDI:rEDI);
-			if (mode&DATA16) {
-				sim_write_word(LONG_ES+rd, port_inw(rDX)); dp=2;
-			}
-			else {
-				sim_write_dword(LONG_ES+rd, port_ind(rDX)); dp=4;
-			}
-			if (EFLAGS & EFLAGS_DF) rd-=dp; else rd+=dp;
-			if (mode&ADDR16) rDI=rd; else rEDI=rd;
 			} break;
 /*ed*/	case INvw:
 			if (!test_ioperm(rDX)) goto not_permitted_sim;

--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -198,10 +198,6 @@
 
 /////////////////////////////////////////////////////////////////////////////
 
-/* x386 */
-#define GetSWord(w)	((*w) = read_word(LONG_SS+sp))
-#define GetSLong(w)	((*w) = read_dword(LONG_SS+sp))
-
 // returns 1(16 bit), 0(32 bit)
 #define BTA(bpos, mode) (((mode) >> (bpos)) & 1)
 
@@ -214,55 +210,6 @@ static __inline__ int FastLog2(int v)
 }
 
 /////////////////////////////////////////////////////////////////////////////
-
-static __inline__ void PUSH(int m, uint32_t w)
-{
-	unsigned int sp;
-	unsigned int addr;
-
-	sp = (TheCPU.esp-BT24(BitDATA16, m)) & TheCPU.StackMask;
-	addr = LONG_SS + sp;
-	if (m&DATA16) {
-		e_invalidate(addr, 2);
-		WRITE_WORD(addr, w);
-	} else {
-		e_invalidate(addr, 4);
-		WRITE_DWORD(addr, w);
-	}
-#ifdef KEEP_ESP
-	TheCPU.esp = (sp&TheCPU.StackMask) | (TheCPU.esp&~TheCPU.StackMask);
-#else
-	TheCPU.esp = sp;
-#endif
-}
-
-/////////////////////////////////////////////////////////////////////////////
-
-static __inline__ void POP(int m, uint32_t *w)
-{
-	unsigned int sp = TheCPU.esp & TheCPU.StackMask;
-	if (m&DATA16) {
-		uint16_t w16;
-		GetSWord(&w16);
-		*w = (*w & 0xffff0000) | w16; sp+=2;
-	}
-	else {
-		GetSLong(w); sp+=4;
-	}
-	TheCPU.esp = (sp&TheCPU.StackMask) | (TheCPU.esp&~TheCPU.StackMask);
-}
-
-static __inline__ void NOS_WORD(int m, uint16_t *w)		// for segments
-{
-	unsigned int sp = (TheCPU.esp+(m&DATA16? 2:4)) & TheCPU.StackMask;
-	GetSWord(w);
-}
-
-static __inline__ void POP_ONLY(int m)
-{
-	unsigned int sp = TheCPU.esp + (m&DATA16? 2:4);
-	TheCPU.esp = (sp&TheCPU.StackMask) | (TheCPU.esp&~TheCPU.StackMask);
-}
 
 void InitGen(void);
 int NewIMeta(int npc);

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -2228,6 +2228,14 @@ repag0:
 			PC++; }
 			break;
 /*6e*/	case OUTSb:
+/*6f*/	case OUTSw: {	int m = _mode|MOVSSRC;
+			if (opc == OUTSb) m |= MBYTE;
+			Gen(O_MOVS_SetA, m, OVERR_DS);
+			Gen(L_DI_R1, m);
+			Gen(O_SIM, m, opc, 0, P0);
+			Gen(O_MOVS_SavA, m, OVERR_DS);
+			PC++; }
+			break;
 /*ec*/	case INvb:
 /*ed*/	case INvw:
 /*ee*/	case OUTvb:
@@ -2242,9 +2250,6 @@ repag0:
 			Gen(O_SIM, _mode, opc, Fetch(PC+1), P0);
 			PC += 2;
 			break;
-
-/*6f*/	case OUTSw:
-			PC++; goto not_permitted;
 
 /*d8*/	case ESC0:
 /*d9*/	case ESC1:

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -64,6 +64,7 @@ static void prejit_run(TNode *G);
 #define can_speculate() 0
 #endif
 static TNode *prejit_G;
+static unsigned short prejit_cs;
 #if PROFILE
 int SpecPrejits;
 #endif
@@ -87,6 +88,13 @@ static char R1Tab_l[14] =
 #define INC_WL_PCA(m,i)	PC=(PC+(i)+BT24(BitADDR16, m))
 #define INC_WL_PC(m,i)	PC=(PC+(i)+BT24(BitDATA16, m))
 
+/*
+ * close any pending instruction in the code cache.
+ * P0 is the start of current code cache.
+ * PC is the address of the next instruction after the sequence stops.
+ * The compiled code is then moved into the tree and can be picked up
+ * by the next DoExec.
+ */
 static TNode *DoClose(unsigned int PC, unsigned int Interp_LONG_CS, int mode)
 {
 	unsigned int P0 = InstrMeta[0].npc;
@@ -111,24 +119,6 @@ static TNode *DoClose(unsigned int PC, unsigned int Interp_LONG_CS, int mode)
 	    }
 	}
 	return Close(PC, Interp_LONG_CS, mode);
-}
-
-/*
- * close any pending instruction in the code cache and execute the
- * current sequence.
- * P0 is the start of current instruction, where the sequence stops
- *	if there are no jumps at the end.
- * P2 is the address of the next instruction to execute. If different
- *	from P0, abort the current instruction and resume the parsing
- *	loop at P2.
- */
-static TNode *do_flush(unsigned P0, unsigned Interp_LONG_CS, unsigned mode)
-{
-  assert (CurrIMeta>=0);
-  unsigned int flags = can_speculate();
-  TNode *G = DoClose(P0, Interp_LONG_CS, mode);
-  G->flags |= flags;
-  return G;
 }
 
 static inline unsigned int UNPREFIX(unsigned int m)
@@ -339,13 +329,18 @@ static int can_speculate(void)
 	IGen *IG = &GL->gen[GL->ngen-1];
 	int opc = IG->op;
 	/* With uncond JMP or RET nothing to speculate. */
-	if (opc == JMP_LINK && GL->ngen > 1) {
-		IG = &GL->gen[GL->ngen-2];
-		if (IG->op == O_PUSHI) // PUSHI before means CALL
-			return F_SPEC;
-	}
-	if (opc <= JMP_LINK)
+	if (opc < JMP_LINK)
 		return 0;
+	if (opc == JMP_LINK &&
+	    (GL->ngen <= 1 || GL->gen[GL->ngen-2].op != O_PUSHI))
+		// PUSHI before means CALL
+		return 0;
+	if (debug_level('e')) {
+		unsigned short ocs = TheCPU.cs;
+		unsigned int P2 = GL->npc;
+		char *ds = e_emu_disasm(EMU_BASE32(P2),IG->mode&MBIGCS,ocs);
+		e_printf("prejit after  %s\n", ds);
+	}
 	return F_SPEC;
 }
 #endif
@@ -482,10 +477,10 @@ static void HandleEmuSignals(void)
 }
 
 static unsigned int _Interp86(unsigned int PC, unsigned int Interp_LONG_CS,
-			      int basemode, int flags);
+			      unsigned short ocs, int basemode, int flags);
 static unsigned int interp_pre(unsigned int PC);
 static unsigned int InterpOne(unsigned int PC, unsigned int Interp_LONG_CS,
-			      int basemode);
+			      unsigned short ocs, int basemode);
 
 void Interp86(void)
 {
@@ -507,7 +502,7 @@ void Interp86(void)
       PC = interp_pre(PC);
       if (TheCPU.err)
         break;
-      PC = _Interp86(PC, LONG_CS, TheCPU.mode, 0);
+      PC = _Interp86(PC, LONG_CS, TheCPU.cs, TheCPU.mode, 0);
     }
     assert(CurrIMeta<0);
     TheCPU.eip = PC - LONG_CS;
@@ -580,7 +575,10 @@ static TNode *interp_post(unsigned int PC, unsigned int Interp_LONG_CS,
 		    e_querymark(PC, gap))
 #endif
 		{
-			G = do_flush(PC, Interp_LONG_CS, mode);
+			if (!(flags & F_SPRJ))
+				/* don't do recursive speculation ! */
+				flags |= can_speculate();
+			G = DoClose(PC, Interp_LONG_CS, mode);
 			G->flags |= flags;
 		}
 
@@ -588,23 +586,22 @@ static TNode *interp_post(unsigned int PC, unsigned int Interp_LONG_CS,
 }
 
 static unsigned int _Interp86(unsigned int PC, unsigned int Interp_LONG_CS,
-			      int basemode, int flags)
+			      unsigned short ocs, int basemode, int flags)
 {
 	TNode *G;
 
 	do {
-		PC = InterpOne(PC, Interp_LONG_CS, basemode);
+		PC = InterpOne(PC, Interp_LONG_CS, ocs, basemode);
 		G = interp_post(PC, Interp_LONG_CS, basemode, flags);
 	} while (!G);
 	return G->key;
 }
 
 static unsigned int InterpOne(unsigned int PC, unsigned int Interp_LONG_CS,
-			      int basemode)
+			      unsigned short ocs, int basemode)
 {
 	unsigned int P0 = PC;
 	unsigned char opc;
-	unsigned short ocs;
 	int _mode = basemode;
 	/* WARNING - these are signed char offsets, NOT pointers! */
 	signed char OVERR_DS = Ofs_XDS;
@@ -612,7 +609,6 @@ static unsigned int InterpOne(unsigned int PC, unsigned int Interp_LONG_CS,
 
 	if (debug_level('e')>2) {
 		char *ds;
-		unsigned short ocs = TheCPU.cs;
 		ds = e_emu_disasm(EMU_BASE32(PC),TheCPU.mode&MBIGCS,ocs);
 		e_printf("  %s\n", ds);
 	}
@@ -1607,15 +1603,17 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 /*9a*/	case CALLl:
 /*ea*/	case JMPld: {
 		    int len = 3 + BT24(BitDATA16,_mode);
-		    dosaddr_t oip = PC + len - LONG_CS;
-		    ocs = TheCPU.cs;
 		    PC = JumpGen(PC, Interp_LONG_CS, _mode, opc, len);
 		    if (debug_level('e')>2) {
+			dosaddr_t oip = PC - ocs;
+			unsigned short ncs = FetchW(PC-2);
+			dosaddr_t nip = DataFetchWL_U(_mode,PC-2-
+						      BT24(BitDATA16,_mode));
 			if (opc==CALLl)
 			    e_printf("CALL_FAR: ret=%04x:%08x\n  calling:	   %04x:%08x\n",
-				     ocs,oip,TheCPU.cs,PC-LONG_CS);
+				     ocs,oip,ncs,nip);
 			else
-			    e_printf("JMP_FAR: %04x:%08x\n",TheCPU.cs,PC-LONG_CS);
+			    e_printf("JMP_FAR: %04x:%08x\n",ncs,nip);
 		    }
 		    }
 		    break;
@@ -1725,7 +1723,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 				PC = JumpGen(PC, Interp_LONG_CS, _mode, opc, 2);
 				if (debug_level('e')>1)
 					dbug_printf("EMU86: directly called int %#x ax=%#x at %#x:%#x\n",
-						    inum, TheCPU.eax, TheCPU.cs, PC - Interp_LONG_CS);
+						    inum, TheCPU.eax, ocs, PC - Interp_LONG_CS);
 				break;
 			}
 			// V86: always #GP(0) if revectored or without VME
@@ -1765,8 +1763,6 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 				AddrGen(A_SR_PROT, _mode, Ofs_CS, P0);
 			Gen(O_POP3, _mode);
 			PC = JumpGen(PC, Interp_LONG_CS, _mode, opc, 1);
-			if (debug_level('e')>1)
-			    e_printf("RET_FAR: ret=%04x:%08x\n",TheCPU.cs,TheCPU.eip);
 			break;
 
 /*cf*/	case IRET:	/* restartable */
@@ -1787,8 +1783,6 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			/* to process EXCP_TFSET */
 			Gen(S_REG, _mode & ~DATA16, Ofs_ERR);
 			PC = JumpGen(PC, Interp_LONG_CS, _mode, opc, 1);
-			if (debug_level('e')>1)
-			    e_printf("IRET: ret=%04x:%08x\n",TheCPU.cs,TheCPU.eip);
 			break;
 /*9d*/	case POPF:
 			PC++;
@@ -2183,7 +2177,6 @@ repag0:
 				{
 					dosaddr_t oip = 0;
 					int len = ModRM(opc, PC, _mode|NOFLDR);
-					ocs = TheCPU.cs;
 					Gen(L_LXS2, _mode);
 					if (REALADDR())
 					    AddrGen(A_SR_SH4, _mode, Ofs_CS, Ofs_XCS);
@@ -2199,13 +2192,9 @@ repag0:
 					PC = JumpGen(PC, Interp_LONG_CS, _mode,
 						     (opc<<8)|REG1, len);
 					if (debug_level('e')>2) {
-					    unsigned short jcs = TheCPU.cs;
-					    dosaddr_t jip = PC - Interp_LONG_CS;
 					    if (REG1==Ofs_BX)
-						e_printf("CALL_FAR indirect: ret=%04x:%08x\n\tcalling: %04x:%08x\n",
-							 ocs,oip,jcs,jip);
-					    else
-						e_printf("JMP_FAR indirect: %04x:%08x\n",jcs,jip);
+						e_printf("CALL_FAR indirect: ret=%04x:%08x\n",
+							 ocs,oip);
 					}
 				}
 				break;
@@ -2750,9 +2739,9 @@ void instr_emu_sim_reset_count(void)
 }
 
 static void _PreJit86(unsigned int PC, unsigned int Interp_LONG_CS,
-		      int basemode, int flags)
+		      unsigned short ocs, int basemode, int flags)
 {
-	_Interp86(PC, Interp_LONG_CS, basemode, flags);
+	_Interp86(PC, Interp_LONG_CS, ocs, basemode, flags);
 	NodesPrejitted++;
 }
 
@@ -2760,7 +2749,7 @@ void PreJit86(unsigned int PC, int basemode)
 {
 	if (e_querymark(PC, 1))
 		return;
-	_PreJit86(PC, LONG_CS, basemode, F_PREJ);
+	_PreJit86(PC, LONG_CS, TheCPU.cs, basemode, F_PREJ);
 	e_mdrop();
 }
 
@@ -2769,7 +2758,8 @@ static void *prejit_thread(void *arg)
   while (1) {
     sem_wait(&prejit_sem);
     TNode *G = __atomic_load_n(&prejit_G, __ATOMIC_RELAXED);
-    _PreJit86(G->key + G->seqlen, G->cs, G->mode, F_PREJ|F_SPRJ);
+    unsigned short ocs = __atomic_load_n(&prejit_cs, __ATOMIC_RELAXED);
+    _PreJit86(G->key + G->seqlen, G->cs, ocs, G->mode, F_PREJ|F_SPRJ);
     pthread_mutex_lock(&run_mtx);
     prejit_running = 0;
     pthread_mutex_unlock(&run_mtx);
@@ -2785,10 +2775,7 @@ static void prejit_run(TNode *G)
   if (debug_level('e')) {
     char *ds;
     unsigned short ocs = TheCPU.cs;
-    unsigned int P2 = InstrMeta[CurrIMeta].npc;
     unsigned int basemode = G->mode;
-    ds = e_emu_disasm(EMU_BASE32(P2),basemode&MBIGCS,ocs);
-    e_printf("prejit after  %s\n", ds);
     ds = e_emu_disasm(EMU_BASE32(PC),basemode&MBIGCS,ocs);
     e_printf("prejit at  %s\n", ds);
   }
@@ -2798,6 +2785,7 @@ static void prejit_run(TNode *G)
   SpecPrejits++;
 #endif
   __atomic_store_n(&prejit_G, G, __ATOMIC_RELAXED);
+  __atomic_store_n(&prejit_cs, TheCPU.cs, __ATOMIC_RELAXED);
   pthread_mutex_lock(&run_mtx);
   assert(!prejit_running);
   prejit_running = 1;

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -2219,7 +2219,14 @@ repag0:
 			break;
 
 /*6c*/	case INSb:
-/*6d*/	case INSw:
+/*6d*/	case INSw: {	int m = _mode|MOVSDST;
+			if (opc == INSb) m |= MBYTE;
+			Gen(O_MOVS_SetA, m, OVERR_DS);
+			Gen(O_SIM, m, opc, 0, P0);
+			Gen(S_DI, m);
+			Gen(O_MOVS_SavA, m, OVERR_DS);
+			PC++; }
+			break;
 /*6e*/	case OUTSb:
 /*ec*/	case INvb:
 /*ed*/	case INvw:


### PR DESCRIPTION
I closed #2612 by deleting the branch but moved its first commit here. So this PR now removes the obsolete helper functions instead. To reduce Sim_helper a bit further,  compile memory read/writes for INSx/OUTSx (only with real ports), and remove superfluous EFLAGS manipulations.

Lastly, there was still some code using TheCPU.cs in the interpreter, which is wrong with SPEC_PREJIT, but only applied to debug printfs. Those are now fixed.