### PR TITLE
codegen: fix typo in expression [#2615]

### DIFF
--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -260,7 +260,7 @@ void Gen(int op, int mode, ...)
 		break;
 
 	case O_POP2:
-		if (!(mode & MNOREG) || (mode && MRETISP))
+		if (!(mode & MNOREG) || (mode & MRETISP))
 			IG->p0 = va_arg(ap,unsigned int);
 		break;
 


### PR DESCRIPTION
&& vs & confusion.