### PR TITLE
simx86: zero extend segreg in A_SR_PROT code

### DIFF
--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -284,6 +284,8 @@ static unsigned char *CodeGen_x86(unsigned char *CodePtr, unsigned char *BaseGen
 		}
 		break;
 	case A_SR_PROT: {	// prot mode make base addr from seg
+		// movzwl %%ax,%%eax: zero extend segreg
+		G3(0xc0b70f,Cp);
 #ifdef __x86_64__
 		// pushq %rdi: save memory address for LDS etc.
 		G1(0x57,Cp);


### PR DESCRIPTION
Fixes #2615

(I think it fixes that, to be confirmed!)

It would be better to have %eax/%rax always have the zero extended value when dealing with segregs, but that's more of an optimization (at the moment this happens sometimes, like with L_LXS2 for  for LDS/LES/..., but not always). With this fix the zero extend now mirrors what's happening both in codegen-sim.c for A_SR_PROT, and the logic for real mode registers in A_SR_SH4.