### PR TITLE
simx86: improved handling of optimized multi-push and pop

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -1940,35 +1940,42 @@ static unsigned int Gen_sim(IGen *IG, unsigned int *pmem_ref,
 		} break;
 
 /* PUSH derived (sub-)sequences: */
-	case O_PUSH1:
+	case O_PUSH1: {
+		uint32_t sp;
 		GTRACE0("O_PUSH1");
-		SR1.d = CPULONG(Ofs_ESP);
-		break;
+		sp = CPULONG(Ofs_ESP);
+		IG++;
 
-	case O_PUSH2: {
-		dosaddr_t addr;
-		unsigned int o = IG->p0;
-		unsigned long stackm = CPULONG(Ofs_STACKM);
-		GTRACE1("O_PUSH2",o);
-		if (mode & DATA16)
-			SR1.d -= 2;
-		else
-			SR1.d -= 4;
-		SR1.d &= stackm;
-		addr = CPULONG(Ofs_XSS) + SR1.d;
-		if (mode & (SEGREG|DATA16))
-			sim_write_word(addr, CPUWORD(o));
-		else
-			sim_write_dword(addr, CPULONG(o));
-		if (debug_level('e')>3) dbug_printf("(V) %08x\n",DR1.d);
-		} break;
+		assert(IG->op == O_PUSH2);
+		do {
+			dosaddr_t addr;
+			unsigned int o = IG->p0;
+			unsigned long stackm = CPULONG(Ofs_STACKM);
+			mode = IG->mode;
+			GTRACE1("O_PUSH2",o);
+			if (mode & DATA16)
+				sp -= 2;
+			else
+				sp -= 4;
+			sp &= stackm;
+			addr = CPULONG(Ofs_XSS) + sp;
+			currentIG = (unsigned char *)IG;
+			if (mode & (SEGREG|DATA16))
+				sim_write_word(addr, CPUWORD(o));
+			else
+				sim_write_dword(addr, CPULONG(o));
+			if (debug_level('e')>3) dbug_printf("(V) %08x\n",DR1.d);
+			IG++;
+		} while (IG->op == O_PUSH2);
 
-	case O_PUSH3:
+		assert(IG->op == O_PUSH3);
+		mode = IG->mode;
 		GTRACE0("O_PUSH3");
 #ifdef KEEP_ESP	/* keep high 16-bits of ESP in small-stack mode */
-		SR1.d |= (CPULONG(Ofs_ESP) & ~CPULONG(Ofs_STACKM));
+		sp |= (CPULONG(Ofs_ESP) & ~CPULONG(Ofs_STACKM));
 #endif
-		CPULONG(Ofs_ESP) = SR1.d;
+		CPULONG(Ofs_ESP) = sp;
+		}
 		break;
 
 	case O_PUSH2F: {

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -430,12 +430,44 @@ static dosaddr_t AddrGen_sim(const IGen *IG)
 	return mem_ref;
 }
 
+static void Gen_A_SR_SH4(const IGen *IG, unsigned seg)
+{
+	int mode = IG->mode;
+	unsigned int o = IG->p0;
+	GTRACE1("A_SR_SH4",o);
+	SetSegReal(seg, o);
+}
+
+static unsigned int Gen_A_SR_PROT(const IGen *IG, unsigned seg)
+{
+	int mode = IG->mode;
+	unsigned int o = IG->p0;
+	GTRACE1("A_SR_PROT",o);
+	SetSegProt(o, seg);
+	return TheCPU.err ? IG->p1 : (unsigned)-1;
+}
+
+static void Gen_S_DI(const IGen *IG, dosaddr_t addr, unsigned v)
+{
+	int mode = IG->mode;
+	GTRACE0("S_DI");
+	if (mode&MBYTE) {
+		sim_write_byte(addr, v);
+	}
+	else if (mode & DATA16) {
+		sim_write_word(addr, v);
+	}
+	else {
+		sim_write_dword(addr, v);
+	}
+	if (debug_level('e')>3) dbug_printf("(V) %08x\n",v);
+}
+
 static unsigned int Gen_sim(IGen *IG, unsigned int *pmem_ref,
 			    unsigned int *seqbase)
 {
     /* working registers of the host CPU */
     wkreg DR1;	// "eax"
-    wkreg SR1;	// "ecx"
 
     unsigned int mem_ref = 0;
     unsigned int P0 = (unsigned)-1;
@@ -464,19 +496,11 @@ static unsigned int Gen_sim(IGen *IG, unsigned int *pmem_ref,
 	op = IG->op;
 	mode = IG->mode;
 	switch(op) {
-	case A_SR_SH4: {	// real mode make base addr from seg
-		unsigned int o = IG->p0;
-		GTRACE1("A_SR_SH4",o);
-		SetSegReal(DR1.w.l, o);
-		}
+	case A_SR_SH4:		// real mode make base addr from seg
+		Gen_A_SR_SH4(IG, DR1.w.l);
 		break;
-	case A_SR_PROT: {	// protected mode make base addr from seg
-		unsigned int o = IG->p0;
-		GTRACE1("A_SR_PROT",o);
-		SetSegProt(o, DR1.w.l);
-		if (TheCPU.err)
-			P0 = IG->p1;
-		}
+	case A_SR_PROT: 	// protected mode make base addr from seg
+		P0 = Gen_A_SR_PROT(IG, DR1.w.l);
 		break;
 	case L_NOP:
 		GTRACE0("L_NOP");
@@ -649,20 +673,8 @@ static unsigned int Gen_sim(IGen *IG, unsigned int *pmem_ref,
 		if (debug_level('e')>3) dbug_printf("(V) %08x\n",DR1.d);
 		}
 		break;
-	case S_DI: {
-		dosaddr_t addr = mem_ref;
-		GTRACE0("S_DI");
-		if (mode&MBYTE) {
-		    sim_write_byte(addr, DR1.b.bl);
-		}
-		else if (mode & DATA16) {
-		    sim_write_word(addr, DR1.w.l);
-		}
-		else {
-		    sim_write_dword(addr, DR1.d);
-		}
-		if (debug_level('e')>3) dbug_printf("(V) %08x\n",DR1.d);
-		}
+	case S_DI:
+		Gen_S_DI(IG, mem_ref, DR1.d);
 		break;
 
 	case O_ADD_R: {		// OSZAPC
@@ -2057,49 +2069,62 @@ static unsigned int Gen_sim(IGen *IG, unsigned int *pmem_ref,
 		} break;
 
 /* POP derived (sub-)sequences: */
-	case O_POP1:
+	case O_POP1: {
+		uint32_t sp, v = 0;
 		GTRACE0("O_POP1");
-		SR1.d = CPULONG(Ofs_ESP);
-		break;
+		sp = CPULONG(Ofs_ESP);
+		IG++;
 
-	case O_POP2: {
-		dosaddr_t addr;
-		unsigned int o = (mode & MNOREG) ? 0 : IG->p0;
-		long stackm = CPULONG(Ofs_STACKM);
-		int imm16 = (mode&MRETISP) ? IG->p0 : 0;
-		GTRACE2("O_POP2",o,imm16);
-		SR1.d &= stackm;
-		addr = CPULONG(Ofs_XSS) + SR1.d;
-		if (mode & (DATA16|SEGREG)) {
-			uint16_t v = sim_read_word(addr);
-			if (mode & MNOREG)
-				DR1.w.l = v;
+		assert(IG->op == O_POP2);
+		do {
+			mode = IG->mode;
+			dosaddr_t addr;
+			unsigned int o = (mode & MNOREG) ? 0 : IG->p0;
+			long stackm = CPULONG(Ofs_STACKM);
+			int imm16 = (mode&MRETISP) ? IG->p0 : 0;
+			GTRACE2("O_POP2",o,imm16);
+			sp &= stackm;
+			addr = CPULONG(Ofs_XSS) + sp;
+			currentIG = (unsigned char *)IG;
+			if (mode & (DATA16|SEGREG)) {
+				v = sim_read_word(addr);
+				if (!(mode & MNOREG))
+					CPUWORD(o) = v;
+			}
+			else {
+				v = sim_read_dword(addr);
+				if (!(mode & MNOREG))
+					CPULONG(o) = v;
+			}
+			if (mode & DATA16)
+				sp += 2 + imm16;
 			else
-				CPUWORD(o) = v;
-		}
-		else {
-			uint32_t v = sim_read_dword(addr);
-			if (mode & MNOREG)
-				DR1.d = v;
-			else
-				CPULONG(o) = v;
-		}
-		if (mode & DATA16)
-			SR1.d += 2 + imm16;
-		else
-			SR1.d += 4 + imm16;
-		if (debug_level('e')>3) dbug_printf("(V) %08x\n",DR1.d);
-		} break;
+				sp += 4 + imm16;
+			if (debug_level('e')>3) dbug_printf("(V) %08x\n",DR1.d);
+			IG++;
+		} while (IG->op == O_POP2);
 
-	case O_POP3:
+		if (IG->op == A_SR_SH4) // for "pop segreg"
+			Gen_A_SR_SH4(IG++, v);
+		else if (IG->op == A_SR_PROT) {
+			P0 = Gen_A_SR_PROT(IG, v);
+			if (P0 != (unsigned)-1) break;
+			IG++;
+		}
+		else if (IG->op == S_DI) // for "pop [mem]"
+			Gen_S_DI(IG++, mem_ref, v);
+
+		assert(IG->op==O_POP3);
+		mode = IG->mode;
 		GTRACE0("O_POP3");
 #ifdef STACK_WRAP_MP	/* mask after incrementing */
-		SR1.d &= CPULONG(Ofs_STACKM);
+		sp &= CPULONG(Ofs_STACKM);
 #endif
 #ifdef KEEP_ESP	/* keep high 16-bits of ESP in small-stack mode */
-		SR1.d |= (CPULONG(Ofs_ESP) & ~CPULONG(Ofs_STACKM));
+		sp |= (CPULONG(Ofs_ESP) & ~CPULONG(Ofs_STACKM));
 #endif
-		CPULONG(Ofs_ESP) = SR1.d;
+		CPULONG(Ofs_ESP) = sp;
+		}
 		break;
 
 	case O_LEAVE: {

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -400,7 +400,8 @@ static void OptimizeCode(IMeta *I)
 	IGen *firstIG = &I1->gen[0];
 
 	if ((lastIG->mode & MOPT) && (firstIG->mode & MOPT) &&
-	    (lastIG->op == O_PUSH3 && firstIG->op == O_PUSH1)) {
+	    ((lastIG->op == O_PUSH3 && firstIG->op == O_PUSH1) ||
+	     (lastIG->op == O_POP3  && firstIG->op == O_POP1))) {
 		I->ngen--;
 		I1->ngen--;
 		memmove(I1->gen, I1->gen+1, I1->ngen * sizeof(IGen));

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -390,6 +390,25 @@ void Gen(int op, int mode, ...)
 
 /////////////////////////////////////////////////////////////////////////////
 
+static void OptimizeCode(IMeta *I)
+{
+	/* check if we can optimize away the first intermediate op
+	   of the next instruction against the last intermediate op
+	   of the present instruction */
+	IMeta *I1 = I + 1;
+	IGen *lastIG = &I->gen[I->ngen-1];
+	IGen *firstIG = &I1->gen[0];
+
+	if ((lastIG->mode & MOPT) && (firstIG->mode & MOPT) &&
+	    (lastIG->op == O_PUSH3 && firstIG->op == O_PUSH1)) {
+		I->ngen--;
+		I1->ngen--;
+		memmove(I1->gen, I1->gen+1, I1->ngen * sizeof(IGen));
+		if (debug_level('e')>1)
+			e_printf("Optimized op=%x at PC=%x\n",
+				 firstIG->op, I1->npc);
+	}
+}
 
 static unsigned char *ProduceCode(unsigned int PC, IMeta *I0)
 {
@@ -422,6 +441,8 @@ static unsigned char *ProduceCode(unsigned int PC, IMeta *I0)
 
 	for (i=0; i<=CurrIMeta; i++) {
 	    IMeta *I = &I0[i];
+	    if (i < CurrIMeta)
+		OptimizeCode(I);
 	    cp = cp1 = CodePtr;
 	    I->daddr = cp - BaseGenBuf;
 	    for (j=0; j<I->ngen; j++) {

--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -190,6 +190,7 @@
 #define MSSTP	0x02000000	// generate only one instruction
 #define MTRAP	0x04000000	// INT01 Sstep active: generate EXCP01_SSTP
 #define MINHI	0x08000000	// inhibits IRQs (MOVss/POPss/STI)
+#define MOPT	0x10000000	// optimize this op
 
 // values for TNode.flags and IMeta.flags
 #define F_FPOP	0x0001	// has at least one FP instruction

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -1045,32 +1045,20 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 /*59*/	case POPcx:
 /*5a*/	case POPdx:
 /*5b*/	case POPbx:
-/*5c*/	case POPsp:
 /*5d*/	case POPbp:
 /*5e*/	case POPsi:
 /*5f*/	case POPdi:
-#ifndef SINGLESTEP
-			if (!(_mode & MSSTP)) {
-			int m = _mode;
-			int cnt = 2;
-			Gen(O_POP1, m);
-			do {
-				opc = Fetch(PC);
-				Gen(O_POP2, m, R1Tab_l[D_LO(opc)]);
-				m = UNPREFIX(m);
-				PC++;
-				/* for pop sp reload stack pointer */
-				if (opc == POPsp)
-					Gen(O_POP1, m);
-			} while (++cnt < NUMGENS && (Fetch(PC)&0xf8)==0x58 &&
-					!e_querymark(PC, 1));
-			if (opc!=POPsp) Gen(O_POP3, m);
-			} else
-#endif
-			{
+			Gen(O_POP1, _mode|MOPT);
+			Gen(O_POP2, _mode, R1Tab_l[D_LO(opc)]);
+			Gen(O_POP3, _mode|MOPT);
+			PC++;
+			/* this can be optimized later in OptimizeCode */
+			break;
+
+/*5c*/	case POPsp:	// this one doesn't fit nicely in pop1/pop2/pop3
+			// as eSP needs to be reloaded.
 			Gen(O_POP, _mode);
-			Gen(S_REG, _mode, R1Tab_l[D_LO(opc)]); PC++;
-			}
+			Gen(S_REG, _mode, Ofs_ESP); PC++;
 			break;
 /*8f*/	case POPrm:
 			// now calculate address. This way when using %esp

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -997,49 +997,19 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 /*54*/	case PUSHsp:
 /*55*/	case PUSHbp:
 /*56*/	case PUSHsi:
-/*57*/	case PUSHdi:	opc = OpIsPush[opc];
-#ifndef SINGLESTEP
-			if (!(_mode & MSSTP)) {
-			int m = _mode;		// enter with prefix
-			int cnt = 2;
-			int is_66;
-			Gen(O_PUSH1, m);
-			/* optimized multiple register push */
-			while (1) {
-			    int op;
-			    if (opc > 8)
-				m |= SEGREG;
-			    Gen(O_PUSH2, m, R1Tab_l[opc-1]);
-			    PC++;
-			    opc = OpIsPush[op = Fetch(PC)];
-			    is_66 = (op == 0x66);
-			    if (++cnt >= NUMGENS || (!opc && !is_66) ||
-				    e_querymark(PC, 1 + is_66))
-				break;
-			    m &= ~(DATA16|SEGREG);
-			    if (is_66) {	// prefix 0x66
-				m |= (~basemode & DATA16);
-				if ((opc=OpIsPush[(op = Fetch(PC+1))])!=0) PC++;
-				else break;
-			    }
-			    else {
-				m |= (basemode & DATA16);
-			    }
-			    if (op == PUSHsp) {
-				/* reload SP before pushing it */
-				Gen(O_PUSH3, m);
-			    }
-			}
-			Gen(O_PUSH3, m); } else
-#endif
-			{
-			if (opc > 8) {
-			    _mode |= SEGREG;
-			    Gen(L_REG, _mode|DATA16, R1Tab_l[opc-1]);
-			} else
-			    Gen(L_REG, _mode, R1Tab_l[opc-1]);
-			Gen(O_PUSH, _mode); PC++;
-			}
+/*57*/	case PUSHdi:
+			if (opc == PUSHsp)
+				/* don't optimize: force a reload for eSP */
+				Gen(O_PUSH1, _mode);
+			else
+				Gen(O_PUSH1, _mode|MOPT);
+			opc = OpIsPush[opc];
+			if (opc > 8)
+				_mode |= SEGREG;
+			Gen(O_PUSH2, _mode, R1Tab_l[opc-1]);
+			Gen(O_PUSH3, _mode|MOPT);
+			PC++;
+			/* this can be optimized later in OptimizeCode */
 			break;
 /*68*/	case PUSHwi:
 			Gen(O_PUSHI, _mode, DataFetchWL_U(_mode,(PC+1)));
@@ -2492,8 +2462,12 @@ repag0:
 				break;
 ///
 			case 0xa0: /* PUSHfs */
-				Gen(L_REG, _mode|DATA16, Ofs_FS);
-				Gen(O_PUSH, _mode|SEGREG); PC+=2;
+			case 0xa8: /* PUSHgs */
+				Gen(O_PUSH1, _mode|MOPT);
+				Gen(O_PUSH2, _mode|SEGREG,
+				    opc2 == 0xa0 ? Ofs_FS : Ofs_GS);
+				Gen(O_PUSH3, _mode|MOPT);
+				PC+=2;
 				break;
 			case 0xa1: /* POPfs */
 				_mode |= SEGREG;
@@ -2585,10 +2559,6 @@ repag0:
 			/* case 0xa6: CMPXCHGb (486 STEP A only) */
 			/* case 0xa7: CMPXCHGw (486 STEP A only) */
 ///
-			case 0xa8: /* PUSHgs */
-				Gen(L_REG, _mode|DATA16, Ofs_GS);
-				Gen(O_PUSH, _mode|SEGREG); PC+=2;
-				break;
 			case 0xa9: /* POPgs */
 				_mode |= SEGREG;
 				if (REALADDR()) {


### PR DESCRIPTION
This PR moves them into separate IMeta's, which is more proper since we have multiple instructions. Which will open the door to reducing NUMGENS as well, but for that I also need to look at multi-MOVS/STOS.

By separating out POPsp, and redoing PUSH1 for PUSHsp, the sequence is always PUSH1/PUSH2/.../PUSH2/PUSH3 or POP1/POP2/.../POP2/(optional A_SR_SH4/PROT/S_DI)/POP3, and Sim can take advantage of that, making the `SR1` cached stack pointer completely local to the blocks.
This improved Sim performance a bit.
