### PR TITLE
CI: Split out the cpu specific tests

### DIFF
--- a/ci_test.sh
+++ b/ci_test.sh
@@ -22,18 +22,6 @@ python3 test/test_dosemu.py --get-test-binaries
 # Make cpu tests here so that we see any failures
 make -C test/cpu clean all
 
-cat >&2 << EOF
-=====================================================
-=        Tests run on various flavours of DOS       =
-=====================================================
-EOF
-# all DOS flavours, all tests
-# python3 test/test_dosemu.py
-# single DOS example
-# python3 test/test_dosemu.py FRDOS120TestCase
-# single test example
-# python3 test/test_dosemu.py FRDOS120TestCase.test_mfs_fcb_rename_wild_1
-
 export PYTHONUNBUFFERED=1
 export TEST_DOSEMU=/usr/local/bin/dosemu
 export TEST_CMDDIR=/usr/local/share/dosemu/commands
@@ -47,62 +35,19 @@ if [ "${BLDTYPE}" = "packaged" ] ; then
   export TEST_CMDDIR=/usr/share/dosemu/dosemu2-cmds-0.3
 fi
 
-if [ "${BLDTYPE}" != "packaged" ] ; then  # Only makes sense if we are building the source
-  is_primary() {
-    [ "${GITHUB_REPOSITORY:-}" = "dosemu2/dosemu2" ]
-  }
+cat >&2 << EOF
+=====================================================
+=         Tests run on KVM and emulated CPU         =
+=====================================================
+EOF
 
-  is_devel() {
-    [ "$(git branch --show-current)" = "devel" ]
-  }
+env NO_FAILFAST=1 python3 test/test_processor.py
 
-  is_merge() {
-    git log -1 HEAD | grep -Fq 'Merge pull request'
-  }
-
-  branch_has_kvmoff() {
-    git log ${BASE_SHA:-}..HEAD | grep -Fq '[kvmoff ci]'
-  }
-
-  head_has_kvmoff() {
-    git log -1 HEAD | grep -Fq '[kvmoff ci]'
-  }
-
-  merge_has_kvmoff() {
-    git log HEAD ^HEAD^1 | grep -Fq '[kvmoff ci]'
-  }
-
-  branch_has_emulator_changes() {
-    [ "$(git diff --name-only ${BASE_SHA:-}..HEAD -- src/base/emu-i386/simx86 | wc -l)" != "0" ]
-  }
-
-  last5_has_emulator_changes() {
-    [ "$(git diff --name-only HEAD~5 -- src/base/emu-i386/simx86 | wc -l)" != "0" ]
-  }
-
-  merge_has_emulator_changes() {
-    [ "$(git diff --name-only HEAD ^HEAD^1 -- src/base/emu-i386/simx86 | wc -l)" != "0" ]
-  }
-
-  if is_primary ; then
-    if is_devel ; then # could be push direct to devel, or merge commit
-      if (is_merge && (merge_has_kvmoff || merge_has_emulator_changes)) ||
-          head_has_kvmoff || last5_has_emulator_changes ; then
-        export NO_KVM=1
-      fi
-    else # could be test merge for a PR (I tested), or a topic branch for dosemu2
-      if branch_has_kvmoff || branch_has_emulator_changes ; then
-        export NO_KVM=1
-      fi
-    fi
-
-  else # someone else's repo, default or topic branch prior to PR (I tested)
-    # Can't assume anything about repo, main branch name, whether it's up to date, etc.
-    if head_has_kvmoff || last5_has_emulator_changes ; then
-      export NO_KVM=1
-    fi
-  fi
-fi
+cat >&2 << EOF2
+=====================================================
+=        Tests run on various flavours of DOS       =
+=====================================================
+EOF2
 
 case "${RUNTYPE}" in
   "full")

--- a/ci_test.sh
+++ b/ci_test.sh
@@ -19,9 +19,6 @@ else
 fi
 python3 test/test_dosemu.py --get-test-binaries
 
-# Make cpu tests here so that we see any failures
-make -C test/cpu clean all
-
 export PYTHONUNBUFFERED=1
 export TEST_DOSEMU=/usr/local/bin/dosemu
 export TEST_CMDDIR=/usr/local/share/dosemu/commands

--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -16,7 +16,7 @@ from ptyprocess import PtyProcessError
 from shutil import copy, rmtree
 from subprocess import (Popen, call, check_call, check_output,
                         DEVNULL, STDOUT, TimeoutExpired, CalledProcessError)
-from sys import argv, exit, modules, stdout, stderr, version_info
+from sys import argv, exit, stdout, stderr, version_info
 from tarfile import open as topen
 from time import sleep
 from unittest.util import strclass
@@ -205,6 +205,35 @@ class BaseTestCase(object):
     @classmethod
     def tearDownClass(cls):
         pass
+
+    @classmethod
+    def getTests(cls):
+        funcs = inspect.getmembers(cls, predicate=inspect.isfunction)
+        return [t for t in funcs if t[0].startswith('test')]
+
+    @classmethod
+    def getTestsDefinedIn(cls):
+        parent = []
+        us = []
+
+        funcs = cls.getTests()
+        for f in funcs:
+            if f[0] in cls.__dict__:
+                us += [f,]
+            else:
+                parent += [f,]
+
+        return (parent, us)
+
+    @classmethod
+    def getTestnames(cls):
+        funcs = cls.getTests()
+        return [cls.__name__ + '.' + t[0] for t in funcs]
+
+    @classmethod
+    def getTestnames_with_attr(cls, attr):
+        funcs = cls.getTests()
+        return [cls.__name__ + '.' + t[0] for t in funcs if hasattr(t[1], attr)]
 
     def setUp(self):
         # Process and skip actions
@@ -606,7 +635,7 @@ class MyTestResult(unittest.TextTestResult):
         return '%-80s' % test.shortDescription()
 
     def startTest(self, test):
-        super(MyTestResult, self).startTest(test)
+        super().startTest(test)
         self.starttime = test.utcnow()
 
         name = test.id()
@@ -771,47 +800,7 @@ def main(argv=None):
     unittest.main(testRunner=MyTestRunner, argv=argv, verbosity=2, failfast=failfast)
 
 
-def main_setup(testcase):
-
-    tests = [t[0] for t in
-            inspect.getmembers(testcase, predicate=inspect.isfunction)
-            if t[0].startswith("test")]
-
-    xtests = [t[0] for t in
-            inspect.getmembers(testcase, predicate=inspect.isfunction)
-            if t[0].startswith("xtest")]
-
-    ocases = [c[0] for c in
-            inspect.getmembers(modules['__main__'], predicate=inspect.isclass)
-            if issubclass(c[1], testcase) and c[0] != testcase.__name__]
-
-    # Place interesting testcases at the start
-    cases = []
-    for c in ['PPDOSGITTestCase', 'MSDOS622TestCase']:
-        if c in ocases:
-            cases.append(c)
-            ocases.remove(c)
-    cases.extend(ocases)
-
-    attrs = sorted(testcase.attrs)
-
-    def explode(n, attr=None):
-        if n in tests:
-            return [c + "." + n for c in cases]
-        if n in xtests:
-            return [c + "." + n for c in cases]
-        if n in cases:
-            if attr:
-                return [n + "." + t[0] for t in
-                    inspect.getmembers(testcase, predicate=inspect.isfunction)
-                    if hasattr(t[1], attr)]
-            else:
-                return [n,]
-        p = n.split('.')
-        if p and p[0] in cases and (p[1] in tests or p[1] in xtests):
-            return [n,]
-        return []
-
+def main_setup(cases):
     if len(argv) > 1:
         if argv[1] == "--help":
             print(("Usage: %s [--help | --get-test-binaries | " +
@@ -819,37 +808,86 @@ def main_setup(testcase):
                    "[--require-attr=STRING TestCase ...] | " +
                    "[TestCase[.testname] ...]") % argv[0])
             exit(0)
-        elif argv[1] == "--get-test-binaries":
+
+        if argv[1] == "--get-test-binaries":
             get_test_binaries()
             exit(0)
-        elif argv[1] == "--list-attrs":
-            for a in attrs:
-                print(str(a))
-            exit(0)
-        elif argv[1] == "--list-cases":
-            for m in cases:
-                print(str(m))
-            exit(0)
-        elif argv[1] == "--list-tests":
-            for m in tests:
-                print(str(m))
-            exit(0)
-        else:
-            x = re.match(r"^--require-attr=(\S+).*$", argv[1])
-            if x:
-                attr = x.groups()[0]
-                del argv[1]
-            else:
-                attr = None
 
-            a = []
-            for b in [explode(x, attr=attr) for x in argv[1:]]:
-                a.extend(b)
+        if argv[1] == "--list-attrs":
+            for c in cases:
+                print(c.__name__)
+                print("    %s" % str(c.attrs))
+            exit(0)
 
-            if not len(a):
-                print("No tests found, was your testcase or testname incorrect? See --help")
+        if argv[1] == "--list-cases":
+            for c in cases:
+                print(c.__name__)
+            exit(0)
+
+        if argv[1] == "--list-tests":
+            common = set()
+            children = {}
+            for c in cases:
+                parent, child = c.getTestsDefinedIn()
+                common.update(parent)
+                children[c.__name__] = child
+
+            print("Common:")
+            for tname in sorted([t[0] for t in common]):
+                print("    %s" % tname)
+
+            for cname, tests in children.items():
+                print("%s:" % cname)
+                for tname in sorted([t[0] for t in tests]):
+                    print("    %s" % tname)
+            exit(0)
+
+        x = re.match(r"^--require-attr=(\S+).*$", argv[1])
+        if x:
+            attr = x.groups()[0]
+            tests = []
+            for c in cases:
+                for arg in argv[2:]:
+                    if c.__name__ == arg:
+                        tests += [n for n in c.getTestnames_with_attr(attr)]
+            if not len(tests):
+                print("No tests found with attr, was it correct? See --help")
                 exit(1)
-            return [argv[0],] + a
+            return [argv[0],] + tests
 
-    return [argv[0],] + cases
+        # Need to expand multiple TestCases on command line
+        cnames = [ c.__name__ for c in cases]
+        cvalid = []
+        tvalid = []
+        for a in argv[1:]:
+            if a in cnames:  # Test case
+                cvalid += [a,]
+
+            elif '.' in a:  # Potentially it's a fully qualified test name
+                cname, tname = a.split('.')
+                for c in cases:
+                    if c.__name__ == cname and hasattr(c, tname):
+                        tvalid += [a,]
+
+            else:  # Maybe we are a test name, and qualify if so
+                for c in cases:
+                    if hasattr(c, a):
+                        tvalid += [c.__name__ + '.' + a,]
+
+        if len(cvalid) == 0 and len(tvalid) == 0:
+            print("No valid testcases or testnames on command line")
+            exit(1)
+
+        if len(cvalid) and len(tvalid):
+            print("Invalid to have both testcases and testnames on command line")
+            exit(1)
+
+        return [argv[0],] + sorted(cvalid + tvalid)
+
+    else:  # No args, so expand all tests from all cases
+        tests = []
+        for c in cases:
+            tests += [c.__name__ + '.' + t[0] for t in c.getTests()]
+
+        return [argv[0],] + tests
 

--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -132,6 +132,7 @@ def get_test_binaries():
 class BaseTestCase(object):
 
     attrs = []
+    use_cpu = None
 
     @classmethod
     def setUpClass(cls):
@@ -184,23 +185,40 @@ class BaseTestCase(object):
             if machine() == 'i686':
                 cls.have_vm86 = True
 
+            if cls.use_cpu == 'emu':
+                print(" \nUsing Emulation", file=stderr, flush=True)
+                return
+
+            reason = ""
             try:
-                with open("/dev/kvm", "r+b") as f:
+                with open("/dev/kvm", "r+b"):
                     major, minor = release().split('.')[0:2]
                     if not (major == '6' and minor in ['11', '12', '13']):
                         if environ.get("NO_KVM", '0') == '1':
-                            print(" \nUsable KVM found but NO_KVM=1 - Disabling", file=stderr, flush=True)
+                            reason = "NO_KVM=1"
                         else:
-                            print(" \nUsable KVM found", file=stderr, flush=True)
                             cls.have_kvm = True
                     else:
-                        print(" \nUsable KVM found but blacklisted kernel (6.11 - 6.13) - Disabling", file=stderr, flush=True)
+                        reason = "Blacklisted kernel [6.11 - 6.13]"
 
             except FileNotFoundError:
                 pass
             except PermissionError:
                 op = check_output(["getfacl", "/dev/kvm"])
-                print(" \nPermissions wrong on /dev/kvm\n%s" % op.decode('ASCII'), file=stderr, flush=True)
+                reason = "Permissions wrong on /dev/kvm\n%s" % op.decode('ASCII')
+
+            if cls.use_cpu == 'kvm':
+                if not cls.have_kvm:
+                    print(" \nUsing KVM ", end='', file=stderr, flush=True)
+                    raise unittest.SkipTest("KVM not available: %s" % reason)
+                print(" \nUsing KVM", file=stderr, flush=True)
+                return
+
+            # No use_cpu specified, use whatever
+            if cls.have_kvm:
+                print(" \nUsable KVM found", file=stderr, flush=True)
+            else:
+                print(" \nUsable KVM not found, falling back to emulation: %s" % reason , file=stderr, flush=True)
 
     @classmethod
     def tearDownClass(cls):
@@ -523,7 +541,7 @@ class BaseTestCase(object):
                 "-td",
                 #    "-Da",
                 "--Fimagedir", str(self.imagedir)]
-        if environ.get("NO_KVM", '0') == '1':
+        if environ.get("NO_KVM", '0') == '1' or self.use_cpu == 'emu':
             args.extend(["-z", "0"])
 
         if opts is not None:
@@ -579,7 +597,7 @@ class BaseTestCase(object):
                 "-o", str(self.topdir / self.logfiles['log'][0]),
                 "-td",
                 "-ks"]
-        if environ.get("NO_KVM", '0') == '1':
+        if environ.get("NO_KVM", '0') == '1' or self.use_cpu == 'emu':
             args.extend(["-z", "0"])
         args.extend(xargs)
 

--- a/test/func_build_freecom.py
+++ b/test/func_build_freecom.py
@@ -1,0 +1,65 @@
+from os import environ
+from subprocess import check_call, CalledProcessError, run, STDOUT
+
+
+def build_freecom(self):
+    if environ.get("SKIP_EXPENSIVE"):
+        self.skipTest("expensive test")
+
+    giturl = 'https://github.com/FDOS/freecom.git'
+    root = self.imagedir / 'freecom.git'
+
+    try:
+        run(["git", "clone", "-q", "--depth=1", giturl, str(root)], check=True)
+    except CalledProcessError:
+        self.skipTest("repository unavailable")
+
+    # Now need to download Watcom 1.9 packages and unpack
+    # Path to watcom binaries will be 'c:/devel/watcomc/binw'
+    pkgurl = 'https://www.ibiblio.org/pub/micro/pc-stuff/freedos/files/repositories/1.3/devel'
+    try:
+        for pkg in ['watcomc', 'nasm']:
+            check_call([
+                "wget",
+                "-q",
+                pkgurl + '/%s.zip' % pkg,
+            ], stderr=STDOUT, cwd=self.imagedir)
+            check_call([
+                "unzip",
+                "-LL",
+                "-q",
+                str(self.imagedir) + '/%s.zip' % pkg,
+            ], stderr=STDOUT, cwd=self.workdir)
+    except:
+        self.skipTest("DOS pkgs unavailable")
+
+    # Generate the config
+    # (note nasty interaction with comcom64, means switch to dos32a)
+    self.mkfile("config.bat", """\
+set COMPILER=WATCOM
+set WATCOM=C:\\devel\\watcomc
+set DOS4GPATH=%WATCOM%\\binw\\dos32a.exe
+set XCPU=386
+set XFAT=32
+set XNASM=nasm
+set OLDPATH=%PATH%
+set PATH=C:\\devel\\watcomc\\binw;C:\\devel\\nasm;C:\\bin;%OLDPATH%
+""", dname=root, newline="\r\n")
+
+    check_call([
+        "cp",
+        "config.std",
+        "config.mak",
+    ], stderr=STDOUT, cwd=root)
+
+    # Run build.bat script from git repository root
+    # Note:
+    #     We have to avoid runDosemu() as this test is non-interactive
+    args = ["-q", "-K", ".", "-E", "build.bat"]
+    results = self.runDosemuCmdline(args, cwd=root, timeout=450)
+
+    self.assertNotIn('Timeout', results)
+    self.assertNotIn('NonZeroReturn', results)
+
+    # Test for resultant command.com file
+    self.assertTrue((root / 'command.com').exists(), "Resultant (command.com) missing")

--- a/test/func_cpu_methods.py
+++ b/test/func_cpu_methods.py
@@ -69,23 +69,24 @@ $_ignore_djgpp_null_derefs = (off)
         diff = unified_diff(refoutput, dosoutput, fromfile=reffile.name, tofile=dosfile.name)
         self.fail('differences detected\n' + ''.join(list(diff)))
 
-TESTS = (
-#   cpu (native, kvm, jit, sim),  dpmi(native, kvm, remote)
-
+EMU_TESTS = (
     ('native', 'native'), #  CPU native vm86(i386 only) + native DPMI
-    ('kvm',    'native'), #  CPU KVM vm86 + native DPMI
+
     ('jit',    'native'), #  CPU JIT vm86 + native DPMI
     ('sim',    'native'), #  CPU simulated vm86 + native DPMI
 
+    ('jit',    'jit'),    #  CPU JIT vm86 + JIT DPMI
+    ('sim',    'sim'),    #  CPU simulated vm86 + simulated DPMI
+)
+
+KVM_TESTS = (
+    ('kvm',    'native'), #  CPU KVM vm86 + native DPMI
     ('kvm',    'kvm'),    #  CPU KVM vm86 + KVM DPMI
+    ('kvm',    'jit'),    #  CPU KVM vm86 + JIT DPMI
+    ('kvm',    'sim'),    #  CPU KVM vm86 + simulated DPMI
+
     ('jit',    'kvm'),    #  CPU JIT vm86 + KVM DPMI
     ('sim',    'kvm'),    #  CPU simulated vm86 + KVM DPMI
-
-    ('kvm',    'jit'),    #  CPU KVM vm86 + JIT DPMI
-    ('jit',    'jit'),    #  CPU JIT vm86 + JIT DPMI
-
-    ('kvm',    'sim'),    #  CPU KVM vm86 + simulated DPMI
-    ('sim',    'sim'),    #  CPU simulated vm86 + simulated DPMI
 )
 
 
@@ -112,8 +113,11 @@ def create_test(test):
 
 
 def cpu_create_items(testcase):
+
+    tests = KVM_TESTS if testcase.use_cpu == 'kvm' else EMU_TESTS
+
     # Insert each test into the testcase
-    for test in TESTS:
+    for test in tests:
         name = 'test_cpu_method_%s_%s' % test
         setattr(testcase, name, create_test(test))
 

--- a/test/func_cpu_trap_flag.py
+++ b/test/func_cpu_trap_flag.py
@@ -3,18 +3,21 @@ import re
 from cpuinfo import get_cpu_info
 
 
-def cpu_trap_flag(self, cpu_vm):
-    if cpu_vm not in ("kvm", "emulated"):
-        raise ValueError('invalid argument')
+def cpu_trap_flag(self):
+    if self.use_cpu == "kvm":
+        if not self.have_kvm:
+            self.skipTest("requires KVM")
+        cpu_vm = 'kvm'
+    elif self.use_cpu == "emu":
+        cpu_vm = 'emulated'
+    else:
+        raise ValueError('invalid self.use_cpu')
 
-    if cpu_vm == "kvm" and not self.have_kvm:
-        self.skipTest("requires KVM")
-
-    config = """
-    $_hdimage = "dXXXXs/c:hdtype1 +1"
-    $_floppy_a = ""
-    $_cpu_vm = "%s"
-    """ % cpu_vm
+    config = """\
+$_hdimage = "dXXXXs/c:hdtype1 +1"
+$_floppy_a = ""
+$_cpu_vm = "%s"
+""" % cpu_vm
 
     self.mkfile("testit.bat", """\
 c:\\cputrapf

--- a/test/test_dosemu.py
+++ b/test/test_dosemu.py
@@ -8,7 +8,7 @@ from os import statvfs, utime, environ
 from os.path import exists, isdir, join
 from pathlib import Path
 from shutil import copy
-from subprocess import call, check_call, CalledProcessError, run, STDOUT
+from subprocess import call, CalledProcessError, run
 from sys import argv
 from time import mktime
 
@@ -20,8 +20,6 @@ from common_os import (drdos701, frdos120, frdos130, frdosgit, msdos622,
 
 from func_comcom_r200fix import comcom_r200fix
 from func_command_com_cmdline_length import command_com_cmdline_length
-from func_cpu_trap_flag import cpu_trap_flag
-from func_cpu_methods import cpu_create_items
 from func_ds2_file_seek_tell import ds2_file_seek_tell
 from func_ds2_file_seek_read import ds2_file_seek_read
 from func_ds2_set_fattrs import ds2_set_fattrs
@@ -63,8 +61,7 @@ PRGFIL_LFN = "Program Files"
 
 class OurTestCase(BaseTestCase):
 
-    attrs = ['cputest', 'dpmitest', 'hmatest', 'nettest', 'umatest', 'xmstest',
-             'labeltest']
+    attrs = ['dpmitest', 'hmatest', 'nettest', 'umatest', 'xmstest', 'labeltest']
 
     def test_comcom_r200fix_real(self):
         """Comcom r200fix Real Mode"""
@@ -4829,79 +4826,6 @@ $_floppy_a = ""
         network_pktdriver_mtcp(self, 'ne2000')
     test_network_pktdriver_mtcp_ne2000.nettest = True
 
-    def test_cpu_trap_flag_emulated(self):
-        """CPU Trap Flag emulated"""
-        cpu_trap_flag(self, 'emulated')
-    test_cpu_trap_flag_emulated.cputest = True
-
-    def test_cpu_trap_flag_kvm(self):
-        """CPU Trap Flag KVM"""
-        cpu_trap_flag(self, 'kvm')
-    test_cpu_trap_flag_kvm.cputest = True
-
-    def test_freecom_build(self):
-        """FreeCOM build script"""
-        if environ.get("SKIP_EXPENSIVE"):
-            self.skipTest("expensive test")
-
-        giturl = 'https://github.com/FDOS/freecom.git'
-        root = self.imagedir / 'freecom.git'
-
-        try:
-            run(["git", "clone", "-q", "--depth=1", giturl, str(root)], check=True)
-        except CalledProcessError:
-            self.skipTest("repository unavailable")
-
-        # Now need to download Watcom 1.9 packages and unpack
-        # Path to watcom binaries will be 'c:/devel/watcomc/binw'
-        pkgurl = 'https://www.ibiblio.org/pub/micro/pc-stuff/freedos/files/repositories/1.3/devel'
-        try:
-            for pkg in ['watcomc', 'nasm']:
-                check_call([
-                    "wget",
-                    "-q",
-                    pkgurl + '/%s.zip' % pkg,
-                ], stderr=STDOUT, cwd=self.imagedir)
-                check_call([
-                    "unzip",
-                    "-LL",
-                    "-q",
-                    str(self.imagedir) + '/%s.zip' % pkg,
-                ], stderr=STDOUT, cwd=self.workdir)
-        except:
-            self.skipTest("DOS pkgs unavailable")
-
-        # Generate the configr
-        # (note nasty interaction with comcom64, means switch to dos32a)
-        self.mkfile("config.bat", """\
-set COMPILER=WATCOM
-set WATCOM=C:\\devel\\watcomc
-set DOS4GPATH=%WATCOM%\\binw\\dos32a.exe
-set XCPU=386
-set XFAT=32
-set XNASM=nasm
-set OLDPATH=%PATH%
-set PATH=C:\\devel\\watcomc\\binw;C:\\devel\\nasm;C:\\bin;%OLDPATH%
-""", dname=root, newline="\r\n")
-
-        check_call([
-            "cp",
-            "config.std",
-            "config.mak",
-        ], stderr=STDOUT, cwd=root)
-
-        # Run build.bat script from git repository root
-        # Note:
-        #     We have to avoid runDosemu() as this test is non-interactive
-        args = ["-q", "-K", ".", "-E", "build.bat"]
-        results = self.runDosemuCmdline(args, cwd=root, timeout=450)
-
-        self.assertNotIn('Timeout', results)
-        self.assertNotIn('NonZeroReturn', results)
-
-        # Test for resultant command.com file
-        self.assertTrue((root / 'command.com').exists(), "Resultant (command.com) missing")
-
     def test_pcmos_build(self):
         """PC-MOS build script"""
         if environ.get("SKIP_EXPENSIVE"):
@@ -5213,8 +5137,6 @@ if __name__ == '__main__':
                 is_libi86 = True
     if not specific or is_libi86:
         libi86_create_items(OurTestCase)
-
-    cpu_create_items(OurTestCase)
 
     cases = [
         PPDOSGITTestCase,

--- a/test/test_dosemu.py
+++ b/test/test_dosemu.py
@@ -5216,5 +5216,15 @@ if __name__ == '__main__':
 
     cpu_create_items(OurTestCase)
 
-    argv = main_setup(OurTestCase)
-    main(argv)
+    cases = [
+        PPDOSGITTestCase,
+        MSDOS622TestCase,
+        DRDOS701TestCase,
+        FRDOS120TestCase,
+        FRDOS130TestCase,
+        FRDOSGITTestCase,
+        MSDOS700TestCase,
+        MSDOS710TestCase,
+    ]
+    xargv = main_setup(cases)
+    main(xargv)

--- a/test/test_processor.py
+++ b/test/test_processor.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python3
+
+from common_framework import BaseTestCase, main, main_setup
+from common_os import ppdosgit
+
+from func_build_freecom import build_freecom
+from func_cpu_trap_flag import cpu_trap_flag
+from func_cpu_methods import cpu_create_items
+
+
+class OurTestCase(BaseTestCase):
+
+    def test_build_freecom(self):
+        """Build FreeCOM"""
+        build_freecom(self)
+
+    def test_cpu_trap_flag(self):
+        """CPU Trap Flag"""
+        cpu_trap_flag(self)
+
+    test_cpu_trap_flag.cputests=True
+
+
+class KVMTestCase(ppdosgit(OurTestCase, { })):
+    use_cpu = 'kvm'
+
+
+class EMUTestCase(ppdosgit(OurTestCase, { })):
+    use_cpu = 'emu'
+
+
+if __name__ == '__main__':
+
+    cases = [
+        EMUTestCase,
+        KVMTestCase,
+    ]
+
+    # Dynamically create tests
+    for tc in cases:
+        cpu_create_items(tc)
+
+    xargv = main_setup(cases)
+    main(xargv)

--- a/test/test_processor.py
+++ b/test/test_processor.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python3
 
+from subprocess import check_call
+
 from common_framework import BaseTestCase, main, main_setup
 from common_os import ppdosgit
 
@@ -30,6 +32,9 @@ class EMUTestCase(ppdosgit(OurTestCase, { })):
 
 
 if __name__ == '__main__':
+
+    # Make cpu tests here so that we see any failures
+    check_call(["make", "--quiet", "-C", "test/cpu", "clean", "all"])
 
     cases = [
         EMUTestCase,


### PR DESCRIPTION
1/ Maybe run each test twice depending upon the use_cpu class variable.
  use_cpu
    unset: use whatever is found by dosemu's autodetection
    'emu': use emulation (specific type determined by dosemu, or conf)
    'kvm': use kvm

2/ Move freecom build and cpu tests to be tested under both kvm and emulation.
    Note the cpu tests to be run are chosen according to the kvm/emu selection.

3/ Simplify kvm / emulated cpu selection

The following is what you'll see on a platform that has working KVM (not Github's 24.04 runner at the moment)
~~~
ajb@sophie:/local/src/dosemu2.git$ env SKIP_EXPENSIVE=1 test/test_cpu.py 
 
Using Emulation
Test PP-DOS-GIT  Basic boot test                                                 ... ok (  0.39s)
Test PP-DOS-GIT  Build FreeCOM                                                   ... skipped 'expensive test'
Test PP-DOS-GIT  CPU JIT vm86 + JIT DPMI                                         ... ok (  0.46s)
Test PP-DOS-GIT  CPU JIT vm86 + native DPMI                                      ... ok (  0.46s)
Test PP-DOS-GIT  CPU native vm86(i386 only) + native DPMI                        ... skipped 'native vm86() only on 32bit x86'
Test PP-DOS-GIT  CPU simulated vm86 + native DPMI                                ... ok (  0.49s)
Test PP-DOS-GIT  CPU simulated vm86 + simulated DPMI                             ... ok (  0.71s)
Test PP-DOS-GIT  CPU Trap Flag                                                   ... ok (  0.44s)
 
Using KVM
Test PP-DOS-GIT  Basic boot test                                                 ... ok (  0.48s)
Test PP-DOS-GIT  Build FreeCOM                                                   ... skipped 'expensive test'
Test PP-DOS-GIT  CPU JIT vm86 + KVM DPMI                                         ... ok (  0.46s)
Test PP-DOS-GIT  CPU KVM vm86 + JIT DPMI                                         ... ok (  0.52s)
Test PP-DOS-GIT  CPU KVM vm86 + KVM DPMI                                         ... ok (  0.50s)
Test PP-DOS-GIT  CPU KVM vm86 + native DPMI                                      ... ok (  0.53s)
Test PP-DOS-GIT  CPU KVM vm86 + simulated DPMI                                   ... ok (  0.73s)
Test PP-DOS-GIT  CPU simulated vm86 + KVM DPMI                                   ... ok (  0.48s)
Test PP-DOS-GIT  CPU Trap Flag                                                   ... ok (  1.56s)

----------------------------------------------------------------------
Ran 17 tests in 8.232s

OK (skipped=3)
~~~