### PR TITLE
simx86: disassemble JIT-generated code for 'e' level>7

### DIFF
--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -1898,12 +1898,11 @@ shrot0:
 #endif
 		    {
 			if ((ra > -127) && (ra < 128)) {
-			    ra -= 1; G1(JMPsid,Cp);
+			    ra -= 1; G1(JMPsid,Cp); G1(ra,Cp);
 			}
 			else {
-			    ra -= 4; G1(JMPd,Cp);
+			    ra -= 4; G1(JMPd,Cp); G4(ra,Cp);
 			}
-			G4(ra,Cp);
 		    }
 		    break;
 		}

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -104,6 +104,7 @@
 #include "emu86.h"
 #include "cpatch.h"
 #include "codegen-x86.h"
+#include "misc/dis8086.h"
 
 static unsigned char *CodeGen_x86(unsigned char *CodePtr, unsigned char *BaseGenBuf, const IGen *IG);
 static unsigned Exec_x86(unsigned *mem_ref, unsigned long *flg,
@@ -1999,6 +2000,26 @@ shrot0:
 		break;
 
 	}
+
+#ifdef USE_MHPDBG
+	CpTemp = CodePtr;
+	if (debug_level('e')>7) do {
+		static char frmtbuf[256];
+		int i;
+		unsigned int ref;
+		int rc = dis_8086((uintptr_t)CpTemp, frmtbuf, 5, &ref, 0);
+		dbug_printf("%16p: ", CpTemp);
+		for (i=0; i < 11; i++) {
+			if (i < rc)
+				dbug_printf("%02x", CpTemp[i]);
+			else
+				dbug_printf("%s", "  ");
+		}
+		dbug_printf("%s\n", frmtbuf);
+		CpTemp += rc;
+	} while (CpTemp < Cp);
+#endif
+
 #if PROFILE >= 2
 	if (debug_level('e')) GenTime += (GETTSC() - t0);
 #endif

--- a/src/base/lib/misc/dis8086.c
+++ b/src/base/lib/misc/dis8086.c
@@ -77,10 +77,10 @@ Any comments/updates/bug reports to:
 #define INLINE static inline
 #undef REG
 static int disasunix;
-static inline unsigned char mem_readb(unsigned int x)
+static inline unsigned char mem_readb(uintptr_t x)
 {
   if (disasunix)
-    return UNIX_READ_BYTE((uintptr_t)x);
+    return UNIX_READ_BYTE(x);
   else
     return READ_BYTE(x);
 }
@@ -88,7 +88,8 @@ static inline unsigned char mem_readb(unsigned int x)
 typedef Bit8u  UINT8;
 typedef Bit16u UINT16;
 typedef Bit32u UINT32;
-typedef unsigned int PhysPt;
+typedef Bit64u UINT64;
+typedef uintptr_t PhysPt;
 
 typedef Bit8s  INT8;
 typedef Bit16s INT16;
@@ -119,7 +120,7 @@ INLINE UINT32 le_uint32(const void* ptr) {
 static UINT8 must_do_size;   /* used with size of operand */
 static int wordop;           /* dealing with word or byte operand */
 
-static int instruction_offset;
+static PhysPt instruction_offset;
 //static UINT16 instruction_segment;
 
 static char* ubufs;           /* start of buffer */
@@ -135,6 +136,10 @@ static int addrsize;
 static int addr32bit=0;
 
 static int refoff;
+
+#ifdef __x86_64__
+static int x86_64_rex_w = 0;
+#endif
 
 /* some defines for extracting instruction bit fields from bytes */
 
@@ -448,14 +453,19 @@ static const char *floatops[] = { /* assumed " %EF" at end of each.  mod != 3 on
        "fbldt", "fildq", "fbstpt", "fistpq"
 };
 
-static char *addr_to_hex(UINT32 addr) {
-  static char buffer[11];
+static char *addr_to_hex(UINT64 addr) {
+  static char buffer[21];
 
+#ifdef __x86_64__
+  if (disasunix)
+    sprintf(buffer, "%lx", addr);
+  else
+#endif
   if (opsize == 32)
-    sprintf(buffer, "%08X", addr);
+    sprintf(buffer, "%08X", (UINT32)addr);
   else {
     addr = fp_offset(addr);
-    sprintf(buffer, "%04X", addr);
+    sprintf(buffer, "%04X", (UINT32)addr);
   }
   refoff = addr;
   return buffer;
@@ -684,6 +694,11 @@ static void reg_name(int regnum, char size)
     uprintf("st(%d)", regnum);
     return;
   }
+#ifdef __x86_64__
+  if (x86_64_rex_w)
+    uputchar('r');
+  else
+#endif
   if ((((size == 'c') || (size == 'v')) && (opsize == 32)) || (size == 'd'))
     uputchar('e');
   if ((size=='q' || size == 'b' || size=='c') && !wordop) {
@@ -744,6 +759,52 @@ static void do_sib(int m)
   }
 }
 
+#ifdef __x86_64__
+// No RIP-relative addressing yet (unused in JIT)
+static void do_sib64(int m)
+{
+  int s, i, b;
+
+  s = SCALE(sib());
+  i = INDEX(sib());
+  b = BASE(sib());
+  switch (b) {     /* pick base */
+  case 0: ua_str("%p:[rax"); break;
+  case 1: ua_str("%p:[rcx"); break;
+  case 2: ua_str("%p:[rdx"); break;
+  case 3: ua_str("%p:[rbx"); break;
+  case 4: ua_str("%p:[rsp"); break;
+  case 5:
+       if (m == 0) {
+         ua_str("%p:[");
+         outhex('d', 4, 0, addrsize, 0);
+       } else {
+         ua_str("%p:[rbp");
+       }
+       break;
+  case 6: ua_str("%p:[rsi"); break;
+  case 7: ua_str("%p:[rdi"); break;
+  }
+  switch (i) {     /* and index */
+  case 0: uprintf("+rax"); break;
+  case 1: uprintf("+rcx"); break;
+  case 2: uprintf("+rdx"); break;
+  case 3: uprintf("+rbx"); break;
+  case 4: break;
+  case 5: uprintf("+rbp"); break;
+  case 6: uprintf("+rsi"); break;
+  case 7: uprintf("+rdi"); break;
+  }
+  if (i != 4) {
+    switch (s) {    /* and scale */
+      case 0: /*uprintf("");*/ break;
+      case 1: uprintf("*2"); break;
+      case 2: uprintf("*4"); break;
+      case 3: uprintf("*8"); break;
+    }
+  }
+}
+#endif
 
 
 /*------------------------------------------------------------------------*/
@@ -782,6 +843,20 @@ static void do_modrm(char subtype)
   }
   if ((addrsize != 32) || (rm != 4))
     ua_str("%p:[");
+#ifdef __x86_64__
+  if (disasunix) {
+    switch (rm) {
+    case 0: uprintf("rax"); break;
+    case 1: uprintf("rcx"); break;
+    case 2: uprintf("rdx"); break;
+    case 3: uprintf("rbx"); break;
+    case 4: do_sib64(mod); break;
+    case 5: uprintf("rbp"); break;
+    case 6: uprintf("rsi"); break;
+    case 7: uprintf("rdi"); break;
+    }
+  } else
+#endif
   if (addrsize == 16) {
     switch (rm) {
     case 0: uprintf("bx+si"); break;
@@ -1097,7 +1172,8 @@ static void ua_str(const char *str)
 }
 
 
-static Bitu DasmI386(char* buffer, PhysPt pc, Bitu cur_ip, bool bit32)
+#include "dosemu_debug.h"
+static Bitu DasmI386(char* buffer, PhysPt pc, PhysPt cur_ip, bool bit32)
 {
   	Bitu c;
 
@@ -1119,6 +1195,15 @@ static Bitu DasmI386(char* buffer, PhysPt pc, Bitu cur_ip, bool bit32)
 	if (bit32) opsize = addrsize = 32;
 	else opsize = addrsize = 16;
 	c = getbyte();
+#ifdef __x86_64__
+	/* this is extremely basic and bare-bones and only
+	   meant for disassembling JIT-generated code */
+	x86_64_rex_w = 0;
+	if (disasunix && c == 0x48) {
+		x86_64_rex_w = 1;
+		c = getbyte();
+	}
+#endif
 	wordop = c & 1;
 	must_do_size = 1;
 	invalid_opcode = 0;
@@ -1136,7 +1221,7 @@ static Bitu DasmI386(char* buffer, PhysPt pc, Bitu cur_ip, bool bit32)
 	return getbyte_mac-pc;
 }
 
-int  dis_8086(unsigned int code,
+int  dis_8086(uintptr_t code,
 	      char *outbuf,
 	      int def_size,
 	      unsigned int * refof,

--- a/src/base/lib/misc/dis8086.h
+++ b/src/base/lib/misc/dis8086.h
@@ -4,6 +4,6 @@
  * for details see file COPYING in the DOSEMU distribution
  */
 
-int  dis_8086(unsigned int, char *, int, unsigned int *, unsigned int);
+int  dis_8086(uintptr_t, char *, int, unsigned int *, unsigned int);
 
 


### PR DESCRIPTION
Some very basic changes were made to dis8086.c so it understands JIT-generated x86-64 code.

Output looks like this

```
============ Opening sequence at 000ffff0
  000ffff0: ea5be000f0        ffff:0000 jmp  F000:E05B
CGEN:  13  40001
adding ff000 to cache
CGEN:  13  40003
CGEN:  13  40001
CGEN:  13  40001
CGEN: 114 140003
JMP_FAR: f000:0000e05b
==== Closing sequence at 000ffff5
---------------------------------------------
ProduceCode: CurrIMeta=0
CodeBuf=0x7f6868e8e3c8 siz 380
  0x7f6868e8e3c8: c7432c00000000        mov  dword [rbx+002C],0
PGEN(00,00)  13  40001  7 0000002c 00000000 00000000 00000000 00000000
  0x7f6868e8e3cf: 66c7433600f0          mov  word [rbx+0036],F000
PGEN(00,01)  13  40003  6 00000036 0000f000 00000000 00000000 00000000
  0x7f6868e8e3d5: c7434800000f00        mov  dword [rbx+0048],f0000
PGEN(00,02)  13  40001  7 00000048 000f0000 00000000 00000000 00000000
  0x7f6868e8e3dc: c7434cffff0f00        mov  dword [rbx+004C],fffff
PGEN(00,03)  13  40001  7 0000004c 000fffff 00000000 00000000 00000000
JMP_Link 000fe05b 000ffff0
  0x7f6868e8e3e3: 0fb74b72              movzx ecx,[rbx+0072]
  0x7f6868e8e3e7: e309                  jecxz 7f6868e8e3f2 ($+9)
  0x7f6868e8e3e9: b85be00f00            mov  eax,fe05b
  0x7f6868e8e3ee: 89c1                  mov  ecx,eax
  0x7f6868e8e3f0: 5a                    pop  edx
  0x7f6868e8e3f1: c3                    ret
  0x7f6868e8e3f2: b9f0ff0f00            mov  ecx,ffff0
  0x7f6868e8e3f7: b85be00f00            mov  eax,fe05b
  0x7f6868e8e3fc: 5a                    pop  edx
  0x7f6868e8e3fd: c3                    ret
PGEN(00,04) 114 140003 27 000fe05b 000ffff0 0000001b 00000000 00000000
```