### PR TITLE
simx86: handle PM far calls via Sim_helper (#2650)

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -2977,6 +2977,14 @@ static __inline__ void SetCPU_WL(int m, signed char o, unsigned long v)
 	unsigned int __res = sim_read_dword(LONG_SS + sp); \
 	sp += 4; sp &= TheCPU.StackMask; __res; })
 
+#define PUSHw(sp,w) ({ \
+	sp -= 2; sp &= TheCPU.StackMask; \
+	sim_write_word(LONG_SS + sp, w); })
+
+#define PUSHl(sp,l) ({ \
+	sp -= 4; sp &= TheCPU.StackMask; \
+	sim_write_dword(LONG_SS + sp, l); })
+
 /* This generic helper function is called from JIT generated code and from
  * Gen_sim to simulate hard-to-compile and rarely used ops.
  * parameters:
@@ -3093,6 +3101,33 @@ static unsigned int _Sim_helper(unsigned int mem_ref, unsigned int data, int mod
 					    inum, _AX, _CS, _IP);
 			break;
 		       }
+/*9a*/	case CALLl: {	/* restartable */
+			unsigned int oldcs = TheCPU.cs;
+			unsigned int oldeip = arg;
+			unsigned int newcs = data;
+			unsigned int sp;
+			int e = SetSegProt_check(Ofs_CS, newcs);
+			if (e > 0)
+				break;
+			sp = rESP;
+			if (mode&DATA16) {
+				PUSHw(sp,oldcs);
+				PUSHw(sp,oldeip);
+			}
+			else {
+				PUSHl(sp,oldcs);
+				PUSHl(sp,oldeip);
+			}
+			if (debug_level('e')>2) {
+				dbug_printf("CALL_FAR: ret=%04x:%08x\n  calling:      cs=%04x\n",
+					    oldcs,oldeip,newcs);
+			}
+			rESP = sp | (rESP&~TheCPU.StackMask);
+			// -1 means cached, nothing to set
+			if (e == 0)
+				SetSegProt_set(Ofs_CS, data);
+			break;
+			}
 /*ca*/	case RETlisp:
 /*cb*/	case RETl:
 /*cf*/	case IRET: {	/* restartable */

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -706,20 +706,20 @@ static void Scp2CpuD(cpuctx_t *scp)
   TheCPU.cr[0] |= 1;
   mode |= ADDR16;
   InvalidateSegs(); // makes sure real mode segs aren't confused with PM sels
-  TheCPU.err = SetSegProt(mode&ADDR16,Ofs_CS,&big,_cs);
+  TheCPU.err = SetSegProt(Ofs_CS,&big,_cs);
   if (TheCPU.err) goto erseg;
   if (big) mode=MBIGCS; else mode |= DATA16;
 
-  TheCPU.err = SetSegProt(mode&ADDR16,Ofs_DS,&big,_ds);
+  TheCPU.err = SetSegProt(Ofs_DS,&big,_ds);
   if (TheCPU.err) goto erseg;
-  TheCPU.err = SetSegProt(mode&ADDR16,Ofs_SS,&big,_ss);
+  TheCPU.err = SetSegProt(Ofs_SS,&big,_ss);
   if (TheCPU.err) goto erseg;
   TheCPU.StackMask = (big? 0xffffffff : 0x0000ffff);
-  TheCPU.err = SetSegProt(mode&ADDR16,Ofs_ES,&big,_es);
+  TheCPU.err = SetSegProt(Ofs_ES,&big,_es);
   if (TheCPU.err) goto erseg;
-  TheCPU.err = SetSegProt(mode&ADDR16,Ofs_FS,&big,_fs);
+  TheCPU.err = SetSegProt(Ofs_FS,&big,_fs);
   if (TheCPU.err) goto erseg;
-  TheCPU.err = SetSegProt(mode&ADDR16,Ofs_GS,&big,_gs);
+  TheCPU.err = SetSegProt(Ofs_GS,&big,_gs);
 erseg:
   if (debug_level('e')>1) {
 	e_printf("Scp2CpuD%s: CS:IP=%08x:%08x\n%s\n",

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -704,18 +704,18 @@ static void Scp2CpuD(cpuctx_t *scp)
   TheCPU.cr[0] |= 1;
   InvalidateSegs(); // makes sure real mode segs aren't confused with PM sels
   TheCPU.mode = 0;
-  TheCPU.err = SetSegProt(Ofs_CS,_cs);
+  SetSegProt(Ofs_CS,_cs);
   if (TheCPU.err) goto erseg;
 
-  TheCPU.err = SetSegProt(Ofs_DS,_ds);
+  SetSegProt(Ofs_DS,_ds);
   if (TheCPU.err) goto erseg;
-  TheCPU.err = SetSegProt(Ofs_SS,_ss);
+  SetSegProt(Ofs_SS,_ss);
   if (TheCPU.err) goto erseg;
-  TheCPU.err = SetSegProt(Ofs_ES,_es);
+  SetSegProt(Ofs_ES,_es);
   if (TheCPU.err) goto erseg;
-  TheCPU.err = SetSegProt(Ofs_FS,_fs);
+  SetSegProt(Ofs_FS,_fs);
   if (TheCPU.err) goto erseg;
-  TheCPU.err = SetSegProt(Ofs_GS,_gs);
+  SetSegProt(Ofs_GS,_gs);
 erseg:
   if (debug_level('e')>1) {
 	e_printf("Scp2CpuD%s: CS:IP=%08x:%08x\n%s\n",

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -698,28 +698,24 @@ static void Cpu2Scp(cpuctx_t *scp, int trapno)
  */
 static void Scp2CpuD(cpuctx_t *scp)
 {
-  unsigned char big; int mode=0;
-
   Scp2Cpu(scp);
 
   /* make clear we are in PM now */
   TheCPU.cr[0] |= 1;
-  mode |= ADDR16;
   InvalidateSegs(); // makes sure real mode segs aren't confused with PM sels
-  TheCPU.err = SetSegProt(Ofs_CS,&big,_cs);
+  TheCPU.mode = 0;
+  TheCPU.err = SetSegProt(Ofs_CS,_cs);
   if (TheCPU.err) goto erseg;
-  if (big) mode=MBIGCS; else mode |= DATA16;
 
-  TheCPU.err = SetSegProt(Ofs_DS,&big,_ds);
+  TheCPU.err = SetSegProt(Ofs_DS,_ds);
   if (TheCPU.err) goto erseg;
-  TheCPU.err = SetSegProt(Ofs_SS,&big,_ss);
+  TheCPU.err = SetSegProt(Ofs_SS,_ss);
   if (TheCPU.err) goto erseg;
-  TheCPU.StackMask = (big? 0xffffffff : 0x0000ffff);
-  TheCPU.err = SetSegProt(Ofs_ES,&big,_es);
+  TheCPU.err = SetSegProt(Ofs_ES,_es);
   if (TheCPU.err) goto erseg;
-  TheCPU.err = SetSegProt(Ofs_FS,&big,_fs);
+  TheCPU.err = SetSegProt(Ofs_FS,_fs);
   if (TheCPU.err) goto erseg;
-  TheCPU.err = SetSegProt(Ofs_GS,&big,_gs);
+  TheCPU.err = SetSegProt(Ofs_GS,_gs);
 erseg:
   if (debug_level('e')>1) {
 	e_printf("Scp2CpuD%s: CS:IP=%08x:%08x\n%s\n",
@@ -727,7 +723,6 @@ erseg:
 			LONG_CS, _eip,
 			e_print_regs(LONG_CS));
   }
-  TheCPU.mode = mode;
 }
 
 

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -295,16 +295,16 @@ static unsigned int JumpGen(unsigned int P2, unsigned int Interp_LONG_CS,
 		break;
 	case CALLl: {   /* call far */
 		unsigned short jcs = FetchW(P2 + pskip - 2);
-		Gen(L_IMM_R1, mode|DATA16, jcs);
-		if (REALADDR())
+		Gen(L_IMM_R1, mode&~DATA16, jcs);
+		if (REALADDR()) {
 		    AddrGen(A_SR_SH4, mode, Ofs_CS, Ofs_XCS);
-		else
-		    /* check if new cs is valid, load if so */
-		    AddrGen(A_SR_PROT, mode, Ofs_CS, P2);
-		/* ok, now push old cs (returned by A_SR_*):eip */
-		Gen(O_PUSH, mode);
-		if (!REALADDR()) {
-		    Gen(O_PUSHI, mode, d_nt);
+		    /* ok, now push old cs (returned by A_SR_SH4):eip */
+		    Gen(O_PUSH, mode);
+		    /* fall through */
+		}
+		else {
+		    /* handle PM far calls via Sim_helper() */
+		    Gen(O_SIM, mode, opc, d_nt, P2);
 		    /* transfer to new PC (indirect jmp) */
 		    Gen(L_IMM_R1, mode, d_t);
 		    Gen(JMP_INDIRECT, mode);
@@ -2185,13 +2185,19 @@ repag0:
 					Gen(L_LXS2, _mode);
 					if (REALADDR())
 					    AddrGen(A_SR_SH4, _mode, Ofs_CS, Ofs_XCS);
-					else
+					else if (REG1==Ofs_BP) /* PM JMP */
 					    AddrGen(A_SR_PROT, _mode, Ofs_CS, P0);
 					if (REG1==Ofs_BX) {
 					    /* ok, now push old cs:eip */
 					    oip = PC + len - Interp_LONG_CS;
-					    Gen(O_PUSH, _mode);
-					    Gen(O_PUSHI, _mode, oip);
+					    if (REALADDR()) {
+						Gen(O_PUSH, _mode);
+						Gen(O_PUSHI, _mode, oip);
+					    }
+					    else {
+						/* handle PM far calls via Sim_helper() */
+						Gen(O_SIM, _mode, CALLl, oip, P0);
+					    }
 					}
 					Gen(L_DI_R1, _mode);
 					PC = JumpGen(PC, Interp_LONG_CS, _mode,

--- a/src/base/emu-i386/simx86/protmode.c
+++ b/src/base/emu-i386/simx86/protmode.c
@@ -97,11 +97,9 @@ int SetSegReal(unsigned short sel, int ofs)
 static int _SetSegProt_helper(unsigned short sel, int ofs)
 {
 	int oldsel = CPUWORD(ofs);
-	int e = SetSegProt(ofs, sel);
-	if (e) {
-		TheCPU.err = e;
-		oldsel = -1; /* invalid old value flags error */
-	}
+	SetSegProt(ofs, sel);
+	if (TheCPU.err)
+		return -1; /* -1 flags error */
 	return oldsel;
 }
 
@@ -115,30 +113,24 @@ int SetSegProt_helper(unsigned short sel, int ofs)
 	return ret;
 }
 
-int SetSegProt(int ofs, unsigned long sel)
+static int _SetSegProt_check(int ofs, unsigned long sel)
 {
 	static char buf[4];
 	unsigned short wFlags, sys;
-	unsigned char lbig = 0;
 	Descriptor *dt;
 	SDTR *sd;
-	int a16;
-	unsigned int orig_scp_err = TheCPU.scp_err;
 
 	sd = (SDTR *)CPUOFFS(e_ofsseg(ofs));
 
 	if (CPUWORD(ofs) == sel && (sd->BoundH - sd->BoundL) != SDTR_INVALID_LIMIT) {
 	    if (debug_level('e') >= 9)
 		e_printf("SetSeg PROT %s%04lx cached\n",MKOFSNAM(ofs,buf),sel);
-	    return 0;
+	    return -1;
 	}
-	TheCPU.scp_err = sel & 0xfffc;
 
 	if (sel < 4) {
 	    if ((ofs==Ofs_CS)||(ofs==Ofs_SS)) return EXCP0D_GPF;
-	    sd->BoundL = 0xc0000000;
-	    sd->BoundH = sd->BoundL;
-	    goto valid;	/* DS..GS can be 0 for some while */
+	    return 0;	/* DS..GS can be 0 for some while */
 	}
 
 	/* DT checks */
@@ -161,7 +153,6 @@ int SetSegProt(int ofs, unsigned long sel)
 	    }
 #endif
 	}
-	/* should set CPL here if seg==CS ??? */
 	wFlags = GetSelectorFlags(sel);
 	sys = (wFlags & DF_USER);
 	if (!(wFlags & DF_PRESENT)) {
@@ -169,15 +160,12 @@ int SetSegProt(int ofs, unsigned long sel)
 	    if (ofs==Ofs_SS) return EXCP0C_STACK;
 		else return EXCP0B_NOSEG;
 	}
-	lbig = (wFlags & DF_32)? 0xff : 0;
 	if (!sys) {	/* must be GDT now */
 	    unsigned short sx = sysxfer[wFlags&15];
 	    if (debug_level('e')>3)
 	        e_printf("GDT system segment %#lx type %d\n",sel,sx);
 	    if (sx==DT_NO_XFER) return EXCP0D_GPF;
-	    sd->BoundL = 0;
-	    sd->BoundH = 0;	  /* try to trap if not checked */
-	    goto valid;	  /* will check sys segment again later */
+	    return 0;	  /* will check sys segment again later */
 	}
 	/* check data/code */
 	if (ofs==Ofs_CS) {
@@ -186,10 +174,8 @@ int SetSegProt(int ofs, unsigned long sel)
 		dbug_printf("Attempt to execute into data segment %lx\n",sel);
 		return EXCP0D_GPF;
 	    }
-	    a16 = (lbig? 0:ADDR16);
 	}
 	else {
-	    a16 = TheCPU.mode & ADDR16;
 	    /* we CAN move a code sel into [DEFG]S provided that it
 	     * can be read - but how can we trap writes? */
 	    /* Error summary (Intel):
@@ -206,6 +192,32 @@ int SetSegProt(int ofs, unsigned long sel)
 	    if ((wFlags & DF_CODE)&&(!(wFlags & DF_CREADABLE)))
 		    return EXCP0D_GPF;
 	}
+	return 0;
+}
+
+static int SetSegProt_check(int ofs, unsigned long sel)
+{
+	int e = _SetSegProt_check(ofs, sel);
+	if (e > 0) {
+		TheCPU.err = e;
+		TheCPU.scp_err = sel & 0xfffc;
+	}
+	return e;
+}
+
+static void SetSegProt_set(int ofs, unsigned long sel)
+{
+	static char buf[4];
+	unsigned short wFlags = GetSelectorFlags(sel);
+	unsigned char lbig = (wFlags & DF_32)? 0xff : 0;
+	SDTR *sd = (SDTR *)CPUOFFS(e_ofsseg(ofs));
+	int a16;
+
+	/* should set CPL here if seg==CS ??? */
+	if (ofs==Ofs_CS)
+	    a16 = (lbig? 0:ADDR16);
+	else
+	    a16 = TheCPU.mode & ADDR16;
 	if (lbig && a16) {
 	    if (debug_level('e')>3)
 	        e_printf("Large segment %#lx in 16-bit mode\n",sel);
@@ -214,18 +226,24 @@ int SetSegProt(int ofs, unsigned long sel)
 	    if (debug_level('e')>3)
 	        e_printf("Small segment %#lx in 32-bit mode\n",sel);
 	}
-	SetFlagAccessed(sel);
-	sd->BoundL = GetPhysicalAddress(sel);
-	sd->BoundH = sd->BoundL + GetSelectorByteLimit(sel);
-	if (debug_level('e')>7)
-	    e_printf("SetSeg PROT %s%04lx\n",MKOFSNAM(ofs,buf),sel);
-
+	if (sel < 4) {
+	    sd->BoundL = 0xc0000000;
+	    sd->BoundH = sd->BoundL;
+	}
+	else if (!(wFlags & DF_USER)) { /* must be GDT now */
+	    sd->BoundL = 0;
+	    sd->BoundH = 0;	  /* try to trap if not checked */
+	}
+	else {
+	    SetFlagAccessed(sel);
+	    sd->BoundL = GetPhysicalAddress(sel);
+	    sd->BoundH = sd->BoundL + GetSelectorByteLimit(sel);
+	}
 	if (debug_level('e')>7) {
+		e_printf("SetSeg PROT %s%04lx\n",MKOFSNAM(ofs,buf),sel);
 		e_printf("PMSEL %#04lx bounds=%08x:%08x flg=%04x big=%d\n",
 			sel, sd->BoundL, sd->BoundH, wFlags, lbig&1);
 	}
-valid:
-	TheCPU.scp_err = orig_scp_err;
 	CPUWORD(ofs) = sel;
 	if (ofs==Ofs_SS) {
 		TheCPU.StackMask = (lbig? 0xffffffff : 0x0000ffff);
@@ -236,7 +254,14 @@ valid:
 		else TheCPU.mode |= (ADDR16|DATA16);
 		if (debug_level('e')>1) e_printf("MAKESEG CS: big=%d basemode=%04x\n",lbig&1,TheCPU.mode);
 	}
-	return 0;
+}
+
+void SetSegProt(int ofs, unsigned long sel)
+{
+	int e = SetSegProt_check(ofs, sel);
+	/* e == -1 means cached, no need to set */
+	if (e == 0)
+		SetSegProt_set(ofs, sel);
 }
 
 #if 0

--- a/src/base/emu-i386/simx86/protmode.c
+++ b/src/base/emu-i386/simx86/protmode.c
@@ -98,7 +98,7 @@ static int _SetSegProt_helper(unsigned short sel, int ofs)
 {
 	unsigned char big;
 	int oldsel = CPUWORD(ofs);
-	int e = SetSegProt(TheCPU.mode&ADDR16, ofs, &big, sel);
+	int e = SetSegProt(ofs, &big, sel);
 	if (e) {
 		TheCPU.err = e;
 		oldsel = -1; /* invalid old value flags error */
@@ -124,13 +124,14 @@ int SetSegProt_helper(unsigned short sel, int ofs)
 	return ret;
 }
 
-int SetSegProt(int a16, int ofs, unsigned char *big, unsigned long sel)
+int SetSegProt(int ofs, unsigned char *big, unsigned long sel)
 {
 	static char buf[4];
 	unsigned short wFlags, sys;
 	unsigned char lbig;
 	Descriptor *dt;
 	SDTR *sd;
+	int a16;
 	unsigned int orig_scp_err = TheCPU.scp_err;
 
 	sd = (SDTR *)CPUOFFS(e_ofsseg(ofs));
@@ -200,6 +201,7 @@ int SetSegProt(int a16, int ofs, unsigned char *big, unsigned long sel)
 	    a16 = (lbig? 0:ADDR16);
 	}
 	else {
+	    a16 = TheCPU.mode & ADDR16;
 	    /* we CAN move a code sel into [DEFG]S provided that it
 	     * can be read - but how can we trap writes? */
 	    /* Error summary (Intel):
@@ -413,9 +415,9 @@ int emu_ldt_write(dosaddr_t addr, uint32_t op, int len)
 	_fs = TheCPU.fs;
 	_gs = TheCPU.gs;
 	msdos_ldt_write(scp, op, len, _cr2);
-	if (_ds == 0) { TheCPU.ds = 0; SetSegProt(0,Ofs_DS,NULL,0); }
-	if (_es == 0) { TheCPU.es = 0; SetSegProt(0,Ofs_ES,NULL,0); }
-	if (_fs == 0) { TheCPU.fs = 0; SetSegProt(0,Ofs_FS,NULL,0); }
-	if (_gs == 0) { TheCPU.gs = 0; SetSegProt(0,Ofs_GS,NULL,0); }
+	if (_ds == 0) { TheCPU.ds = 0; SetSegProt(Ofs_DS,NULL,0); }
+	if (_es == 0) { TheCPU.es = 0; SetSegProt(Ofs_ES,NULL,0); }
+	if (_fs == 0) { TheCPU.fs = 0; SetSegProt(Ofs_FS,NULL,0); }
+	if (_gs == 0) { TheCPU.gs = 0; SetSegProt(Ofs_GS,NULL,0); }
 	return 1;
 }

--- a/src/base/emu-i386/simx86/protmode.c
+++ b/src/base/emu-i386/simx86/protmode.c
@@ -96,20 +96,11 @@ int SetSegReal(unsigned short sel, int ofs)
 // this function is called from JIT-generated code
 static int _SetSegProt_helper(unsigned short sel, int ofs)
 {
-	unsigned char big;
 	int oldsel = CPUWORD(ofs);
-	int e = SetSegProt(ofs, &big, sel);
+	int e = SetSegProt(ofs, sel);
 	if (e) {
 		TheCPU.err = e;
 		oldsel = -1; /* invalid old value flags error */
-	} else if (ofs==Ofs_SS) {
-		TheCPU.StackMask = (big? 0xffffffff : 0x0000ffff);
-		if (debug_level('e')>1) e_printf("MAKESEG SS: big=%d basemode=%04x\n",big&1,TheCPU.mode);
-	} else if (ofs==Ofs_CS) {
-		TheCPU.mode &= ~(ADDR16|DATA16|MBIGCS);
-		if (big) TheCPU.mode |= MBIGCS;
-		else TheCPU.mode |= (ADDR16|DATA16);
-		if (debug_level('e')>1) e_printf("MAKESEG CS: big=%d basemode=%04x\n",big&1,TheCPU.mode);
 	}
 	return oldsel;
 }
@@ -124,11 +115,11 @@ int SetSegProt_helper(unsigned short sel, int ofs)
 	return ret;
 }
 
-int SetSegProt(int ofs, unsigned char *big, unsigned long sel)
+int SetSegProt(int ofs, unsigned long sel)
 {
 	static char buf[4];
 	unsigned short wFlags, sys;
-	unsigned char lbig;
+	unsigned char lbig = 0;
 	Descriptor *dt;
 	SDTR *sd;
 	int a16;
@@ -139,7 +130,6 @@ int SetSegProt(int ofs, unsigned char *big, unsigned long sel)
 	if (CPUWORD(ofs) == sel && (sd->BoundH - sd->BoundL) != SDTR_INVALID_LIMIT) {
 	    if (debug_level('e') >= 9)
 		e_printf("SetSeg PROT %s%04lx cached\n",MKOFSNAM(ofs,buf),sel);
-	    if (big) *big = (GetSelectorFlags(sel) & DF_32)? 0xff : 0;
 	    return 0;
 	}
 	TheCPU.scp_err = sel & 0xfffc;
@@ -148,8 +138,7 @@ int SetSegProt(int ofs, unsigned char *big, unsigned long sel)
 	    if ((ofs==Ofs_CS)||(ofs==Ofs_SS)) return EXCP0D_GPF;
 	    sd->BoundL = 0xc0000000;
 	    sd->BoundH = sd->BoundL;
-	    CPUWORD(ofs) = sel;
-	    return 0;	/* DS..GS can be 0 for some while */
+	    goto valid;	/* DS..GS can be 0 for some while */
 	}
 
 	/* DT checks */
@@ -180,6 +169,7 @@ int SetSegProt(int ofs, unsigned char *big, unsigned long sel)
 	    if (ofs==Ofs_SS) return EXCP0C_STACK;
 		else return EXCP0B_NOSEG;
 	}
+	lbig = (wFlags & DF_32)? 0xff : 0;
 	if (!sys) {	/* must be GDT now */
 	    unsigned short sx = sysxfer[wFlags&15];
 	    if (debug_level('e')>3)
@@ -187,10 +177,8 @@ int SetSegProt(int ofs, unsigned char *big, unsigned long sel)
 	    if (sx==DT_NO_XFER) return EXCP0D_GPF;
 	    sd->BoundL = 0;
 	    sd->BoundH = 0;	  /* try to trap if not checked */
-	    CPUWORD(ofs) = sel;
-	    return 0;	  /* will check sys segment again later */
+	    goto valid;	  /* will check sys segment again later */
 	}
-	lbig = (wFlags & DF_32)? 0xff : 0;
 	/* check data/code */
 	if (ofs==Ofs_CS) {
 	    /* data can't be executed... really? */
@@ -232,13 +220,22 @@ int SetSegProt(int ofs, unsigned char *big, unsigned long sel)
 	if (debug_level('e')>7)
 	    e_printf("SetSeg PROT %s%04lx\n",MKOFSNAM(ofs,buf),sel);
 
-	if (big) *big = lbig;
 	if (debug_level('e')>7) {
 		e_printf("PMSEL %#04lx bounds=%08x:%08x flg=%04x big=%d\n",
 			sel, sd->BoundL, sd->BoundH, wFlags, lbig&1);
 	}
+valid:
 	TheCPU.scp_err = orig_scp_err;
 	CPUWORD(ofs) = sel;
+	if (ofs==Ofs_SS) {
+		TheCPU.StackMask = (lbig? 0xffffffff : 0x0000ffff);
+		if (debug_level('e')>1) e_printf("MAKESEG SS: big=%d basemode=%04x\n",lbig&1,TheCPU.mode);
+	} else if (ofs==Ofs_CS) {
+		TheCPU.mode &= ~(ADDR16|DATA16|MBIGCS);
+		if (lbig) TheCPU.mode |= MBIGCS;
+		else TheCPU.mode |= (ADDR16|DATA16);
+		if (debug_level('e')>1) e_printf("MAKESEG CS: big=%d basemode=%04x\n",lbig&1,TheCPU.mode);
+	}
 	return 0;
 }
 
@@ -415,9 +412,9 @@ int emu_ldt_write(dosaddr_t addr, uint32_t op, int len)
 	_fs = TheCPU.fs;
 	_gs = TheCPU.gs;
 	msdos_ldt_write(scp, op, len, _cr2);
-	if (_ds == 0) { TheCPU.ds = 0; SetSegProt(Ofs_DS,NULL,0); }
-	if (_es == 0) { TheCPU.es = 0; SetSegProt(Ofs_ES,NULL,0); }
-	if (_fs == 0) { TheCPU.fs = 0; SetSegProt(Ofs_FS,NULL,0); }
-	if (_gs == 0) { TheCPU.gs = 0; SetSegProt(Ofs_GS,NULL,0); }
+	if (_ds == 0) { TheCPU.ds = 0; SetSegProt(Ofs_DS,0); }
+	if (_es == 0) { TheCPU.es = 0; SetSegProt(Ofs_ES,0); }
+	if (_fs == 0) { TheCPU.fs = 0; SetSegProt(Ofs_FS,0); }
+	if (_gs == 0) { TheCPU.gs = 0; SetSegProt(Ofs_GS,0); }
 	return 1;
 }

--- a/src/base/emu-i386/simx86/protmode.c
+++ b/src/base/emu-i386/simx86/protmode.c
@@ -195,7 +195,7 @@ static int _SetSegProt_check(int ofs, unsigned long sel)
 	return 0;
 }
 
-static int SetSegProt_check(int ofs, unsigned long sel)
+int SetSegProt_check(int ofs, unsigned long sel)
 {
 	int e = _SetSegProt_check(ofs, sel);
 	if (e > 0) {
@@ -205,7 +205,7 @@ static int SetSegProt_check(int ofs, unsigned long sel)
 	return e;
 }
 
-static void SetSegProt_set(int ofs, unsigned long sel)
+void SetSegProt_set(int ofs, unsigned long sel)
 {
 	static char buf[4];
 	unsigned short wFlags = GetSelectorFlags(sel);

--- a/src/base/emu-i386/simx86/protmode.h
+++ b/src/base/emu-i386/simx86/protmode.h
@@ -228,6 +228,8 @@ typedef struct {
 //
 extern unsigned char e_ofsseg(int ofs);
 //
+int SetSegProt_check(int ofs, unsigned long sel);
+void SetSegProt_set(int ofs, unsigned long sel);
 void SetSegProt(int ofs, unsigned long sel);
 int SetSegProt_helper(unsigned short sv, int ofs);
 int SetSegReal(unsigned short sel, int ofs);

--- a/src/base/emu-i386/simx86/protmode.h
+++ b/src/base/emu-i386/simx86/protmode.h
@@ -228,7 +228,7 @@ typedef struct {
 //
 extern unsigned char e_ofsseg(int ofs);
 //
-int SetSegProt(int ofs, unsigned char *big, unsigned long sel);
+int SetSegProt(int ofs, unsigned long sel);
 int SetSegProt_helper(unsigned short sv, int ofs);
 int SetSegReal(unsigned short sel, int ofs);
 int e_larlsl(int mode, unsigned short sel);

--- a/src/base/emu-i386/simx86/protmode.h
+++ b/src/base/emu-i386/simx86/protmode.h
@@ -228,7 +228,7 @@ typedef struct {
 //
 extern unsigned char e_ofsseg(int ofs);
 //
-int SetSegProt(int ofs, unsigned long sel);
+void SetSegProt(int ofs, unsigned long sel);
 int SetSegProt_helper(unsigned short sv, int ofs);
 int SetSegReal(unsigned short sel, int ofs);
 int e_larlsl(int mode, unsigned short sel);

--- a/src/base/emu-i386/simx86/protmode.h
+++ b/src/base/emu-i386/simx86/protmode.h
@@ -228,7 +228,7 @@ typedef struct {
 //
 extern unsigned char e_ofsseg(int ofs);
 //
-int SetSegProt(int a16, int ofs, unsigned char *big, unsigned long sel);
+int SetSegProt(int ofs, unsigned char *big, unsigned long sel);
 int SetSegProt_helper(unsigned short sv, int ofs);
 int SetSegReal(unsigned short sel, int ofs);
 int e_larlsl(int mode, unsigned short sel);


### PR DESCRIPTION
To address https://github.com/dosemu2/dosemu2/pull/2650#discussion_r2463943595
far calls in PM need to be treated specially.

I had to cleanup SetSegProt and split it into two, a check and a set function, for this to work.