### PR TITLE
dpmi: fix floating point exceptions with DJGPP

### DIFF
--- a/src/base/emu-i386/cpu.c
+++ b/src/base/emu-i386/cpu.c
@@ -279,6 +279,18 @@ static void fpu_reset(void)
     kvm_update_fpu();
 }
 
+static int fpu_ignne;
+
+int fpu_get_ignne(void)
+{
+  return fpu_ignne;
+}
+
+void fpu_clear_ignne(void)
+{
+  fpu_ignne = 0;
+}
+
 static Bit8u fpu_io_read(ioport_t port, void *arg)
 {
   return 0xff;
@@ -290,9 +302,14 @@ static void fpu_io_write(ioport_t port, Bit8u val, void *arg)
   case 0xf0:
     /* We need to check if the FPU exception is pending, and set IGNNE
      * if it is, before untriggering an IRQ. But we don't (and probably
-     * can't) emulate IGNNE properly. So the trick is to do fnclex in
+     * can't) always emulate IGNNE properly. So the trick is to do fnclex in
      * bios.S, then untrigger IRQ unconditionally. */
     pic_untrigger(13); /* done by default via int75 handler in bios.S */
+    /* DJGPP's int75 pm handler for example does not use fnclex;
+       but we can force it in return_from_hw_int() in dpmi.c, so
+       this only makes sense in DPMI, as this variable is not checked in RM */
+    if (in_dpmi_pm()) // this also implies we are not using the handler in bios.S
+      fpu_ignne = !!(vm86_fpu_state.swd & 0x80);
     break;
   case 0xf1:
     fpu_reset();

--- a/src/base/emu-i386/kvm.c
+++ b/src/base/emu-i386/kvm.c
@@ -1581,8 +1581,10 @@ int true_kvm_dpmi(cpuctx_t *scp)
 	_eip -= 2;
     }
 
-#if 0
     if (_trapno == 0x10) {
+        kvm_get_fpu(); // needed for the swd check in the port f0 handler
+    }
+#if 0
         struct kvm_fpu fpu;
         ioctl(vcpufd, KVM_GET_FPU, &fpu);
 #ifdef __x86_64__

--- a/src/base/emu-i386/kvm.c
+++ b/src/base/emu-i386/kvm.c
@@ -1581,8 +1581,8 @@ int true_kvm_dpmi(cpuctx_t *scp)
 	_eip -= 2;
     }
 
-    if (_trapno == 0x10) {
 #if 0
+    if (_trapno == 0x10) {
         struct kvm_fpu fpu;
         ioctl(vcpufd, KVM_GET_FPU, &fpu);
 #ifdef __x86_64__
@@ -1605,12 +1605,9 @@ int true_kvm_dpmi(cpuctx_t *scp)
         __fpstate->datasel = _ds;
 #endif
         print_exception_info(scp);
-#endif
-        dbug_printf("coprocessor exception, calling IRQ13\n");
-        raise_fpu_irq();
-        ret = DPMI_RET_DOSEMU;
       } else
-	ret = DPMI_RET_FAULT;
+#endif
+      ret = DPMI_RET_FAULT;
   }
 #if USE_INSTREMU
   else if (exit_reason == KVM_EXIT_MMIO) {

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -5005,6 +5005,30 @@ static void return_from_hwint(cpuctx_t *scp, void * const sp)
   if (mhpdbg.active && tf)
     _eflags |= TF;
 #endif
+
+  /* DJGPP's int75 pm handler for example does not use fnclex;
+     if we can't emulate IGNNE we can force the fnclex if needed
+     here, just before returning to the faulting instruction,
+     as a workaround */
+  if (fpu_get_ignne()) {
+    fpu_clear_ignne();
+    if (config.cpu_vm_dpmi == CPUVM_KVM)
+      kvm_get_fpu();
+    if (vm86_fpu_state.swd & 0x80) {
+      // 0x80 = FPU_ES, set when an unmasked FP exception has
+      // occurred. In real DOS after outb(0xf0,0) is done, IGNNE
+      // is active until the FPU_ES bit is no longer set, and
+      // will mask all further FPU exceptions.
+      // As that's hard to do we force an fnclex if not already
+      // done so in the int75 handler to avoid retriggering a
+      // floating point exception; the best we can do without single
+      // stepping. See also bios.S for the real mode handler.
+      D_printf("DPMI: forcing fnclex\n");
+      vm86_fpu_state.swd &= 0x7f00;
+      if (config.cpu_vm_dpmi == CPUVM_KVM)
+	kvm_update_fpu();
+    }
+  }
 }
 
 static void do_dpmi_hlt(cpuctx_t *scp, uint8_t *lina, void *sp)

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -5940,6 +5940,12 @@ out:
 #endif
       }
     }
+    else if (_trapno == 0x10) {
+      dbug_printf("coprocessor exception, calling IRQ13\n");
+      raise_fpu_irq();
+      return ret;
+    }
+
     do_cpu_exception(scp);
   }
 

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -391,6 +391,8 @@ extern void disk_close(void);
 extern void cpu_setup(void);
 extern void cpu_reset(void);
 extern void raise_fpu_irq(void);
+extern int fpu_get_ignne(void);
+extern void fpu_clear_ignne(void);
 extern void real_run_int(int);
 extern void mfs_reset(void);
 extern void mfs_done(void);

--- a/src/plugin/dnative/sigsegv.c
+++ b/src/plugin/dnative/sigsegv.c
@@ -287,11 +287,7 @@ static void dosemu_fault1(int signum, sigcontext_t *scp, const siginfo_t *si)
     int ret;
     assert(config.cpu_vm_dpmi == CPUVM_NATIVE);
     if (_scp_trapno == 0x10) {
-      dbug_printf("coprocessor exception, calling IRQ13\n");
       print_exception_info(scp);
-      raise_fpu_irq();
-      dpmi_return(scp, DPMI_RET_DOSEMU);
-      return;
     }
 
     /* Not in dosemu code: dpmi_fault() will handle that */


### PR DESCRIPTION
I was testing floating point exceptions for #2680 with DJGPP and they failed in all 4 DPMI backends.

This one fixes them (mostly*) with native and KVM backends.
Native was stuck in an error loop because calling raise_fpu_irq() wasn't possible any more in the remote backend, so I moved it to dpmi.c which merged the one from kvm.c.

KVM was stuck retriggering the same FP exception because the DJGPP int75 handler does not call fnclex unlike our handler in bios.S. However in a PM hwint handler we can also force a simulated fnclex, so that is done in the second patch.

CPUEMU presently ignores FP exceptions in DJGPP, but that's because DJGPP uses a secondary exception, by setting a 4K limit on the data/stack segment, and simx86 doesn't support selector limits yet. In any case simx86 could emulate IGNNE properly so I'll rework #2680 to make that work.

(*) DJGPP reports the FPU status word contents in its default crash handler. Those are lost from the `fnclex`, so the output is different from real DOS.