### PR TITLE
simx86: remove Exec_sim counter used for profiling

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -2870,15 +2870,12 @@ static unsigned Exec_sim(unsigned *pmem_ref, unsigned long *flg,
 			 unsigned short seqflg)
 {
 	unsigned int P0;
-	static int count;
 
 	if (seqflg & F_FPOP)
 		/* mask all exceptions, and set rounding properly */
 		fp87_mask_except();
 
 	FlagSync_RFL(*flg);
-	count++;
-	if (count %1000==0) dbug_printf("%d\n", count);
 	P0 = Gen_sim(SeqStart, pmem_ref);
 	currentIG = NULL;
 	*flg = FlagSync_All();


### PR DESCRIPTION
I accidentally left in a counter to see how effective the node linker was (the count was ~50% less with it), which fills up boot.log.