### PR TITLE
simx86: nodelinker and other exec improvements

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -75,7 +75,7 @@
 static unsigned char *CodeGen_sim(unsigned char *CodePtr, unsigned char *BaseGenBuf, const IGen *IG);
 static unsigned Exec_sim(unsigned *mem_ref, unsigned long *flg,
 			 unsigned char *ecpu, void *SeqStart,
-			 unsigned short seqflg);
+			 unsigned short seqflg, unsigned *seqbase);
 
 static unsigned char *currentIG = NULL;
 
@@ -430,7 +430,8 @@ static dosaddr_t AddrGen_sim(const IGen *IG)
 	return mem_ref;
 }
 
-static unsigned int Gen_sim(IGen *IG, unsigned int *pmem_ref)
+static unsigned int Gen_sim(IGen *IG, unsigned int *pmem_ref,
+			    unsigned int *seqbase)
 {
     /* working registers of the host CPU */
     wkreg DR1;	// "eax"
@@ -2720,6 +2721,7 @@ static unsigned int Gen_sim(IGen *IG, unsigned int *pmem_ref)
 
 	case JMP_TAILCODE: {	// retaddr
 		P0 = (unsigned int)IG->p0;
+		*seqbase = P0;
 		if (debug_level('e')>2) {
 			dbug_printf("** Tail code: return from %08x\n",P0);
 		} }
@@ -2727,6 +2729,7 @@ static unsigned int Gen_sim(IGen *IG, unsigned int *pmem_ref)
 
 	case JMP_INDIRECT:
 		P0 = LONG_CS + ((mode & DATA16) ? DR1.w.l : DR1.d);
+		*seqbase = P0;
 		if (debug_level('e')>2)
 			dbug_printf("** Jump taken to %08x\n",P0);
 		break;
@@ -2738,6 +2741,7 @@ static unsigned int Gen_sim(IGen *IG, unsigned int *pmem_ref)
 			continue;
 		}
 		P0 = (unsigned int)IG->p0;
+		*seqbase = IG->p1;
 		if (debug_level('e')>2) {
 			dbug_printf("** Jump taken to %08x\n",P0);
 		}
@@ -2781,6 +2785,7 @@ static unsigned int Gen_sim(IGen *IG, unsigned int *pmem_ref)
 			continue;
 		}
 		P0 = IG->p0;
+		*seqbase = IG->p1;
 		if (debug_level('e')>2 && (IG-1)->op == JMP_LINK)
 			dbug_printf("** Jump taken to %08x\n",P0);
 		}
@@ -2803,6 +2808,7 @@ static unsigned int Gen_sim(IGen *IG, unsigned int *pmem_ref)
 			continue;
 		}
 		P0 = IG->p0;
+		*seqbase = IG->p1;
 		if (debug_level('e')>2 && (IG-1)->op == JMP_LINK)
 			dbug_printf("** Jump taken to %08x\n",P0);
 		}
@@ -2867,7 +2873,7 @@ static unsigned char *CodeGen_sim(unsigned char *CodePtr, unsigned char *BaseGen
 
 static unsigned Exec_sim(unsigned *pmem_ref, unsigned long *flg,
 			 unsigned char *ecpu, void *SeqStart,
-			 unsigned short seqflg)
+			 unsigned short seqflg, unsigned int *seqbase)
 {
 	unsigned int P0;
 
@@ -2876,9 +2882,10 @@ static unsigned Exec_sim(unsigned *pmem_ref, unsigned long *flg,
 		fp87_mask_except();
 
 	FlagSync_RFL(*flg);
-	P0 = Gen_sim(SeqStart, pmem_ref);
+	P0 = Gen_sim(SeqStart, pmem_ref, seqbase);
 	currentIG = NULL;
 	*flg = FlagSync_All();
+	if (TheCPU.err) *seqbase = P0;
 
 	return P0;
 }

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -108,7 +108,7 @@
 static unsigned char *CodeGen_x86(unsigned char *CodePtr, unsigned char *BaseGenBuf, const IGen *IG);
 static unsigned Exec_x86(unsigned *mem_ref, unsigned long *flg,
 			 unsigned char *ecpu, void *SeqStart,
-			 unsigned short seqflg);
+			 unsigned short seqflg, unsigned *seqbase);
 
 /////////////////////////////////////////////////////////////////////////////
 
@@ -117,18 +117,13 @@ static unsigned Exec_x86(unsigned *mem_ref, unsigned long *flg,
  * (the one where we switch back to interpreted code).
  *
  *		movl #return_PC,eax
+ *		movl eax, ecx (signal no link)
  *		popl edx (flags)
  *		ret
  */
-static unsigned char TailCode[TAILSIZE+1] =
-	{ 0xb8,0,0,0,0,0x5a,0xc3,0xf4 };
 
-#ifdef __x86_64__
-/* create space for 64 bit jumps (taking 12 bytes total) behing tail code */
-#define PADJMP		G5(0x9090909090,Cp)
-#else
-#define PADJMP
-#endif
+static unsigned char TailCode[TAILSIZE+1] =
+	{ 0xb8,0,0,0,0,0x89,0xc1,0x5a,0xc3,0xf4 };
 
 /*
  * This function is only here for looking at the generated binary code
@@ -315,8 +310,8 @@ static unsigned char *CodeGen_x86(unsigned char *CodePtr, unsigned char *BaseGen
 		G2M(0x09,0xc0,Cp);
 		// jns skip
 		G2M(0x79,TAILSIZE,Cp);
-		// movl {exit_addr},%%eax; pop %%edx; ret
-		G1(0xb8,Cp); G4(IG->p1,Cp); G2M(0x5a,0xc3,Cp);
+		// movl {exit_addr},%%eax; movl %%eax, %%ecx; pop %%edx; ret
+		G1(0xb8,Cp); G4(IG->p1,Cp); G4M(0x89,0xc1,0x5a,0xc3,Cp);
 		}
 		break;
 	case L_NOP:
@@ -1632,8 +1627,8 @@ shrot0:
 		G2M(0x73,TAILSIZE+7,Cp);
 		// movb EXCP0D_GPF, Ofs_ERR(%%ebx)
 		G2M(0xc6,0x83,Cp); G4(Ofs_ERR,Cp); G1(EXCP0D_GPF,Cp);
-		// movl {exit_addr},%%eax; pop %%edx; ret
-		G1(0xb8,Cp); G4(jpc,Cp); G2M(0x5a,0xc3,Cp);
+		// movl {exit_addr},%%eax; mov %%eax, %%ecx; pop %%edx; ret
+		G1(0xb8,Cp); G4(jpc,Cp); G4M(0x89,0xc1,0x5a,0xc3,Cp);
 		// address to call in edi
 		// movl $(inum*4), %edi
 		G1(0xbf,Cp); G4(intno*4, Cp);
@@ -1673,8 +1668,8 @@ shrot0:
 #else
 		G2M(JE_JZ,TAILSIZE+1+4+1+4+1+1+4+1+1+3+3+1,Cp);
 #endif
-		// movl {exit_addr},%%eax; pop %%edx; ret
-		G1(MOViax,Cp); G4(IG->p2,Cp); G2M(POPdx,RET,Cp);
+		// movl {exit_addr},%%eax; movl %eax,%ecx;  pop %%edx; ret
+		G1(MOViax,Cp); G4(IG->p2,Cp); G4M(0x89,0xc1,POPdx,RET,Cp);
 
 		// 1:
 #ifndef __x86_64__
@@ -2272,6 +2267,8 @@ shrot0:
 			G3M(0x0f,0xb7,0xc0,Cp);
 		// addl Ofs_XCS(%%ebx),%%eax
 		G3M(0x03,0x43,Ofs_XCS,Cp);
+		// movl %%eax, %%ecx // signals indirect
+		G2M(0x89,0xc1,Cp);
 		// pop %%edx; ret
 		G2M(0x5a,0xc3,Cp);
 		}
@@ -2313,13 +2310,15 @@ shrot0:
 		    G4M(0x0f,0xb7,0x4b,Ofs_EXITPEND,Cp);
 		    // jecxz {continue}: exit if exitpend not 0
 		    G2M(0xe3,TAILSIZE,Cp);
-		    // movl {exit_addr},%%eax; pop %%edx; ret
-		    G1(0xb8,Cp); G4(dspt,Cp); G2(0xc35a,Cp);
+		    // movl {exit_addr},%%eax; pop %%edx; movl %%eax, %%ecx; ret
+		    G1(0xb8,Cp); G4(dspt,Cp); G4M(0x89,0xc1,0x5a,0xc3,Cp);
 	        }
+		// mov [node_pc], %%ecx
+		G1(0xb9,Cp); G4(IG->p1,Cp);
 		// t:	b8 [exit_pc] 5a c3
 		G1(0xb8,Cp);
-		G4(dspt,Cp); G2(0xc35a,Cp); PADJMP;
-		if (debug_level('e')>2) e_printf("JMP_Link %08x\n", dspt);
+		G4(dspt,Cp); G2(0xc35a,Cp);
+		if (debug_level('e')>2) e_printf("JMP_Link %08x %08x\n", dspt, IG->p1);
 		}
 		break;
 
@@ -2422,7 +2421,8 @@ shrot0:
 #define EXEC_CLOBBERS
 #endif
 static unsigned Exec_x86_asm(unsigned *mem_ref, unsigned long *flg,
-		unsigned char *ecpu, unsigned char *SeqStart)
+		unsigned char *ecpu, unsigned char *SeqStart,
+		unsigned int *seqbase)
 {
 	unsigned ePC;
 	void *jb;
@@ -2443,14 +2443,14 @@ static unsigned Exec_x86_asm(unsigned *mem_ref, unsigned long *flg,
 		"call	1f\n"		/* save return addr		*/
 		"jmp	2f\n"
 		"1:\n"
-		"push	%4\n"
-		"jmp	*%5\n"
+		"push	%5\n"
+		"jmp	*%6\n"
 		"2:\n"
 #ifdef __x86_64__
 		"movq	%%r12,%%rsp\n"
 #endif
 		"pop	"RE_REG(bp)"\n"
-		: "=d"(*flg),"=a"(ePC),"=D"(*mem_ref)
+		: "=d"(*flg),"=a"(ePC),"=D"(*mem_ref),"=c"(*seqbase)
 		: "b"(ecpu),"d"(*flg),"a"(SeqStart),
 		  [mb]"D"(jb)  // don't use "r" or can assign to %rbp
 		/* Note: we need to clobber "class-less" regs (like %rbp) even
@@ -2473,7 +2473,7 @@ static unsigned Exec_x86_asm(unsigned *mem_ref, unsigned long *flg,
 		 * fixed reg for mem_base and move it to %ebp after push,
 		 * rather than using a mem-ref with modified %esp.
 		 */
-		: "memory", "cc", "ecx", "esi" EXEC_CLOBBERS
+		: "memory", "cc", "esi" EXEC_CLOBBERS
 	);
 	InCompiledCode = 0;
 	/* even though InCompiledCode is volatile, we also need a barrier */
@@ -2483,7 +2483,7 @@ static unsigned Exec_x86_asm(unsigned *mem_ref, unsigned long *flg,
 
 static unsigned Exec_x86(unsigned *mem_ref, unsigned long *flg,
 		unsigned char *ecpu, void *SeqStart,
-		unsigned short seqflg)
+		unsigned short seqflg, unsigned int *seqbase)
 {
 	unsigned ePC;
 	if (seqflg & F_FPOP) {
@@ -2497,7 +2497,7 @@ static unsigned Exec_x86(unsigned *mem_ref, unsigned long *flg,
 		fpuc = TheCPU.fpuc | 0x3f;
 		asm ("fldcw	%0" :: "m"(fpuc));
 	}
-	ePC = Exec_x86_asm(mem_ref, flg, ecpu, SeqStart);
+	ePC = Exec_x86_asm(mem_ref, flg, ecpu, SeqStart, seqbase);
 	/* was there at least one FP op in the sequence? */
 	if (seqflg & F_FPOP) {
 		int exs;

--- a/src/base/emu-i386/simx86/codegen-x86.h
+++ b/src/base/emu-i386/simx86/codegen-x86.h
@@ -37,14 +37,10 @@
 
 #include "codegen.h"
 
-#define TAILSIZE	7
-#ifdef __x86_64__
+#define TAILSIZE	9
 #define JMPTAILSIZE	12
-#else
-#define JMPTAILSIZE	TAILSIZE
-#endif
 #define TAILFIX		1
-#define CKSIGNSIZE	13
+#define CKSIGNSIZE	15
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -62,11 +62,10 @@
 unsigned char * (*CodeGen)(unsigned char *CodePtr, unsigned char *BaseGenBuf, const IGen *IG);
 unsigned (*Exec)(unsigned *mem_ref, unsigned long *flg,
 		 unsigned char *ecpu, void *SeqStart,
-		 unsigned short seqflg);
+		 unsigned short seqflg, unsigned *seqbase);
 
 int UseLinker = 0;
 hitimer_u TimeStartExec;
-TNode *LastXNode = NULL;
 
 /////////////////////////////////////////////////////////////////////////////
 
@@ -372,6 +371,7 @@ void Gen(int op, int mode, ...)
 
 	case JMP_LINK:		// dspt
 		IG->p0 = va_arg(ap,unsigned int);	// dspt
+		IG->p1 = va_arg(ap,unsigned int);	// PC of node
 		break;
 
 	case JLOOP_LINK:
@@ -442,7 +442,7 @@ static CodeBuf *ProduceCode(unsigned int PC, IMeta *I0)
 	    for (j=0; j<I->ngen; j++) {
 		IGen *IG = &I->gen[j];
 		if (IG->op == JMP_LINK)
-			IG->p1 = CodePtr - BaseGenBuf;
+			IG->p2 = CodePtr - BaseGenBuf;
 		CodePtr = CodeGen(CodePtr, BaseGenBuf, IG);
 		if (CodePtr-cp1 > MAX_GEND_BYTES_PER_OP) {
 		    dosemu_error("Generated code (%zd bytes) overflowed into buffer, please "
@@ -607,7 +607,7 @@ static void Exec_post(unsigned long flg, unsigned int mem_ref, const TNode *G)
 	}
 }
 
-unsigned int DoExec(TNode *G)
+unsigned int DoExec(TNode *G, unsigned *pLastXKey)
 {
 	unsigned long flg;
 	unsigned char *ecpu;
@@ -631,9 +631,34 @@ unsigned int DoExec(TNode *G)
 	hitimer_t TimeStartExec;
 	if (debug_level('e')) TimeStartExec = GETTSC();
 #endif
+	/*
+	 * Just before execution comes the linker stage.
+	 * So the order is:
+	 *	1) build code sequence in the IMeta buffer
+	 *	2) move buffer to a newly allocated node in the tree
+	 *	3) link the previous node to this node
+	 *	4) execute it, always returning back at the end
+	 * Linking: a node is linked with the next
+	 * one in execution order, provided that the end source address
+	 * of the preceding node matches the start source address of the
+	 * following (i.e. no interpreted instructions in between).
+	 *
+	 * A complication here is that the previous node may already
+	 * be linked, so an unlinked exit will return the start PC
+	 * of the original (unlinked) block in seqbase.
+	 * Unlinkable exits are flagged using ePC==LastXKey; self-links
+	 * are already handled at the compile stage.
+	 */
+	/* check links FROM LastXNode TO current node */
+	if (*pLastXKey != G->key)
+		NodeLinker(FindTree(*pLastXKey), G);
+
 	flg = Exec_pre(ecpu);
-	ePC = Exec(&mem_ref, &flg, ecpu, SeqStart, seqflg);
+	ePC = Exec(&mem_ref, &flg, ecpu, SeqStart, seqflg, pLastXKey);
 	Exec_post(flg, mem_ref, G);
+
+	if (debug_level('e')>2 && *pLastXKey != ePC)
+		e_printf("New LastXKey=%08x\n",*pLastXKey);
 
 #ifdef SKIP_EMU_VBIOS
 	if ((jcs&0xf000)==config.vbios_seg && !TheCPU.err)
@@ -675,27 +700,6 @@ unsigned int DoExec(TNode *G)
 #if defined(SINGLESTEP)
 	InvalidateNodeRange(G->key, 1, NULL);
 	avltr_delete(G->key);
-#else
-	/*
-	 * After execution comes the linker stage.
-	 * So the order is:
-	 *	1) build code sequence in the IMeta buffer
-	 *	2) move buffer to a newly allocated node in the tree
-	 *	3) execute it, always returning back at the end
-	 *	4) link it to other nodes
-	 * Linking: a node is linked with the next
-	 * one in execution order, provided that the end source address
-	 * of the preceding node matches the start source address of the
-	 * following (i.e. no interpreted instructions in between).
-	 */
-	if (G && G->alive>0) {
-		/* check links FROM LastXNode TO current node */
-		if (LastXNode && LastXNode->alive > 0)
-			NodeLinker(LastXNode, G);
-		if (debug_level('e')>2 && G != LastXNode)
-			e_printf("New LastXNode=%08x\n",G->key);
-		LastXNode = G;
-	}
 #endif
 
 	return ePC;
@@ -703,21 +707,17 @@ unsigned int DoExec(TNode *G)
 
 /* fast loop, only used if nothing special is going on; if anything
    out of the ordinary happens, the above DoExec() is called */
-unsigned int DoExec_fast(TNode *G)
+unsigned int DoExec_fast(TNode *G, unsigned *pLastXKey)
 {
 	unsigned char *ecpu = CPUOFFS(0);
+	unsigned LastXKey = *pLastXKey;
 	unsigned long flg = Exec_pre(ecpu);
 	unsigned int ePC, mem_ref, e;
 
 	do {
-		ePC = Exec(&mem_ref, &flg, ecpu, G->addr, 0);
-		if (G->alive > 0 && LastXNode && LastXNode->alive > 0) {
-			if (LastXNode->unlinked_jmp_targets &&
-			    (LastXNode->clink_t.target == G->key ||
-			     LastXNode->clink_nt.target == G->key))
-				NodeLinker(LastXNode, G);
-			LastXNode = G;
-		}
+		if (LastXKey != G->key)
+			NodeLinker(FindTree(LastXKey), G);
+		ePC = Exec(&mem_ref, &flg, ecpu, G->addr, 0, &LastXKey);
 		if (TheCPU.err == EXCP_STISHADOW) {
 			/* as STI can exit here as well from the middle
 			   of a block we must mirror DoExec here */
@@ -738,6 +738,7 @@ unsigned int DoExec_fast(TNode *G)
 		 GoodNode(G) && !(G->flags & (F_FPOP|F_INHI|F_SLFJ)));
 
 	Exec_post(flg, mem_ref, G);
+	*pLastXKey = LastXKey;
 	return ePC;
 }
 

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -589,7 +589,8 @@ static unsigned int Exec_pre(unsigned char *ecpu)
 	return flg;
 }
 
-static void Exec_post(unsigned long flg, unsigned int mem_ref, const TNode *G)
+static void Exec_post(unsigned long flg, unsigned int mem_ref,
+		      unsigned short seqflg)
 {
 	EFLAGS = (EFLAGS & ~EFLAGS_CC) | (flg &	EFLAGS_CC);
 	TheCPU.mem_ref = mem_ref;
@@ -601,7 +602,7 @@ static void Exec_post(unsigned long flg, unsigned int mem_ref, const TNode *G)
 	if (TheCPU.err == EXCP_TFSET)
 		TheCPU.err = 0;
 	/* checking for infinite loops, flagged in JumpGen() */
-	if (G && (G->flags & F_SLFJ) && !(EFLAGS & (VIF|IF|TF))) {
+	if ((seqflg & F_SLFJ) && !(EFLAGS & (VIF|IF|TF))) {
 		error("!Forever loop!\n");
 		leavedos_main(0xebfe);
 	}
@@ -655,7 +656,8 @@ unsigned int DoExec(TNode *G, unsigned *pLastXKey)
 
 	flg = Exec_pre(ecpu);
 	ePC = Exec(&mem_ref, &flg, ecpu, SeqStart, seqflg, pLastXKey);
-	Exec_post(flg, mem_ref, G);
+	// G is unreliable (maybe deleted) past this point!
+	Exec_post(flg, mem_ref, seqflg);
 
 	if (debug_level('e')>2 && *pLastXKey != ePC)
 		e_printf("New LastXKey=%08x\n",*pLastXKey);
@@ -685,7 +687,7 @@ unsigned int DoExec(TNode *G, unsigned *pLastXKey)
 	/* signal_pending at this point is 1 if there was ANY signal,
 	 * not just a SIGALRM
 	 */
-	if (((G->flags & F_INHI) || (CEmuStat & CeS_STI)) &&
+	if (((seqflg & F_INHI) || (CEmuStat & CeS_STI)) &&
 	    !(G->seqnum == 1 && (CEmuStat & CeS_INHI))) {
 		/* ignore signals and traps for movss/popss; if there is just
 		   one compiled instruction it should be ignored unconditionally
@@ -713,11 +715,13 @@ unsigned int DoExec_fast(TNode *G, unsigned *pLastXKey)
 	unsigned LastXKey = *pLastXKey;
 	unsigned long flg = Exec_pre(ecpu);
 	unsigned int ePC, mem_ref, e;
+	unsigned short seqflg = G->flags;
 
 	do {
 		if (LastXKey != G->key)
 			NodeLinker(FindTree(LastXKey), G);
 		ePC = Exec(&mem_ref, &flg, ecpu, G->addr, 0, &LastXKey);
+		// G is unreliable (maybe deleted) past this point!
 		if (TheCPU.err == EXCP_STISHADOW) {
 			/* as STI can exit here as well from the middle
 			   of a block we must mirror DoExec here */
@@ -735,9 +739,9 @@ unsigned int DoExec_fast(TNode *G, unsigned *pLastXKey)
 			TheCPU.err = EXCP_GOBACK;
 #endif
 	} while (!TheCPU.err && (G=FindTree(ePC)) &&
-		 GoodNode(G) && !(G->flags & (F_FPOP|F_INHI|F_SLFJ)));
+		 !((seqflg=G->flags) & (F_FPOP|F_INHI|F_SLFJ)) && GoodNode(G));
 
-	Exec_post(flg, mem_ref, G);
+	Exec_post(flg, mem_ref, G ? seqflg : 0);
 	*pLastXKey = LastXKey;
 	return ePC;
 }

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -714,7 +714,7 @@ unsigned int DoExec_fast(TNode *G, unsigned *pLastXKey)
 	unsigned char *ecpu = CPUOFFS(0);
 	unsigned LastXKey = *pLastXKey;
 	unsigned long flg = Exec_pre(ecpu);
-	unsigned int ePC, mem_ref, e;
+	unsigned int ePC, mem_ref;
 	unsigned short seqflg = G->flags;
 
 	do {
@@ -729,11 +729,8 @@ unsigned int DoExec_fast(TNode *G, unsigned *pLastXKey)
 			CEmuStat &= ~CeS_TRAP;
 			break;
 		}
-		e = exit_pending_xchg(0);
-		if (e) {
-			CEmuStat |= e;
+		if (exit_pending())
 			break;
-		}
 #ifdef SKIP_EMU_VBIOS
 		if ((jcs&0xf000)==config.vbios_seg && !TheCPU.err)
 			TheCPU.err = EXCP_GOBACK;
@@ -741,6 +738,7 @@ unsigned int DoExec_fast(TNode *G, unsigned *pLastXKey)
 	} while (!TheCPU.err && (G=FindTree(ePC)) &&
 		 !((seqflg=G->flags) & (F_FPOP|F_INHI|F_SLFJ)) && GoodNode(G));
 
+	CEmuStat |= exit_pending_xchg(0);
 	Exec_post(flg, mem_ref, G ? seqflg : 0);
 	*pLastXKey = LastXKey;
 	return ePC;

--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -227,9 +227,9 @@ extern unsigned char * (*CodeGen)(unsigned char *CodePtr,
 				  unsigned char *BaseGenBuf, const IGen *IG);
 extern unsigned (*Exec)(unsigned *mem_ref, unsigned long *flg,
 			unsigned char *ecpu, void *SeqStart,
-			unsigned short seqflg);
-unsigned int DoExec(TNode *G);
-unsigned int DoExec_fast(TNode *G);
+			unsigned short seqflg, unsigned *seqbase);
+unsigned int DoExec(TNode *G, unsigned *LastXKey);
+unsigned int DoExec_fast(TNode *G, unsigned *LastXKey);
 void EndGen(void);
 extern void fp87_mask_except(void);
 extern void fp87_save_except(void);
@@ -256,7 +256,6 @@ extern char RmIsReg[];
 extern char OpIsPush[];
 extern char OpSize[];
 extern char OpSizeBit[];
-extern TNode *LastXNode;
 
 #define OPSIZE(m) (OpSize[(m)&(DATA16|MBYTE)])
 #define OPSIZEBIT(m) (OpSizeBit[(m)&(DATA16|MBYTE)])

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -256,8 +256,8 @@ static unsigned int JumpGen(unsigned int P2, unsigned int Interp_LONG_CS,
 			    e_printf("### dsp=0 jmp=%x pskip=%d\n",opc,pskip);
 		    }
 		    Gen(JB_LINK, mode, opc);
-		    Gen(JMP_LINK, mode, j_nt);
-		    Gen(JMP_LINK, mode|CKSIGN, j_t);
+		    Gen(JMP_LINK, mode, j_nt, InstrMeta[0].npc);
+		    Gen(JMP_LINK, mode|CKSIGN, j_t, InstrMeta[0].npc);
 		}
 		else {
 		    if (dsp == pskip) {
@@ -265,8 +265,8 @@ static unsigned int JumpGen(unsigned int P2, unsigned int Interp_LONG_CS,
 		    }
 		    /* forward jump or backward jump >=256 bytes */
 		    Gen(JF_LINK, mode, opc);
-		    Gen(JMP_LINK, mode, j_nt);
-		    Gen(JMP_LINK, mode&~CKSIGN, j_t);
+		    Gen(JMP_LINK, mode, j_nt, InstrMeta[0].npc);
+		    Gen(JMP_LINK, mode&~CKSIGN, j_t, InstrMeta[0].npc);
 		}
 		break;
 	case JMPld: {   /* uncond jmp far */
@@ -291,7 +291,7 @@ static unsigned int JumpGen(unsigned int P2, unsigned int Interp_LONG_CS,
 		    InstrMeta[CurrIMeta].flags |= F_SLFJ;
 		}
 		if (dsp <= 0) mode |= CKSIGN;
-		Gen(JMP_LINK, mode, j_t);
+		Gen(JMP_LINK, mode, j_t, InstrMeta[0].npc);
 		break;
 	case CALLl: {   /* call far */
 		unsigned short jcs = FetchW(P2 + pskip - 2);
@@ -314,13 +314,13 @@ static unsigned int JumpGen(unsigned int P2, unsigned int Interp_LONG_CS,
 	/* no break for realaddr call */
 	case CALLd:    /* call, unfortunately also uses JMP_LINK */
 		Gen(O_PUSHI, mode, d_nt);
-		Gen(JMP_LINK, mode, j_t);
+		Gen(JMP_LINK, mode, j_t, InstrMeta[0].npc);
 		break;
 	case LOOP: case LOOPZ_LOOPE: case LOOPNZ_LOOPNE:
 		Gen(JLOOP_LINK, mode, opc);
 		/* CKSIGN is likely not needed for loops */
-		Gen(JMP_LINK, mode, j_nt);
-		Gen(JMP_LINK, mode, j_t);
+		Gen(JMP_LINK, mode, j_nt, InstrMeta[0].npc);
+		Gen(JMP_LINK, mode, j_t, InstrMeta[0].npc);
 		break;
 	case RETl: case RETlisp: case IRET: // far ret, indirect
 	case JMPli: case CALLli: case INT: // far jmp/call, indirect
@@ -384,6 +384,7 @@ static void HandleEmuSignals(void);
 static unsigned int FindExecCode(unsigned int PC)
 {
 	TNode *G;
+	unsigned LastXKey = PC;
 
 	/* for a sequence to be found, it must begin with
 	 * an allowable opcode. Look into table.
@@ -452,7 +453,7 @@ static unsigned int FindExecCode(unsigned int PC)
 		if (!(EFLAGS & TF) && !(CEmuStat & (CeS_INHI)) &&
 		    !debug_level('e') &&
 		    GoodNode(G) && !(G->flags & (F_FPOP|F_INHI|F_SPEC|F_LEAV)))
-			PC = DoExec_fast(G);
+			PC = DoExec_fast(G, &LastXKey);
 		else
 #endif
 		{
@@ -460,7 +461,7 @@ static unsigned int FindExecCode(unsigned int PC)
 			if (G->flags & F_SPEC)
 				prejit_run(G);
 #endif
-			PC = DoExec(G);
+			PC = DoExec(G, &LastXKey);
 #if SPEC_PREJIT
 			if (G->flags & F_SPEC) {
 				G->flags &= ~F_SPEC;
@@ -1991,8 +1992,8 @@ repag0:
 				if (repmod & MREPCOND)
 					op = (realrepmod&MREP) ? LOOPZ_LOOPE : LOOPNZ_LOOPNE;
 				Gen(JLOOP_LINK, _mode, op);
-				Gen(JMP_LINK, _mode, PC);
-				Gen(JMP_LINK, _mode, P0);
+				Gen(JMP_LINK, _mode, PC, InstrMeta[0].npc);
+				Gen(JMP_LINK, _mode, P0, InstrMeta[0].npc);
 				/* code will be flushed immediately
 				   in interp_post because TF is set */
 				break;

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -447,7 +447,10 @@ static unsigned int FindExecCode(unsigned int PC)
 		NodesExecd++;
 #if PROFILE
 		TotalNodesExecd++;
+		if (G->flags & F_PREJ)
+			PrejitNodesExecd++;
 #endif
+		assert(G->seqlen);
 #if !defined(ASM_DUMP) && !defined(SINGLESTEP)
 		/* try fast inner loop if nothing special is going on */
 		if (!(EFLAGS & TF) && !(CEmuStat & (CeS_INHI)) &&
@@ -457,27 +460,25 @@ static unsigned int FindExecCode(unsigned int PC)
 		else
 #endif
 		{
+			unsigned short seqflg = G->flags;
+			G->flags &= ~(F_SPEC|F_LEAV);
 #if SPEC_PREJIT
-			if (G->flags & F_SPEC)
+			if (seqflg & F_SPEC)
 				prejit_run(G);
 #endif
 			PC = DoExec(G, &LastXKey);
+			// G is unreliable (maybe deleted) past this point!
 #if SPEC_PREJIT
-			if (G->flags & F_SPEC) {
-				G->flags &= ~F_SPEC;
+			if (seqflg & F_SPEC) {
 				prejit_sync();
 			}
 #endif
-			if (G->flags & F_LEAV) {
-				G->flags &= ~F_LEAV;
+			if (seqflg & F_LEAV) {
 				TheCPU.err = EXCP_EMULEAVE;
 			}
 		}
 #if PROFILE
-		if (G->flags & F_PREJ)
-			PrejitNodesExecd++;
 #endif
-		assert(G->seqlen);
 		if (TheCPU.err) return PC;
 		if (CEmuStat & (CeS_TRAP|CeS_DRTRAP|CeS_SIGPEND|CeS_RPIC))
 			HandleEmuSignals();

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -425,7 +425,6 @@ void avltr_delete(const int key)
   if (G->mblock) dlfree(G->mblock);
   __atomic_store_n(&findtree_cache[G->key&FINDTREE_CACHE_HASH_MASK],
 		   NULL, __ATOMIC_RELAXED);
-  if (G == LastXNode) LastXNode = NULL;
   free(G);
   Tfree(p);
 
@@ -614,7 +613,6 @@ void avltr_destroy(void)
 		  free(B2);
 	      }
 	      if (p->data->mblock) dlfree(p->data->mblock);
-	      if (p->data == LastXNode) LastXNode = NULL;
 	      free(p->data);
 	      p->data = NULL;
 	  }
@@ -880,7 +878,8 @@ static void NodeUnlinker(TNode *G)
 			B->branch, L->target, G->key);
 		    leavedos_main(0x8110);
 		}
-		IGen IG = (IGen){.op = JMP_LINK, .mode = MPATCH, .p0 = L->target};
+		IGen IG = (IGen){.op = JMP_LINK, .mode = MPATCH,
+				 .p0 = L->target, .p1 = H->key};
 		CodeGen(H->addr + L->link, H->addr, &IG);
 		L->ref = NULL; H->unlinked_jmp_targets |= target_type;
 		G->nrefs--;
@@ -1176,7 +1175,6 @@ TNode *Move2Tree(IMeta *I0, CodeBuf *GenCodeBuf)
 	   compiled version */
 	NodeUnlinker(nG);
 	if (nG->mblock) dlfree(nG->mblock);
-	if (nG == LastXNode) LastXNode = NULL;
 	free(nG);
   }
   else {
@@ -1231,12 +1229,12 @@ TNode *Move2Tree(IMeta *I0, CodeBuf *GenCodeBuf)
   IG = &I0[CurrIMeta].gen[I0[CurrIMeta].ngen-1];
   op = IG->op;
   if (op == JMP_LINK) {
-    nG->clink_t.link = IG->p1;
+    nG->clink_t.link = IG->p2;
     nG->clink_t.target = IG->p0;
     nG->unlinked_jmp_targets |= TARGET_T;
     if (I0[CurrIMeta].ngen > 1 && (IG-1)->op == JMP_LINK) {
       IG--;
-      nG->clink_nt.link = IG->p1;
+      nG->clink_nt.link = IG->p2;
       nG->clink_nt.target = IG->p0;
       nG->unlinked_jmp_targets |= TARGET_NT;
     }


### PR DESCRIPTION
This PR contains the change mentioned in #2641 regarding LastXNode. It was more involved then initially thought, because I realized we were trying to link the first node in a potentially long already linked chain to the current node, thereby missing some possible links. We need the last executed node instead. But for that we need the generated code to return the last node, which I did for JIT with a new key variable returned in %ecx for linkable nodes.

The result then works really well and reduced the number of calls to FindTree by ~70% in a FreeCOM compilation. See the commit message for more details.

The other two patches are about bad performance of `__atomic_exchange_n` (moved outside the loop) and avoiding the access of node G after Exec(G), in some stress testing I found it occasionally gone through invalidatenoderange.

Comparing to last week (commit 333710a, before I introduced some regressions), with "./default-configure -d" for a test run that builds freecom and runs a few other short tests:
```
before:
JIT
real    3m57.033s
user    3m12.706s
sys     0m21.344s
SIM
real    10m5.792s
user    9m17.934s
sys     0m21.568s

after (this PR)
JIT
real    2m48.264s
user    2m6.898s
sys     0m20.573s
SIM
real    8m26.791s
user    7m39.923s
sys     0m20.765s


comparison: KVM:
real    2m10.837s
user    1m21.021s
sys     0m30.120s
```