### PR TITLE
simx86: invalidate LastXNode when it is free()ed

### DIFF
--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -66,7 +66,7 @@ unsigned (*Exec)(unsigned *mem_ref, unsigned long *flg,
 
 int UseLinker = 0;
 hitimer_u TimeStartExec;
-static TNode *LastXNode = NULL;
+TNode *LastXNode = NULL;
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -256,6 +256,7 @@ extern char RmIsReg[];
 extern char OpIsPush[];
 extern char OpSize[];
 extern char OpSizeBit[];
+extern TNode *LastXNode;
 
 #define OPSIZE(m) (OpSize[(m)&(DATA16|MBYTE)])
 #define OPSIZEBIT(m) (OpSizeBit[(m)&(DATA16|MBYTE)])

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -425,6 +425,7 @@ void avltr_delete(const int key)
   if (G->mblock) dlfree(G->mblock);
   __atomic_store_n(&findtree_cache[G->key&FINDTREE_CACHE_HASH_MASK],
 		   NULL, __ATOMIC_RELAXED);
+  if (G == LastXNode) LastXNode = NULL;
   free(G);
   Tfree(p);
 
@@ -613,6 +614,7 @@ void avltr_destroy(void)
 		  free(B2);
 	      }
 	      if (p->data->mblock) dlfree(p->data->mblock);
+	      if (p->data == LastXNode) LastXNode = NULL;
 	      free(p->data);
 	      p->data = NULL;
 	  }
@@ -1174,6 +1176,7 @@ TNode *Move2Tree(IMeta *I0, CodeBuf *GenCodeBuf)
 	   compiled version */
 	NodeUnlinker(nG);
 	if (nG->mblock) dlfree(nG->mblock);
+	if (nG == LastXNode) LastXNode = NULL;
 	free(nG);
   }
   else {


### PR DESCRIPTION
Similar to d0f65163, checking for alive is no longer sufficient since the actual node is now free()ed.

Another regression from 65db4096c, found with ASAN enabled in CI