### PR TITLE
FPU: handle IGNNE# by bypassing exceptions for FPU control instructions and the "unrecommended" design.

### DIFF
--- a/src/base/bios/x86/bios.S
+++ b/src/base/bios/x86/bios.S
@@ -1012,15 +1012,17 @@ bios_text_font:
 	_ORG(0xfea6)
 	.globl INT75_OFF
 INT75_OFF:
+	pushw %ax
+	xorb %al, %al
+	outb %al, $0xf0	/* set IGNNE */
 	int $2		/* Bochs does this; RBIL says: redirected to INT 02 */
 			/* by the BIOS, for compatibility with the PC */
 	fnclex		/* Clear FP exceptions just in case a hooked
 			   handler hasn't already done so, so we won't
 			   get stuck (in real mode IGNNE would prevent
 			   further exceptions but we don't emulate that) */
-	pushw %ax
 	xorb %al, %al
-	outb %al, $0xf0
+	outb %al, $0xf0	/* clear IGNNE */
 	movb $0x20, %al
 	outb %al, $0xa0
 	outb %al, $0x20

--- a/src/base/emu-i386/cpu.c
+++ b/src/base/emu-i386/cpu.c
@@ -304,6 +304,18 @@ static void fpu_io_write(ioport_t port, Bit8u val, void *arg)
   case 0xf1:
     fpu_reset();
     break;
+  /* undocumented port for our "unrecommended" design */
+  case 0xf2:
+    if (fpu_ignne) {
+      fpu_ignne = 0;
+      /* fnclex */
+      vm86_fpu_state.swd &= 0x7f00;
+      if (config.cpu_vm == CPUVM_KVM || config.cpu_vm_dpmi == CPUVM_KVM)
+        kvm_update_fpu();
+      if (config.cpu_vm == CPUVM_EMU || config.cpu_vm_dpmi == CPUVM_EMU)
+        cpuemu_update_fpu();
+    }
+    break;
   }
 }
 

--- a/src/base/emu-i386/cpu.c
+++ b/src/base/emu-i386/cpu.c
@@ -281,16 +281,6 @@ static void fpu_reset(void)
 
 static int fpu_ignne;
 
-int fpu_get_ignne(void)
-{
-  return fpu_ignne;
-}
-
-void fpu_clear_ignne(void)
-{
-  fpu_ignne = 0;
-}
-
 static Bit8u fpu_io_read(ioport_t port, void *arg)
 {
   return 0xff;

--- a/src/base/emu-i386/cpu.c
+++ b/src/base/emu-i386/cpu.c
@@ -290,16 +290,10 @@ static void fpu_io_write(ioport_t port, Bit8u val, void *arg)
 {
   switch (port) {
   case 0xf0:
-    /* We need to check if the FPU exception is pending, and set IGNNE
-     * if it is, before untriggering an IRQ. But we don't (and probably
-     * can't) always emulate IGNNE properly. So the trick is to do fnclex in
-     * bios.S, then untrigger IRQ unconditionally. */
-    pic_untrigger(13); /* done by default via int75 handler in bios.S */
-    /* DJGPP's int75 pm handler for example does not use fnclex;
-       but we can force it in return_from_hw_int() in dpmi.c, so
-       this only makes sense in DPMI, as this variable is not checked in RM */
-    if (in_dpmi_pm()) // this also implies we are not using the handler in bios.S
-      fpu_ignne = !!(vm86_fpu_state.swd & 0x80);
+    pic_untrigger(13);
+    fpu_ignne = !!(vm86_fpu_state.swd & 0x80);
+    /* Note: we emuate the "unrecommended" (by Intel) design where the
+     * untriggering of IGNNE requires an extra write to 0xf0 after fnclex */
     break;
   case 0xf1:
     fpu_reset();
@@ -326,7 +320,7 @@ static int fpu_is_masked(void)
     return ((imr[0] & 4) || !!(real_imr & (1 << 13)));
 }
 
-void raise_fpu_irq(void)
+static void raise_fpu_irq(void)
 {
   if (fpu_is_masked() || !isset_IF_async()) {
     error("FPU IRQ cannot be injected (%i %i), bye\n",
@@ -334,6 +328,58 @@ void raise_fpu_irq(void)
     leavedos(2);
   }
   pic_request(13);
+}
+
+int fpu_fpe_handler (unsigned char *csp)
+{
+  if (fpu_ignne) {
+    /* do some basic emulation:
+       we only deal with control FPU instructions,
+       non-control FPU instructions always cause an exception
+    */
+    if (csp[0] == 0x9b) csp++; // wait
+    if (csp[0] >= 0xd8 && csp[0] <= 0xdf) {
+      int exop = (csp[1] & 0x38) | (csp[0] & 7); // same as interp.c
+      if (exop == 0x63 || exop == 0x67)
+	exop |= ((csp[1] & 7) << 8);
+      if ((csp[1]&0xc0)==0xc0) exop |= 0x40;
+      switch (exop) {
+      case 0x31: //fstenv
+      case 0x35: //fsave
+      case 0x0263: //fclex
+      case 0x0363: //finit
+	fpu_ignne = 0;
+	g_printf("FPU_IGNNE set to %x\n", fpu_ignne);
+	/* fall through */
+      case 0x39: //fstcw
+      case 0x3d: //fstsw
+      case 0x0063: //fneni
+      case 0x0163: //fndisi
+      case 0x0463: //fnsetpm
+      case 0x0067: //fstsw %ax
+	assert(csp[-1] == 0x9b);
+	dbug_printf("coprocessor exception, skipping WAIT because of IGNNE#\n");
+	return 1;
+      case 0x21: //fldenv
+      case 0x25: //frstor
+	fpu_ignne = 0;
+	g_printf("FPU_IGNNE set to %x\n", fpu_ignne);
+	/* fall through */
+      case 0x29: //fldcw
+	dbug_printf("coprocessor exception, disabling CW load exception because of IGNNE#\n");
+	vm86_fpu_state.cwd = 0x37f;
+	if (config.cpu_vm == CPUVM_KVM || config.cpu_vm_dpmi == CPUVM_KVM)
+	  kvm_update_fpu();
+	if (config.cpu_vm == CPUVM_EMU || config.cpu_vm_dpmi == CPUVM_EMU)
+	  cpuemu_update_fpu();
+	return 0;
+      }
+    }
+  }
+
+  dbug_printf("coprocessor exception, calling IRQ13\n");
+  raise_fpu_irq();
+  return 0;
 }
 
 /*

--- a/src/base/emu-i386/do_vm86.c
+++ b/src/base/emu-i386/do_vm86.c
@@ -77,7 +77,8 @@ int vm86_fault(unsigned trapno, unsigned err, dosaddr_t cr2)
     return 0;
 
   case 0x10: /* coprocessor error */
-    raise_fpu_irq(); /* this is the 386 way of signalling this */
+    unsigned char *csp = SEG_ADR((unsigned char *), cs, ip);
+    LWORD(eip) += fpu_fpe_handler(csp);
     return 0;
 
   case 0x11: /* alignment check */

--- a/src/base/emu-i386/simx86/fp87-sim.c
+++ b/src/base/emu-i386/simx86/fp87-sim.c
@@ -171,7 +171,7 @@ static void fxam(long double d)
    we need to save before and clear after */
 void fp87_save_except(void)
 {
-	unsigned short fps = TheCPU.fpus;
+	unsigned short fps = TheCPU.fpus & ~(FPUS_ES | FPUS_B);
 #if FE_ALL_EXCEPT > 0
 	int exceptions = fetestexcept(FE_ALL_EXCEPT);
 	if (exceptions & FE_INVALID) fps |= FPUS_IE;

--- a/src/base/emu-i386/simx86/fp87-sim.c
+++ b/src/base/emu-i386/simx86/fp87-sim.c
@@ -196,13 +196,10 @@ void fp87_save_except(void)
 
 void fp87_mask_except(void)
 {
-	if (TheCPU.fpstate) {
-		/* For simulator, only need to mask all
-		   exceptions, and set rounding properly */
-		fesetenv(FE_DFL_ENV);
-		fp87_set_rounding();
-	}
-	TheCPU.fpstate = NULL;
+	/* For simulator, only need to mask all
+	   exceptions, and set rounding properly */
+	fesetenv(FE_DFL_ENV);
+	fp87_set_rounding();
 }
 
 static float read_float(dosaddr_t addr)
@@ -1092,7 +1089,6 @@ fcom00:			TheCPU.fpus &= ~(FPUS_C0 | FPUS_C2 | FPUS_C3);
 //	25	DD xx100nnn	FRSTOR	94/108byte
 		    dosaddr_t p = mem_ref, q;
 		    TheCPU.fpuc = sim_read_word(p) | 0x40;
-		    fp87_mask_except();
 		    feclearexcept(FE_ALL_EXCEPT);
 		    fp87_set_rounding();
 		    if (reg&DATA16) {
@@ -1104,6 +1100,7 @@ fcom00:			TheCPU.fpus &= ~(FPUS_C0 | FPUS_C2 | FPUS_C3);
 			q = p+28;
 		    }
 		    TheCPU.fpstt = (TheCPU.fpus>>FPUS_TOP_BIT)&7;
+		    fp87_save_except();
 		    if (exop==0x25) {
 			int i, k;
 			k = TheCPU.fpstt;
@@ -1165,7 +1162,6 @@ fcom00:			TheCPU.fpus &= ~(FPUS_C0 | FPUS_C2 | FPUS_C3);
 		    unsigned fptag, ntag;
 //*	31	D9 xx110nnn	FSTENV	14/28byte
 //	35	DD xx110nnn	FSAVE	94/108byte
-		    fp87_mask_except();
 		    fp87_save_except();
 		    TheCPU.fpus = (TheCPU.fpus & ~FPUS_TOP) | (TheCPU.fpstt<<FPUS_TOP_BIT);
 //
@@ -1199,6 +1195,7 @@ fcom00:			TheCPU.fpus &= ~(FPUS_C0 | FPUS_C2 | FPUS_C3);
 			q = p+28;
 		    }
 		    TheCPU.fpuc |= 0x3f;
+		    fp87_save_except();
 		    if (exop==0x35) {
 			int i, k;
 			k = TheCPU.fpstt;

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -5951,8 +5951,7 @@ out:
       }
     }
     else if (_trapno == 0x10) {
-      dbug_printf("coprocessor exception, calling IRQ13\n");
-      raise_fpu_irq();
+      _eip += fpu_fpe_handler(csp);
       return ret;
     }
 

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -3948,7 +3948,7 @@ static void do_pm_int(cpuctx_t *scp, int i)
   D_printf("DPMI: Calling protected mode handler for int 0x%02x\n", i);
   if (DPMI_CLIENT.is_32) {
     unsigned int *ssp = sp;
-    *--ssp = imr;
+    *--ssp = imr | (i << 8);
     *--ssp = 0;	/* reserved */
     *--ssp = 0;	/* reserved */
     *--ssp = in_dpmi_pm();
@@ -3966,7 +3966,7 @@ static void do_pm_int(cpuctx_t *scp, int i)
     _esp -= 48;
   } else {
     unsigned short *ssp = sp;
-    *--ssp = imr;
+    *--ssp = imr | (i << 8);
     /* store the high word of EIP in case we interrupted 32bit code */
     *--ssp = HI_WORD(_eip);
     /* full ESP must be preserved */
@@ -4960,6 +4960,8 @@ static void return_from_hwint(cpuctx_t *scp, void * const sp)
   int tf = _isset_TF();
 #endif
   unsigned char imr;
+  unsigned int val;
+  int inum;
   leave_lpms(scp);
       D_printf("DPMI: Return from hardware interrupt handler, "
     "in_dpmi_pm_stack=%i\n", DPMI_CLIENT.in_dpmi_pm_stack);
@@ -4979,7 +4981,7 @@ static void return_from_hwint(cpuctx_t *scp, void * const sp)
     dpmi_set_pm(pm);
     ssp++;  // reserve
     ssp++;  // reserve
-    imr = *ssp++;
+    val = *ssp++;
   } else {
     unsigned short *ssp = sp;
     int pm;
@@ -4996,11 +4998,14 @@ static void return_from_hwint(cpuctx_t *scp, void * const sp)
     dpmi_set_pm(pm);
     _HWORD(esp) = *ssp++;
     _HWORD(eip) = *ssp++;
-    imr = *ssp++;
+    val = *ssp++;
   }
   in_dpmi_irq--;
+  imr = val & 0xff;
   port_outb(0x21, imr);
   dpmi_sti();
+  inum = val >> 8;
+
 #ifdef USE_MHPDBG
   /* allow tracing from PM hwints */
   if (mhpdbg.active && tf)
@@ -5010,9 +5015,12 @@ static void return_from_hwint(cpuctx_t *scp, void * const sp)
   /* DJGPP's int75 pm handler for example does not use fnclex;
      if we can't emulate IGNNE we can force the fnclex if needed
      here, just before returning to the faulting instruction,
-     as a workaround */
-  if (fpu_get_ignne()) {
-    fpu_clear_ignne();
+     as a workaround
+     Also, in general we need to reset IGNNE via port 0xf0 to mirror
+     the bios.S handler, see
+     https://github.com/dosemu2/dosemu2/pull/2687
+   */
+  if (inum == 0x75) {
     if (config.cpu_vm_dpmi == CPUVM_KVM)
       kvm_get_fpu();
     if (vm86_fpu_state.swd & 0x80) {
@@ -5029,6 +5037,7 @@ static void return_from_hwint(cpuctx_t *scp, void * const sp)
       if (config.cpu_vm_dpmi == CPUVM_KVM)
 	kvm_update_fpu();
     }
+    port_outb(0xf0, 0);
   }
 }
 

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -5005,40 +5005,16 @@ static void return_from_hwint(cpuctx_t *scp, void * const sp)
   port_outb(0x21, imr);
   dpmi_sti();
   inum = val >> 8;
-
+  /* w/a for DJGPP, see
+   * https://github.com/dosemu2/dosemu2/pull/2687
+   */
+  if (inum == 0x75)
+    port_outb(0xf2, 0);
 #ifdef USE_MHPDBG
   /* allow tracing from PM hwints */
   if (mhpdbg.active && tf)
     _eflags |= TF;
 #endif
-
-  /* DJGPP's int75 pm handler for example does not use fnclex;
-     if we can't emulate IGNNE we can force the fnclex if needed
-     here, just before returning to the faulting instruction,
-     as a workaround
-     Also, in general we need to reset IGNNE via port 0xf0 to mirror
-     the bios.S handler, see
-     https://github.com/dosemu2/dosemu2/pull/2687
-   */
-  if (inum == 0x75) {
-    if (config.cpu_vm_dpmi == CPUVM_KVM)
-      kvm_get_fpu();
-    if (vm86_fpu_state.swd & 0x80) {
-      // 0x80 = FPU_ES, set when an unmasked FP exception has
-      // occurred. In real DOS after outb(0xf0,0) is done, IGNNE
-      // is active until the FPU_ES bit is no longer set, and
-      // will mask all further FPU exceptions.
-      // As that's hard to do we force an fnclex if not already
-      // done so in the int75 handler to avoid retriggering a
-      // floating point exception; the best we can do without single
-      // stepping. See also bios.S for the real mode handler.
-      D_printf("DPMI: forcing fnclex\n");
-      vm86_fpu_state.swd &= 0x7f00;
-      if (config.cpu_vm_dpmi == CPUVM_KVM)
-	kvm_update_fpu();
-    }
-    port_outb(0xf0, 0);
-  }
 }
 
 static void do_dpmi_hlt(cpuctx_t *scp, uint8_t *lina, void *sp)

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -391,8 +391,6 @@ extern void disk_close(void);
 extern void cpu_setup(void);
 extern void cpu_reset(void);
 extern void raise_fpu_irq(void);
-extern int fpu_get_ignne(void);
-extern void fpu_clear_ignne(void);
 extern void real_run_int(int);
 extern void mfs_reset(void);
 extern void mfs_done(void);

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -390,7 +390,7 @@ extern void parent_nextscan(void);
 extern void disk_close(void);
 extern void cpu_setup(void);
 extern void cpu_reset(void);
-extern void raise_fpu_irq(void);
+extern int fpu_fpe_handler(unsigned char *csp);
 extern void real_run_int(int);
 extern void mfs_reset(void);
 extern void mfs_done(void);

--- a/test/cpu/reffile.log
+++ b/test/cpu/reffile.log
@@ -4494,9 +4494,12 @@ smc_code2(4) = 4
 DIVZ exception:
 si_signo=289
 trapno=00000000 err=00000000 EIP=+00000002
-FPE exception:
+FPE exception 1:
 si_signo=289
-trapno=00000075 err=00000000 EIP=+00000015
+trapno=00000075 err=00000000 EIP=+00000012
+FPE exception 2:
+si_signo=289
+trapno=00000075 err=00000000 EIP=+00000012
 BOUND exception:
 si_signo=291
 trapno=00000005 err=00000000 EIP=+00000002

--- a/test/cpu/test-i386.c
+++ b/test/cpu/test-i386.c
@@ -1926,14 +1926,19 @@ void sig_handler(int sig, siginfo_t *info, void *puc)
 void sig_handler(int sig)
 #endif
 {
+    static int fpe_cnt;
+    int cnt = 1;
 #ifdef SA_SIGINFO
     ucontext_t *uc = puc;
 #endif
 
 #ifdef __DJGPP__
     /* clear FPU exceptions before anything else */
-    if (sig == SIGFPE)
+    if (sig == SIGFPE && (__djgpp_exception_state->__signum == 0x75 ||
+            __djgpp_exception_state->__signum == 0x10)) {
         asm volatile ("fnclex; outb %b0, $0xf0\n" ::"a"(0));
+        cnt = ++fpe_cnt;
+    }
 #endif
 
 #ifdef SA_SIGINFO
@@ -1959,7 +1964,7 @@ void sig_handler(int sig)
     }
 #endif
     printf("\n");
-    siglongjmp(jmp_env, 1);
+    siglongjmp(jmp_env, cnt);
 }
 
 #define EXCEPTION(ins,...) \
@@ -1970,6 +1975,8 @@ void test_exceptions(void)
 {
     struct sigaction act;
     volatile int val;
+    int rc;
+    uint16_t orig_fpuc, fpuc;
 
 #ifdef SA_SIGINFO
     act.sa_sigaction = sig_handler;
@@ -1999,18 +2006,23 @@ void test_exceptions(void)
         EXCEPTION("idiv %3", "=a"(divlo), "=d"(divhi): "a"(1), "d"(0),);
     }
 
-    printf("FPE exception:\n");
-    if (_sigsetjmp(jmp_env) == 0) {
-        uint16_t orig_fpuc, fpuc;
-        asm volatile ("fnclex; fnstcw  %0" : "=m"(orig_fpuc));
-        fpuc = orig_fpuc & ~0x3f;
+    asm volatile ("fnclex; fnstcw  %0" : "=m"(orig_fpuc));
+    fpuc = orig_fpuc & ~0x3f;
+    asm volatile ("fldcw %0" : "=m"(fpuc));
+    switch ((rc = _sigsetjmp(jmp_env))) {
+    case 0:
+    case 1: {
         /* now divide by zero (FP); the lret triggers a segment limit check
            in dosemu2, which DJGPP catches */
+        printf("FPE exception %i:\n", rc + 1);
         EXCEPTION("push %%cs; call 1f; jmp 2f; "
-                  "1: sti; fldcw %0; fldz; fld1; fdivp; wait; lret; "
-                  "2: fnclex; fldcw %1",
-                  : "m"(fpuc), "m"(orig_fpuc),);
+                  "1: sti; fldz; fld1; fdivp; wait; lret; "
+                  "2: fnclex", :);
+        printf("Exception didn't work\n");
+        break;
     }
+    }
+    asm volatile ("fldcw %0" : "=m"(orig_fpuc));
 
 #if !defined(__x86_64__)
     printf("BOUND exception:\n");

--- a/test/cpu/test-i386.c
+++ b/test/cpu/test-i386.c
@@ -1936,7 +1936,7 @@ void sig_handler(int sig)
     /* clear FPU exceptions before anything else */
     if (sig == SIGFPE && (__djgpp_exception_state->__signum == 0x75 ||
             __djgpp_exception_state->__signum == 0x10)) {
-        asm volatile ("fnclex; outb %b0, $0xf0\n" ::"a"(0));
+        asm volatile ("fnclex\n" ::"a"(0));
         cnt = ++fpe_cnt;
     }
 #endif


### PR DESCRIPTION
Based on the discussion in #2687 in particular 
https://github.com/dosemu2/dosemu2/pull/2687#issuecomment-3539184817
I applied https://github.com/dosemu2/dosemu2/commit/c843c652ab12802217ffa59ee93a39e4053c13dc
but for that to work I had to apply most of #2687 first (except the control word bits).

So this is a mix of patches by @stsp and myself.

The DJGPP workaround is the same as in #2687 (fnclex via port 0xf2)... this could still be refined a bit but I think this PR has all the things we agree upon so far.
