### PR TITLE
simx86: eliminate more users of TheCPU.eip

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -2149,7 +2149,7 @@ static unsigned int Gen_sim(IGen *IG, unsigned int *pmem_ref,
 		DR1.d = Sim_helper(mem_ref, DR1.d, mode,
 				   &flags, IG->p0, IG->p1, currentIG);
 		FlagSync_RFL(flags);
-		if (TheCPU.err)
+		if (TheCPU.err > 0)
 			P0 = IG->p2;
 		break;
 		}
@@ -3124,10 +3124,11 @@ static unsigned int _Sim_helper(unsigned int mem_ref, unsigned int data, int mod
 			/* non-segment GPF handled in interpreter */
 			assert(!(V86MODE() && IOPL!=3 && !(TheCPU.cr[4] & CR4_VME)));
 			temp = data;
-			/* IRET always returns with the new PC, we need to
-			   flag that TF is set via an exception code that doesn't
+			/* IRET always returns with the new PC;
+			   TF is set via a negative exception code that doesn't
 			   interrupt the IRET */
-			data = (temp & TF) ? EXCP_TFSET : 0;
+			if (temp & TF)
+			    TheCPU.err = -EXCP_TFSET;
 			if (debug_level('e')>1) {
 				e_printf("IRET: ret=%04x:%08x\n",TheCPU.cs,TheCPU.eip);
 			}
@@ -3197,10 +3198,9 @@ stack_return_from_vm86:
 				    if (debug_level('e')>1)
 					e_printf("Return for STI fl=%08x\n",
 						 EFLAGS);
-				    if (opc == POPF)
-					TheCPU.err = (is_tf ? EXCP01_SSTP : EXCP_STISIGNAL);
-				    else
-					data = (is_tf ? EXCP01_SSTP : EXCP_STISIGNAL);
+				    TheCPU.err = (is_tf ? EXCP01_SSTP : EXCP_STISIGNAL);
+				    if (opc == IRET)
+					TheCPU.err = -TheCPU.err; /* avoid early exit */
 				}
 			    }
 			}

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -3096,34 +3096,37 @@ static unsigned int _Sim_helper(unsigned int mem_ref, unsigned int data, int mod
 /*ca*/	case RETlisp:
 /*cb*/	case RETl:
 /*cf*/	case IRET: {	/* restartable */
-			if (!REALADDR()) {
+			temp = data;
+			if (!REALADDR() || opc == IRET) {
 				unsigned int cs, eip;
 				unsigned int sp = rESP & TheCPU.StackMask;
 				if (mode&DATA16) {
 					eip = POPw(sp);
 					cs = POPw(sp);
-					if (opc == IRET) data = POPw(sp);
+					if (opc == IRET) temp = POPw(sp);
 				}
 				else {
 					eip = POPl(sp);
 					cs = POPl(sp);
-					if (opc == IRET) data = POPl(sp);
+					if (opc == IRET) temp = POPl(sp);
 				}
 				if (opc == RETlisp) {
 					sp += arg;
 					sp &= TheCPU.StackMask;
 				}
 				rESP = sp | (rESP&~TheCPU.StackMask);
-				if (SetSegProt_helper(cs, Ofs_CS) < 0)
+				if (REALADDR()) {
+					TheCPU.cs = cs;
+					LONG_CS = cs << 4;
+				}
+				else if (SetSegProt_helper(cs, Ofs_CS) < 0)
 					break;
-				/* safe to do here after any potential
-				   page fault: we return to the main loop after */
-				TheCPU.eip = eip;
+				/* eax used by JMP_INDIRECT */
+				data = eip;
 			}
 			if (opc != IRET) break;
 			/* non-segment GPF handled in interpreter */
 			assert(!(V86MODE() && IOPL!=3 && !(TheCPU.cr[4] & CR4_VME)));
-			temp = data;
 			/* IRET always returns with the new PC;
 			   TF is set via a negative exception code that doesn't
 			   interrupt the IRET */

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -1644,11 +1644,11 @@ shrot0:
 
 		// cmpl $0x0,Ofs_ERR(%rbx)
 		G4M(0x83,0x7b,Ofs_ERR,0x00,Cp);
-		// jz skip
+		// jle skip: negative TheCPU.err allow completion
 #ifdef __x86_64__
-		G2M(JE_JZ,TAILSIZE+4,Cp);
+		G2M(JLE_JNG,TAILSIZE+4,Cp);
 #else
-		G2M(JE_JZ,TAILSIZE+1+4+1+4+1+1+4+1+1+3+3+1,Cp);
+		G2M(JLE_JNG,TAILSIZE+1+4+1+4+1+1+4+1+1+3+3+1,Cp);
 #endif
 		// movl {exit_addr},%%eax; movl %eax,%ecx;  pop %%edx; ret
 		G1(MOViax,Cp); G4(IG->p2,Cp); G4M(0x89,0xc1,POPdx,RET,Cp);

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -595,6 +595,7 @@ static void Exec_post(unsigned long flg, unsigned int mem_ref,
 	EFLAGS = (EFLAGS & ~EFLAGS_CC) | (flg &	EFLAGS_CC);
 	TheCPU.mem_ref = mem_ref;
 	CEmuStat &= ~CeS_STI;
+	TheCPU.err = abs(TheCPU.err);
 	if (TheCPU.err == EXCP_STISHADOW) {
 		CEmuStat |= CeS_STI;
 		TheCPU.err = 0;

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -1794,8 +1794,6 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 				Gen(O_POP, _mode);
 			}
 			Gen(O_SIM, _mode, opc, 0, P0);
-			/* to process EXCP_TFSET */
-			Gen(S_REG, _mode & ~DATA16, Ofs_ERR);
 			PC = JumpGen(PC, Interp_LONG_CS, _mode, opc, 1);
 			break;
 /*9d*/	case POPF:

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -323,8 +323,6 @@ static unsigned int JumpGen(unsigned int P2, unsigned int Interp_LONG_CS,
 		Gen(JMP_LINK, mode, j_t, InstrMeta[0].npc);
 		break;
 	case RETl: case RETlisp: case IRET: // far ret, indirect
-		Gen(L_REG, mode, Ofs_EIP);
-		/* fall through */
 	case JMPli: case CALLli: case INT: // far jmp/call, indirect
 	case RET: case RETisp: case JMPi: case CALLi: // ret, indirect
 		Gen(JMP_INDIRECT, mode);
@@ -1695,6 +1693,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 				Gen(O_POP2, _mode|MNOREG|MRETISP, dr);
 				AddrGen(A_SR_SH4, _mode, Ofs_CS, Ofs_XCS);
 				Gen(O_POP3, _mode);
+				Gen(L_REG, _mode, Ofs_EIP);
 			}
 			else {
 				Gen(O_SIM, _mode, opc, dr, P0);
@@ -1773,6 +1772,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 				Gen(O_POP2, _mode|MNOREG);
 				AddrGen(A_SR_SH4, _mode, Ofs_CS, Ofs_XCS);
 				Gen(O_POP3, _mode);
+				Gen(L_REG, _mode, Ofs_EIP);
 			}
 			else {
 				Gen(O_SIM, _mode, opc, 0, P0);
@@ -1783,15 +1783,6 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 /*cf*/	case IRET:	/* restartable */
 			if (V86MODE() && IOPL!=3 && !(TheCPU.cr[4] & CR4_VME)) {
 			    PC++; goto not_permitted;	/* GPF */
-			}
-			if (REALADDR()) {
-				/* pop from stack without adjusting esp before A_SR_* */
-				Gen(O_POP1, _mode);
-				Gen(O_POP2, _mode, Ofs_EIP);
-				Gen(O_POP2, _mode|MNOREG);
-				AddrGen(A_SR_SH4, _mode, Ofs_CS, Ofs_XCS);
-				Gen(O_POP3, _mode);
-				Gen(O_POP, _mode);
 			}
 			Gen(O_SIM, _mode, opc, 0, P0);
 			PC = JumpGen(PC, Interp_LONG_CS, _mode, opc, 1);

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -1699,7 +1699,6 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			else {
 				Gen(O_SIM, _mode, opc, dr, P0);
 			}
-			Gen(O_POP3, _mode);
 			PC = JumpGen(PC, Interp_LONG_CS, _mode, opc, 3);
 			if (debug_level('e')>2)
 				e_printf("RET_%d: ret=%08x\n",dr,TheCPU.eip);


### PR DESCRIPTION
Follow-up to #2651 to address comments.
Also found a small regression.

Only vm86 lret/lretisp still set TheCPU.eip, they are more tricky.
