### PR TITLE
simx86: handle multi-lods/stos via OptimizeCode, reduce NUMGENS to 16

### DIFF
--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -399,10 +399,13 @@ static void OptimizeCode(IMeta *I)
 	IGen *lastIG = &I->gen[I->ngen-1];
 	IGen *firstIG = &I1->gen[0];
 
-	if ((lastIG->mode & MOPT) && (firstIG->mode & MOPT) &&
+	if ((firstIG->mode & MOPT) && (firstIG->mode == lastIG->mode) &&
 	    ((lastIG->op == O_PUSH3 && firstIG->op == O_PUSH1) ||
-	     (lastIG->op == O_POP3  && firstIG->op == O_POP1))) {
-		I->ngen--;
+	     (lastIG->op == O_POP3  && firstIG->op == O_POP1) ||
+	     (lastIG->op == O_MOVS_SavA && firstIG->op == L_REG))) {
+		if (lastIG->op != O_MOVS_SavA)
+			/* multiple stosb/stosw only eliminate L_REG */
+			I->ngen--;
 		I1->ngen--;
 		memmove(I1->gen, I1->gen+1, I1->ngen * sizeof(IGen));
 		if (debug_level('e')>1)

--- a/src/base/emu-i386/simx86/econfig.h
+++ b/src/base/emu-i386/simx86/econfig.h
@@ -48,7 +48,7 @@
 #define MAXINODES	4096
 #define MAX_GEND_BYTES_PER_OP 76
 /* NUMGENS must be large enough in !SINGLESTEP mode */
-#define NUMGENS		128
+#define NUMGENS		16
 #undef	ASM_DUMP
 #define ASM_DUMP_FILE	"/DOS/asmdump.log"
 

--- a/src/base/emu-i386/simx86/econfig.h
+++ b/src/base/emu-i386/simx86/econfig.h
@@ -47,7 +47,6 @@
 
 #define MAXINODES	4096
 #define MAX_GEND_BYTES_PER_OP 76
-/* NUMGENS must be large enough in !SINGLESTEP mode */
 #define NUMGENS		16
 #undef	ASM_DUMP
 #define ASM_DUMP_FILE	"/DOS/asmdump.log"

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -1380,33 +1380,13 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			Gen(O_MOVS_SetA, m, OVERR_DS);
 			Gen(L_DI_R1, m);
 			Gen(S_REG, m, Ofs_AL); PC++;
-#ifndef SINGLESTEP
-			/* optimize common sequence LODSb-STOSb */
-			if (!(_mode & MSSTP) && Fetch(PC) == STOSb &&
-					!e_querymark(PC, 1)) {
-				Gen(O_MOVS_SetA, (m&ADDR16)|MOVSDST, OVERR_DS);
-				Gen(S_DI, m);
-				m |= MOVSDST;
-				PC++;
-			}
-#endif
-			Gen(O_MOVS_SavA, m, OVERR_DS);
+			Gen(O_MOVS_SavA, m|MOPT, OVERR_DS);
 			} break;
 /*ad*/	case LODSw: {	int m = _mode|MOVSSRC;
 			Gen(O_MOVS_SetA, m, OVERR_DS);
 			Gen(L_DI_R1, m);
 			Gen(S_REG, m, Ofs_EAX); PC++;
-#ifndef SINGLESTEP
-			/* optimize common sequence LODSw-STOSw */
-			if (!(_mode & MSSTP) && Fetch(PC) == STOSw &&
-					!e_querymark(PC, 1)) {
-				Gen(O_MOVS_SetA, (m&ADDR16)|MOVSDST, OVERR_DS);
-				Gen(S_DI, m);
-				m |= MOVSDST;
-				PC++;
-			}
-#endif
-			Gen(O_MOVS_SavA, m, OVERR_DS);
+			Gen(O_MOVS_SavA, m|MOPT, OVERR_DS);
 			} break;
 /*ae*/	case SCASb: {	int m = _mode|(MBYTE|MOVSDST);
 			Gen(O_MOVS_SetA, m, OVERR_DS);

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -1365,29 +1365,16 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			Gen(O_MOVS_SavA, m, OVERR_DS);
 			PC++; } break;
 /*aa*/	case STOSb: {	int m = _mode|(MBYTE|MOVSDST);
+			Gen(L_REG, m|MOPT, Ofs_AL);
 			Gen(O_MOVS_SetA, m, OVERR_DS);
-			Gen(L_REG, m, Ofs_AL);
 			Gen(S_DI, m);
-			Gen(O_MOVS_SavA, m, OVERR_DS);
+			Gen(O_MOVS_SavA, m|MOPT, OVERR_DS);
 			PC++; } break;
 /*ab*/	case STOSw: {	int m = _mode|MOVSDST;
+			Gen(L_REG, m|MOPT, Ofs_EAX);
 			Gen(O_MOVS_SetA, m, OVERR_DS);
-			Gen(L_REG, m, Ofs_EAX);
 			Gen(S_DI, m); PC++;
-			Gen(O_MOVS_SavA, m, OVERR_DS);
-#ifndef SINGLESTEP
-			if (!(_mode & MSSTP)) {
-			    int cnt = 3;
-			    m = UNPREFIX(m);
-			    while (++cnt < NUMGENS && Fetch(PC) == STOSw &&
-					!e_querymark(PC, 1)) {
-				Gen(O_MOVS_SetA, m, OVERR_DS);
-				Gen(S_DI, m);
-				Gen(O_MOVS_SavA, m, OVERR_DS);
-				PC++;
-			    }
-			}
-#endif
+			Gen(O_MOVS_SavA, m|MOPT, OVERR_DS);
 			} break;
 /*ac*/	case LODSb: {	int m = _mode|(MBYTE|MOVSSRC);
 			Gen(O_MOVS_SetA, m, OVERR_DS);

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -1349,31 +1349,6 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			Gen(S_DI, m);
 			PC++;
 			Gen(O_MOVS_SavA, m, OVERR_DS);
-#ifndef SINGLESTEP
-			/* optimize common sequence MOVSw..MOVSw..MOVSb */
-			if (!(_mode & MSSTP)) {
-				int cnt = 3;
-				m = UNPREFIX(m);
-				while (++cnt < NUMGENS && Fetch(PC) == MOVSw &&
-						!e_querymark(PC, 1)) {
-					Gen(O_MOVS_SetA, m&~MOVSDST, OVERR_DS);
-					Gen(L_DI_R1, m);
-					Gen(O_MOVS_SetA, m&~MOVSSRC, OVERR_DS);
-					Gen(S_DI, m);
-					PC++;
-					Gen(O_MOVS_SavA, m, OVERR_DS);
-				}
-				if (Fetch(PC) == MOVSb && !e_querymark(PC, 1)) {
-					m |= MBYTE;
-					Gen(O_MOVS_SetA, m&~MOVSDST, OVERR_DS);
-					Gen(L_DI_R1, m);
-					Gen(O_MOVS_SetA, m&~MOVSSRC, OVERR_DS);
-					Gen(S_DI, m);
-					PC++;
-					Gen(O_MOVS_SavA, m, OVERR_DS);
-				}
-			}
-#endif
 			} break;
 /*a6*/	case CMPSb: {	int m = _mode|(MBYTE|MOVSSRC|MOVSDST);
 			Gen(O_MOVS_SetA, m&~MOVSDST, OVERR_DS);


### PR DESCRIPTION
Similar to multi push/pop we can generate multiple IMeta's for lods/stos/movs and still optimize.
The code for multi-movs didn't actually optimize anything any more (that's a left-over from a long time ago, when it generated actual movs instructions), so I removed it.

With this, we can't overflow NUMGENS any more using a variable number of ops, so it can be much lower: we need 11 for INT, but let's do 16 to be on the safe side (the code checks for overflows).