### PR TITLE
CI: Add exception handling

### DIFF
--- a/test/func_command_com_cmdline_length.py
+++ b/test/func_command_com_cmdline_length.py
@@ -137,8 +137,15 @@ numwrite:
 
     results = self.runDosemu("testit.bat")
 
-    buffer1 = (self.workdir / 'psp_dump.bin').read_bytes()[0x80:]
-    buffer2 = (self.workdir / 'env_dump.bin').read_bytes()
+    try:
+        buffer1 = (self.workdir / 'psp_dump.bin').read_bytes()[0x80:]
+    except:
+        raise self.failureException("Read error on 'psp_dump.bin'") from None
+    try:
+        buffer2 = (self.workdir / 'env_dump.bin').read_bytes()
+    except:
+        raise self.failureException("Read error on 'env_dump.bin'") from None
+
     endofenv = buffer2.find(b'\x00\x00')
     if endofenv != -1:
         buffer2 = buffer2[0:endofenv + 2]

--- a/test/func_label_create.py
+++ b/test/func_label_create.py
@@ -172,7 +172,10 @@ int main(int argc, char *argv[])
     elif itype in ['bpb12', 'bpb16', 'bpb32']:
         fat = itype[3:5]
         img = self.topdir / IMAGEDIR / ("fat%s.img" % fat)
-        data = img.read_bytes()
+        try:
+            data = img.read_bytes()
+        except:
+            raise self.failureException("Read error on '%s'" % img.name) from None
         if data[0x26] == 0x29:      # v4 BPB
             v1 = 0x2b
             v2 = v1 + len(name)


### PR DESCRIPTION
Failure to read the output files from tests should be treated as a FAILURE, not a python exception.