### PR TITLE
simx86: fix Sim_helper regressions in 16726e7 and a6405384

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -3142,14 +3142,16 @@ static unsigned int _Sim_helper(unsigned int mem_ref, unsigned int data, int mod
 					sp += arg;
 					sp &= TheCPU.StackMask;
 				}
-				rESP = sp | (rESP&~TheCPU.StackMask);
 				if (REALADDR()) {
 					TheCPU.cs = cs;
 					LONG_CS = cs << 4;
 				}
-				SetSegProt(Ofs_CS, cs);
-				if (TheCPU.err)
-					break;
+				else {
+					SetSegProt(Ofs_CS, cs);
+					if (TheCPU.err)
+						break;
+				}
+				rESP = sp | (rESP&~TheCPU.StackMask);
 				/* eax used by JMP_INDIRECT */
 				data = eip;
 			}


### PR DESCRIPTION
First one set ESP before the fault, it should be the other way around, and cause a GPF in BC31, because the stack was wrong after the first fault. Second one was calling SetSegProt for real mode segments which I noticed looking at that code.

Fixes #2659