### PR TITLE
simx86: load FPU state via Sim_helper

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -75,7 +75,7 @@
 static unsigned char *CodeGen_sim(unsigned char *CodePtr, unsigned char *BaseGenBuf, const IGen *IG);
 static unsigned Exec_sim(unsigned *mem_ref, unsigned long *flg,
 			 unsigned char *ecpu, void *SeqStart,
-			 unsigned short seqflg, unsigned *seqbase);
+			 unsigned *seqbase);
 
 static unsigned char *currentIG = NULL;
 
@@ -2773,16 +2773,9 @@ static unsigned char *CodeGen_sim(unsigned char *CodePtr, unsigned char *BaseGen
 
 static unsigned Exec_sim(unsigned *pmem_ref, unsigned long *flg,
 			 unsigned char *ecpu, void *SeqStart,
-			 unsigned short seqflg, unsigned int *seqbase)
+			 unsigned int *seqbase)
 {
 	unsigned int P0;
-
-	if ((seqflg & F_FPOP) && TheCPU.fpstate) {
-		/* mask all exceptions, and set rounding properly */
-		fp87_mask_except();
-		cpuemu_update_fpu();
-		TheCPU.fpstate = NULL;
-	}
 
 	FlagSync_RFL(*flg);
 	P0 = Gen_sim(SeqStart, pmem_ref, seqbase);
@@ -3336,6 +3329,7 @@ stack_return_from_vm86:
 			if (mode&DATA16) port_outw(a,rAX); else port_outd(a,rEAX);
 			} break;
 
+/*9b*/	case oWAIT:
 /*d9*/	case ESC1:
 /*dd*/	case ESC5:
 			Fp87_op(arg, mode, mem_ref);

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -109,7 +109,7 @@
 static unsigned char *CodeGen_x86(unsigned char *CodePtr, unsigned char *BaseGenBuf, const IGen *IG);
 static unsigned Exec_x86(unsigned *mem_ref, unsigned long *flg,
 			 unsigned char *ecpu, void *SeqStart,
-			 unsigned short seqflg, unsigned *seqbase);
+			 unsigned *seqbase);
 
 /////////////////////////////////////////////////////////////////////////////
 
@@ -2043,8 +2043,8 @@ shrot0:
 #define R_REG(r) "%e"#r
 #define EXEC_CLOBBERS
 #endif
-static unsigned Exec_x86_asm(unsigned *mem_ref, unsigned long *flg,
-		unsigned char *ecpu, unsigned char *SeqStart,
+static unsigned Exec_x86(unsigned *mem_ref, unsigned long *flg,
+		unsigned char *ecpu, void *SeqStart,
 		unsigned int *seqbase)
 {
 	unsigned ePC;
@@ -2102,19 +2102,6 @@ static unsigned Exec_x86_asm(unsigned *mem_ref, unsigned long *flg,
 	/* even though InCompiledCode is volatile, we also need a barrier */
 	asm volatile ("":::"memory");
 	return ePC;
-}
-
-static unsigned Exec_x86(unsigned *mem_ref, unsigned long *flg,
-		unsigned char *ecpu, void *SeqStart,
-		unsigned short seqflg, unsigned int *seqbase)
-{
-	/* was there at least one FP op in the sequence? */
-	if ((seqflg & F_FPOP) && TheCPU.fpstate) {
-		TheCPU.fpuc = TheCPU.fpstate->cwd;
-		loadfpstate(*TheCPU.fpstate);
-		TheCPU.fpstate = NULL;
-	}
-	return Exec_x86_asm(mem_ref, flg, ecpu, SeqStart, seqbase);
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -60,7 +60,7 @@
 unsigned char * (*CodeGen)(unsigned char *CodePtr, unsigned char *BaseGenBuf, const IGen *IG);
 unsigned (*Exec)(unsigned *mem_ref, unsigned long *flg,
 		 unsigned char *ecpu, void *SeqStart,
-		 unsigned short seqflg, unsigned *seqbase);
+		 unsigned *seqbase);
 
 int UseLinker = 0;
 hitimer_u TimeStartExec;
@@ -327,8 +327,6 @@ void Gen(int op, int mode, ...)
 		break;
 
 	case O_FOP:
-		I->flags |= F_FPOP;
-		// fall through
 	case O_INT: {
 		unsigned char exop = (unsigned char)va_arg(ap,unsigned int);
 		IG->p0 = exop;
@@ -613,7 +611,7 @@ static unsigned ExecOne(TNode *G, unsigned *mem_ref, unsigned long *flg,
 	/* check links FROM LastXNode TO current node */
 	if (*pLastXKey != G->key)
 		NodeLinker(FindTree(*pLastXKey), G);
-	ePC = Exec(mem_ref, flg, ecpu, G->addr, G->flags, pLastXKey);
+	ePC = Exec(mem_ref, flg, ecpu, G->addr, pLastXKey);
 #ifdef SKIP_EMU_VBIOS
 	if ((TheCPU.cs&0xf000)==config.vbios_seg && !TheCPU.err)
 		TheCPU.err = EXCP_GOBACK;

--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -225,10 +225,9 @@ extern unsigned char * (*CodeGen)(unsigned char *CodePtr,
 				  unsigned char *BaseGenBuf, const IGen *IG);
 extern unsigned (*Exec)(unsigned *mem_ref, unsigned long *flg,
 			unsigned char *ecpu, void *SeqStart,
-			unsigned short seqflg, unsigned *seqbase);
+			unsigned *seqbase);
 unsigned int DoExec(TNode *G, unsigned *LastXKey);
 void EndGen(void);
-extern void fp87_mask_except(void);
 extern void fp87_save_except(void);
 //
 static __inline__ int GoodNode(TNode *G)

--- a/src/base/emu-i386/simx86/fp87-sim.c
+++ b/src/base/emu-i386/simx86/fp87-sim.c
@@ -194,7 +194,7 @@ void fp87_save_except(void)
 	TheCPU.fpus = (fps&~FPUS_TOP)|(TheCPU.fpstt<<FPUS_TOP_BIT);
 }
 
-void fp87_mask_except(void)
+static void fp87_mask_except(void)
 {
 	/* For simulator, only need to mask all
 	   exceptions, and set rounding properly */
@@ -273,6 +273,14 @@ static void Fp87_op_sim(int exop, int reg, unsigned mem_ref)
 //	5B	DB 11011nnn	FCMOVNU	st(0),st(n)
 
 	e_printf("FPop %x.%d\n", exop, reg);
+
+	/* this is called with oWAIT for the first FP op in the sequence */
+	if (exop == oWAIT && TheCPU.fpstate) {
+		/* mask all exceptions, and set rounding properly */
+		fp87_mask_except();
+		cpuemu_update_fpu();
+		TheCPU.fpstate = NULL;
+	}
 
 	if (~TheCPU.fpuc & 0x3f)
 		// always check for unmasked exception

--- a/src/base/emu-i386/simx86/fp87-x86.c
+++ b/src/base/emu-i386/simx86/fp87-x86.c
@@ -459,14 +459,20 @@ fp_ok:
 static void Fp87_op_x86_sim(int exop, int reg, unsigned mem_ref)
 {
 	e_printf("FPop %x.%d\n", exop, reg);
-	if (TheCPU.fpstate) {
-		/* load emulated FPU state into real FPU, if not already
-		   done so by Exec_x86 */
-		loadfpstate(*TheCPU.fpstate);
-		TheCPU.fpstate = NULL;
-	}
 
 	switch(exop) {
+/*9b*/	case oWAIT:
+		/* this is called with oWAIT for the first FP op in the
+		   sequence */
+		if (TheCPU.fpstate) {
+			/* load emulated FPU state into real FPU,
+			   if not already done so */
+			TheCPU.fpuc = TheCPU.fpstate->cwd;
+			loadfpstate(*TheCPU.fpstate);
+			TheCPU.fpstate = NULL;
+		}
+		break;
+
 /*21*/	case 0x21:
 /*25*/	case 0x25: {
 //*	21	D9 xx100nnn	FLDENV	14/28byte

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -2233,9 +2233,6 @@ repag0:
 			break;
 
 /*9b*/	case oWAIT:
-			Gen(O_FOP, _mode, opc, 0);
-			PC++;
-			break;
 /*d8*/	case ESC0:
 /*d9*/	case ESC1:
 /*da*/	case ESC2:
@@ -2244,6 +2241,17 @@ repag0:
 /*dd*/	case ESC5:
 /*de*/	case ESC6:
 /*df*/	case ESC7:  {
+			if (~(InstrMeta[0].flags & F_FPOP)) {
+				/* load fp state if needed for
+				   first FPOP in sequence */
+				InstrMeta[0].flags |= F_FPOP;
+				Gen(O_SIM, _mode, oWAIT, oWAIT, P0);
+			}
+			if (opc == oWAIT) {
+				Gen(O_FOP, _mode, opc, 0);
+				PC++;
+				break;
+			}
 			unsigned char b=Fetch(PC+1);
 			// extended opcode
 			// 1101.1ooo xxeeerrr -> eeeooo,rrr

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -733,22 +733,6 @@ static unsigned tnode_nrefs(const TNode *G)
 	return nrefs;
 }
 
-static void _nodeflagbackrefs(TNode *LG, unsigned short flags)
-{
-	/* helper routine to flag all back references:
-	   if the current node uses FP then all nodes that link to
-	   it must be flagged as such, which is a recursive procedure
-	*/
-	backref *B;
-
-	if ((LG->flags & flags) != flags) {
-	    /* only go as far back as long as flags change */
-	    LG->flags |= flags;
-	    for (B=LG->bkr; B; B=B->next)
-		_nodeflagbackrefs(B->ref, flags);
-	}
-}
-
 static void linknode(TNode *LG, TNode *G, linkdesc *L, char branch)
 {
 	backref *B;
@@ -789,7 +773,6 @@ static void linknode(TNode *LG, TNode *G, linkdesc *L, char branch)
 			 G,G->key,G->addr,
 			 L->target, B->branch, tnode_nrefs(G), L->ref);
 	}
-	_nodeflagbackrefs(LG, G->flags & F_FPOP);
 	if (debug_level('e')>8) {
 		backref *bk = G->bkr;
 #ifdef DEBUG_LINKER


### PR DESCRIPTION
The first FP op in a sequence can call Sim_helper to check if the FPU state needs to be loaded. This simplifies Exec(), as it no longer needs to check it there then.

Moreover, any nodes that link to the node no longer need to be flagged for loading FPU state then.