### PR TITLE
simx86: re-enable garbage collector for tree nodes

### DIFF
--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -520,7 +520,8 @@ static CodeBuf *ProduceCode(unsigned int PC, IMeta *I0)
  *
  */
 
-TNode *Close(unsigned int PC, unsigned int Interp_LONG_CS, int mode)
+TNode *Close(unsigned int PC, unsigned int Interp_LONG_CS, int mode,
+		int flags)
 {
 	IMeta *I0;
 	TNode *G;
@@ -553,6 +554,10 @@ TNode *Close(unsigned int PC, unsigned int Interp_LONG_CS, int mode)
 	if (!(CEmuStat & CeS_TRAP)) {
 		NodeLinker(G, G);
 	}
+
+	/* must be done after a_markpage() to avoid excessive m_unprots */
+	if (!(flags & (F_PREJ | F_SPRJ)))
+		tree_gc();
 	return G;
 }
 

--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -222,7 +222,7 @@ extern void Gen(int op, int mode, ...);
 extern void AddrGen(int op, int mode, ...);
 extern void (*Fp87_op)(int exop, int reg, unsigned mem_ref);
 extern int Fp87_illegal_op(int exop, int reg);
-TNode *Close(unsigned int PC, unsigned int Interp_LONGCS, int mode);
+TNode *Close(unsigned int PC, unsigned int Interp_LONGCS, int mode, int flags);
 extern unsigned char * (*CodeGen)(unsigned char *CodePtr,
 				  unsigned char *BaseGenBuf, const IGen *IG);
 extern unsigned (*Exec)(unsigned *mem_ref, unsigned long *flg,

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -816,6 +816,9 @@ void e_gen_sigalrm(void)
 	 * the passed context is that of dosemu, NOT that of the
 	 * emulated CPU! */
 	exit_pending_or(CeS_SIGPEND);
+
+	/* this triggers calculation of paramaters for garbage collect */
+	TheCPU.sigprof_pending = 1;
 }
 
 void e_gen_sigalrm_from_thread(void)

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -124,7 +124,7 @@ static TNode *DoClose(unsigned int PC, unsigned int Interp_LONG_CS, int mode,
 			Fetch(abeg);
 	    }
 	}
-	return Close(PC, Interp_LONG_CS, mode);
+	return Close(PC, Interp_LONG_CS, mode, flags);
 }
 
 static inline unsigned int UNPREFIX(unsigned int m)

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -95,7 +95,8 @@ static char R1Tab_l[14] =
  * The compiled code is then moved into the tree and can be picked up
  * by the next DoExec.
  */
-static TNode *DoClose(unsigned int PC, unsigned int Interp_LONG_CS, int mode)
+static TNode *DoClose(unsigned int PC, unsigned int Interp_LONG_CS, int mode,
+		int flags)
 {
 	unsigned int P0 = InstrMeta[0].npc;
 
@@ -111,6 +112,11 @@ static TNode *DoClose(unsigned int PC, unsigned int Interp_LONG_CS, int mode)
 	    InvalidateNodeRange(P0, PC - P0, NULL);
 	    if (!e_querymprotrange_full(P0, PC - P0)) {
 		unsigned int abeg, aend;
+
+		/* in case of prejit, the page content could
+		 * be altered, so we better re-jit */
+		if (flags & (F_PREJ | F_SPRJ))
+			return NULL;
 		abeg = P0 & _PAGE_MASK;
 		aend = PC & _PAGE_MASK;
 		/* re-populate cache */
@@ -401,7 +407,9 @@ static unsigned int FindExecCode(unsigned int PC)
 			/* slow path */
 			InvalidateNodeRange(PC, 1, NULL);
 		}
-		if (!G) {
+		/* future proofing: _Interp86() can't fail now in non-prejit mode
+		   but if it ever does, retry */
+		while (!G) {
 			if (CEmuStat & (CeS_PREJIT_RM | CeS_PREJIT_PM)) {
 				TheCPU.err = EXCP_GOBACK;
 				return PC;
@@ -537,10 +545,9 @@ void Interp86(void)
  * overwrite something unintentionally */
 #define SAFE_PRJ_GAP 16
 
-static TNode *interp_post(unsigned int PC, unsigned int Interp_LONG_CS,
-			  const int mode, int flags)
+static int interp_post(unsigned int PC, unsigned int Interp_LONG_CS,
+		       const int mode, int flags)
 {
-		TNode *G = NULL;
 		int gap = (flags & F_SPRJ) ? SAFE_PRJ_GAP : 1;
 		assert (CurrIMeta>=0);
 
@@ -571,11 +578,11 @@ static TNode *interp_post(unsigned int PC, unsigned int Interp_LONG_CS,
 			if (!(flags & F_SPRJ))
 				/* don't do recursive speculation ! */
 				flags |= can_speculate();
-			G = DoClose(PC, Interp_LONG_CS, mode);
-			G->flags |= flags;
+			InstrMeta[0].flags |= flags;
+			return 1;
 		}
 
-		return G;
+		return 0;
 }
 
 static TNode *_Interp86(unsigned int PC, unsigned int Interp_LONG_CS,
@@ -585,8 +592,8 @@ static TNode *_Interp86(unsigned int PC, unsigned int Interp_LONG_CS,
 
 	do {
 		PC = InterpOne(PC, Interp_LONG_CS, ocs, basemode);
-		G = interp_post(PC, Interp_LONG_CS, basemode, flags);
-	} while (!G);
+	} while (!interp_post(PC, Interp_LONG_CS, basemode, flags));
+	G = DoClose(PC, Interp_LONG_CS, basemode, flags);
 	ret = G;
 #if !defined(SINGLEBLOCK) && SPEC_PREJIT
 	int gap = (flags & F_SPRJ) ? SAFE_PRJ_GAP : 1;
@@ -599,8 +606,8 @@ static TNode *_Interp86(unsigned int PC, unsigned int Interp_LONG_CS,
 		if (e_querymark(PC, gap)) break;
 		do {
 			PC = InterpOne(PC, Interp_LONG_CS, ocs, basemode);
-			G = interp_post(PC, Interp_LONG_CS, basemode, flags);
-		} while (!G);
+		} while (!interp_post(PC, Interp_LONG_CS, basemode, flags));
+		G = DoClose(PC, Interp_LONG_CS, basemode, flags);
 		i++;
 		NodeLinker(oldG, G);
 	}

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -116,25 +116,12 @@ static inline avltr_node *Tmalloc(void)
 
 static inline void Tfree(avltr_node *p)
 {
-  TNode *G = p->data;
-  if (G)
-    __atomic_store_n(&findtree_cache[G->key&FINDTREE_CACHE_HASH_MASK],
-		     NULL, __ATOMIC_RELAXED);
-  free(G);
   p->data = NULL;
   p->link[0] = TNodePool->link[0];
   TNodePool->link[0] = p;
 }
 
 /////////////////////////////////////////////////////////////////////////////
-
-static inline void datacopy(TNode *nd, TNode *ns)
-{
-  char *s = (char *)&(ns->key);
-  char *d = (char *)&(nd->key);
-  int l = sizeof(TNode)-offsetof(TNode,key);
-  memcpy(d,s,l);
-}
 
 static TNode **avltr_probe (TNode *item)
 {
@@ -314,6 +301,7 @@ void avltr_delete(const int key)
   unsigned char a[AVL_MAX_HEIGHT];	/* Stack P: Bits. */
   int k = 1;				/* Stack P: Pointer. */
   avltr_node *p;
+  TNode *G;
 
   a[0] = 0;
   pa[0] = &tree->root;
@@ -345,6 +333,8 @@ void avltr_delete(const int key)
 #endif
   tree->count--;
   ninodes = tree->count;
+
+  G = p->data;
 
   {
     avltr_node *t = p;
@@ -397,29 +387,8 @@ void avltr_delete(const int key)
 		pa[k++] = r;
 	    }
 
-	    TNode *Gt = t->data;
-	    TNode *Gs = s->data;
-	    if (Gt->mblock) dlfree(Gt->mblock);
-	    __atomic_store_n(&findtree_cache[Gt->key&FINDTREE_CACHE_HASH_MASK],
-			     NULL, __ATOMIC_RELAXED);
+	    t->data = s->data;
 /* e_printf("<03 node exchange %p->%p>\n",s,t); */
-	    datacopy(Gt, Gs);
-/**/	    if (Gt->addr==NULL) {
-	      pthread_mutex_unlock(&trees_mtx);
-	      leavedos_main(0x8130);
-	    }
-	    /* keep the node reference to itself */
-	    Gt->mblock->bkptr = Gt;
-	    Gs->addr = NULL;
-	    Gs->mblock = NULL;
-	    Gs->nrefs = 0;
-	    memset(&Gs->clink_t, 0, sizeof(linkdesc));
-	    memset(&Gs->clink_nt, 0, sizeof(linkdesc));
-	    Gs->unlinked_jmp_targets = 0;
-	    memset(&Gs->bkr, 0, sizeof(backref));
-	    Gs->key = 0;
-	    free(Gs);
-	    s->data = NULL;
 
 	    if (s->rtag == PLUS) r->link[0] = s->link[1];
 	      else r->link[0] = NULL;
@@ -449,7 +418,14 @@ void avltr_delete(const int key)
 	    leavedos_main(0x9142);
 	}
 #endif
-  if (p->data && p->data->mblock) dlfree(p->data->mblock);
+/**/ if (G->addr==NULL) {
+      pthread_mutex_unlock(&trees_mtx);
+      leavedos_main(0x8130);
+  }
+  if (G->mblock) dlfree(G->mblock);
+  __atomic_store_n(&findtree_cache[G->key&FINDTREE_CACHE_HASH_MASK],
+		   NULL, __ATOMIC_RELAXED);
+  free(G);
   Tfree(p);
 
   while (--k) {

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -87,7 +87,7 @@ static void DumpTree (FILE *fd);
 static TNode *findtree_cache[FINDTREE_CACHE_HASH_MASK+1];
 
 static avltr_node *TNodePool;
-//static int NodeLimit = 10000;
+static int NodeLimit = 10000;
 
 #define RANGE_INTERSECT(al,ah,l,h)	({int _l2=(al);\
 	int _h2=(ah); ((_h2 > (l)) && (_l2 < (h))); })
@@ -1291,6 +1291,15 @@ TNode *Move2Tree(IMeta *I0, CodeBuf *GenCodeBuf)
   if (debug_level('e')) AddTime += (GETTSC() - t0);
 #endif
   return nG;
+}
+
+void tree_gc(void)
+{
+  int i;
+
+  if (ninodes > NodeLimit) {
+	for (i=0; i<CreationIndex; i++) TraverseAndClean();
+  }
 }
 
 static TNode *FindTree_tail(int key)

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -1654,7 +1654,8 @@ static int xCS1 = 0;
 
 void CollectStat (void)
 {
-	int i, m = 0;
+	int i;
+	unsigned int m = 0;
 #ifdef SHOW_STAT
 	int csm = config.CPUSpeedInMhz*1000;
 //	xCST[cstx].a = TheCPU.EMUtime;

--- a/src/base/emu-i386/simx86/trees.h
+++ b/src/base/emu-i386/simx86/trees.h
@@ -162,6 +162,7 @@ typedef struct avltr_tree
 
 TNode *FindTree(int key);
 TNode *Move2Tree(IMeta *I0, CodeBuf *GenCodeBuf);
+void tree_gc(void);
 
 void InitTrees(void);
 


### PR DESCRIPTION
I used @stsp's jpage branch as a base to re-enable it. Doing so I tested with 100 nodes max to stress it a bit and I found another regression in avltr_delete so fixed that too.

It may still be nice (if not to expensive) to immediately remove nodes that are invalidated (of course we need GC for those that expire), as I think it would avoid code such as this in tree.c:
```
          if (G->alive <= 0) {
            /* remove dead node as it may be overlapped by good one */
            p = DoDelNode(p);
            continue;
          } 
```
as this refers to an explicitly invalidated dead node, if it were gone immediately we would never encounter it.

Fixes #2634