### PR TITLE
simx86: nodelinker cleanups, fix debug code

### DIFF
--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -567,7 +567,7 @@ static void sprj_deep(TNode *G, unsigned PC, unsigned int Interp_LONG_CS,
 #ifdef SPEC_PREJIT
 	int i = 0;
 
-	while ((G->unlinked_jmp_targets & TARGET_T) && !(G->flags & (F_LJMP|F_LEAV))) {
+	while (G->clink_t.link && !(G->flags & (F_LJMP|F_LEAV))) {
 		TNode *oldG = G;
 		PC = G->clink_t.target;
 		if (e_querymark(PC, SAFE_PRJ_GAP)) break;

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -430,7 +430,7 @@ void avltr_delete(const int key)
 	    pthread_mutex_unlock(&trees_mtx);
 	    leavedos_main(0x9140);
 	}
-	if (G->bkr.next) {
+	if (G->bkr) {
 	    dbug_printf("Cannot delete - bkr busy\n");
 	    pthread_mutex_unlock(&trees_mtx);
 	    leavedos_main(0x9141);
@@ -629,7 +629,7 @@ void avltr_destroy(void)
 		  p = p->link[1];
 		  break;
 	      }
-	      B = p->data->bkr.next;
+	      B = p->data->bkr;
 	      while (B) {
 		  backref *B2 = B;
 		  B = B->next;
@@ -739,7 +739,7 @@ static void _nodeflagbackrefs(TNode *LG, unsigned short flags)
 	if ((LG->flags & flags) != flags) {
 	    /* only go as far back as long as flags change */
 	    LG->flags |= flags;
-	    for (B=LG->bkr.next; B; B=B->next)
+	    for (B=LG->bkr; B; B=B->next)
 		_nodeflagbackrefs(B->ref, flags);
 	}
 }
@@ -763,8 +763,8 @@ static void linknode(TNode *LG, TNode *G, linkdesc *L, char branch)
 	L->ref = G;
 	B = calloc(1,sizeof(backref));
 	// head insertion
-	B->next = G->bkr.next;
-	G->bkr.next = B;
+	B->next = G->bkr;
+	G->bkr = B;
 	B->ref = LG;
 	B->branch = branch;
 	G->nrefs++;
@@ -787,7 +787,7 @@ static void linknode(TNode *LG, TNode *G, linkdesc *L, char branch)
 	}
 	_nodeflagbackrefs(LG, G->flags & F_FPOP);
 	if (debug_level('e')>8) {
-		backref *bk = G->bkr.next;
+		backref *bk = G->bkr;
 #ifdef DEBUG_LINKER
 		if (bk==NULL) {
 			dbug_printf("bkr null\n");
@@ -829,18 +829,18 @@ static void unlinknode(TNode *G, linkdesc *T, char branch)
 	if (!T->ref) return;
 
 	TNode *H = T->ref;
-	backref *Bq = &H->bkr;
-	backref *B  = H->bkr.next;
+	backref **Bq = &H->bkr;
+	backref *B  = H->bkr;
 	if (debug_level('e')>2) e_printf("Unlink fwd %c ref to node %p(%08x)\n",
 					 branch, H, H->key);
 	while (B) {
 		if (B->ref==G) {
-			Bq->next = B->next;
+			*Bq = B->next;
 			H->nrefs--;
 			free(B);
 			break;
 		}
-		Bq = B;
+		Bq = &B->next;
 		B = B->next;
 	}
 	if (B==NULL) {	// not found...
@@ -854,7 +854,7 @@ static void NodeUnlinker(TNode *G)
 {
 	linkdesc *T_t = &G->clink_t;
 	linkdesc *T_nt = &G->clink_nt;
-	backref *B = G->bkr.next;
+	backref *B = G->bkr;
 #if PROFILE >= 2
 	hitimer_t t0 = 0;
 #endif
@@ -869,7 +869,7 @@ static void NodeUnlinker(TNode *G)
 	// unlink backward references (from other nodes to the current
 	// node)
 	if (debug_level('e')>8)
-	    e_printf("Unlinker: bkr.next=%p\n",B);
+	    e_printf("Unlinker: bkr=%p\n",B);
 	while (B) {
 	    backref *b2 = B;
 	    if (B->branch=='T' || B->branch=='N') {
@@ -912,7 +912,7 @@ static void NodeUnlinker(TNode *G)
 	G->nrefs = 0;
 	memset(T_t, 0, sizeof(linkdesc));
 	memset(T_nt, 0, sizeof(linkdesc));
-	memset(&G->bkr, 0, sizeof(backref));
+	G->bkr = NULL;
 #if PROFILE >= 2
 	if (debug_level('e')) LinkTime += (GETTSC() - t0);
 #endif
@@ -940,7 +940,7 @@ static void checklink(const TNode *G, const linkdesc *L, char branch)
 	    if (debug_level('e')>5)
 		e_printf("  %c: links to %p at %08x with jmp %08x\n",branch,GL,GL->key,
 		*p);
-	    const backref *B = GL->bkr.next;
+	    const backref *B = GL->bkr;
 	    if ((B==NULL) || (GL->nrefs < 1)) {
 		error("bad backref B=%p n=%d\n",B,GL->nrefs);
 		goto nquit;
@@ -1042,7 +1042,7 @@ static void DumpTree (FILE *fd)
 	}
     }
     if (G->nrefs) {
-	B = G->bkr.next;
+	B = G->bkr;
 	while (B) {
 	    fprintf(fd,"         bkref %c -> %p\n",B->branch,B->ref);
 	    B = B->next;

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -1009,7 +1009,8 @@ static void CheckLinks(void)
 
 static void DumpTree (FILE *fd)
 {
-  TNode *G = &CollectTree.root;
+  avltr_node *p = &CollectTree.root;
+  TNode *G;
   linkdesc *L;
   backref *B;
   int nn;
@@ -1020,13 +1021,14 @@ static void DumpTree (FILE *fd)
 
   while (nn < 10000) {		// sorry,only 4 digits available
     /* walk to next node */
-    G = NEXTNODE(G);
-    if (G == &CollectTree.root) {
+    p = NEXTNODE(p);
+    if (p == &CollectTree.root) {
 	fprintf(fd,"\n== EOT ====================================================\n");
 	fflush(fd);
 	return;
     }
     fprintf(fd,"\n-----------------------------------------------------------\n");
+    G = p->data;
     if (G->alive <= 0) {
 	fprintf(fd,"%04d Node %p invalidated\n",nn,G);
 	nn++;
@@ -1034,18 +1036,18 @@ static void DumpTree (FILE *fd)
     }
     fprintf(fd,"%04d Node %p at %08x..%08x addr=%p flags=%#x\n",
 	nn,G,G->key,(G->key+G->seqlen-1),G->addr,G->flags);
-    fprintf(fd,"     AVL (%p:%p),%d,%d,%d,%d\n",G->link[0],G->link[1],
-		G->bal,G->cache,G->pad,G->rtag);
+    fprintf(fd,"     AVL (%p:%p),%d,%d,%d,%d\n",p->link[0],p->link[1],
+		p->bal,p->cache,p->pad,p->rtag);
     fprintf(fd,"     source:     instr=%d, len=%#x\n",G->seqnum,G->seqlen);
     fprintf(fd,"     translated: len=%#x\n",G->len);
     L = &G->clink_t;
     fprintf(fd,"     LINK refs=%d\n",G->nrefs);
     if (L->link) {
-	fprintf(fd,"         T ref=%p patch=%08x at %p\n",L->ref,
+	fprintf(fd,"         T ref=%p patch=%08x at %x\n",L->ref,
 		L->target,L->link);
 	L = &G->clink_nt;
 	if (L->link) {
-	    fprintf(fd,"         N ref=%p patch=%08x at %p\n",L->ref,
+	    fprintf(fd,"         N ref=%p patch=%08x at %x\n",L->ref,
 		L->target,L->link);
 	}
     }

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -906,8 +906,6 @@ static void NodeUnlinker(TNode *G)
 	    e_printf("Unlinker: refs=T%p N%p\n",T_t->ref,T_nt->ref);
 	unlinknode(G, T_t, 'T');
 	unlinknode(G, T_nt, 'N');
-	memset(T_t, 0, sizeof(linkdesc));
-	memset(T_nt, 0, sizeof(linkdesc));
 #if PROFILE >= 2
 	if (debug_level('e')) LinkTime += (GETTSC() - t0);
 #endif

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -425,11 +425,6 @@ void avltr_delete(const int key)
   if (debug_level('e')>2) e_printf("Remove node %p\n",p);
 #endif
 #ifdef DEBUG_LINKER
-	if (G->nrefs) {
-	    dbug_printf("Cannot delete - nrefs=%d\n",G->nrefs);
-	    pthread_mutex_unlock(&trees_mtx);
-	    leavedos_main(0x9140);
-	}
 	if (G->bkr) {
 	    dbug_printf("Cannot delete - bkr busy\n");
 	    pthread_mutex_unlock(&trees_mtx);
@@ -728,6 +723,16 @@ unsigned int FindPC(const unsigned char *addr)
  * "back-references" in a list in order to unlink it.
  */
 
+static unsigned tnode_nrefs(const TNode *G)
+{
+	unsigned nrefs = 0;
+	backref *B;
+
+	for (B=G->bkr; B; B=B->next)
+		nrefs++;
+	return nrefs;
+}
+
 static void _nodeflagbackrefs(TNode *LG, unsigned short flags)
 {
 	/* helper routine to flag all back references:
@@ -767,14 +772,13 @@ static void linknode(TNode *LG, TNode *G, linkdesc *L, char branch)
 	G->bkr = B;
 	B->ref = LG;
 	B->branch = branch;
-	G->nrefs++;
 	if (G==LG) {
 		G->flags |= F_SLFL;
 		if (debug_level('e')>1) {
 			e_printf("Linker: node (%p:%08x:%p) SELF link\n"
 				 "\t\ttarget=%08x, %c_ref %d=%p\n",
 				 G,G->key,G->addr,
-				 L->target, B->branch, G->nrefs, L->ref);
+				 L->target, B->branch, tnode_nrefs(G), L->ref);
 		}
 	}
 	else if (debug_level('e')>1) {
@@ -783,7 +787,7 @@ static void linknode(TNode *LG, TNode *G, linkdesc *L, char branch)
 			 "\t\ttarget=%08x, %c_ref %d=%p\n",
 			 LG,LG->key,LG->addr,
 			 G,G->key,G->addr,
-			 L->target, B->branch, G->nrefs, L->ref);
+			 L->target, B->branch, tnode_nrefs(G), L->ref);
 	}
 	_nodeflagbackrefs(LG, G->flags & F_FPOP);
 	if (debug_level('e')>8) {
@@ -836,7 +840,6 @@ static void unlinknode(TNode *G, linkdesc *T, char branch)
 	while (B) {
 		if (B->ref==G) {
 			*Bq = B->next;
-			H->nrefs--;
 			free(B);
 			break;
 		}
@@ -871,7 +874,6 @@ static void NodeUnlinker(TNode *G)
 	if (debug_level('e')>8)
 	    e_printf("Unlinker: bkr=%p\n",B);
 	while (B) {
-	    backref *b2 = B;
 	    if (B->branch=='T' || B->branch=='N') {
 		TNode *H = B->ref;
 		linkdesc *L;
@@ -887,20 +889,15 @@ static void NodeUnlinker(TNode *G)
 				 .p0 = L->target, .p1 = H->key};
 		CodeGen(H->addr + L->link, H->addr, &IG);
 		L->ref = NULL;
-		G->nrefs--;
 	    }
 	    else {
 		e_printf("Invalid unlink [%c] ref %p from node ?(?) to %08x\n",
 			B->branch, B->ref, G->key);
 		leavedos_main(0x8116);
 	    }
-	    B = B->next;
-	    free(b2);
-	}
-
-	if (G->nrefs) {
-	    dbug_printf("Unlinker: nrefs error\n");
-	    leavedos_main(0x8115);
+	    G->bkr = B->next;
+	    free(B);
+	    B = G->bkr;
 	}
 
 	// unlink forward references (from the current node to other
@@ -909,10 +906,8 @@ static void NodeUnlinker(TNode *G)
 	    e_printf("Unlinker: refs=T%p N%p\n",T_t->ref,T_nt->ref);
 	unlinknode(G, T_t, 'T');
 	unlinknode(G, T_nt, 'N');
-	G->nrefs = 0;
 	memset(T_t, 0, sizeof(linkdesc));
 	memset(T_nt, 0, sizeof(linkdesc));
-	G->bkr = NULL;
 #if PROFILE >= 2
 	if (debug_level('e')) LinkTime += (GETTSC() - t0);
 #endif
@@ -941,10 +936,7 @@ static void checklink(const TNode *G, const linkdesc *L, char branch)
 		e_printf("  %c: links to %p at %08x with jmp %08x\n",branch,GL,GL->key,
 		*p);
 	    const backref *B = GL->bkr;
-	    if ((B==NULL) || (GL->nrefs < 1)) {
-		error("bad backref B=%p n=%d\n",B,GL->nrefs);
-		goto nquit;
-	    }
+	    assert(B); // bad backref if NULL
 	    int n = 0;
 	    int brt = 0;
 	    while (B) {
@@ -1031,7 +1023,7 @@ static void DumpTree (FILE *fd)
     fprintf(fd,"     source:     instr=%d, len=%#x\n",G->seqnum,G->seqlen);
     fprintf(fd,"     translated: len=%#x\n",G->len);
     L = &G->clink_t;
-    fprintf(fd,"     LINK refs=%d\n",G->nrefs);
+    fprintf(fd,"     LINK refs=%d\n",tnode_nrefs(G));
     if (L->link) {
 	fprintf(fd,"         T ref=%p patch=%08x at %x\n",L->ref,
 		L->target,L->link);
@@ -1041,7 +1033,7 @@ static void DumpTree (FILE *fd)
 		L->target,L->link);
 	}
     }
-    if (G->nrefs) {
+    if (G->bkr) {
 	B = G->bkr;
 	while (B) {
 	    fprintf(fd,"         bkref %c -> %p\n",B->branch,B->ref);

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -744,20 +744,19 @@ static void _nodeflagbackrefs(TNode *LG, unsigned short flags)
 	}
 }
 
-static void linknode(TNode *LG, TNode *G, linkdesc *L, unsigned target_type)
+static void linknode(TNode *LG, TNode *G, linkdesc *L, char branch)
 {
 	backref *B;
 
 	// points to current node, which can't be a forever loop?
-	if (L->target!=G->key || !(LG->unlinked_jmp_targets & target_type) ||
+	if (L->target!=G->key || !L->link ||
 	    (G->mode & MTRAP) || (LG->mode & MTRAP))
 		return;
 
 	if (L->ref!=0) {
 		dbug_printf("Linker: ref at %08x busy\n",LG->key);
-		leavedos_main(0x8102 + (target_type == TARGET_NT));
+		leavedos_main(0x8102 + (branch == 'N'));
 	}
-	LG->unlinked_jmp_targets &= ~target_type;
 	IGen IG = (IGen){.op = JMP_LINK, .mode = MPATCH|MLINK,
 			 .p0 = L->target, .link = G->addr};
 	CodeGen(LG->addr + L->link, LG->addr, &IG);
@@ -767,7 +766,7 @@ static void linknode(TNode *LG, TNode *G, linkdesc *L, unsigned target_type)
 	B->next = G->bkr.next;
 	G->bkr.next = B;
 	B->ref = LG;
-	B->branch = target_type == TARGET_T ? 'T' : 'N';
+	B->branch = branch;
 	G->nrefs++;
 	if (G==LG) {
 		G->flags |= F_SLFL;
@@ -792,7 +791,7 @@ static void linknode(TNode *LG, TNode *G, linkdesc *L, unsigned target_type)
 #ifdef DEBUG_LINKER
 		if (bk==NULL) {
 			dbug_printf("bkr null\n");
-			leavedos_main(0x8108 + (target_type == TARGET_NT));
+			leavedos_main(0x8108 + (branch == 'N'));
 		}
 #endif
 		while (bk) { dbug_printf("bkref=%c%p\n",bk->branch,
@@ -816,9 +815,9 @@ void NodeLinker(TNode *LG, TNode *G)
 #endif
 	if (debug_level('e')>8 && LG) e_printf("NodeLinker: %08x->%08x\n",LG->key,G->key);
 
-	if (LG && LG->alive>0 && LG->unlinked_jmp_targets) {	// node ends with links
-		linknode(LG, G, &LG->clink_t, TARGET_T);
-		linknode(LG, G, &LG->clink_nt, TARGET_NT);
+	if (LG && LG->alive>0) {
+		linknode(LG, G, &LG->clink_t, 'T');
+		linknode(LG, G, &LG->clink_nt, 'N');
 	}
 #if PROFILE >= 2
 	if (debug_level('e')) LinkTime += (GETTSC() - t0);
@@ -875,16 +874,8 @@ static void NodeUnlinker(TNode *G)
 	    backref *b2 = B;
 	    if (B->branch=='T' || B->branch=='N') {
 		TNode *H = B->ref;
-		unsigned target_type;
 		linkdesc *L;
-		if (B->branch=='T') {
-			target_type = TARGET_T;
-			L = &H->clink_t;
-		}
-		else {
-			target_type = TARGET_NT;
-			L = &H->clink_nt;
-		}
+		L = (B->branch=='T') ? &H->clink_t : &H->clink_nt;
 		if (debug_level('e')>2) e_printf("Unlinking %c ref from node %p(%08x) to %08x\n",
 			B->branch, H, L->target, G->key);
 		if (L->target != G->key) {
@@ -895,7 +886,7 @@ static void NodeUnlinker(TNode *G)
 		IGen IG = (IGen){.op = JMP_LINK, .mode = MPATCH,
 				 .p0 = L->target, .p1 = H->key};
 		CodeGen(H->addr + L->link, H->addr, &IG);
-		L->ref = NULL; H->unlinked_jmp_targets |= target_type;
+		L->ref = NULL;
 		G->nrefs--;
 	    }
 	    else {
@@ -921,7 +912,6 @@ static void NodeUnlinker(TNode *G)
 	G->nrefs = 0;
 	memset(T_t, 0, sizeof(linkdesc));
 	memset(T_nt, 0, sizeof(linkdesc));
-	G->unlinked_jmp_targets = 0;
 	memset(&G->bkr, 0, sizeof(backref));
 #if PROFILE >= 2
 	if (debug_level('e')) LinkTime += (GETTSC() - t0);
@@ -1220,24 +1210,23 @@ TNode *Move2Tree(IMeta *I0, unsigned char *GenCodeBuf)
   nG->addr = GenCodeBuf;
 
   /* setup structures for inter-node linking */
-  nG->unlinked_jmp_targets = 0;
   nG->clink_nt.link = nG->clink_t.link = 0;
   IG = &I0[CurrIMeta].gen[I0[CurrIMeta].ngen-1];
   op = IG->op;
   if (op == JMP_LINK) {
+    assert(IG->p2); // because TheCPU.eip is set first, this can never be 0
     nG->clink_t.link = IG->p2;
     nG->clink_t.target = IG->p0;
-    nG->unlinked_jmp_targets |= TARGET_T;
     if (I0[CurrIMeta].ngen > 1 && (IG-1)->op == JMP_LINK) {
       IG--;
+      assert(IG->p2);
       nG->clink_nt.link = IG->p2;
       nG->clink_nt.target = IG->p0;
-      nG->unlinked_jmp_targets |= TARGET_NT;
     }
     if ((debug_level('e')>3))
 	dbug_printf("Link %d: %x:%08x\n",op,
 		nG->clink_nt.link,
-		((nG->unlinked_jmp_targets & TARGET_NT)? nG->clink_nt.target:0));
+		(nG->clink_nt.link? nG->clink_nt.target:0));
   }
 
   /* setup source/xlated instruction offsets */

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -425,17 +425,17 @@ void avltr_delete(const int key)
   if (debug_level('e')>2) e_printf("Remove node %p\n",p);
 #endif
 #ifdef DEBUG_LINKER
-	if (p->nrefs) {
-	    dbug_printf("Cannot delete - nrefs=%d\n",p->nrefs);
+	if (G->nrefs) {
+	    dbug_printf("Cannot delete - nrefs=%d\n",G->nrefs);
 	    pthread_mutex_unlock(&trees_mtx);
 	    leavedos_main(0x9140);
 	}
-	if (p->bkr.next) {
+	if (G->bkr.next) {
 	    dbug_printf("Cannot delete - bkr busy\n");
 	    pthread_mutex_unlock(&trees_mtx);
 	    leavedos_main(0x9141);
 	}
-	if (p->clink_t.ref || p->clink_nt.ref) {
+	if (G->clink_t.ref || G->clink_nt.ref) {
 	    dbug_printf("Cannot delete - ref busy\n");
 	    pthread_mutex_unlock(&trees_mtx);
 	    leavedos_main(0x9142);
@@ -931,23 +931,25 @@ static void NodeUnlinker(TNode *G)
 /////////////////////////////////////////////////////////////////////////////
 
 #ifdef DEBUG_LINKER
+#include "codegen-x86.h"
 
 static void checklink(const TNode *G, const linkdesc *L, char branch)
 {
   if (!L->link) return;
 
-  const unsigned char *p = ((unsigned char *)L->link) - 1;
+  const unsigned char *p = G->addr + L->link;
+  if (p[0] == 0x0f) p += CKSIGNSIZE;
   if (L->ref) {
 	    const TNode *GL = L->ref;
 	    if (debug_level('e')>5)
-		e_printf("  %c: ref=%p link=%p\n",
+		e_printf("  %c: ref=%p link=%x\n",
 			 branch,GL,L->link);
 	    if ((*p!=0xe9)&&(*p!=0xeb)&&(*p!=0x48)) {
 		error("bad %c link jmp\n", branch); goto nquit;
 	    }
 	    if (debug_level('e')>5)
 		e_printf("  %c: links to %p at %08x with jmp %08x\n",branch,GL,GL->key,
-		*L->link);
+		*p);
 	    const backref *B = GL->bkr.next;
 	    if ((B==NULL) || (GL->nrefs < 1)) {
 		error("bad backref B=%p n=%d\n",B,GL->nrefs);
@@ -968,7 +970,7 @@ static void checklink(const TNode *G, const linkdesc *L, char branch)
 	    }
   }
   else {
-	    if (*p!=0xb8) {
+	    if (*p!=0xb9) {
 		error("bad %c link jmp\n", branch); goto nquit;
 	    }
   }
@@ -979,15 +981,17 @@ nquit:
 
 static void CheckLinks(void)
 {
-  TNode *G = &CollectTree.root;
+  avltr_node *p = &CollectTree.root;
+  TNode *G;
 
   for (;;) {
     /* walk to next node */
-    G = NEXTNODE(G);
-    if (G == &CollectTree.root) {
+    p = NEXTNODE(p);
+    if (p == &CollectTree.root) {
 	e_printf("DEBUG: node link check ok\n");
 	return;
     }
+    G = p->data;
     if (G->alive <= 0) {
 	e_printf("Node %p invalidated\n",G);
 	continue;
@@ -996,7 +1000,6 @@ static void CheckLinks(void)
     checklink(G, &G->clink_t, 'T');
     checklink(G, &G->clink_nt, 'N');
   }
-nquit:
   leavedos_main(0x9143);
 }
 

--- a/src/base/emu-i386/simx86/trees.h
+++ b/src/base/emu-i386/simx86/trees.h
@@ -121,7 +121,6 @@ typedef struct TNode
 	int alive;
 	unsigned char *addr;
 	unsigned short len, flags, seqlen, seqnum __attribute__ ((packed));
-	unsigned short nrefs;
 	linkdesc clink_t;
 	linkdesc clink_nt;
 	backref *bkr;

--- a/src/base/emu-i386/simx86/trees.h
+++ b/src/base/emu-i386/simx86/trees.h
@@ -124,7 +124,7 @@ typedef struct TNode
 	unsigned short nrefs;
 	linkdesc clink_t;
 	linkdesc clink_nt;
-	backref bkr;
+	backref *bkr;
 	unsigned cs;
 	unsigned mode;
 	Addr2Pc meta[]; /* there are seqnum+1 of these */

--- a/src/base/emu-i386/simx86/trees.h
+++ b/src/base/emu-i386/simx86/trees.h
@@ -55,9 +55,6 @@ typedef struct _bkref {
 	char branch;
 } backref;
 
-#define TARGET_T 1
-#define TARGET_NT 2
-
 typedef struct _lnkdesc {
 	unsigned int link;
 	unsigned int target;
@@ -127,7 +124,6 @@ typedef struct TNode
 	unsigned short nrefs;
 	linkdesc clink_t;
 	linkdesc clink_nt;
-	unsigned unlinked_jmp_targets;
 	backref bkr;
 	unsigned cs;
 	unsigned mode;


### PR DESCRIPTION
This PR fixes DEBUG_TREE and DEBUG_LINKER (not enabled by default), as well as doing some cleanups for redundant fields in the TNode struct:
1. `unlinked_jmp_targets` this was used as an optimization in `DoExec` but not any more; we can check `ref` and `link` fields instead.
2. `backref` TNode had a full struct but was only using the `next` pointer, so use a pointer only instead.
3. `nrefs` This is the length of the backrefs linked list. It was only used for debugging: we can calculate it dynamically instead.
Some explicit `leavedos_main()` were now redundant, others better done as `assert()`.