### PR TITLE
simx86: compile single step exceptions

### DIFF
--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -188,7 +188,8 @@
 #define MREPCOND 0x01000000	// this is SCASx or CMPSx, REP can be terminated
 				// by flags
 #define MSSTP	0x02000000	// generate only one instruction
-#define MINHI	0x04000000	// inhibits IRQs (MOVss/POPss/STI)
+#define MTRAP	0x04000000	// INT01 Sstep active: generate EXCP01_SSTP
+#define MINHI	0x08000000	// inhibits IRQs (MOVss/POPss/STI)
 
 // values for TNode.flags and IMeta.flags
 #define F_FPOP	0x0001	// has at least one FP instruction

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -2123,7 +2123,8 @@ repag0:
 			Gen(O_SIM, _mode, opc, 0, PC);
 			/* real mode inhibits after STI as well but
 			   we've always relied on trapping behaviour with vm86 */
-			if (!V86MODE() && !(_mode & MINHI)) {
+			/* note that TF does not inhibit after STI! */
+			if (!V86MODE() && !(_mode & (MTRAP|MINHI))) {
 				PC = InterpOne(PC, Interp_LONG_CS, ocs,
 					       basemode|MINHI|MSSTP);
 				/* check signals immediately after the

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -48,6 +48,8 @@
 int EmuSignals = 0;
 #endif
 
+static void JMPGen(int op, int mode, ...);
+
 /* this is probably unsafe with cpatch */
 #define SPEC_PREJIT 0
 
@@ -105,7 +107,7 @@ static TNode *DoClose(unsigned int PC, unsigned int Interp_LONG_CS, int mode,
 	 * it still lacks the tail code; add it here */
 	IMeta *GL = &InstrMeta[CurrIMeta];
 	if (GL->gen[GL->ngen-1].op < JMP_TAILCODE) {
-		Gen(JMP_TAILCODE, mode, PC);
+		JMPGen(JMP_TAILCODE, mode, PC);
 	}
 
 	assert(PC > P0);
@@ -141,6 +143,42 @@ static inline unsigned int UNPREFIX(unsigned int m)
 // jcc  	7x 06 b8 a a a a 5a c3 b8 b b b b 5a c3
 //	link	7x 06 e9 l l l l -- -- e9 l l l l -- --
 //
+
+/* generates the actual jumps */
+static void JMPGen(int op, int mode, ...)
+{
+	va_list	ap;
+	va_start(ap, mode);
+	unsigned int P0 = InstrMeta[0].npc;
+	switch(op) {
+	case JMP_TAILCODE:
+		Gen(op, mode, va_arg(ap, unsigned int));
+		break;
+	case JMP_INDIRECT:
+		Gen(op, mode);
+		break;
+	case JMP_LINK:
+		Gen(op, mode, va_arg(ap, unsigned int), P0);
+		break;
+	case JB_LINK:
+		Gen(op, mode, va_arg(ap, unsigned int));
+		Gen(JMP_LINK, mode, va_arg(ap, unsigned int), P0);
+		Gen(JMP_LINK, mode|CKSIGN, va_arg(ap, unsigned int), P0);
+		break;
+	case JF_LINK:
+		Gen(op, mode, va_arg(ap, unsigned int));
+		Gen(JMP_LINK, mode, va_arg(ap, unsigned int), P0);
+		Gen(JMP_LINK, mode&~CKSIGN, va_arg(ap, unsigned int), P0);
+		break;
+	case JLOOP_LINK:
+		Gen(op, mode, va_arg(ap, unsigned int));
+		/* CKSIGN is likely not needed for loops */
+		Gen(JMP_LINK, mode, va_arg(ap, unsigned int), P0);
+		Gen(JMP_LINK, mode, va_arg(ap, unsigned int), P0);
+		break;
+	}
+	va_end(ap);
+}
 
 static unsigned int JumpGen(unsigned int P2, unsigned int Interp_LONG_CS,
 			    int mode, int opc, int pskip)
@@ -247,18 +285,14 @@ static unsigned int JumpGen(unsigned int P2, unsigned int Interp_LONG_CS,
 			     * condition changing a flag */
 			    e_printf("### dsp=0 jmp=%x pskip=%d\n",opc,pskip);
 		    }
-		    Gen(JB_LINK, mode, opc);
-		    Gen(JMP_LINK, mode, j_nt, InstrMeta[0].npc);
-		    Gen(JMP_LINK, mode|CKSIGN, j_t, InstrMeta[0].npc);
+		    JMPGen(JB_LINK, mode, opc, j_nt, j_t);
 		}
 		else {
 		    if (dsp == pskip) {
 			e_printf("### jmp %x 00\n",opc);
 		    }
 		    /* forward jump or backward jump >=256 bytes */
-		    Gen(JF_LINK, mode, opc);
-		    Gen(JMP_LINK, mode, j_nt, InstrMeta[0].npc);
-		    Gen(JMP_LINK, mode&~CKSIGN, j_t, InstrMeta[0].npc);
+		    JMPGen(JF_LINK, mode, opc, j_nt, j_t);
 		}
 		break;
 	case CALLl:	/* call far */
@@ -289,7 +323,7 @@ static unsigned int JumpGen(unsigned int P2, unsigned int Interp_LONG_CS,
 		    /* transfer to new PC
 		       (new cs base dynamic, so indirect jmp) */
 		    Gen(L_IMM_R1, mode, d_t);
-		    Gen(JMP_INDIRECT, mode);
+		    JMPGen(JMP_INDIRECT, mode);
 		    break;
 		}
 	}
@@ -300,22 +334,20 @@ static unsigned int JumpGen(unsigned int P2, unsigned int Interp_LONG_CS,
 		    InstrMeta[CurrIMeta].flags |= F_SLFJ;
 		}
 		if (dsp <= 0) mode |= CKSIGN;
-		Gen(JMP_LINK, mode, j_t, InstrMeta[0].npc);
+		JMPGen(JMP_LINK, mode, j_t);
 		break;
 	case CALLd:    /* call, unfortunately also uses JMP_LINK */
 		Gen(O_PUSHI, mode, d_nt);
-		Gen(JMP_LINK, mode, j_t, InstrMeta[0].npc);
+		JMPGen(JMP_LINK, mode, j_t);
 		break;
 	case LOOP: case LOOPZ_LOOPE: case LOOPNZ_LOOPNE:
-		Gen(JLOOP_LINK, mode, opc);
 		/* CKSIGN is likely not needed for loops */
-		Gen(JMP_LINK, mode, j_nt, InstrMeta[0].npc);
-		Gen(JMP_LINK, mode, j_t, InstrMeta[0].npc);
+		JMPGen(JLOOP_LINK, mode, opc, j_nt, j_t);
 		break;
 	case RETl: case RETlisp: case IRET: // far ret, indirect
 	case JMPli: case CALLli: case INT: // far jmp/call, indirect
 	case RET: case RETisp: case JMPi: case CALLi: // ret, indirect
-		Gen(JMP_INDIRECT, mode);
+		JMPGen(JMP_INDIRECT, mode);
 		break;
 	default: dbug_printf("JumpGen: unknown condition\n");
 		break;
@@ -357,9 +389,9 @@ static unsigned int ExceptionGen(unsigned int PC, int basemode, int trapno,
 	if (trapno == EXCP0D_GPF)
 		Gen(L_IMM, basemode, Ofs_SCP_ERR, scp_err);
 	if (trapno != EXCP03_INT3 && trapno != EXCP04_INTO)
-		Gen(JMP_TAILCODE, basemode, P0); // fault: use current instr
+		JMPGen(JMP_TAILCODE, basemode, P0); // fault: use current instr
 	else
-		Gen(JMP_TAILCODE, basemode, PC); // trap: use next instr
+		JMPGen(JMP_TAILCODE, basemode, PC); // trap: use next instr
 	return PC;
 }
 
@@ -619,7 +651,7 @@ static unsigned int InterpOne(unsigned int PC, unsigned int Interp_LONG_CS,
 			e_printf("============ Tab full:cannot close sequence\n");
 
 		// close previous instruction with tail code and try again later
-		Gen(JMP_TAILCODE, basemode, P0);
+		JMPGen(JMP_TAILCODE, basemode, P0);
 		return P0;
 	}
 
@@ -1984,9 +2016,7 @@ repag0:
 				int op = LOOP;
 				if (repmod & MREPCOND)
 					op = (realrepmod&MREP) ? LOOPZ_LOOPE : LOOPNZ_LOOPNE;
-				Gen(JLOOP_LINK, _mode, op);
-				Gen(JMP_LINK, _mode, PC, InstrMeta[0].npc);
-				Gen(JMP_LINK, _mode, P0, InstrMeta[0].npc);
+				JMPGen(JLOOP_LINK, _mode, op, PC, P0);
 				/* code will be flushed immediately
 				   in interp_post because TF is set */
 				break;
@@ -2106,7 +2136,7 @@ repag0:
 				   already a jump */
 				IMeta *GL = &InstrMeta[CurrIMeta];
 				if (GL->gen[GL->ngen-1].op < JMP_TAILCODE)
-					Gen(JMP_LINK, _mode|CKSIGN, PC, InstrMeta[0].npc);
+					JMPGen(JMP_LINK, _mode|CKSIGN, PC);
 			}
 			break;
 /*fc*/	case CLD:	PC++;

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -148,6 +148,10 @@ static inline unsigned int UNPREFIX(unsigned int m)
 static void JMPGen(int op, int mode, ...)
 {
 	va_list	ap;
+
+	if (mode & MTRAP)
+		Gen(L_IMM, mode, Ofs_ERR, EXCP01_SSTP);
+
 	va_start(ap, mode);
 	unsigned int P0 = InstrMeta[0].npc;
 	switch(op) {
@@ -385,6 +389,7 @@ static int can_speculate(void)
 static unsigned int ExceptionGen(unsigned int PC, int basemode, int trapno,
 	unsigned int scp_err, unsigned int P0)
 {
+	basemode &= ~MTRAP; // exceptions override single step trap
 	Gen(L_IMM, basemode, Ofs_ERR, trapno);
 	if (trapno == EXCP0D_GPF)
 		Gen(L_IMM, basemode, Ofs_SCP_ERR, scp_err);
@@ -413,12 +418,9 @@ static unsigned int FindExecCode(unsigned int PC)
 	 * a 'descheduling point' for checking signals.
 	 */
 	while (1) {
+		TheCPU.mode &= ~(MSSTP|MTRAP);
 		if (EFLAGS & TF)
-			CEmuStat |= CeS_TRAP;
-		if (CEmuStat & CeS_TRAP)
-			TheCPU.mode |= MSSTP;
-		else
-			TheCPU.mode &= ~MSSTP;
+			TheCPU.mode |= MSSTP|MTRAP;
 		G = FindTree(PC);
 		if (G) {
 			if (!GoodNode(G)) {
@@ -490,7 +492,7 @@ static unsigned int FindExecCode(unsigned int PC)
 			TheCPU.err = EXCP_EMULEAVE;
 
 		if (TheCPU.err) return PC;
-		if (CEmuStat & (CeS_TRAP|CeS_DRTRAP|CeS_SIGPEND|CeS_RPIC))
+		if (CEmuStat & (CeS_DRTRAP|CeS_SIGPEND|CeS_RPIC))
 			HandleEmuSignals();
 		if (TheCPU.err) return PC;
 	}
@@ -502,17 +504,12 @@ static void HandleEmuSignals(void)
 #if PROFILE
 	if (debug_level('e')) EmuSignals++;
 #endif
-	if (CEmuStat & CeS_TRAP) {
-		/* force exit for single step trap */
-		if (!TheCPU.err)
-			TheCPU.err = EXCP01_SSTP;
-	}
 	//else if (CEmuStat & CeS_DRTRAP) {
 	//	if (e_debug_check(PC)) {
 	//		TheCPU.err = EXCP01_SSTP;
 	//	}
 	//}
-	else if (CEmuStat & CeS_SIGPEND) {
+	if (CEmuStat & CeS_SIGPEND) {
 		/* force exit after signal */
 		CEmuStat = (CEmuStat & ~CeS_SIGPEND) | CeS_SIGACT;
 		TheCPU.err=EXCP_SIGNAL;
@@ -524,7 +521,6 @@ static void HandleEmuSignals(void)
 			TheCPU.err=EXCP_PICSIGNAL;
 	}
 	/* clear optional exit conditions */
-	CEmuStat &= ~CeS_TRAP;
 	if (TheCPU.err)
 		CEmuStat &= ~(CeS_SIGPEND | CeS_RPIC);
 }
@@ -543,8 +539,6 @@ void Interp86(void)
          via Gen_sim or Sim_helper, with different cs:eip */
       return;
     }
-
-    CEmuStat &= ~CeS_TRAP;
 
     PC = LONG_CS + TheCPU.eip;
     assert(CurrIMeta < 0);
@@ -1760,6 +1754,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 #endif
 			if (V86MODE() && (TheCPU.cr[4] & CR4_VME)) {
 				_mode |= DATA16|ADDR16; // no operand size prefix
+				_mode &= ~MTRAP; // INT clears TF
 				if (IOPL == 3) {
 					Gen(O_INT, _mode, inum, P0);
 					Gen(O_PUSH2F, _mode);

--- a/src/include/cpu-emu.h
+++ b/src/include/cpu-emu.h
@@ -50,7 +50,6 @@ extern void e_priv_iopl(int);
 #define CeS_SIGPEND	0x01	/* signal pending mask */
 #define CeS_SIGACT	0x02	/* signal active mask */
 #define CeS_RPIC	0x04	/* pic asks for interruption */
-#define CeS_TRAP	0x1000	/* INT01 Sstep active */
 #define CeS_DRTRAP	0x2000	/* Debug Registers active */
 #define CeS_INSTREMU_RM	0x4000
 #define CeS_INSTREMU_PM	0x8000


### PR DESCRIPTION
This way HandleEmuSignals() no longer sets EXCP01_SSTP, but compiled code, thereby eliminating CeS_TRAP.