### PR TITLE
simx86: segreg cleanup

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -1928,25 +1928,23 @@ static unsigned int Gen_sim(IGen *IG, unsigned int *pmem_ref,
 		break;
 
 	case O_PUSH: {
-		wkreg SR1, AR2;
+		dosaddr_t esp, addr;
 		unsigned long stackm = CPULONG(Ofs_STACKM);
 		GTRACE0("O_PUSH");
-		if (mode & DATA16) {
-			AR2.d = CPULONG(Ofs_XSS);
-			SR1.d = CPULONG(Ofs_ESP) - 2;
-			SR1.d &= stackm;
-			sim_write_word(AR2.d + SR1.d, DR1.w.l);
-		}
-		else {
-			AR2.d = CPULONG(Ofs_XSS);
-			SR1.d = CPULONG(Ofs_ESP) - 4;
-			SR1.d &= stackm;
-			sim_write_dword(AR2.d + SR1.d, DR1.d);
-		}
+		if (mode & DATA16)
+			esp = CPULONG(Ofs_ESP) - 2;
+		else
+			esp = CPULONG(Ofs_ESP) - 4;
+		esp &= stackm;
+		addr = CPULONG(Ofs_XSS) + esp;
+		if (mode & (SEGREG|DATA16))
+			sim_write_word(addr, DR1.w.l);
+		else
+			sim_write_dword(addr, DR1.d);
 #ifdef KEEP_ESP	/* keep high 16-bits of ESP in small-stack mode */
-		SR1.d |= (CPULONG(Ofs_ESP) & ~stackm);
+		esp |= (CPULONG(Ofs_ESP) & ~stackm);
 #endif
-		CPULONG(Ofs_ESP) = SR1.d;
+		CPULONG(Ofs_ESP) = esp;
 		if (debug_level('e')>3) dbug_printf("(V) %08x\n",DR1.d);
 		} break;
 
@@ -1957,23 +1955,20 @@ static unsigned int Gen_sim(IGen *IG, unsigned int *pmem_ref,
 		break;
 
 	case O_PUSH2: {
-		wkreg AR2;
+		dosaddr_t addr;
 		unsigned int o = IG->p0;
 		unsigned long stackm = CPULONG(Ofs_STACKM);
 		GTRACE1("O_PUSH2",o);
-		AR2.d = CPULONG(Ofs_XSS);
-		if (mode & DATA16) {
-			DR1.w.l = CPUWORD(o);
+		if (mode & DATA16)
 			SR1.d -= 2;
-			SR1.d &= stackm;
-			sim_write_word(AR2.d + SR1.d, DR1.w.l);
-		}
-		else {
-			DR1.d = (mode & SEGREG) ? CPUWORD(o) : CPULONG(o);
+		else
 			SR1.d -= 4;
-			SR1.d &= stackm;
-			sim_write_dword(AR2.d + SR1.d, DR1.d);
-		}
+		SR1.d &= stackm;
+		addr = CPULONG(Ofs_XSS) + SR1.d;
+		if (mode & (SEGREG|DATA16))
+			sim_write_word(addr, CPUWORD(o));
+		else
+			sim_write_dword(addr, CPULONG(o));
 		if (debug_level('e')>3) dbug_printf("(V) %08x\n",DR1.d);
 		} break;
 
@@ -2981,6 +2976,10 @@ static __inline__ void SetCPU_WL(int m, signed char o, unsigned long v)
 	sp -= 2; sp &= TheCPU.StackMask; \
 	sim_write_word(LONG_SS + sp, w); })
 
+#define PUSHwl(sp,w) ({ \
+	sp -= 4; sp &= TheCPU.StackMask; \
+	sim_write_word(LONG_SS + sp, w); })
+
 #define PUSHl(sp,l) ({ \
 	sp -= 4; sp &= TheCPU.StackMask; \
 	sim_write_dword(LONG_SS + sp, l); })
@@ -3115,7 +3114,7 @@ static unsigned int _Sim_helper(unsigned int mem_ref, unsigned int data, int mod
 				PUSHw(sp,oldeip);
 			}
 			else {
-				PUSHl(sp,oldcs);
+				PUSHwl(sp,oldcs);
 				PUSHl(sp,oldeip);
 			}
 			if (debug_level('e')>2) {

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -2034,34 +2034,27 @@ static unsigned int Gen_sim(IGen *IG, unsigned int *pmem_ref,
 		} break;
 
 	case O_POP: {
-		wkreg SR1, AR2;
+		dosaddr_t esp, addr;
 		int imm16 = (mode&MRETISP) ? IG->p0 : 0;
 		long stackm = CPULONG(Ofs_STACKM);
 		GTRACE1("O_POP",imm16);
-		if (mode & DATA16) {
-			AR2.d = CPULONG(Ofs_XSS);
-			SR1.d = CPULONG(Ofs_ESP);
-			SR1.d &= stackm;
-			DR1.w.l = sim_read_word(AR2.d + SR1.d);
-			SR1.d += 2 + imm16;
+		esp = CPULONG(Ofs_ESP) & stackm;
+		addr = CPULONG(Ofs_XSS) + esp;
+		if (mode & (DATA16|SEGREG))
+			DR1.w.l = sim_read_word(addr);
+		else
+			DR1.d = sim_read_dword(addr);
+		if (mode & DATA16)
+			esp += 2 + imm16;
+		else
+			esp += 4 + imm16;
 #ifdef STACK_WRAP_MP	/* mask after incrementing */
-			SR1.d &= stackm;
+		esp &= stackm;
 #endif
-		}
-		else {
-			AR2.d = CPULONG(Ofs_XSS);
-			SR1.d = CPULONG(Ofs_ESP);
-			SR1.d &= stackm;
-			DR1.d = sim_read_dword(AR2.d + SR1.d);
-			SR1.d += 4 + imm16;
-#ifdef STACK_WRAP_MP	/* mask after incrementing */
-			SR1.d &= stackm;
-#endif
-		}
 #ifdef KEEP_ESP	/* keep high 16-bits of ESP in small-stack mode */
-		SR1.d |= (CPULONG(Ofs_ESP) & ~stackm);
+		esp |= (CPULONG(Ofs_ESP) & ~stackm);
 #endif
-		CPULONG(Ofs_ESP) = SR1.d;
+		CPULONG(Ofs_ESP) = esp;
 		if (debug_level('e')>3) dbug_printf("(V) %08x\n",DR1.d);
 		} break;
 
@@ -2072,26 +2065,31 @@ static unsigned int Gen_sim(IGen *IG, unsigned int *pmem_ref,
 		break;
 
 	case O_POP2: {
-		wkreg AR2;
+		dosaddr_t addr;
 		unsigned int o = (mode & MNOREG) ? 0 : IG->p0;
 		long stackm = CPULONG(Ofs_STACKM);
 		int imm16 = (mode&MRETISP) ? IG->p0 : 0;
 		GTRACE2("O_POP2",o,imm16);
-		AR2.d = CPULONG(Ofs_XSS);
-		if (mode & DATA16) {
-			SR1.d &= stackm;
-			DR1.w.l = sim_read_word(AR2.d + SR1.d);
-			if (!(mode & MNOREG))
-				CPUWORD(o) = DR1.w.l;
-			SR1.d += 2 + imm16;
+		SR1.d &= stackm;
+		addr = CPULONG(Ofs_XSS) + SR1.d;
+		if (mode & (DATA16|SEGREG)) {
+			uint16_t v = sim_read_word(addr);
+			if (mode & MNOREG)
+				DR1.w.l = v;
+			else
+				CPUWORD(o) = v;
 		}
 		else {
-			SR1.d &= stackm;
-			DR1.d = sim_read_dword(AR2.d + SR1.d);
-			if (!(mode & MNOREG))
-				CPULONG(o) = DR1.d;
-			SR1.d += 4 + imm16;
+			uint32_t v = sim_read_dword(addr);
+			if (mode & MNOREG)
+				DR1.d = v;
+			else
+				CPULONG(o) = v;
 		}
+		if (mode & DATA16)
+			SR1.d += 2 + imm16;
+		else
+			SR1.d += 4 + imm16;
 		if (debug_level('e')>3) dbug_printf("(V) %08x\n",DR1.d);
 		} break;
 
@@ -2968,6 +2966,11 @@ static __inline__ void SetCPU_WL(int m, signed char o, unsigned long v)
 	unsigned int __res = sim_read_word(LONG_SS + sp); \
 	sp += 2; sp &= TheCPU.StackMask; __res; })
 
+/* for popping segment registers in 32-bit mode */
+#define POPwl(sp) ({ \
+	unsigned int __res = sim_read_word(LONG_SS + sp); \
+	sp += 4; sp &= TheCPU.StackMask; __res; })
+
 #define POPl(sp) ({ \
 	unsigned int __res = sim_read_dword(LONG_SS + sp); \
 	sp += 4; sp &= TheCPU.StackMask; __res; })
@@ -3141,7 +3144,7 @@ static unsigned int _Sim_helper(unsigned int mem_ref, unsigned int data, int mod
 				}
 				else {
 					eip = POPl(sp);
-					cs = POPl(sp);
+					cs = POPwl(sp);
 					if (opc == IRET) temp = POPl(sp);
 				}
 				if (opc == RETlisp) {

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -638,10 +638,6 @@ static unsigned int Gen_sim(IGen *IG, unsigned int *pmem_ref,
 		GTRACE0("L_LXS2");
 		DR1.d = sim_read_word(mem_ref + BT24(BitDATA16, mode));
 		break;
-	case L_ZXAX:
-		GTRACE0("L_ZXAX");
-		DR1.w.h = 0;
-		break;
 
 	case L_DI_R1: {
 		dosaddr_t addr = mem_ref;

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -466,21 +466,16 @@ static unsigned int Gen_sim(IGen *IG, unsigned int *pmem_ref,
 	switch(op) {
 	case A_SR_SH4: {	// real mode make base addr from seg
 		unsigned int o = IG->p0;
-		unsigned int v = CPUWORD(o);
 		GTRACE1("A_SR_SH4",o);
 		SetSegReal(DR1.w.l, o);
-		DR1.d = v; // only needed for pushing old CS
 		}
 		break;
 	case A_SR_PROT: {	// protected mode make base addr from seg
 		unsigned int o = IG->p0;
-		int e;
 		GTRACE1("A_SR_PROT",o);
-		e = SetSegProt_helper(DR1.w.l, o);
-		if (e < 0)
+		SetSegProt_helper(DR1.w.l, o);
+		if (TheCPU.err)
 			P0 = IG->p1;
-		else
-			DR1.d = e;
 		}
 		break;
 	case L_NOP:
@@ -3152,7 +3147,8 @@ static unsigned int _Sim_helper(unsigned int mem_ref, unsigned int data, int mod
 					TheCPU.cs = cs;
 					LONG_CS = cs << 4;
 				}
-				else if (SetSegProt_helper(cs, Ofs_CS) < 0)
+				SetSegProt(Ofs_CS, cs);
+				if (TheCPU.err)
 					break;
 				/* eax used by JMP_INDIRECT */
 				data = eip;

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -255,10 +255,6 @@ static unsigned char *CodeGen_x86(unsigned char *CodePtr, unsigned char *BaseGen
 		} }
 		break;
 	case A_SR_SH4: {	// real mode make base addr from seg
-		if (IG->p0 == Ofs_CS) {
-			// movzwl offs(%%ebx),%%edx
-			G4M(0x0f,0xb7,0x53,IG->p0,Cp);
-		}
 		// movw %%ax,offs(%%ebx)
 		G4M(0x66,0x89,0x43,IG->p0,Cp);
 		// movzwl %%ax,%%eax
@@ -271,10 +267,6 @@ static unsigned char *CodeGen_x86(unsigned char *CodePtr, unsigned char *BaseGen
 		G1(0x05,Cp); G4(0x0000ffff,Cp);
 		// movl %%eax,ofs(%%ebx)
 		G3M(0x89,0x43,IG->p1+4,Cp);
-		if (IG->p0 == Ofs_CS) {
-			// movl %%edx,%%eax : old cs in eax
-			G2M(0x89,0xd0,Cp);
-		}
 		}
 		break;
 	case A_SR_PROT: {	// prot mode make base addr from seg
@@ -306,10 +298,10 @@ static unsigned char *CodeGen_x86(unsigned char *CodePtr, unsigned char *BaseGen
 		// popl %edx; popl %edx
 		G2M(0x5a,0x5a,Cp);
 #endif
-		// or %%eax,%%eax
-		G2M(0x09,0xc0,Cp);
-		// jns skip
-		G2M(0x79,TAILSIZE,Cp);
+		// cmpl $0x0,Ofs_ERR(%rbx)
+		G4M(0x83,0x7b,Ofs_ERR,0x00,Cp);
+		// jz skip
+		G2M(JE_JZ,TAILSIZE,Cp);
 		// movl {exit_addr},%%eax; movl %%eax, %%ecx; pop %%edx; ret
 		G1(0xb8,Cp); G4(IG->p1,Cp); G4M(0x89,0xc1,0x5a,0xc3,Cp);
 		}

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -1104,7 +1104,7 @@ shrot0:
 			0x8b,0x73,Ofs_XSS,
 			// movl Ofs_ESP(%%ebx),%%ecx
 			0x8b,0x4b,Ofs_ESP,
-			// leal -2(%%ecx),%%ecx
+/*06*/			// leal -2(%%ecx),%%ecx
 			0x8d,0x49,0xfe,
 			// 16-bit stack seg w/underflow (RM)
 			// andl StackMask(%%ebx),%%ecx
@@ -1154,9 +1154,14 @@ shrot0:
 			0x89,0x4b,Ofs_ESP
 		};
 		const unsigned char *p; int sz;
-		if (mode&DATA16) p=pseq16,sz=sizeof(pseq16);
+		if (mode&(SEGREG|DATA16)) p=pseq16,sz=sizeof(pseq16);
 			else p=pseq32,sz=sizeof(pseq32);
 		GNX(Cp, p, sz);
+		if ((mode & (SEGREG|DATA16)) == SEGREG) {
+			// use pseq16 but -4 for 32-bit segreg
+			// mirroring Core Intel CPUs and newer
+			Cp[-sz+8] = 0xfc;
+		}
 		} break;
 
 /* PUSH derived (sub-)sequences: */
@@ -1172,10 +1177,10 @@ shrot0:
 
 	case O_PUSH2: {		/* register push only */
 		const unsigned char pseq16[] = {
-			// movl offs(%%ebx),%%ax
-/*00*/			0x66,0x8b,0x43,0x00,
+			// movw offs(%%ebx),%%ax (with 66 prefix)
+/*00*/			0x8b,0x43,0x00,
 			// leal -2(%%ecx),%%ecx
-			0x8d,0x49,0xfe,
+/*03*/			0x8d,0x49,0xfe,
 			// andl StackMask(%%ebx),%%ecx
 			0x23,0x4b,Ofs_STACKM,
 			// leal (%%esi,%%ecx,1),%%edx
@@ -1184,8 +1189,8 @@ shrot0:
 			0x66,0x89,0x04,0x2a,
 		};
 		const unsigned char pseq32[] = {
-			// nop; movl offs(%%ebx),%%eax
-/*00*/			0x90,0x8b,0x43,0x00,
+			// movl offs(%%ebx),%%eax
+/*00*/			0x8b,0x43,0x00,
 			// leal -4(%%ecx),%%ecx
 			0x8d,0x49,0xfc,
 			// andl StackMask(%%ebx),%%ecx
@@ -1198,14 +1203,14 @@ shrot0:
 		const unsigned char *p;
 		unsigned char *q;
 		int sz;
-		if (mode&DATA16) p=pseq16,sz=sizeof(pseq16);
+		if (mode&(SEGREG|DATA16)) G1(0x66,Cp),p=pseq16,sz=sizeof(pseq16);
 			else p=pseq32,sz=sizeof(pseq32);
 		q=Cp; GNX(Cp, p, sz);
-		q[3] = IG->p0;
+		q[2] = IG->p0;
 		if ((mode & (SEGREG|DATA16)) == SEGREG) {
-			// change to movzx for 32bit segreg
-			q[0] = 0x0f;
-			q[1] = 0xb7;
+			// use pseq16 but -4 for 32-bit segreg
+			// mirroring recent Intel CPUs
+			q[5] = 0xfc;
 		}
 		} break;
 

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -1445,12 +1445,17 @@ shrot0:
 		};
 		const unsigned char *p; int sz;
 		unsigned char *q;
-		if (mode&DATA16) p=pseq16,sz=sizeof(pseq16);
+		if (mode&(SEGREG|DATA16)) p=pseq16,sz=sizeof(pseq16);
 			else p=pseq32,sz=sizeof(pseq32);
 		// for popping into memory the sequence is:
 		//	first do address calculation, then pop,
 		//	then store data, and last adjust stack
 		q = Cp; GNX(Cp, p, sz);
+		if ((mode & (SEGREG|DATA16)) == SEGREG) {
+			// use pseq16 but +4 for 32-bit segreg
+			// mirroring recent Intel CPUs
+			q[12] = 0x04;
+		}
 		if (mode&MRETISP)
 			/* adjust stack after pop */
 			*(int32_t *)(q+0x12) += IG->p0;
@@ -1475,7 +1480,7 @@ shrot0:
 			0x8d,0x14,0x0e,
 			// movw (%%edx,%%ebp,1),%%ax
 			0x66,0x8b,0x04,0x2a,
-			// leal 2(%%esi),%%esi
+/*10*/			// leal 2(%%esi),%%esi
 			0x8d,0x76,0x02,
 		};
 		const unsigned char pseq32[] = {
@@ -1490,12 +1495,17 @@ shrot0:
 		};
 		const unsigned char *p;
 		int sz;
-		if (mode&DATA16) p=pseq16,sz=sizeof(pseq16);
+		if (mode&(SEGREG|DATA16)) p=pseq16,sz=sizeof(pseq16);
 			else p=pseq32,sz=sizeof(pseq32);
 		// for popping into memory the sequence is:
 		//	first do address calculation, then pop,
 		//	then store data, and last adjust stack
 		GNX(Cp, p, sz);
+		if ((mode & (SEGREG|DATA16)) == SEGREG) {
+			// use pseq16 but +4 for 32-bit segreg
+			// mirroring recent Intel CPUs
+			Cp[-sz+12] = 0x04;
+		}
 		if (mode & MRETISP) {
 			// leal IG->p0(%%esi),%%esi
 			G2M(0x8d,0xb6,Cp); G4(IG->p0,Cp);

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -444,10 +444,6 @@ static unsigned char *CodeGen_x86(unsigned char *CodePtr, unsigned char *BaseGen
 		G2M(0x8d,0x7f,Cp); G1((mode&DATA16? -2:-4),Cp);
 		}
 		break;
-	case L_ZXAX:
-		// movzwl %%ax,%%eax
-		G3(0xc0b70f,Cp);
-		break;
 
 	case L_DI_R1:
 		if (mode&(MBYTE|MBYTX)) {

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -202,7 +202,6 @@ void Gen(int op, int mode, ...)
 	switch(op) {
 	case L_NOP:
 	case L_CR0:
-	case L_ZXAX:
 	case L_DI_R1:
 	case L_LXS2:	/* load segment value from mem +2/4 */
 	case S_DI:

--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -67,7 +67,6 @@
 #define L_MOVZS		17
 #define L_LXS1		18
 #define L_LXS2		19
-#define L_ZXAX		20
 #define L_CR0		21
 #define L_DI_R1		22
 #define S_DI		23

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -867,7 +867,8 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 /*99*/	case CWD:
 			Gen(O_CBWD, _mode); PC++; break;
 
-/*07*/	case POPes:	if (REALADDR()) {
+/*07*/	case POPes:	_mode |= SEGREG;
+			if (REALADDR()) {
 			    Gen(O_POP, _mode);
 			    AddrGen(A_SR_SH4, _mode, Ofs_ES, Ofs_XES);
 			} else { /* restartable */
@@ -881,7 +882,8 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			}
 			PC++;
 			break;
-/*17*/	case POPss:	if (REALADDR()) {
+/*17*/	case POPss:	_mode |= SEGREG;
+			if (REALADDR()) {
 			    Gen(O_POP, _mode);
 			    AddrGen(A_SR_SH4, _mode, Ofs_SS, Ofs_XSS);
 			} else { /* restartable */
@@ -893,7 +895,8 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			InstrMeta[CurrIMeta].flags |= F_INHI;
 			PC++;
 			break;
-/*1f*/	case POPds:	if (REALADDR()) {
+/*1f*/	case POPds:	_mode |= SEGREG;
+			if (REALADDR()) {
 			    Gen(O_POP, _mode);
 			    AddrGen(A_SR_SH4, _mode, Ofs_DS, Ofs_XDS);
 			} else { /* restartable */
@@ -1697,7 +1700,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			if (REALADDR()) {
 				Gen(O_POP1, _mode);
 				Gen(O_POP2, _mode, Ofs_EIP);
-				Gen(O_POP2, _mode|MNOREG|MRETISP, dr);
+				Gen(O_POP2, _mode|MNOREG|SEGREG|MRETISP, dr);
 				AddrGen(A_SR_SH4, _mode, Ofs_CS, Ofs_XCS);
 				Gen(O_POP3, _mode);
 				Gen(L_REG, _mode, Ofs_EIP);
@@ -1777,7 +1780,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			if (REALADDR()) {
 				Gen(O_POP1, _mode);
 				Gen(O_POP2, _mode, Ofs_EIP);
-				Gen(O_POP2, _mode|MNOREG);
+				Gen(O_POP2, _mode|MNOREG|SEGREG);
 				AddrGen(A_SR_SH4, _mode, Ofs_CS, Ofs_XCS);
 				Gen(O_POP3, _mode);
 				Gen(L_REG, _mode, Ofs_EIP);
@@ -2484,6 +2487,7 @@ repag0:
 				Gen(O_PUSH, _mode|SEGREG); PC+=2;
 				break;
 			case 0xa1: /* POPfs */
+				_mode |= SEGREG;
 				if (REALADDR()) {
 				    Gen(O_POP, _mode);
 				    AddrGen(A_SR_SH4, _mode, Ofs_FS, Ofs_XFS);
@@ -2577,6 +2581,7 @@ repag0:
 				Gen(O_PUSH, _mode|SEGREG); PC+=2;
 				break;
 			case 0xa9: /* POPgs */
+				_mode |= SEGREG;
 				if (REALADDR()) {
 				    Gen(O_POP, _mode);
 				    AddrGen(A_SR_SH4, _mode, Ofs_GS, Ofs_XGS);

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -270,14 +270,26 @@ static unsigned int JumpGen(unsigned int P2, unsigned int Interp_LONG_CS,
 		    Gen(JMP_LINK, mode&~CKSIGN, j_t, InstrMeta[0].npc);
 		}
 		break;
+	case CALLl:	/* call far */
+		if (REALADDR()) {
+		    /* ok, first push old cs:eip */
+		    Gen(L_REG, mode|DATA16, Ofs_CS);
+		    Gen(O_PUSH, mode|SEGREG);
+		    Gen(O_PUSHI, mode, d_nt);
+		}
+		/* fall through */
 	case JMPld: {   /* uncond jmp far */
 		unsigned short jcs = FetchW(P2 + pskip - 2);
-		Gen(L_IMM_R1, mode|DATA16, jcs);
+		Gen(L_IMM_R1, mode&~DATA16, jcs);
 		if (REALADDR()) {
 		    AddrGen(A_SR_SH4, mode, Ofs_CS, Ofs_XCS);
 		}
 		else {
-		    AddrGen(A_SR_PROT, mode, Ofs_CS, P2);
+		    if (opc == CALLl)
+			/* handle PM far calls via Sim_helper() */
+			Gen(O_SIM, mode, opc, d_nt, P2);
+		    else
+			AddrGen(A_SR_PROT, mode, Ofs_CS, P2);
 		    /* transfer to new PC
 		       (new cs base dynamic, so indirect jmp) */
 		    Gen(L_IMM_R1, mode, d_t);
@@ -294,27 +306,6 @@ static unsigned int JumpGen(unsigned int P2, unsigned int Interp_LONG_CS,
 		if (dsp <= 0) mode |= CKSIGN;
 		Gen(JMP_LINK, mode, j_t, InstrMeta[0].npc);
 		break;
-	case CALLl: {   /* call far */
-		unsigned short jcs = FetchW(P2 + pskip - 2);
-		if (REALADDR()) {
-		    /* ok, first push old cs:eip */
-		    Gen(L_REG, mode|DATA16, Ofs_CS);
-		    Gen(O_PUSH, mode|SEGREG);
-		    Gen(O_PUSHI, mode, d_nt);
-		    Gen(L_IMM_R1, mode&~DATA16, jcs);
-		    AddrGen(A_SR_SH4, mode, Ofs_CS, Ofs_XCS);
-		    Gen(JMP_LINK, mode, j_t, InstrMeta[0].npc);
-		}
-		else {
-		    Gen(L_IMM_R1, mode&~DATA16, jcs);
-		    /* handle PM far calls via Sim_helper() */
-		    Gen(O_SIM, mode, opc, d_nt, P2);
-		    /* transfer to new PC (indirect jmp) */
-		    Gen(L_IMM_R1, mode, d_t);
-		    Gen(JMP_INDIRECT, mode);
-		}
-		break;
-	}
 	case CALLd:    /* call, unfortunately also uses JMP_LINK */
 		Gen(O_PUSHI, mode, d_nt);
 		Gen(JMP_LINK, mode, j_t, InstrMeta[0].npc);

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -1279,13 +1279,17 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			break;
 /*8c*/	case MOVsrtrm:
 			PC += ModRM(opc, PC, _mode|SEGREG);
-			Gen(L_REG, _mode|DATA16, REG1);
 			if (REG3) {
-			    if (!(_mode & DATA16))
-				Gen(L_ZXAX, _mode);
-			    Gen(S_REG, _mode, REG3);
-			} else
+			    if (_mode & DATA16)
+				Gen(L_REG2REG, _mode, REG1, REG3);
+			    else {
+				Gen(L_REG, _mode|DATA16, REG1);
+				Gen(L_MOVZS, _mode&~DATA16, 0, REG3);
+			    }
+			} else {
+			    Gen(L_REG, _mode|DATA16, REG1);
 			    Gen(S_DI, _mode|DATA16);
+			}
 			break;
 /*8d*/	case LEA:
 			if (Fetch(PC+1) >= 0xc0) {

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -298,8 +298,8 @@ static unsigned int JumpGen(unsigned int P2, unsigned int Interp_LONG_CS,
 		unsigned short jcs = FetchW(P2 + pskip - 2);
 		if (REALADDR()) {
 		    /* ok, first push old cs:eip */
-		    Gen(L_REG, mode, Ofs_CS);
-		    Gen(O_PUSH, mode);
+		    Gen(L_REG, mode|DATA16, Ofs_CS);
+		    Gen(O_PUSH, mode|SEGREG);
 		    Gen(O_PUSHI, mode, d_nt);
 		    Gen(L_IMM_R1, mode&~DATA16, jcs);
 		    AddrGen(A_SR_SH4, mode, Ofs_CS, Ofs_XCS);
@@ -1013,7 +1013,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			/* optimized multiple register push */
 			while (1) {
 			    int op;
-			    if (opc > 8 && !(m & DATA16)) // 32-bit segreg
+			    if (opc > 8)
 				m |= SEGREG;
 			    Gen(O_PUSH2, m, R1Tab_l[opc-1]);
 			    PC++;
@@ -1039,9 +1039,9 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			Gen(O_PUSH3, m); } else
 #endif
 			{
-			if (opc > 8 && !(_mode & DATA16)) { // 32-bit segreg
+			if (opc > 8) {
+			    _mode |= SEGREG;
 			    Gen(L_REG, _mode|DATA16, R1Tab_l[opc-1]);
-			    Gen(L_ZXAX, _mode);
 			} else
 			    Gen(L_REG, _mode, R1Tab_l[opc-1]);
 			Gen(O_PUSH, _mode); PC++;
@@ -1724,6 +1724,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			fprintf(aLog,"%08x:\t\tint %02x\n", P0, inum);
 #endif
 			if (V86MODE() && (TheCPU.cr[4] & CR4_VME)) {
+				_mode |= DATA16|ADDR16; // no operand size prefix
 				if (IOPL == 3) {
 					Gen(O_INT, _mode, inum, P0);
 					Gen(O_PUSH2F, _mode);
@@ -2193,8 +2194,8 @@ repag0:
 					    /* first push old cs:eip */
 					    oip = PC + len - Interp_LONG_CS;
 					    if (REALADDR()) {
-						Gen(L_REG, _mode, Ofs_CS);
-						Gen(O_PUSH, _mode);
+						Gen(L_REG, _mode|DATA16, Ofs_CS);
+						Gen(O_PUSH, _mode|SEGREG);
 						Gen(O_PUSHI, _mode, oip);
 					    }
 					    else {
@@ -2480,9 +2481,7 @@ repag0:
 ///
 			case 0xa0: /* PUSHfs */
 				Gen(L_REG, _mode|DATA16, Ofs_FS);
-				if (!(_mode & DATA16)) // 32-bit segreg padding
-				    Gen(L_ZXAX, _mode);
-				Gen(O_PUSH, _mode); PC+=2;
+				Gen(O_PUSH, _mode|SEGREG); PC+=2;
 				break;
 			case 0xa1: /* POPfs */
 				if (REALADDR()) {
@@ -2575,9 +2574,7 @@ repag0:
 ///
 			case 0xa8: /* PUSHgs */
 				Gen(L_REG, _mode|DATA16, Ofs_GS);
-				if (!(_mode & DATA16)) // 32-bit segreg padding
-				    Gen(L_ZXAX, _mode);
-				Gen(O_PUSH, _mode); PC+=2;
+				Gen(O_PUSH, _mode|SEGREG); PC+=2;
 				break;
 			case 0xa9: /* POPgs */
 				if (REALADDR()) {

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -148,8 +148,8 @@ static unsigned int JumpGen(unsigned int P2, unsigned int Interp_LONG_CS,
 #if !defined(SINGLESTEP)
 	unsigned int P1;
 #endif
-	int dsp;
-	unsigned int d_t, d_nt, j_t, j_nt;
+	int dsp = 0;
+	unsigned int d_t = 0, d_nt, j_t = 0, j_nt;
 	unsigned int PC;
 
 	/* pskip points to start of next instruction
@@ -163,20 +163,11 @@ static unsigned int JumpGen(unsigned int P2, unsigned int Interp_LONG_CS,
 	case RET: case RETisp: case JMPi: case CALLi:
 	case RETl: case RETlisp: case JMPli: case CALLli:
 	case IRET: case INT: // indirect jumps
-		dsp = 0;
-		j_t = 0;
-		d_t = 0;
 		break;
 	case JMPld: case CALLl: // far jmp/call
 		d_t = DataFetchWL_U(mode, P2+1);
-		if (REALADDR()) {
+		if (REALADDR())
 			InstrMeta[CurrIMeta].flags |= F_LJMP;
-			j_t = SEGOFF2LINEAR(FetchW(P2 + pskip - 2), d_t);
-			dsp = j_t - P2;
-		} else {
-			j_t = 0;
-			dsp = 0;
-		}
 		break;
 	default:
 		dsp = pskip;
@@ -280,11 +271,16 @@ static unsigned int JumpGen(unsigned int P2, unsigned int Interp_LONG_CS,
 		/* fall through */
 	case JMPld: {   /* uncond jmp far */
 		unsigned short jcs = FetchW(P2 + pskip - 2);
-		Gen(L_IMM_R1, mode&~DATA16, jcs);
 		if (REALADDR()) {
-		    AddrGen(A_SR_SH4, mode, Ofs_CS, Ofs_XCS);
+		    dosaddr_t xcs = jcs << 4;
+		    j_t = xcs + d_t;
+		    dsp = j_t - P2;
+		    Gen(L_IMM, mode|DATA16, Ofs_CS, jcs);
+		    Gen(L_IMM, mode&~DATA16, Ofs_XCS, xcs);
+		    Gen(L_IMM, mode&~DATA16, Ofs_XCS+4, xcs + 0xffff);
 		}
 		else {
+		    Gen(L_IMM_R1, mode&~DATA16, jcs);
 		    if (opc == CALLl)
 			/* handle PM far calls via Sim_helper() */
 			Gen(O_SIM, mode, opc, d_nt, P2);

--- a/src/base/emu-i386/simx86/protmode.c
+++ b/src/base/emu-i386/simx86/protmode.c
@@ -94,23 +94,11 @@ int SetSegReal(unsigned short sel, int ofs)
 }
 
 // this function is called from JIT-generated code
-static int _SetSegProt_helper(unsigned short sel, int ofs)
+void SetSegProt_helper(unsigned short sel, int ofs)
 {
-	int oldsel = CPUWORD(ofs);
-	SetSegProt(ofs, sel);
-	if (TheCPU.err)
-		return -1; /* -1 flags error */
-	return oldsel;
-}
-
-int SetSegProt_helper(unsigned short sel, int ofs)
-{
-	int ret;
-
 	InCompiledCode--;
-	ret = _SetSegProt_helper(sel, ofs);
+	SetSegProt(ofs, sel);
 	InCompiledCode++;
-	return ret;
 }
 
 static int _SetSegProt_check(int ofs, unsigned long sel)

--- a/src/base/emu-i386/simx86/protmode.h
+++ b/src/base/emu-i386/simx86/protmode.h
@@ -231,7 +231,7 @@ extern unsigned char e_ofsseg(int ofs);
 int SetSegProt_check(int ofs, unsigned long sel);
 void SetSegProt_set(int ofs, unsigned long sel);
 void SetSegProt(int ofs, unsigned long sel);
-int SetSegProt_helper(unsigned short sv, int ofs);
+void SetSegProt_helper(unsigned short sv, int ofs);
 int SetSegReal(unsigned short sel, int ofs);
 int e_larlsl(int mode, unsigned short sel);
 int hsw_verr(unsigned short sel);


### PR DESCRIPTION
I looked at segment registers again after #2656 
Basically following https://www.felixcloutier.com/x86/push it's always possible to use 16-bit moves with segment registers, and not zero-extend, with the exception of `movl %cs,%eax` etc.
So the L_ZXAX op was removed, replaced by the existing L_MOVZS for that, and other uses gone.

PUSHes and POPs then take the SEGREG parameter to mean to only read/write a 16-bit value and leave the upper word on the stack untouched in 32-bit mode.

Relatedly I looked at A_SR_SH4 and A_SR_PROT, which could be simplified a bit, and CALL far/JMP far direct, whose code in interp.c could be a merged a bit, and directly store the new CS base in compiled code (via L_IMM) for RM instead of computing it via A_SR_SH4.

I verified Transport Tycoon still works for JIT and SIM.
