### PR TITLE
simx86: Avoid setting TheCPU.eip in protected mode code

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -3093,6 +3093,7 @@ static unsigned int _Sim_helper(unsigned int mem_ref, unsigned int data, int mod
 					    inum, _AX, _CS, _IP);
 			break;
 		       }
+/*cb*/	case RETl:
 /*cf*/	case IRET: {	/* restartable */
 			if (!REALADDR()) {
 				unsigned int cs, eip;
@@ -3100,12 +3101,12 @@ static unsigned int _Sim_helper(unsigned int mem_ref, unsigned int data, int mod
 				if (mode&DATA16) {
 					eip = POPw(sp);
 					cs = POPw(sp);
-					data = POPw(sp);
+					if (opc == IRET) data = POPw(sp);
 				}
 				else {
 					eip = POPl(sp);
 					cs = POPl(sp);
-					data = POPl(sp);
+					if (opc == IRET) data = POPl(sp);
 				}
 				rESP = sp | (rESP&~TheCPU.StackMask);
 				if (SetSegProt_helper(cs, Ofs_CS) < 0)
@@ -3114,6 +3115,7 @@ static unsigned int _Sim_helper(unsigned int mem_ref, unsigned int data, int mod
 				   page fault: we return to the main loop after */
 				TheCPU.eip = eip;
 			}
+			if (opc != IRET) break;
 			/* non-segment GPF handled in interpreter */
 			assert(!(V86MODE() && IOPL!=3 && !(TheCPU.cr[4] & CR4_VME)));
 			temp = data;

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -3093,6 +3093,7 @@ static unsigned int _Sim_helper(unsigned int mem_ref, unsigned int data, int mod
 					    inum, _AX, _CS, _IP);
 			break;
 		       }
+/*ca*/	case RETlisp:
 /*cb*/	case RETl:
 /*cf*/	case IRET: {	/* restartable */
 			if (!REALADDR()) {
@@ -3107,6 +3108,10 @@ static unsigned int _Sim_helper(unsigned int mem_ref, unsigned int data, int mod
 					eip = POPl(sp);
 					cs = POPl(sp);
 					if (opc == IRET) data = POPl(sp);
+				}
+				if (opc == RETlisp) {
+					sp += arg;
+					sp &= TheCPU.StackMask;
 				}
 				rESP = sp | (rESP&~TheCPU.StackMask);
 				if (SetSegProt_helper(cs, Ofs_CS) < 0)

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -2969,6 +2969,14 @@ static __inline__ void SetCPU_WL(int m, signed char o, unsigned long v)
 	if (m&DATA16) CPUWORD(o)=v; else CPULONG(o)=v;
 }
 
+#define POPw(sp) ({ \
+	unsigned int __res = sim_read_word(LONG_SS + sp); \
+	sp += 2; sp &= TheCPU.StackMask; __res; })
+
+#define POPl(sp) ({ \
+	unsigned int __res = sim_read_dword(LONG_SS + sp); \
+	sp += 4; sp &= TheCPU.StackMask; __res; })
+
 /* This generic helper function is called from JIT generated code and from
  * Gen_sim to simulate hard-to-compile and rarely used ops.
  * parameters:
@@ -3086,7 +3094,27 @@ static unsigned int _Sim_helper(unsigned int mem_ref, unsigned int data, int mod
 			break;
 		       }
 /*cf*/	case IRET: {	/* restartable */
-			/* GPF handled in interpreter */
+			if (!REALADDR()) {
+				unsigned int cs, eip;
+				unsigned int sp = rESP & TheCPU.StackMask;
+				if (mode&DATA16) {
+					eip = POPw(sp);
+					cs = POPw(sp);
+					data = POPw(sp);
+				}
+				else {
+					eip = POPl(sp);
+					cs = POPl(sp);
+					data = POPl(sp);
+				}
+				rESP = sp | (rESP&~TheCPU.StackMask);
+				if (SetSegProt_helper(cs, Ofs_CS) < 0)
+					break;
+				/* safe to do here after any potential
+				   page fault: we return to the main loop after */
+				TheCPU.eip = eip;
+			}
+			/* non-segment GPF handled in interpreter */
 			assert(!(V86MODE() && IOPL!=3 && !(TheCPU.cr[4] & CR4_VME)));
 			temp = data;
 			/* IRET always returns with the new PC, we need to

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -843,9 +843,6 @@ arith1:
 		if (mode & MBYTE) {
 			// movw Ofs_AX(%%ebx),%%ax
 			G4M(OPERoverride,0x8b,0x43,Ofs_AX,Cp);
-			/* exception trap: save current PC */
-			// movl $eip,Ofs_EIP(%%ebx)
-			G2M(0xc7,0x43,Cp); G1(Ofs_EIP,Cp); G4(IG->p0,Cp);
 			// div %%cl,%%al
 			G2M(0xf6,0xf1,Cp);
 			// movw %%ax,Ofs_AX(%%ebx)
@@ -856,9 +853,6 @@ arith1:
 			G4M(OPERoverride,0x8b,0x43,Ofs_AX,Cp);
 			// movw Ofs_DX(%%ebx),%%dx
 			G4M(OPERoverride,0x8b,0x53,Ofs_DX,Cp);
-			/* exception trap: save current PC */
-			// movl $eip,Ofs_EIP(%%ebx)
-			G2(0x43c7,Cp); G1(Ofs_EIP,Cp); G4(IG->p0,Cp);
 			// div %%cx,%%ax
 			G3M(OPERoverride,0xf7,0xf1,Cp);
 			// movw %%ax,Ofs_AX(%%ebx)
@@ -871,9 +865,6 @@ arith1:
 			G3M(0x8b,0x43,Ofs_EAX,Cp);
 			// movl Ofs_EDX(%%ebx),%%edx
 			G3M(0x8b,0x53,Ofs_EDX,Cp);
-			/* exception trap: save current PC */
-			// movl $eip,Ofs_EIP(%%ebx)
-			G2(0x43c7,Cp); G1(Ofs_EIP,Cp); G4(IG->p0,Cp);
 			// div %%ecx,%%eax
 			G2M(0xf7,0xf1,Cp);
 			// movl %%eax,Ofs_EAX(%%ebx)
@@ -890,9 +881,6 @@ arith1:
 		if (mode & MBYTE) {
 			// movw Ofs_AX(%%ebx),%%ax
 			G4M(OPERoverride,0x8b,0x43,Ofs_AX,Cp);
-			/* exception trap: save current PC */
-			// movl $eip,Ofs_EIP(%%ebx)
-			G2(0x43c7,Cp); G1(Ofs_EIP,Cp); G4(IG->p0,Cp);
 			// idiv %%cl,%%al
 			G2M(0xf6,0xf9,Cp);
 			// movw %%ax,Ofs_AX(%%ebx)
@@ -903,9 +891,6 @@ arith1:
 			G4M(OPERoverride,0x8b,0x43,Ofs_AX,Cp);
 			// movw Ofs_DX(%%ebx),%%dx
 			G4M(OPERoverride,0x8b,0x53,Ofs_DX,Cp);
-			/* exception trap: save current PC */
-			// movl $eip,Ofs_EIP(%%ebx)
-			G2(0x43c7,Cp); G1(Ofs_EIP,Cp); G4(IG->p0,Cp);
 			// idiv %%cx,%%ax
 			G3M(OPERoverride,0xf7,0xf9,Cp);
 			// movw %%ax,Ofs_AX(%%ebx)
@@ -918,9 +903,6 @@ arith1:
 			G3M(0x8b,0x43,Ofs_EAX,Cp);
 			// movl Ofs_EDX(%%ebx),%%edx
 			G3M(0x8b,0x53,Ofs_EDX,Cp);
-			/* exception trap: save current PC */
-			// movl $eip,Ofs_EIP(%%ebx)
-			G2(0x43c7,Cp); G1(Ofs_EIP,Cp); G4(IG->p0,Cp);
 			// idiv %%ecx,%%eax
 			G2M(0xf7,0xf9,Cp);
 			// movl %%eax,Ofs_EAX(%%ebx)

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -1765,14 +1765,16 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 
 /*cb*/	case RETl:
 			/* pop from stack without adjusting esp before A_SR_* */
-			Gen(O_POP1, _mode);
-			Gen(O_POP2, _mode, Ofs_EIP);
-			Gen(O_POP2, _mode|MNOREG);
-			if (REALADDR())
+			if (REALADDR()) {
+				Gen(O_POP1, _mode);
+				Gen(O_POP2, _mode, Ofs_EIP);
+				Gen(O_POP2, _mode|MNOREG);
 				AddrGen(A_SR_SH4, _mode, Ofs_CS, Ofs_XCS);
-			else
-				AddrGen(A_SR_PROT, _mode, Ofs_CS, P0);
-			Gen(O_POP3, _mode);
+				Gen(O_POP3, _mode);
+			}
+			else {
+				Gen(O_SIM, _mode, opc, 0, P0);
+			}
 			PC = JumpGen(PC, Interp_LONG_CS, _mode, opc, 1);
 			break;
 

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -1689,13 +1689,16 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 /*ca*/	case RETlisp: {	/* restartable */
 			/* pop from stack without adjusting esp before A_SR_* */
 			int dr = (signed short)FetchW(PC+1);
-			Gen(O_POP1, _mode);
-			Gen(O_POP2, _mode, Ofs_EIP);
-			Gen(O_POP2, _mode|MNOREG|MRETISP, dr);
-			if (REALADDR())
+			if (REALADDR()) {
+				Gen(O_POP1, _mode);
+				Gen(O_POP2, _mode, Ofs_EIP);
+				Gen(O_POP2, _mode|MNOREG|MRETISP, dr);
 				AddrGen(A_SR_SH4, _mode, Ofs_CS, Ofs_XCS);
-			else
-				AddrGen(A_SR_PROT, _mode, Ofs_CS, P0);
+				Gen(O_POP3, _mode);
+			}
+			else {
+				Gen(O_SIM, _mode, opc, dr, P0);
+			}
 			Gen(O_POP3, _mode);
 			PC = JumpGen(PC, Interp_LONG_CS, _mode, opc, 3);
 			if (debug_level('e')>2)

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -323,9 +323,9 @@ static unsigned int JumpGen(unsigned int P2, unsigned int Interp_LONG_CS,
 		Gen(JMP_LINK, mode, j_t, InstrMeta[0].npc);
 		break;
 	case RETl: case RETlisp: case IRET: // far ret, indirect
-	case JMPli: case CALLli: case INT: // far jmp/call, indirect
 		Gen(L_REG, mode, Ofs_EIP);
 		/* fall through */
+	case JMPli: case CALLli: case INT: // far jmp/call, indirect
 	case RET: case RETisp: case JMPi: case CALLi: // ret, indirect
 		Gen(JMP_INDIRECT, mode);
 		break;
@@ -1733,7 +1733,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 				Gen(O_PUSHI, _mode, PC + 2 - Interp_LONG_CS);
 				Gen(L_LXS2, _mode);
 				AddrGen(A_SR_SH4, _mode, Ofs_CS, Ofs_XCS);
-				Gen(L_LXS1, _mode, Ofs_EIP);
+				Gen(L_DI_R1, _mode);
 				PC = JumpGen(PC, Interp_LONG_CS, _mode, opc, 2);
 				if (debug_level('e')>1)
 					dbug_printf("EMU86: directly called int %#x ax=%#x at %#x:%#x\n",
@@ -2205,7 +2205,7 @@ repag0:
 					    Gen(O_PUSH, _mode);
 					    Gen(O_PUSHI, _mode, oip);
 					}
-					Gen(L_LXS1, _mode, Ofs_EIP);
+					Gen(L_DI_R1, _mode);
 					PC = JumpGen(PC, Interp_LONG_CS, _mode,
 						     (opc<<8)|REG1, len);
 					if (debug_level('e')>2) {

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -1780,16 +1780,15 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			if (V86MODE() && IOPL!=3 && !(TheCPU.cr[4] & CR4_VME)) {
 			    PC++; goto not_permitted;	/* GPF */
 			}
-			/* pop from stack without adjusting esp before A_SR_* */
-			Gen(O_POP1, _mode);
-			Gen(O_POP2, _mode, Ofs_EIP);
-			Gen(O_POP2, _mode|MNOREG);
-			if (REALADDR())
+			if (REALADDR()) {
+				/* pop from stack without adjusting esp before A_SR_* */
+				Gen(O_POP1, _mode);
+				Gen(O_POP2, _mode, Ofs_EIP);
+				Gen(O_POP2, _mode|MNOREG);
 				AddrGen(A_SR_SH4, _mode, Ofs_CS, Ofs_XCS);
-			else
-				AddrGen(A_SR_PROT, _mode, Ofs_CS, P0);
-			Gen(O_POP3, _mode);
-			Gen(O_POP, _mode);
+				Gen(O_POP3, _mode);
+				Gen(O_POP, _mode);
+			}
 			Gen(O_SIM, _mode, opc, 0, P0);
 			/* to process EXCP_TFSET */
 			Gen(S_REG, _mode & ~DATA16, Ofs_ERR);

--- a/src/base/emu-i386/simx86/sigsegv.c
+++ b/src/base/emu-i386/simx86/sigsegv.c
@@ -245,6 +245,22 @@ static int e_vgaemu_fault(sigcontext_t *scp, dosaddr_t cr2)
 
 #define GetSegmentBaseAddress(s)	GetSegmentBase(s)
 
+/* save eip, eflags, and do a "ret" out of compiled code */
+static int e_return_from_jit(sigcontext_t *scp, int pop_flags)
+{
+	_scp_eax = FindPC((unsigned char *)_scp_rip);
+	e_printf("FindPC: found %x\n",_scp_eax);
+	if (pop_flags) {
+		_scp_edx = *(long *)_scp_rsp; // flags
+		_scp_rsp += sizeof(long);
+	}
+	else
+		_scp_edx = _scp_eflags;
+	_scp_rip = *(long *)_scp_rsp;
+	_scp_rsp += sizeof(long);
+	return 1;
+}
+
 /* this function is called from dosemu_fault */
 static int e_emu_pagefault(sigcontext_t *scp, int pmode)
 {
@@ -259,16 +275,9 @@ static int e_emu_pagefault(sigcontext_t *scp, int pmode)
 	if (msdos_ldt_access(cr2) && Cpatch(scp))
 	    return 1;
 	TheCPU.scp_err = _scp_err;
-	/* save eip, eflags, and do a "ret" out of compiled code */
 	TheCPU.err = EXCP0E_PAGE;
-	_scp_eax = FindPC((unsigned char *)_scp_rip);
-	e_printf("FindPC: found %x\n",_scp_eax);
-	_scp_edx = *(long *)_scp_rsp; // flags
-	_scp_rsp += sizeof(long);
 	TheCPU.cr[2] = cr2;
-	_scp_rip = *(long *)_scp_rsp;
-	_scp_rsp += sizeof(long);
-	return 1;
+	return e_return_from_jit(scp, 1);
     }
     return 0;
 }
@@ -411,11 +420,7 @@ int e_handle_fault(sigcontext_t *scp)
 		return 0;
 	}
 	TheCPU.err = EXCP00_DIVZ + _scp_trapno;
-	_scp_eax = LONG_CS + TheCPU.eip;
-	_scp_edx = _scp_eflags;
-	_scp_rip = *(long *)_scp_rsp;
-	_scp_rsp += sizeof(long);
-	return 1;
+	return e_return_from_jit(scp, 0);
 }
 
 /* ======================================================================= */


### PR DESCRIPTION
To prepare for #2650 

DIV/IDIV can use FindPC for division by 0.
Protected mode IRET/RETl/RETlisp can use Sim_helper.
JMPli, CALLli (pm and rm), INT (rm only, as pm GPFs) can use a register.

Only real mode IRET/RETl/RETlisp still use it but they can't cause a protected mode page fault, and will return from JIT immediately after, so DIVZ exceptions aren't affected either.

I tested this case of wrap with KVM in DOS debug:
`les ax,[fffe]`
and it does wrap around, takes es from ds:0.

So the only wrap that could affect us is on odd accesses (e.g. `les ax,[ffff]`), which we don't handle properly at all, and would be a lot more work, so I kept real mode IRET/RETl/RETlisp compiled.
