### PR TITLE
cpu: add CWD-based IGNNE implementation [#2680]

### DIFF
--- a/src/base/bios/x86/bios.S
+++ b/src/base/bios/x86/bios.S
@@ -1012,15 +1012,17 @@ bios_text_font:
 	_ORG(0xfea6)
 	.globl INT75_OFF
 INT75_OFF:
+	pushw %ax
+	xorb %al, %al
+	outb %al, $0xf0	/* set IGNNE */
 	int $2		/* Bochs does this; RBIL says: redirected to INT 02 */
 			/* by the BIOS, for compatibility with the PC */
 	fnclex		/* Clear FP exceptions just in case a hooked
 			   handler hasn't already done so, so we won't
 			   get stuck (in real mode IGNNE would prevent
 			   further exceptions but we don't emulate that) */
-	pushw %ax
 	xorb %al, %al
-	outb %al, $0xf0
+	outb %al, $0xf0	/* clear IGNNE */
 	movb $0x20, %al
 	outb %al, $0xa0
 	outb %al, $0x20

--- a/src/base/emu-i386/cpu.c
+++ b/src/base/emu-i386/cpu.c
@@ -275,21 +275,10 @@ static void fpu_reset(void)
   vm86_fpu_state.cwd = 0x0040;
   vm86_fpu_state.swd = 0;
 //  vm86_fpu_state.ftw = 0x5555;       //bochs
-  if (config.cpu_vm == CPUVM_KVM || config.cpu_vm_dpmi == CPUVM_KVM)
-    kvm_update_fpu();
 }
 
 static int fpu_ignne;
-
-int fpu_get_ignne(void)
-{
-  return fpu_ignne;
-}
-
-void fpu_clear_ignne(void)
-{
-  fpu_ignne = 0;
-}
+static int fpu_orig_mask;
 
 static Bit8u fpu_io_read(ioport_t port, void *arg)
 {
@@ -298,23 +287,35 @@ static Bit8u fpu_io_read(ioport_t port, void *arg)
 
 static void fpu_io_write(ioport_t port, Bit8u val, void *arg)
 {
+  int old_ignne = fpu_ignne;
+  int mask = old_ignne ? fpu_orig_mask : (vm86_fpu_state.cwd & 0x7f);
+
   switch (port) {
   case 0xf0:
-    /* We need to check if the FPU exception is pending, and set IGNNE
-     * if it is, before untriggering an IRQ. But we don't (and probably
-     * can't) always emulate IGNNE properly. So the trick is to do fnclex in
-     * bios.S, then untrigger IRQ unconditionally. */
-    pic_untrigger(13); /* done by default via int75 handler in bios.S */
-    /* DJGPP's int75 pm handler for example does not use fnclex;
-       but we can force it in return_from_hw_int() in dpmi.c, so
-       this only makes sense in DPMI, as this variable is not checked in RM */
-    if (in_dpmi_pm()) // this also implies we are not using the handler in bios.S
-      fpu_ignne = !!(vm86_fpu_state.swd & 0x80);
+    pic_untrigger(13);
+    /* don't trust bit7 (ES) as it may be suppressed by our fake IGNNE,
+     * which is actually an exception mask in CWD */
+    fpu_ignne = !!(vm86_fpu_state.swd & 0x7f & ~mask);
+    /* Note: we emuate the "unrecommended" (by Intel) design where the
+     * untriggering of IGNNE requires an extra write to 0xf0 after fnclex */
+    if (fpu_ignne) {
+      if (!old_ignne)
+        fpu_orig_mask = mask;
+      vm86_fpu_state.cwd |= 0x7f;
+    } else if (old_ignne) {
+      vm86_fpu_state.cwd &= ~0x7f;
+      vm86_fpu_state.cwd |= mask;
+    }
     break;
   case 0xf1:
     fpu_reset();
     break;
   }
+
+  if (config.cpu_vm == CPUVM_KVM || config.cpu_vm_dpmi == CPUVM_KVM)
+    kvm_update_fpu();
+  if (config.cpu_vm == CPUVM_EMU || config.cpu_vm_dpmi == CPUVM_EMU)
+    cpuemu_update_fpu();
 }
 
 static int fpu_is_masked(void)

--- a/src/base/emu-i386/cpu.c
+++ b/src/base/emu-i386/cpu.c
@@ -310,6 +310,17 @@ static void fpu_io_write(ioport_t port, Bit8u val, void *arg)
   case 0xf1:
     fpu_reset();
     break;
+  /* undocumented port for our "unrecommended" design */
+  case 0xf2:
+    if (fpu_ignne) {
+      fpu_ignne = 0;
+      /* restore mask */
+      vm86_fpu_state.cwd &= ~0x7f;
+      vm86_fpu_state.cwd |= mask;
+      /* fnclex */
+      vm86_fpu_state.swd &= 0x7f00;
+    }
+    break;
   }
 
   if (config.cpu_vm == CPUVM_KVM || config.cpu_vm_dpmi == CPUVM_KVM)

--- a/src/base/emu-i386/simx86/fp87-sim.c
+++ b/src/base/emu-i386/simx86/fp87-sim.c
@@ -171,7 +171,7 @@ static void fxam(long double d)
    we need to save before and clear after */
 void fp87_save_except(void)
 {
-	unsigned short fps = TheCPU.fpus;
+	unsigned short fps = TheCPU.fpus & ~(FPUS_ES | FPUS_B);
 #if FE_ALL_EXCEPT > 0
 	int exceptions = fetestexcept(FE_ALL_EXCEPT);
 	if (exceptions & FE_INVALID) fps |= FPUS_IE;

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -3948,7 +3948,7 @@ static void do_pm_int(cpuctx_t *scp, int i)
   D_printf("DPMI: Calling protected mode handler for int 0x%02x\n", i);
   if (DPMI_CLIENT.is_32) {
     unsigned int *ssp = sp;
-    *--ssp = imr;
+    *--ssp = imr | (i << 8);
     *--ssp = 0;	/* reserved */
     *--ssp = 0;	/* reserved */
     *--ssp = in_dpmi_pm();
@@ -3966,7 +3966,7 @@ static void do_pm_int(cpuctx_t *scp, int i)
     _esp -= 48;
   } else {
     unsigned short *ssp = sp;
-    *--ssp = imr;
+    *--ssp = imr | (i << 8);
     /* store the high word of EIP in case we interrupted 32bit code */
     *--ssp = HI_WORD(_eip);
     /* full ESP must be preserved */
@@ -4960,6 +4960,8 @@ static void return_from_hwint(cpuctx_t *scp, void * const sp)
   int tf = _isset_TF();
 #endif
   unsigned char imr;
+  unsigned int val;
+  int inum;
   leave_lpms(scp);
       D_printf("DPMI: Return from hardware interrupt handler, "
     "in_dpmi_pm_stack=%i\n", DPMI_CLIENT.in_dpmi_pm_stack);
@@ -4979,7 +4981,7 @@ static void return_from_hwint(cpuctx_t *scp, void * const sp)
     dpmi_set_pm(pm);
     ssp++;  // reserve
     ssp++;  // reserve
-    imr = *ssp++;
+    val = *ssp++;
   } else {
     unsigned short *ssp = sp;
     int pm;
@@ -4996,11 +4998,18 @@ static void return_from_hwint(cpuctx_t *scp, void * const sp)
     dpmi_set_pm(pm);
     _HWORD(esp) = *ssp++;
     _HWORD(eip) = *ssp++;
-    imr = *ssp++;
+    val = *ssp++;
   }
   in_dpmi_irq--;
+  imr = val & 0xff;
   port_outb(0x21, imr);
   dpmi_sti();
+  inum = val >> 8;
+  /* w/a for CW extender, see
+   * https://github.com/dosemu2/dosemu2/pull/2687
+   */
+  if (inum == 0x75)
+    port_outb(0xf0, 0);
 #ifdef USE_MHPDBG
   /* allow tracing from PM hwints */
   if (mhpdbg.active && tf)

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -5006,30 +5006,6 @@ static void return_from_hwint(cpuctx_t *scp, void * const sp)
   if (mhpdbg.active && tf)
     _eflags |= TF;
 #endif
-
-  /* DJGPP's int75 pm handler for example does not use fnclex;
-     if we can't emulate IGNNE we can force the fnclex if needed
-     here, just before returning to the faulting instruction,
-     as a workaround */
-  if (fpu_get_ignne()) {
-    fpu_clear_ignne();
-    if (config.cpu_vm_dpmi == CPUVM_KVM)
-      kvm_get_fpu();
-    if (vm86_fpu_state.swd & 0x80) {
-      // 0x80 = FPU_ES, set when an unmasked FP exception has
-      // occurred. In real DOS after outb(0xf0,0) is done, IGNNE
-      // is active until the FPU_ES bit is no longer set, and
-      // will mask all further FPU exceptions.
-      // As that's hard to do we force an fnclex if not already
-      // done so in the int75 handler to avoid retriggering a
-      // floating point exception; the best we can do without single
-      // stepping. See also bios.S for the real mode handler.
-      D_printf("DPMI: forcing fnclex\n");
-      vm86_fpu_state.swd &= 0x7f00;
-      if (config.cpu_vm_dpmi == CPUVM_KVM)
-	kvm_update_fpu();
-    }
-  }
 }
 
 static void do_dpmi_hlt(cpuctx_t *scp, uint8_t *lina, void *sp)

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -5005,11 +5005,11 @@ static void return_from_hwint(cpuctx_t *scp, void * const sp)
   port_outb(0x21, imr);
   dpmi_sti();
   inum = val >> 8;
-  /* w/a for CW extender, see
+  /* w/a for DJGPP, see
    * https://github.com/dosemu2/dosemu2/pull/2687
    */
   if (inum == 0x75)
-    port_outb(0xf0, 0);
+    port_outb(0xf2, 0);
 #ifdef USE_MHPDBG
   /* allow tracing from PM hwints */
   if (mhpdbg.active && tf)

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -391,8 +391,6 @@ extern void disk_close(void);
 extern void cpu_setup(void);
 extern void cpu_reset(void);
 extern void raise_fpu_irq(void);
-extern int fpu_get_ignne(void);
-extern void fpu_clear_ignne(void);
 extern void real_run_int(int);
 extern void mfs_reset(void);
 extern void mfs_done(void);

--- a/test/cpu/reffile.log
+++ b/test/cpu/reffile.log
@@ -4494,9 +4494,12 @@ smc_code2(4) = 4
 DIVZ exception:
 si_signo=289
 trapno=00000000 err=00000000 EIP=+00000002
-FPE exception:
+FPE exception 1:
 si_signo=289
-trapno=00000075 err=00000000 EIP=+00000015
+trapno=00000075 err=00000000 EIP=+00000012
+FPE exception 2:
+si_signo=289
+trapno=00000075 err=00000000 EIP=+00000012
 BOUND exception:
 si_signo=291
 trapno=00000005 err=00000000 EIP=+00000002

--- a/test/cpu/test-i386.c
+++ b/test/cpu/test-i386.c
@@ -1926,14 +1926,19 @@ void sig_handler(int sig, siginfo_t *info, void *puc)
 void sig_handler(int sig)
 #endif
 {
+    static int fpe_cnt;
+    int cnt = 1;
 #ifdef SA_SIGINFO
     ucontext_t *uc = puc;
 #endif
 
 #ifdef __DJGPP__
     /* clear FPU exceptions before anything else */
-    if (sig == SIGFPE)
+    if (sig == SIGFPE && (__djgpp_exception_state->__signum == 0x75 ||
+            __djgpp_exception_state->__signum == 0x10)) {
         asm volatile ("fnclex; outb %b0, $0xf0\n" ::"a"(0));
+        cnt = ++fpe_cnt;
+    }
 #endif
 
 #ifdef SA_SIGINFO
@@ -1959,7 +1964,7 @@ void sig_handler(int sig)
     }
 #endif
     printf("\n");
-    siglongjmp(jmp_env, 1);
+    siglongjmp(jmp_env, cnt);
 }
 
 #define EXCEPTION(ins,...) \
@@ -1970,6 +1975,8 @@ void test_exceptions(void)
 {
     struct sigaction act;
     volatile int val;
+    int rc;
+    uint16_t orig_fpuc, fpuc;
 
 #ifdef SA_SIGINFO
     act.sa_sigaction = sig_handler;
@@ -1999,18 +2006,23 @@ void test_exceptions(void)
         EXCEPTION("idiv %3", "=a"(divlo), "=d"(divhi): "a"(1), "d"(0),);
     }
 
-    printf("FPE exception:\n");
-    if (_sigsetjmp(jmp_env) == 0) {
-        uint16_t orig_fpuc, fpuc;
-        asm volatile ("fnclex; fnstcw  %0" : "=m"(orig_fpuc));
-        fpuc = orig_fpuc & ~0x3f;
+    asm volatile ("fnclex; fnstcw  %0" : "=m"(orig_fpuc));
+    fpuc = orig_fpuc & ~0x3f;
+    asm volatile ("fldcw %0" : "=m"(fpuc));
+    switch ((rc = _sigsetjmp(jmp_env))) {
+    case 0:
+    case 1: {
         /* now divide by zero (FP); the lret triggers a segment limit check
            in dosemu2, which DJGPP catches */
+        printf("FPE exception %i:\n", rc + 1);
         EXCEPTION("push %%cs; call 1f; jmp 2f; "
-                  "1: sti; fldcw %0; fldz; fld1; fdivp; wait; lret; "
-                  "2: fnclex; fldcw %1",
-                  : "m"(fpuc), "m"(orig_fpuc),);
+                  "1: sti; fldz; fld1; fdivp; wait; lret; "
+                  "2: fnclex", :);
+        printf("Exception didn't work\n");
+        break;
     }
+    }
+    asm volatile ("fldcw %0" : "=m"(orig_fpuc));
 
 #if !defined(__x86_64__)
     printf("BOUND exception:\n");

--- a/test/cpu/test-i386.c
+++ b/test/cpu/test-i386.c
@@ -1936,7 +1936,7 @@ void sig_handler(int sig)
     /* clear FPU exceptions before anything else */
     if (sig == SIGFPE && (__djgpp_exception_state->__signum == 0x75 ||
             __djgpp_exception_state->__signum == 0x10)) {
-        asm volatile ("fnclex; outb %b0, $0xf0\n" ::"a"(0));
+        asm volatile ("fnclex\n" ::"a"(0));
         cnt = ++fpe_cnt;
     }
 #endif


### PR DESCRIPTION
This undoes most of a8b04fb80 work-around.
This however implements the "unrecommended" (by Intel) design, which may theoretically be not properly supported by some DOS program, in which case IGNNE may never get untriggered, preventing further FPU exceptions from happening.
Or the program may save CWD too early (before untriggering IGNNE) and "observe the differences" (get a wrong exception mask). We'll need to find such program though, and evaluate its "importantness".