### PR TITLE
simx86: exit cleanup

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -3198,12 +3198,10 @@ static unsigned int _Sim_helper(unsigned int mem_ref, unsigned int data, int mod
 			if (temp & TF)
 			    exit_pending_or(exit_TFSET);
 			if (V86MODE()) {
-			    int is_tf;
 stack_return_from_vm86:
 			    if (debug_level('e')>1)
 				e_printf("Popped flags %08x fl=%08x\n",
 					temp,EFLAGS);
-			    is_tf = !!(EFLAGS & TF);
 			    if (IOPL==3) {	/* Intel manual */
 				/* keep reserved bits + IOPL,VIP,VIF,VM,RF */
 				if (mode & DATA16)
@@ -3229,14 +3227,11 @@ stack_return_from_vm86:
 				    if (debug_level('e')>1)
 					e_printf("Return for STI fl=%08x\n",
 						 EFLAGS);
-				    TheCPU.err = (is_tf ? EXCP01_SSTP : EXCP_STISIGNAL);
-				    if (opc == IRET)
-					TheCPU.err = -TheCPU.err; /* avoid early exit */
+				    exit_pending_or(exit_STI);
 				}
 			    }
 			}
 			else {
-			    int is_tf = !!(EFLAGS & TF);
 			    int amask = (CPL==0? 0:EFLAGS_IOPL_MASK) |
 					(CPL<=IOPL? 0:EFLAGS_IF) |
 					(EFLAGS_VM|EFLAGS_RF);
@@ -3260,7 +3255,7 @@ stack_return_from_vm86:
 				if (debug_level('e')>1)
 				    e_printf("Return for STI fl=%08x\n",
 					    EFLAGS);
-				TheCPU.err = (is_tf ? EXCP01_SSTP : EXCP_STISIGNAL);
+				exit_pending_or(exit_STI);
 			    }
 			}
 			*flags = (EFLAGS & EFLAGS_CC) | (*flags & ~EFLAGS_CC);
@@ -3290,7 +3285,7 @@ stack_return_from_vm86:
 				    if (debug_level('e')>1)
 					e_printf("Return for STI fl=%08x\n",
 					    EFLAGS);
-				    TheCPU.err=EXCP_STISIGNAL;
+				    exit_pending_or(exit_STI);
 				}
 			}
 			else {

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -3158,11 +3158,8 @@ static unsigned int _Sim_helper(unsigned int mem_ref, unsigned int data, int mod
 			if (opc != IRET) break;
 			/* non-segment GPF handled in interpreter */
 			assert(!(V86MODE() && IOPL!=3 && !(TheCPU.cr[4] & CR4_VME)));
-			/* IRET always returns with the new PC;
-			   TF is set via a negative exception code that doesn't
-			   interrupt the IRET */
 			if (temp & TF)
-			    TheCPU.err = -EXCP_TFSET;
+			    exit_pending_or(exit_TFSET);
 			if (debug_level('e')>1) {
 				e_printf("IRET: ret=%04x:%08x\n",TheCPU.cs,TheCPU.eip);
 			}
@@ -3199,7 +3196,7 @@ static unsigned int _Sim_helper(unsigned int mem_ref, unsigned int data, int mod
 			assert(!(V86MODE() && IOPL!=3 && !(TheCPU.cr[4] & CR4_VME)));
 			temp = data;
 			if (temp & TF)
-			    TheCPU.err = EXCP_TFSET;
+			    exit_pending_or(exit_TFSET);
 			if (V86MODE()) {
 			    int is_tf;
 stack_return_from_vm86:

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -3309,7 +3309,7 @@ stack_return_from_vm86:
 				    e_printf("Return for STI ASAP fl=%08x\n",
 					    EFLAGS);
 				/* force exit after next compiled block execution */
-				exit_pending_or(CeS_RPIC);
+				exit_pending_or(exit_RPIC);
 			    }
 			}
 			break;

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -585,8 +585,6 @@ static void Exec_post(unsigned long flg, unsigned int mem_ref,
 	EFLAGS = (EFLAGS & ~EFLAGS_CC) | (flg &	EFLAGS_CC);
 	TheCPU.mem_ref = mem_ref;
 	TheCPU.err = abs(TheCPU.err);
-	if (TheCPU.err == EXCP_TFSET)
-		TheCPU.err = 0;
 	/* checking for infinite loops, flagged in JumpGen() */
 	if ((seqflg & F_SLFJ) && !(EFLAGS & (VIF|IF|TF))) {
 		error("!Forever loop!\n");

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -627,6 +627,32 @@ static unsigned ExecOne(TNode *G, unsigned *mem_ref, unsigned long *flg,
 	return ePC;
 }
 
+static void HandleEmuSignals(void)
+{
+#if PROFILE
+	if (debug_level('e')) EmuSignals++;
+#endif
+	//else if (CEmuStat & CeS_DRTRAP) {
+	//	if (e_debug_check(PC)) {
+	//		TheCPU.err = EXCP01_SSTP;
+	//	}
+	//}
+	if (CEmuStat & CeS_SIGPEND) {
+		/* force exit after signal */
+		CEmuStat = (CEmuStat & ~CeS_SIGPEND) | CeS_SIGACT;
+		TheCPU.err=EXCP_SIGNAL;
+	}
+	else if (CEmuStat & CeS_RPIC) {
+		/* force exit for PIC */
+		CEmuStat &= ~CeS_RPIC;
+		if (EFLAGS & EFLAGS_IF)
+			TheCPU.err=EXCP_PICSIGNAL;
+	}
+	/* clear optional exit conditions */
+	if (TheCPU.err)
+		CEmuStat &= ~(CeS_SIGPEND | CeS_RPIC);
+}
+
 unsigned int DoExec(TNode *G, unsigned *pLastXKey)
 {
 	unsigned long flg;
@@ -697,7 +723,11 @@ unsigned int DoExec(TNode *G, unsigned *pLastXKey)
 	/* exit_pending at this point is non-zero if there was ANY signal,
 	 * not just a SIGALRM
 	 */
-	CEmuStat |= exit_pending_xchg(0);
+	if (exit_pending()) {
+		CEmuStat |= exit_pending_xchg(0);
+		if (!TheCPU.err)
+			HandleEmuSignals();
+	}
 
 #if defined(SINGLESTEP)
 	InvalidateNodeRange(key, 1, NULL);

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -584,7 +584,6 @@ static void Exec_post(unsigned long flg, unsigned int mem_ref,
 {
 	EFLAGS = (EFLAGS & ~EFLAGS_CC) | (flg &	EFLAGS_CC);
 	TheCPU.mem_ref = mem_ref;
-	TheCPU.err = abs(TheCPU.err);
 	/* checking for infinite loops, flagged in JumpGen() */
 	if ((seqflg & F_SLFJ) && !(EFLAGS & (VIF|IF|TF))) {
 		error("!Forever loop!\n");
@@ -645,6 +644,10 @@ static void HandleEmuSignals(void)
 		/* force exit for PIC */
 		if (EFLAGS & EFLAGS_IF)
 			TheCPU.err=EXCP_PICSIGNAL;
+	}
+	else if (e & exit_STI) {
+		/* force exit for IF set */
+		TheCPU.err=EXCP_STISIGNAL;
 	}
 }
 

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -634,16 +634,16 @@ static void HandleEmuSignals(void)
 	if (debug_level('e')) EmuSignals++;
 #endif
 	//XXX need to figure out something for DRTRAP
-	//if (e & CeS_DRTRAP) {
+	//if (TheCPU.dr[7] & 0xff) {
 	//	if (e_debug_check(PC)) {
 	//		TheCPU.err = EXCP01_SSTP;
 	//	}
 	//}
-	if (e & CeS_SIGPEND) {
+	if (e & exit_SIGPEND) {
 		/* force exit after signal */
 		TheCPU.err=EXCP_SIGNAL;
 	}
-	else if (e & CeS_RPIC) {
+	else if (e & exit_RPIC) {
 		/* force exit for PIC */
 		if (EFLAGS & EFLAGS_IF)
 			TheCPU.err=EXCP_PICSIGNAL;
@@ -664,8 +664,8 @@ unsigned int DoExec(TNode *G, unsigned *pLastXKey)
 	ecpu = CPUOFFS(0);
 	if (debug_level('e')>1) {
 		unsigned e = exit_pending();
-		if (e & CeS_SIGPEND) e_printf("** SIGALRM is pending\n");
-		if (e & CeS_RPIC) e_printf("** PIC is pending\n");
+		if (e & exit_SIGPEND) e_printf("** SIGALRM is pending\n");
+		if (e & exit_RPIC) e_printf("** PIC is pending\n");
 		e_printf("==== Executing code at %p flg=%04x\n",
 			G->addr,seqflg);
 	}

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -629,28 +629,25 @@ static unsigned ExecOne(TNode *G, unsigned *mem_ref, unsigned long *flg,
 
 static void HandleEmuSignals(void)
 {
+	int e = exit_pending_xchg(0);
 #if PROFILE
 	if (debug_level('e')) EmuSignals++;
 #endif
-	//else if (CEmuStat & CeS_DRTRAP) {
+	//XXX need to figure out something for DRTRAP
+	//if (e & CeS_DRTRAP) {
 	//	if (e_debug_check(PC)) {
 	//		TheCPU.err = EXCP01_SSTP;
 	//	}
 	//}
-	if (CEmuStat & CeS_SIGPEND) {
+	if (e & CeS_SIGPEND) {
 		/* force exit after signal */
-		CEmuStat = (CEmuStat & ~CeS_SIGPEND) | CeS_SIGACT;
 		TheCPU.err=EXCP_SIGNAL;
 	}
-	else if (CEmuStat & CeS_RPIC) {
+	else if (e & CeS_RPIC) {
 		/* force exit for PIC */
-		CEmuStat &= ~CeS_RPIC;
 		if (EFLAGS & EFLAGS_IF)
 			TheCPU.err=EXCP_PICSIGNAL;
 	}
-	/* clear optional exit conditions */
-	if (TheCPU.err)
-		CEmuStat &= ~(CeS_SIGPEND | CeS_RPIC);
 }
 
 unsigned int DoExec(TNode *G, unsigned *pLastXKey)
@@ -723,11 +720,8 @@ unsigned int DoExec(TNode *G, unsigned *pLastXKey)
 	/* exit_pending at this point is non-zero if there was ANY signal,
 	 * not just a SIGALRM
 	 */
-	if (exit_pending()) {
-		CEmuStat |= exit_pending_xchg(0);
-		if (!TheCPU.err)
-			HandleEmuSignals();
-	}
+	if (!TheCPU.err && exit_pending())
+		HandleEmuSignals();
 
 #if defined(SINGLESTEP)
 	InvalidateNodeRange(key, 1, NULL);

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -579,16 +579,10 @@ static unsigned int Exec_pre(unsigned char *ecpu)
 	return flg;
 }
 
-static void Exec_post(unsigned long flg, unsigned int mem_ref,
-		      unsigned short seqflg)
+static void Exec_post(unsigned long flg, unsigned int mem_ref)
 {
 	EFLAGS = (EFLAGS & ~EFLAGS_CC) | (flg &	EFLAGS_CC);
 	TheCPU.mem_ref = mem_ref;
-	/* checking for infinite loops, flagged in JumpGen() */
-	if ((seqflg & F_SLFJ) && !(EFLAGS & (VIF|IF|TF))) {
-		error("!Forever loop!\n");
-		leavedos_main(0xebfe);
-	}
 }
 
 static unsigned ExecOne(TNode *G, unsigned *mem_ref, unsigned long *flg,
@@ -682,22 +676,20 @@ unsigned int DoExec(TNode *G, unsigned *pLastXKey)
 	flg = Exec_pre(ecpu);
 #if !defined(ASM_DUMP) && !defined(SINGLESTEP)
 	/* try fast inner loop if nothing special is going on */
-	if (!(EFLAGS & TF) && !debug_level('e')) {
+	if (!(seqflg & (F_SPEC|F_LEAV)) && !debug_level('e')) {
 		while (1) {
 			ePC = ExecOne(G, &mem_ref, &flg, ecpu, pLastXKey);
-			if (TheCPU.err || exit_pending() ||
-			    (seqflg & (F_SLFJ|F_SPEC|F_LEAV)))
+			if (TheCPU.err || exit_pending())
 				break;
 			G = FindTree(ePC);
 			if (!G || !GoodNode(G))
 				break;
-			seqflg = G->flags;
 		}
 	} else
 #endif
 		ePC = ExecOne(G, &mem_ref, &flg, ecpu, pLastXKey);
 	// G is unreliable (maybe deleted) past this point!
-	Exec_post(flg, mem_ref, seqflg);
+	Exec_post(flg, mem_ref);
 
 	if (debug_level('e')) {
 #if PROFILE >= 2
@@ -721,8 +713,21 @@ unsigned int DoExec(TNode *G, unsigned *pLastXKey)
 	/* exit_pending at this point is non-zero if there was ANY signal,
 	 * not just a SIGALRM
 	 */
-	if (!TheCPU.err && exit_pending())
+	if (!TheCPU.err && exit_pending()) {
+		/* checking for infinite loops, flagged in JumpGen() */
+		/* TheCPU.eip points to the first instruction of the last
+		   executed block, except for real-mode retf, which cannot
+		   cause forever loops */
+		if (!(EFLAGS & (VIF|IF|TF))) {
+			TNode *LastG = FindTree(LONG_CS + TheCPU.eip);
+			seqflg = LastG ? LastG->flags : 0;
+			if (seqflg & F_SLFJ) {
+				error("!Forever loop!\n");
+				leavedos_main(0xebfe);
+			}
+		}
 		HandleEmuSignals();
+	}
 
 #if defined(SINGLESTEP)
 	InvalidateNodeRange(key, 1, NULL);

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -1031,8 +1031,7 @@ static int e_vm86_tail(struct vm86_struct *info)
   retval = -1;
 
   if (xval==EXCP_SIGNAL) {	/* coming here for async interruptions */
-    if (CEmuStat & (CeS_SIGPEND|CeS_SIGACT))
-		{ CEmuStat &= ~(CeS_SIGPEND|CeS_SIGACT); retval=VM86_SIGNAL; }
+    retval=VM86_SIGNAL;
   } else if (xval==EXCP_PICSIGNAL) {
     retval = VM86_PICRETURN;
   } else if (xval==EXCP_STISIGNAL) {

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -810,7 +810,7 @@ void e_gen_sigalrm(void)
 	/* here we come from the kernel with cs==UCODESEL, as
 	 * the passed context is that of dosemu, NOT that of the
 	 * emulated CPU! */
-	exit_pending_or(CeS_SIGPEND);
+	exit_pending_or(exit_SIGPEND);
 
 	/* this triggers calculation of paramaters for garbage collect */
 	TheCPU.sigprof_pending = 1;
@@ -818,12 +818,12 @@ void e_gen_sigalrm(void)
 
 void e_gen_sigalrm_from_thread(void)
 {
-	exit_pending_or(CeS_SIGPEND);
+	exit_pending_or(exit_SIGPEND);
 }
 
 void e_gen_rpic_from_thread(void)
 {
-	exit_pending_or(CeS_RPIC);
+	exit_pending_or(exit_RPIC);
 }
 
 static void enter_cpu_emu(void)
@@ -1488,7 +1488,6 @@ void e_dpmi_b0x(int op,cpuctx_t *scp)
 	_eflags |= CF;
 	break;
   }
-  if (TheCPU.dr[7] & 0xff) CEmuStat|=CeS_DRTRAP; else CEmuStat&=~CeS_DRTRAP;
 /*
   e_printf("DR0=%08lx DR1=%08lx DR2=%08lx DR3=%08lx\n",DRs[0],DRs[1],DRs[2],DRs[3]);
   e_printf("DR6=%08lx DR7=%08lx\n",DRs[6],DRs[7]);

--- a/src/base/emu-i386/simx86/emu86.h
+++ b/src/base/emu-i386/simx86/emu86.h
@@ -680,10 +680,10 @@ extern int SpecPrejits;
 #define EXCP_STISIGNAL	67
 #define EXCP_MODESWITCH	68
 #define EXCP_EMULEAVE	69
-#define EXCP_TFSET	71
 
 #define exit_SIGPEND	0x01	/* signal pending mask */
 #define exit_RPIC	0x02	/* pic asks for interruption */
+#define exit_TFSET	0x04	/* popf/iret sets TF */
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/src/base/emu-i386/simx86/emu86.h
+++ b/src/base/emu-i386/simx86/emu86.h
@@ -684,6 +684,7 @@ extern int SpecPrejits;
 #define exit_SIGPEND	0x01	/* signal pending mask */
 #define exit_RPIC	0x02	/* pic asks for interruption */
 #define exit_TFSET	0x04	/* popf/iret sets TF */
+#define exit_STI	0x08	/* IF is set with VIP active */
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/src/base/emu-i386/simx86/emu86.h
+++ b/src/base/emu-i386/simx86/emu86.h
@@ -682,6 +682,9 @@ extern int SpecPrejits;
 #define EXCP_EMULEAVE	69
 #define EXCP_TFSET	71
 
+#define exit_SIGPEND	0x01	/* signal pending mask */
+#define exit_RPIC	0x02	/* pic asks for interruption */
+
 /////////////////////////////////////////////////////////////////////////////
 
 #ifndef min

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -1802,6 +1802,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			}
 			Gen(O_POP, _mode);
 			Gen(O_SIM, _mode, opc, 0, PC);
+			JMPGen(JMP_LINK, _mode|CKSIGN, PC);
 			break;
 
 /*f2*/	case REPNE:

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -404,7 +404,6 @@ static unsigned int ExceptionGen(unsigned int PC, int basemode, int trapno,
 
 static TNode *_Interp86(unsigned int PC, unsigned int Interp_LONG_CS,
 			unsigned short ocs, int basemode, int flags);
-static void HandleEmuSignals(void);
 
 static unsigned int FindExecCode(unsigned int PC)
 {
@@ -492,37 +491,8 @@ static unsigned int FindExecCode(unsigned int PC)
 			TheCPU.err = EXCP_EMULEAVE;
 
 		if (TheCPU.err) return PC;
-		if (CEmuStat & (CeS_DRTRAP|CeS_SIGPEND|CeS_RPIC))
-			HandleEmuSignals();
-		if (TheCPU.err) return PC;
 	}
 	return PC;
-}
-
-static void HandleEmuSignals(void)
-{
-#if PROFILE
-	if (debug_level('e')) EmuSignals++;
-#endif
-	//else if (CEmuStat & CeS_DRTRAP) {
-	//	if (e_debug_check(PC)) {
-	//		TheCPU.err = EXCP01_SSTP;
-	//	}
-	//}
-	if (CEmuStat & CeS_SIGPEND) {
-		/* force exit after signal */
-		CEmuStat = (CEmuStat & ~CeS_SIGPEND) | CeS_SIGACT;
-		TheCPU.err=EXCP_SIGNAL;
-	}
-	else if (CEmuStat & CeS_RPIC) {
-		/* force exit for PIC */
-		CEmuStat &= ~CeS_RPIC;
-		if (EFLAGS & EFLAGS_IF)
-			TheCPU.err=EXCP_PICSIGNAL;
-	}
-	/* clear optional exit conditions */
-	if (TheCPU.err)
-		CEmuStat &= ~(CeS_SIGPEND | CeS_RPIC);
 }
 
 static unsigned int InterpOne(unsigned int PC, unsigned int Interp_LONG_CS,

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -2094,8 +2094,12 @@ repag0:
 			Gen(O_SIM, _mode, opc, 0, PC);
 			/* real mode inhibits after STI as well but
 			   we've always relied on trapping behaviour with vm86 */
+			if (V86MODE()) {
+				// picks up exit_STI
+				JMPGen(JMP_LINK, _mode|CKSIGN, PC);
+			}
 			/* note that TF does not inhibit after STI! */
-			if (!V86MODE() && !(_mode & (MTRAP|MINHI))) {
+			else if (!(_mode & (MTRAP|MINHI))) {
 				PC = InterpOne(PC, Interp_LONG_CS, ocs,
 					       basemode|MINHI|MSSTP);
 				/* check signals immediately after the

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -751,7 +751,7 @@ static void linknode(TNode *LG, TNode *G, linkdesc *L, unsigned target_type)
 
 	// points to current node, which can't be a forever loop?
 	if (L->target!=G->key || !(LG->unlinked_jmp_targets & target_type) ||
-	    (G->flags & F_SLFJ))
+	    (G->mode & MTRAP) || (LG->mode & MTRAP))
 		return;
 
 	if (L->ref!=0) {
@@ -787,7 +787,7 @@ static void linknode(TNode *LG, TNode *G, linkdesc *L, unsigned target_type)
 			 G,G->key,G->addr,
 			 L->target, B->branch, G->nrefs, L->ref, *L->ref);
 	}
-	_nodeflagbackrefs(LG, G->flags);
+	_nodeflagbackrefs(LG, G->flags & F_FPOP);
 	if (debug_level('e')>8) {
 		backref *bk = G->bkr.next;
 #ifdef DEBUG_LINKER

--- a/src/include/cpu-emu.h
+++ b/src/include/cpu-emu.h
@@ -48,7 +48,6 @@ extern void e_priv_iopl(int);
 /* Cpuemu status register - pack as much info as possible here, so to
  * use a single test to check if we have to go further or not */
 #define CeS_SIGPEND	0x01	/* signal pending mask */
-#define CeS_SIGACT	0x02	/* signal active mask */
 #define CeS_RPIC	0x04	/* pic asks for interruption */
 #define CeS_DRTRAP	0x2000	/* Debug Registers active */
 #define CeS_INSTREMU_RM	0x4000

--- a/src/include/cpu-emu.h
+++ b/src/include/cpu-emu.h
@@ -47,9 +47,6 @@ extern void e_priv_iopl(int);
 
 /* Cpuemu status register - pack as much info as possible here, so to
  * use a single test to check if we have to go further or not */
-#define CeS_SIGPEND	0x01	/* signal pending mask */
-#define CeS_RPIC	0x04	/* pic asks for interruption */
-#define CeS_DRTRAP	0x2000	/* Debug Registers active */
 #define CeS_INSTREMU_RM	0x4000
 #define CeS_INSTREMU_PM	0x8000
 #define CeS_INSTREMU	(CeS_INSTREMU_RM | CeS_INSTREMU_PM) /* behave like former instr_emu, with counter for VGAEMU faults */


### PR DESCRIPTION
Sim_helper just sets exit_pending or real exceptions, no more negative or pseudo ones. HandleEmuSignals works directly with exit_pending or TF (from before the instruction). CEmuStat is only used for CeS_INHI in DoExec.

Needs some good testing since this is always tricky to get right with interruptsl, so marking it as draft.