### PR TITLE
simx86: handle fpu exceptions natively in JIT mode, support IGNNE#, basic segment limit support

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -2872,6 +2872,24 @@ static __inline__ void SetCPU_WL(int m, signed char o, unsigned long v)
 	if (m&DATA16) CPUWORD(o)=v; else CPULONG(o)=v;
 }
 
+static int check_stack_limit(unsigned int sp, unsigned int size)
+{
+	unsigned int limit = TheCPU.ss_cache.BoundH - TheCPU.ss_cache.BoundL;
+	unsigned int top = (sp + size - 1) & TheCPU.StackMask;
+	unsigned short wFlags = GetSelectorFlags(TheCPU.ss);
+	sp &= TheCPU.StackMask;
+	if (wFlags & DF_EXPANDDOWN) {
+		if (size <= TheCPU.StackMask - limit && sp > limit)
+			return 1;
+	}
+	else {
+		if (size <= limit && top <= limit)
+			return 1;
+	}
+	TheCPU.err = EXCP0C_STACK;
+	return 0;
+}
+
 #define POPw(sp) ({ \
 	unsigned int __res = sim_read_word(LONG_SS + sp); \
 	sp += 2; sp &= TheCPU.StackMask; __res; })
@@ -3023,10 +3041,14 @@ unsigned int Sim_helper(unsigned int mem_ref, unsigned int data, int mode,
 				break;
 			sp = rESP;
 			if (mode&DATA16) {
+				if (!check_stack_limit(sp - 4, 4))
+					break;
 				PUSHw(sp,oldcs);
 				PUSHw(sp,oldeip);
 			}
 			else {
+				if (!check_stack_limit(sp - 8, 8))
+					break;
 				PUSHwl(sp,oldcs);
 				PUSHl(sp,oldeip);
 			}
@@ -3048,11 +3070,15 @@ unsigned int Sim_helper(unsigned int mem_ref, unsigned int data, int mode,
 				unsigned int cs, eip;
 				unsigned int sp = rESP & TheCPU.StackMask;
 				if (mode&DATA16) {
+					if (!check_stack_limit(sp, (opc == IRET ? 6 : 4)))
+						break;
 					eip = POPw(sp);
 					cs = POPw(sp);
 					if (opc == IRET) temp = POPw(sp);
 				}
 				else {
+					if (!check_stack_limit(sp, (opc == IRET ? 12 : 8)))
+						break;
 					eip = POPl(sp);
 					cs = POPwl(sp);
 					if (opc == IRET) temp = POPl(sp);

--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -516,18 +516,11 @@ static unsigned int Gen_sim(IGen *IG, unsigned int *pmem_ref,
 		int reg = IG->p1;
 		GTRACE2("O_FPOP",exop,reg);
 		Fp87_op(exop, reg, mem_ref);
-		int exs = TheCPU.fpus & 0x7f;
 		if (debug_level('e')>3) {
 		    e_printf("  %s\n", e_trace_fp());
 		}
-		if (exs) {
-			e_printf("FPU: error status %02x\n",exs);
-			if ((exs & ~TheCPU.fpuc) & 0x3f) {
-				e_printf("FPU exception\n");
-				TheCPU.err = EXCP10_COPR;
-				P0 = FindPC((const unsigned char *)IG);
-			}
-		}
+		if (TheCPU.err == EXCP10_COPR)
+			P0 = FindPC((const unsigned char *)IG);
 		}
 		break;
 
@@ -2784,9 +2777,12 @@ static unsigned Exec_sim(unsigned *pmem_ref, unsigned long *flg,
 {
 	unsigned int P0;
 
-	if (seqflg & F_FPOP)
+	if ((seqflg & F_FPOP) && TheCPU.fpstate) {
 		/* mask all exceptions, and set rounding properly */
 		fp87_mask_except();
+		cpuemu_update_fpu();
+		TheCPU.fpstate = NULL;
+	}
 
 	FlagSync_RFL(*flg);
 	P0 = Gen_sim(SeqStart, pmem_ref, seqbase);

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -2108,34 +2108,13 @@ static unsigned Exec_x86(unsigned *mem_ref, unsigned long *flg,
 		unsigned char *ecpu, void *SeqStart,
 		unsigned short seqflg, unsigned int *seqbase)
 {
-	unsigned ePC;
-	if (seqflg & F_FPOP) {
-		if (TheCPU.fpstate) {
-			loadfpstate(*TheCPU.fpstate);
-			TheCPU.fpstate = NULL;
-		}
-		/* mask exceptions in generated code */
-		unsigned short fpuc;
-		asm ("fstcw	%0" : "=m"(TheCPU.fpuc));
-		fpuc = TheCPU.fpuc | 0x3f;
-		asm ("fldcw	%0" :: "m"(fpuc));
-	}
-	ePC = Exec_x86_asm(mem_ref, flg, ecpu, SeqStart, seqbase);
 	/* was there at least one FP op in the sequence? */
-	if (seqflg & F_FPOP) {
-		int exs;
-		__asm__ __volatile__ ("fstsw	%0" : "=m"(exs));
-		exs &= 0x7f;
-		if (exs) {
-			e_printf("FPU: error status %02x\n",exs);
-			if ((exs & ~TheCPU.fpuc) & 0x3f) {
-				__asm__ __volatile__ ("fnclex\n" ::: "memory");
-				e_printf("FPU exception\n");
-				TheCPU.err = EXCP10_COPR;
-			}
-		}
+	if ((seqflg & F_FPOP) && TheCPU.fpstate) {
+		TheCPU.fpuc = TheCPU.fpstate->cwd;
+		loadfpstate(*TheCPU.fpstate);
+		TheCPU.fpstate = NULL;
 	}
-	return ePC;
+	return Exec_x86_asm(mem_ref, flg, ecpu, SeqStart, seqbase);
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -79,6 +79,7 @@ static void *prejit_thread(void *arg);
 static hitimer_t TotalTime;
 static void enter_cpu_emu(void);
 static void do_cpuemu_enter(int pm);
+static void save_fpu_state(void);
 
 /* This needs to be merged someday with 'mode' */
 int CEmuStat = 0;
@@ -595,8 +596,10 @@ static void Cpu2Reg(struct vm86_struct *info)
   if (TheCPU.fpstate == NULL) {
     if (!CONFIG_CPUSIM)
       savefpstate(vm86_fpu_state);
-    else
+    else {
       fp87_save_except();
+      save_fpu_state();
+    }
     fesetenv(&dosemu_fenv);
   }
 
@@ -667,8 +670,10 @@ static void Cpu2Scp(cpuctx_t *scp, int trapno)
   if (TheCPU.fpstate == NULL) {
     if (!CONFIG_CPUSIM)
       savefpstate(vm86_fpu_state);
-    else
+    else {
       fp87_save_except();
+      save_fpu_state();
+    }
     /* there is no real need to save and restore the FPU state of the
        emulator itself: savefpstate (fnsave) also resets the current FPU
        state using fninit; fesetenv then restores trapping of division by

--- a/src/base/emu-i386/simx86/fp87-sim.c
+++ b/src/base/emu-i386/simx86/fp87-sim.c
@@ -310,6 +310,9 @@ static void Fp87_op_sim(int exop, int reg, unsigned mem_ref)
 	}
 
 	switch(exop) {
+/*9b*/	case oWAIT:
+		/* only checks for exceptions, above */
+		break;
 /*01*/	case 0x01:
 /*03*/	case 0x03:
 /*05*/	case 0x05:

--- a/src/base/emu-i386/simx86/fp87-sim.c
+++ b/src/base/emu-i386/simx86/fp87-sim.c
@@ -184,6 +184,13 @@ void fp87_save_except(void)
 #else
 #warning FPU exceptions unsupported
 #endif
+	if (fps) {
+		e_printf("FPU: error status %02x\n",fps);
+		if ((fps & ~TheCPU.fpuc) & 0x3f) {
+			e_printf("FPU exception\n");
+			fps |= FPUS_ES | FPUS_B;
+		}
+	}
 	TheCPU.fpus = (fps&~FPUS_TOP)|(TheCPU.fpstt<<FPUS_TOP_BIT);
 }
 
@@ -269,6 +276,38 @@ static void Fp87_op_sim(int exop, int reg, unsigned mem_ref)
 //	5B	DB 11011nnn	FCMOVNU	st(0),st(n)
 
 	e_printf("FPop %x.%d\n", exop, reg);
+
+	if (~TheCPU.fpuc & 0x3f)
+		// always check for unmasked exception
+		// and set FPU_ES if there is one
+		fp87_save_except();
+
+	switch(exop) {
+/*31*/	case 0x31:
+/*35*/	case 0x35:
+//*	31	D9 xx110nnn	FNSTENV	14/28byte
+//	35	DD xx110nnn	FNSAVE	94/108byte
+/*39*/	case 0x39:
+//*	39	D9 xx111nnn	FNSTCW	2b
+/*3d*/	case 0x3d:
+/*67*/	case 0x67:
+//	3D	DD xx111nnn	FNSTSW	2b
+//	67.0	DF 11000000	FNSTSW	ax
+/*63*/	case 0x63:
+//	63.0*	DB 11000000	FNENI (8087)
+//	63.1*	DB 11000001	FNDISI (8087)
+//	63.2*	DB 11000010	FNCLEX
+//	63.3*	DB 11000011	FNINIT
+//	63.4*	DB 11000011	FNSETPM (80287)
+		// "nowait" instructions don't cause an exception
+		break;
+	default:
+		if (TheCPU.fpus & FPUS_ES) {
+			TheCPU.err = EXCP10_COPR;
+			return;
+		}
+		break;
+	}
 
 	switch(exop) {
 /*01*/	case 0x01:

--- a/src/base/emu-i386/simx86/fp87-x86.c
+++ b/src/base/emu-i386/simx86/fp87-x86.c
@@ -200,16 +200,10 @@ fp_mem:
 //*	29	D9 xx101nnn	FLDCW	2b
 		// movw	(edi,ebp,1),ax
 		G4(0x2f048b66,Cp);
-		// movl	eax,ecx
-		G2(0xc189,Cp);
-		// orb 0x3f,al
-		G2(0x3f0c,Cp);
 		// movw	ax,FPUC(ebx)
 		G3(0x438966,Cp); G1(Ofs_FPUC,Cp);
 		// fldcw FPUC(ebx)
 		G2(0x6bd9,Cp); G1(Ofs_FPUC,Cp);
-		// movw	cx,FPUC(ebx)
-		G3(0x4b8966,Cp); G1(Ofs_FPUC,Cp);
 		break;
 /*39*/	case 0x39:
 //*	39	D9 xx111nnn	FSTCW	2b
@@ -479,8 +473,6 @@ static void Fp87_op_x86_sim(int exop, int reg, unsigned mem_ref)
 			struct float_env16 q;
 		        memcpy(&q, p, (exop == 0x21 ? 14 : 94));
 			TheCPU.fpuc = q.fpuc;
-			/* mask exceptions in real FPU control word */
-			q.fpuc |= 0x3f;
 			if (exop==0x21)
 			    __asm__ __volatile__ ("data16 fldenv %0\n" :: "m"(q));
 			else
@@ -490,8 +482,6 @@ static void Fp87_op_x86_sim(int exop, int reg, unsigned mem_ref)
 			struct float_env32 q;
 		        memcpy(&q, p, (exop == 0x21 ? 28 : 108));
 			TheCPU.fpuc = q.fpuc;
-			/* mask exceptions in real FPU control word */
-			q.fpuc |= 0x3f;
 			if (exop==0x21)
 			    __asm__ __volatile__ ("fldenv	%0\n" :: "m"(q));
 			else

--- a/src/base/emu-i386/simx86/fp87-x86.c
+++ b/src/base/emu-i386/simx86/fp87-x86.c
@@ -91,6 +91,9 @@ unsigned char *Fp87_op_x86(unsigned char *CodePtr, int exop, int reg)
 	e_printf("FPop %x.%d\n", exop, reg);
 
 	switch(exop) {
+/*9b*/	case oWAIT:
+		G1(exop,Cp);
+		break;
 /*01*/	case 0x01:
 /*03*/	case 0x03:
 /*05*/	case 0x05:

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -1318,7 +1318,6 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 					   basemode|MINHI);
 			break;
 
-/*9b*/	case oWAIT:
 /*90*/	case NOP:	//if (!IsCodeInBuf()) Gen(L_NOP, _mode);
 			Gen(L_NOP, _mode);
 			PC++;
@@ -2220,6 +2219,10 @@ repag0:
 			PC += 2;
 			break;
 
+/*9b*/	case oWAIT:
+			Gen(O_FOP, _mode, opc, 0);
+			PC++;
+			break;
 /*d8*/	case ESC0:
 /*d9*/	case ESC1:
 /*da*/	case ESC2:

--- a/src/base/emu-i386/simx86/sigsegv.c
+++ b/src/base/emu-i386/simx86/sigsegv.c
@@ -421,13 +421,14 @@ int e_handle_fault(sigcontext_t *scp)
 		return 0;
 	}
 #endif
-	/* page-faults are handled not here and only DE remains */
-	if (_scp_trapno != 0) {
+	/* page-faults are handled not here and only DE and FPE remain */
+	int err = EXCP00_DIVZ + _scp_trapno;
+	if (err != EXCP00_DIVZ && err != EXCP10_COPR) {
 		error("Fault %i in jit-compiled code\n", _scp_trapno);
 		return 0;
 	}
-	TheCPU.err = EXCP00_DIVZ + _scp_trapno;
-	return e_return_from_jit(scp, 0);
+	TheCPU.err = err;
+	return e_return_from_jit(scp, (err == EXCP10_COPR));
 }
 
 /* ======================================================================= */

--- a/test/cpu/reffile.log
+++ b/test/cpu/reffile.log
@@ -4494,6 +4494,9 @@ smc_code2(4) = 4
 DIVZ exception:
 si_signo=289
 trapno=00000000 err=00000000 EIP=+00000002
+FPE exception:
+si_signo=289
+trapno=00000075 err=00000000 EIP=+00000015
 BOUND exception:
 si_signo=291
 trapno=00000005 err=00000000 EIP=+00000002

--- a/test/cpu/test-i386.c
+++ b/test/cpu/test-i386.c
@@ -1991,6 +1991,19 @@ void test_exceptions(void)
         EXCEPTION("idiv %3", "=a"(divlo), "=d"(divhi): "a"(1), "d"(0),);
     }
 
+    printf("FPE exception:\n");
+    if (_sigsetjmp(jmp_env) == 0) {
+        uint16_t orig_fpuc, fpuc;
+        asm volatile ("fnclex; fnstcw  %0" : "=m"(orig_fpuc));
+        fpuc = orig_fpuc & ~0x3f;
+        /* now divide by zero (FP); the lret triggers a segment limit check
+           in dosemu2, which DJGPP catches */
+        EXCEPTION("push %%cs; call 1f; jmp 2f; "
+                  "1: sti; fldcw %0; fldz; fld1; fdivp; wait; lret; "
+                  "2: fnclex; fldcw %1",
+                  : "m"(fpuc), "m"(orig_fpuc),);
+    }
+
 #if !defined(__x86_64__)
     printf("BOUND exception:\n");
     if (_sigsetjmp(jmp_env) == 0) {


### PR DESCRIPTION
The JIT code was masking FPU exceptions and then randomly checking for them at the end of the block.
It's better to allow them and have the host CPU do a SIGFPE, then use FindPC the same way as for page faults, and integer division by zero. This also saves a lot of code that was used in emulating the exception bits of TheCPU.fpuc.
 
FPU exceptions still aren't quite working correctly at the upper levels, but at least for a locally fabricated floating point div by 0 in the qemu test this makes it report the same cs:eip for KVM as for JIT (Sim is incorrect still)

I'll have to look at #1886 again to understand those things, and @andrewbird 's tests as well..