### PR TITLE
simx86: make jit helpers more like stub functions

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -76,9 +76,6 @@ static unsigned char *CodeGen_sim(unsigned char *CodePtr, unsigned char *BaseGen
 static unsigned Exec_sim(unsigned *mem_ref, unsigned long *flg,
 			 unsigned char *ecpu, void *SeqStart,
 			 unsigned short seqflg, unsigned *seqbase);
-static unsigned int _Sim_helper(unsigned int mem_ref, unsigned int data, int mode,
-			uint32_t *flags, unsigned int opc, unsigned int arg,
-			unsigned char *eip);
 
 static unsigned char *currentIG = NULL;
 
@@ -2133,7 +2130,7 @@ static unsigned int Gen_sim(IGen *IG, unsigned int *pmem_ref,
 
 	case O_SIM: {
 		uint32_t flags = FlagSync_All();
-		DR1.d = _Sim_helper(mem_ref, DR1.d, mode,
+		DR1.d = Sim_helper(mem_ref, DR1.d, mode,
 				   &flags, IG->p0, IG->p1, currentIG);
 		FlagSync_RFL(flags);
 		if (TheCPU.err > 0)
@@ -2992,10 +2989,12 @@ static __inline__ void SetCPU_WL(int m, signed char o, unsigned long v)
  * arg: instruction-dependent argument passed via IG->p1 at compile time
  * returns data (could be modified), so compiled code can write it back
  */
-static unsigned int _Sim_helper(unsigned int mem_ref, unsigned int data, int mode,
+unsigned int Sim_helper(unsigned int mem_ref, unsigned int data, int mode,
 			uint32_t *flags, unsigned int opc, unsigned int arg,
 			unsigned char *eip)
 {
+	/* needed in emu_pagefault_handler */
+	currentIG = eip;
 	EFLAGS = (EFLAGS & ~EFLAGS_CC) | (*flags & EFLAGS_CC);
 
 	unsigned int temp;
@@ -3515,18 +3514,4 @@ not_permitted_sim:
 	if (debug_level('e')>1) e_printf("!!! Not permitted %02x\n",opc);
 	TheCPU.err = EXCP0D_GPF;
 	return data;
-}
-
-unsigned int Sim_helper(unsigned int mem_ref, unsigned int data, int mode,
-			uint32_t *flags, unsigned int opc, unsigned int arg,
-			unsigned char *rip)
-{
-	unsigned int ret;
-
-	InCompiledCode--;
-	/* needed in emu_pagefault_handler */
-	currentIG = GetGenCodeBuf(rip);
-	ret = _Sim_helper(mem_ref, data, mode, flags, opc, arg, currentIG);
-	InCompiledCode++;
-	return ret;
 }

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -473,7 +473,7 @@ static unsigned int Gen_sim(IGen *IG, unsigned int *pmem_ref,
 	case A_SR_PROT: {	// protected mode make base addr from seg
 		unsigned int o = IG->p0;
 		GTRACE1("A_SR_PROT",o);
-		SetSegProt_helper(DR1.w.l, o);
+		SetSegProt(o, DR1.w.l);
 		if (TheCPU.err)
 			P0 = IG->p1;
 		}

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -270,34 +270,10 @@ static unsigned char *CodeGen_x86(unsigned char *CodePtr, unsigned char *BaseGen
 		}
 		break;
 	case A_SR_PROT: {	// prot mode make base addr from seg
-		// movzwl %%ax,%%eax: zero extend segreg
-		G3(0xc0b70f,Cp);
-#ifdef __x86_64__
-		// pushq %rdi: save memory address for LDS etc.
-		G1(0x57,Cp);
-		// pushq %rsi: save stack address for O_POP3
-		G1(0x56,Cp);
-#endif
-		// pushb Ofs
-		G2M(0x6a,IG->p0,Cp)
-#ifdef __x86_64__
-		// popq %%rsi
-		G1(0x5e,Cp);
-		// movq %%rax,%%rdi
-		G2M(0x89,0xc7,Cp);
-#else
-		// pushl %eax
-		G1(0x50,Cp);
-#endif
+		// movl Ofs,%%edx
+		G1(0xba,Cp); G4(IG->p0,Cp);
 		// call Ofs_SetSegProt(%%ebx)
 		G3M(0xff,0x53,Ofs_SetSegProt(),Cp);
-#ifdef __x86_64__
-		// popq %rsi; popq %rdi
-		G2M(0x5e,0x5f,Cp);
-#else
-		// popl %edx; popl %edx
-		G2M(0x5a,0x5a,Cp);
-#endif
 		// cmpl $0x0,Ofs_ERR(%rbx)
 		G4M(0x83,0x7b,Ofs_ERR,0x00,Cp);
 		// jz skip

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -1621,64 +1621,20 @@ shrot0:
 		}
 
 	case O_SIM:
-#ifdef __x86_64__
-		// mov %%eax, %%esi
-		G2M(0x89,0xc6,Cp);
-		// mov $mode, %%edx
-		G1(MOVidx,Cp); G4(mode,Cp);
-		// mov %rsp, %rcx // &flags
-		G3M(0x48,0x89,0xe1,Cp);
-		// mov $opc, %%r8d
-		G2M(0x41,0xb8,Cp); G4(IG->p0,Cp);
-		// mov $arg, %%r9d
-		G2M(0x41,0xb9,Cp); G4(IG->p1,Cp);
-		// push %%rdi // keep mem_ref
-		G1(PUSHdi,Cp);
-		// call 1f (to push eip)
-		G1(CALLd,Cp); G4(1+4+2+TAILSIZE,Cp);
-		// pop %%rdi // mem_ref
-		G1(POPdi,Cp);
-#else
-		// mov %esp, %ecx // flags
-		G2M(0x89,0xe1,Cp);
-		// call 1f (to push eip)
-		G1(CALLd,Cp); G4(4+2+TAILSIZE,Cp);
-#endif
-
-		// cmpl $0x0,Ofs_ERR(%rbx)
-		G4M(0x83,0x7b,Ofs_ERR,0x00,Cp);
-		// jle skip: negative TheCPU.err allow completion
-#ifdef __x86_64__
-		G2M(JLE_JNG,TAILSIZE+4,Cp);
-#else
-		G2M(JLE_JNG,TAILSIZE+1+4+1+4+1+1+4+1+1+3+3+1,Cp);
-#endif
-		// movl {exit_addr},%%eax; movl %eax,%ecx;  pop %%edx; ret
-		G1(MOViax,Cp); G4(IG->p2,Cp); G4M(0x89,0xc1,POPdx,RET,Cp);
-
-		// 1:
-#ifndef __x86_64__
 		// push $arg
 		G1(PUSHwi,Cp); G4(IG->p1,Cp);
 		// push $opc
 		G1(PUSHwi,Cp); G4(IG->p0,Cp);
-		// push %%ecx // &flags
-		G1(PUSHcx,Cp);
 		// push $mode
 		G1(PUSHwi,Cp); G4(mode,Cp);
-		// push %%eax // data
-		G1(PUSHax,Cp);
-		// push %%edi // mem_ref
-		G1(PUSHdi,Cp);
-#endif
 		// call Ofs_SimHelper(%%ebx)
 		G3M(0xff,0x53,Ofs_SimHelper(),Cp);
-#ifndef __x86_64__
-		// addl $24,%%esp
-		G3M(0x83,0xc4,24,Cp)
-#endif
-		G1(RET,Cp);
-		// skip:
+		// cmpl $0x0,Ofs_ERR(%rbx)
+		G4M(0x83,0x7b,Ofs_ERR,0x00,Cp);
+		// je skip
+		G2M(JE_JZ,TAILSIZE,Cp);
+		// movl {exit_addr},%%eax; movl %eax,%ecx;  pop %%edx; ret
+		G1(MOViax,Cp); G4(IG->p2,Cp); G4M(0x89,0xc1,POPdx,RET,Cp);
 
 	case O_MOVS_SetA: {
 		/* use edi for loads unless MOVSDST or REP is set */

--- a/src/base/emu-i386/simx86/cpatch.c
+++ b/src/base/emu-i386/simx86/cpatch.c
@@ -761,6 +761,18 @@ void stub_read_8 (void) asm ("stub_read_8__" );
 void stub_read_16(void) asm ("stub_read_16__");
 void stub_read_32(void) asm ("stub_read_32__");
 
+static unsigned int Sim_helper_jit(unsigned int mem_ref, unsigned int data,
+				   int mode, uint32_t *flags, unsigned int opc,
+				   unsigned int arg, unsigned char *rip)
+{
+    unsigned int ret;
+
+    InCompiledCode--;
+    ret = Sim_helper(mem_ref, data, mode, flags, opc, arg, GetGenCodeBuf(rip));
+    InCompiledCode++;
+    return ret;
+}
+
 void Cpatch_init(void)
 {
     TheCPU_struct.stub_func[STUB_REP] = stub_rep;
@@ -773,7 +785,7 @@ void Cpatch_init(void)
     TheCPU_struct.stub_func[STUB_READ_16] = stub_read_16;
     TheCPU_struct.stub_func[STUB_READ_32] = stub_read_32;
     TheCPU_struct.stub_func[STUB_SETSEGPROT] = (stubfunc_t)SetSegProt_helper;
-    TheCPU_struct.stub_func[STUB_SIMHELPER] = (stubfunc_t)Sim_helper;
+    TheCPU_struct.stub_func[STUB_SIMHELPER] = (stubfunc_t)Sim_helper_jit;
 }
 
 /* ======================================================================= */

--- a/src/base/emu-i386/simx86/cpatch.c
+++ b/src/base/emu-i386/simx86/cpatch.c
@@ -476,6 +476,17 @@ asm (
 "1:		ret	$4\n"
 );
 
+asm (
+".text\n.globl stub_simhelper__\n"
+"stub_simhelper__:\n"
+"		pushl	%esp\n"		// stack
+"		pushl	%eax\n"		// data
+"		pushl	%edi\n"		// mem_ref
+"		call	Sim_helper_jit\n"
+"		addl	$12,%esp\n"	// remove stack parameters
+"		ret	$12\n"
+);
+
 /* ======================================================================= */
 
 #else //__x86_64__
@@ -539,6 +550,18 @@ asm (
 "1:		ret	$8\n"
 );
 
+asm (
+".text\n.globl stub_simhelper__\n"
+"stub_simhelper__:\n"
+"		mov	%eax, %esi\n"	// data
+"		mov	%rsp, %rdx\n"	// stack
+"		push	%rdi\n"		// keep mem_ref
+"		push	%rdi\n"		// stack align
+"		call	Sim_helper_jit\n"
+"		pop	%rdi\n"		// stack align
+"		pop	%rdi\n"		// mem_ref
+"		ret	$24\n"
+);
 #endif
 
 asm (
@@ -760,6 +783,7 @@ void stub_wri_32(void) asm ("stub_wri_32__");
 void stub_read_8 (void) asm ("stub_read_8__" );
 void stub_read_16(void) asm ("stub_read_16__");
 void stub_read_32(void) asm ("stub_read_32__");
+void stub_simhelper(void) asm ("stub_simhelper__");
 
 // this function is called from JIT-generated code
 static void SetSegProt_helper(unsigned short sel, int ofs)
@@ -769,14 +793,24 @@ static void SetSegProt_helper(unsigned short sel, int ofs)
     InCompiledCode++;
 }
 
-static unsigned int Sim_helper_jit(unsigned int mem_ref, unsigned int data,
-				   int mode, uint32_t *flags, unsigned int opc,
-				   unsigned int arg, unsigned char *rip)
+struct sim_stack {
+    unsigned char *rip;
+    long mode;
+    unsigned long opc, arg;
+    unsigned int flags;
+#ifdef __x86_64__
+    unsigned int padding;
+#endif
+} __attribute__((packed));
+
+unsigned int Sim_helper_jit(unsigned int mem_ref, unsigned int data,
+			    struct sim_stack *s)
 {
     unsigned int ret;
 
     InCompiledCode--;
-    ret = Sim_helper(mem_ref, data, mode, flags, opc, arg, GetGenCodeBuf(rip));
+    ret = Sim_helper(mem_ref, data, s->mode, &s->flags, s->opc, s->arg,
+		     GetGenCodeBuf(s->rip));
     InCompiledCode++;
     return ret;
 }
@@ -793,7 +827,7 @@ void Cpatch_init(void)
     TheCPU_struct.stub_func[STUB_READ_16] = stub_read_16;
     TheCPU_struct.stub_func[STUB_READ_32] = stub_read_32;
     TheCPU_struct.stub_func[STUB_SETSEGPROT] = (stubfunc_t)SetSegProt_helper;
-    TheCPU_struct.stub_func[STUB_SIMHELPER] = (stubfunc_t)Sim_helper_jit;
+    TheCPU_struct.stub_func[STUB_SIMHELPER] = stub_simhelper;
 }
 
 /* ======================================================================= */

--- a/src/base/emu-i386/simx86/cpatch.c
+++ b/src/base/emu-i386/simx86/cpatch.c
@@ -761,6 +761,14 @@ void stub_read_8 (void) asm ("stub_read_8__" );
 void stub_read_16(void) asm ("stub_read_16__");
 void stub_read_32(void) asm ("stub_read_32__");
 
+// this function is called from JIT-generated code
+static void SetSegProt_helper(unsigned short sel, int ofs)
+{
+    InCompiledCode--;
+    SetSegProt(ofs, sel);
+    InCompiledCode++;
+}
+
 static unsigned int Sim_helper_jit(unsigned int mem_ref, unsigned int data,
 				   int mode, uint32_t *flags, unsigned int opc,
 				   unsigned int arg, unsigned char *rip)

--- a/src/base/emu-i386/simx86/cpatch.c
+++ b/src/base/emu-i386/simx86/cpatch.c
@@ -477,6 +477,17 @@ asm (
 );
 
 asm (
+".text\n.globl stub_setsegprot__\n"
+"stub_setsegprot__:\n"
+"		pushl	%edx\n"		// ofs
+"		movzx	%ax, %eax\n"
+"		pushl	%eax\n"		// sel (zero-extend)
+"		call	SetSegProt_helper\n"
+"		addl	$8,%esp\n"	// remove stack parameters
+"		ret\n"
+);
+
+asm (
 ".text\n.globl stub_simhelper__\n"
 "stub_simhelper__:\n"
 "		pushl	%esp\n"		// stack
@@ -548,6 +559,21 @@ asm (
 "		popq	%rdx\n"
 "		popq	%rax\n"
 "1:		ret	$8\n"
+);
+
+asm (
+".text\n.globl stub_setsegprot__\n"
+"stub_setsegprot__:\n"
+"		pushq	%rdi\n"		// save memory address for LDS etc.
+"		pushq	%rsi\n"		// save stack address for O_POP3
+"		pushq	%rsi\n"		// stack align
+"		mov	%edx, %esi\n"	// ofs
+"		movzx	%ax, %edi\n"	// sel (zero-extend)
+"		call	SetSegProt_helper\n"
+"		pop	%rsi\n"
+"		pop	%rsi\n"
+"		pop	%rdi\n"
+"		ret\n"
 );
 
 asm (
@@ -783,10 +809,11 @@ void stub_wri_32(void) asm ("stub_wri_32__");
 void stub_read_8 (void) asm ("stub_read_8__" );
 void stub_read_16(void) asm ("stub_read_16__");
 void stub_read_32(void) asm ("stub_read_32__");
+void stub_setsegprot(void) asm ("stub_setsegprot__");
 void stub_simhelper(void) asm ("stub_simhelper__");
 
 // this function is called from JIT-generated code
-static void SetSegProt_helper(unsigned short sel, int ofs)
+void SetSegProt_helper(unsigned short sel, int ofs)
 {
     InCompiledCode--;
     SetSegProt(ofs, sel);
@@ -826,7 +853,7 @@ void Cpatch_init(void)
     TheCPU_struct.stub_func[STUB_READ_8] = stub_read_8;
     TheCPU_struct.stub_func[STUB_READ_16] = stub_read_16;
     TheCPU_struct.stub_func[STUB_READ_32] = stub_read_32;
-    TheCPU_struct.stub_func[STUB_SETSEGPROT] = (stubfunc_t)SetSegProt_helper;
+    TheCPU_struct.stub_func[STUB_SETSEGPROT] = stub_setsegprot;
     TheCPU_struct.stub_func[STUB_SIMHELPER] = stub_simhelper;
 }
 

--- a/src/base/emu-i386/simx86/cpatch.h
+++ b/src/base/emu-i386/simx86/cpatch.h
@@ -10,6 +10,7 @@
 #endif
 
 struct rep_stack;
+struct sim_stack;
 
 ASMLINKAGE(void,rep_movs_stos,(struct rep_stack *stack));
 ASMLINKAGE(void,stk_16,(dosaddr_t addr, Bit16u value));
@@ -20,6 +21,9 @@ ASMLINKAGE(void,wri_32,(dosaddr_t addr, Bit32u value, unsigned char *eip));
 ASMLINKAGE(Bit8u,read_8,(dosaddr_t addr));
 ASMLINKAGE(Bit16u,read_16,(dosaddr_t addr));
 ASMLINKAGE(Bit32u,read_32,(dosaddr_t addr));
+ASMLINKAGE(unsigned int,Sim_helper_jit,(unsigned int mem_ref, \
+					unsigned int data, \
+					struct sim_stack *s));
 
 int Cpatch(sigcontext_t *scp);
 int UnCpatch(unsigned char *eip);

--- a/src/base/emu-i386/simx86/cpatch.h
+++ b/src/base/emu-i386/simx86/cpatch.h
@@ -21,6 +21,7 @@ ASMLINKAGE(void,wri_32,(dosaddr_t addr, Bit32u value, unsigned char *eip));
 ASMLINKAGE(Bit8u,read_8,(dosaddr_t addr));
 ASMLINKAGE(Bit16u,read_16,(dosaddr_t addr));
 ASMLINKAGE(Bit32u,read_32,(dosaddr_t addr));
+ASMLINKAGE(void,SetSegProt_helper,(unsigned short sel, int ofs));
 ASMLINKAGE(unsigned int,Sim_helper_jit,(unsigned int mem_ref, \
 					unsigned int data, \
 					struct sim_stack *s));

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -99,8 +99,6 @@ jmp_buf jmp_env;
 
 struct _SynCPU TheCPU_struct;
 
-int InCompiledCode;
-
 #ifdef DEBUG_TREE
 FILE *tLog = NULL;
 #endif
@@ -1534,11 +1532,6 @@ int e_debug_check(unsigned int PC)
 	}
     }
     return 0;
-}
-
-int e_in_compiled_code(void)
-{
-    return InCompiledCode;
 }
 
 int in_emu_cpu(void)

--- a/src/base/emu-i386/simx86/emu86.h
+++ b/src/base/emu-i386/simx86/emu86.h
@@ -713,7 +713,6 @@ extern int UseLinker;
 extern int PageFaults;
 
 extern int CEmuStat;
-extern int InCompiledCode;
 //
 unsigned char *do_hwint(int mode, int intno);
 void Interp86(void);
@@ -761,9 +760,10 @@ unsigned char *GetExecCodeBuf(const unsigned char *ptr);
 void CollectStat(void);
 //
 /////////////////////////////////////////////////////////////////////////////
+#ifdef X86_JIT
+extern int InCompiledCode;
 int e_handle_pagefault(dosaddr_t addr, unsigned err, sigcontext_t *scp);
 int e_handle_fault(sigcontext_t *scp);
-#ifdef X86_JIT
 void init_emu_npu_x86(void);
 #endif
 int e_querymark(unsigned int addr, size_t len);

--- a/src/base/emu-i386/simx86/protmode.c
+++ b/src/base/emu-i386/simx86/protmode.c
@@ -93,14 +93,6 @@ int SetSegReal(unsigned short sel, int ofs)
 	return 0;
 }
 
-// this function is called from JIT-generated code
-void SetSegProt_helper(unsigned short sel, int ofs)
-{
-	InCompiledCode--;
-	SetSegProt(ofs, sel);
-	InCompiledCode++;
-}
-
 static int _SetSegProt_check(int ofs, unsigned long sel)
 {
 	static char buf[4];

--- a/src/base/emu-i386/simx86/protmode.h
+++ b/src/base/emu-i386/simx86/protmode.h
@@ -231,7 +231,6 @@ extern unsigned char e_ofsseg(int ofs);
 int SetSegProt_check(int ofs, unsigned long sel);
 void SetSegProt_set(int ofs, unsigned long sel);
 void SetSegProt(int ofs, unsigned long sel);
-void SetSegProt_helper(unsigned short sv, int ofs);
 int SetSegReal(unsigned short sel, int ofs);
 int e_larlsl(int mode, unsigned short sel);
 int hsw_verr(unsigned short sel);

--- a/src/base/emu-i386/simx86/sigsegv.c
+++ b/src/base/emu-i386/simx86/sigsegv.c
@@ -50,6 +50,13 @@
 #include "priv.h"
 #include "mapping/mapping.h"
 
+int InCompiledCode;
+
+int e_in_compiled_code(void)
+{
+    return InCompiledCode;
+}
+
 /* ======================================================================= */
 
 void e_VgaMovs(dosaddr_t edi, dosaddr_t esi, unsigned int rep,

--- a/src/include/cpu-emu.h
+++ b/src/include/cpu-emu.h
@@ -95,13 +95,14 @@ void InvalidateSegs(void);
 #ifdef X86_JIT
 /* called from sigsegv.c */
 int e_emu_fault(sigcontext_t *scp, int in_vm86);
+int e_in_compiled_code(void);
 #else
 #define e_emu_fault(scp, in_vm86) 0
+#define e_in_compiled_code() 0
 #endif
 
 #ifdef X86_EMULATOR
 /* called from signal.c */
-int e_in_compiled_code(void);
 void e_gen_sigalrm(void);
 void e_gen_sigalrm_from_thread(void);
 void e_gen_rpic_from_thread(void);
@@ -112,7 +113,6 @@ int _CPU_VM_DPMI(void);
 #else
 #define e_gen_sigalrm()
 #define e_gen_sigalrm_from_thread()
-#define e_in_compiled_code() 0
 #define EMU_V86() 0
 #define EMU_DPMI() 0
 #define _CPU_VM() config.cpu_vm


### PR DESCRIPTION
The generated code is a lot simpler if we use some intermediate asm in the stub, like other cpatch functions, and it's also more consistent that way, I really should have done that from the get go!

Also, `InCompiledCode` is only relevant for JIT, so I moved its use out of Sim.

Tested for both i386 and x86-64.