### PR TITLE
simx86: don't set TheCPU.eip in compiled code, use TheCPU.{temp,key} instead, also for LastXKey

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -74,8 +74,7 @@
 
 static unsigned char *CodeGen_sim(unsigned char *CodePtr, unsigned char *BaseGenBuf, const IGen *IG);
 static unsigned Exec_sim(unsigned *mem_ref, unsigned long *flg,
-			 unsigned char *ecpu, void *SeqStart,
-			 unsigned *seqbase);
+			 unsigned char *ecpu, void *SeqStart);
 
 static unsigned char *currentIG = NULL;
 
@@ -463,8 +462,7 @@ static void Gen_S_DI(const IGen *IG, dosaddr_t addr, unsigned v)
 	if (debug_level('e')>3) dbug_printf("(V) %08x\n",v);
 }
 
-static unsigned int Gen_sim(IGen *IG, unsigned int *pmem_ref,
-			    unsigned int *seqbase)
+static unsigned int Gen_sim(IGen *IG, unsigned int *pmem_ref)
 {
     /* working registers of the host CPU */
     wkreg DR1;	// "eax"
@@ -2621,7 +2619,7 @@ static unsigned int Gen_sim(IGen *IG, unsigned int *pmem_ref,
 
 	case JMP_TAILCODE: {	// retaddr
 		P0 = (unsigned int)IG->p0;
-		*seqbase = P0;
+		TheCPU.key = P0;
 		if (debug_level('e')>2) {
 			dbug_printf("** Tail code: return from %08x\n",P0);
 		} }
@@ -2629,19 +2627,20 @@ static unsigned int Gen_sim(IGen *IG, unsigned int *pmem_ref,
 
 	case JMP_INDIRECT:
 		P0 = LONG_CS + ((mode & DATA16) ? DR1.w.l : DR1.d);
-		*seqbase = P0;
+		TheCPU.key = P0;
 		if (debug_level('e')>2)
 			dbug_printf("** Jump taken to %08x\n",P0);
 		break;
 
 	case JMP_LINK:		// dspt
-		if ((IG->mode & MLINK) &&
-		    !((IG->mode & CKSIGN) && exit_pending())) {
+		if ((IG->mode & CKSIGN) && exit_pending()) {
+			TheCPU.key = IG->p0;
+		}
+		else if (IG->mode & MLINK) {
 			IG = (IGen *)IG->link;
 			continue;
 		}
 		P0 = (unsigned int)IG->p0;
-		*seqbase = IG->p1;
 		if (debug_level('e')>2) {
 			dbug_printf("** Jump taken to %08x\n",P0);
 		}
@@ -2679,13 +2678,14 @@ static unsigned int Gen_sim(IGen *IG, unsigned int *pmem_ref,
 		case JCXZ:
 			IG += ((mode&ADDR16? rCX : rECX) == 0); break;
 		}
-		if ((IG->mode & MLINK) &&
-		    !((IG->mode & CKSIGN) && exit_pending())) {
+		if ((IG->mode & CKSIGN) && exit_pending()) {
+			TheCPU.key = IG->p0;
+		}
+		else if (IG->mode & MLINK) {
 			IG = (IGen *)IG->link;
 			continue;
 		}
 		P0 = IG->p0;
-		*seqbase = IG->p1;
 		if (debug_level('e')>2 && (IG-1)->op == JMP_LINK)
 			dbug_printf("** Jump taken to %08x\n",P0);
 		}
@@ -2708,7 +2708,6 @@ static unsigned int Gen_sim(IGen *IG, unsigned int *pmem_ref,
 			continue;
 		}
 		P0 = IG->p0;
-		*seqbase = IG->p1;
 		if (debug_level('e')>2 && (IG-1)->op == JMP_LINK)
 			dbug_printf("** Jump taken to %08x\n",P0);
 		}
@@ -2772,16 +2771,15 @@ static unsigned char *CodeGen_sim(unsigned char *CodePtr, unsigned char *BaseGen
 }
 
 static unsigned Exec_sim(unsigned *pmem_ref, unsigned long *flg,
-			 unsigned char *ecpu, void *SeqStart,
-			 unsigned int *seqbase)
+			 unsigned char *ecpu, void *SeqStart)
 {
 	unsigned int P0;
 
 	FlagSync_RFL(*flg);
-	P0 = Gen_sim(SeqStart, pmem_ref, seqbase);
+	P0 = Gen_sim(SeqStart, pmem_ref);
 	currentIG = NULL;
 	*flg = FlagSync_All();
-	if (TheCPU.err) *seqbase = P0;
+	if (TheCPU.err) TheCPU.key = P0;
 
 	return P0;
 }

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -289,7 +289,7 @@ static unsigned char *CodeGen_x86(unsigned char *CodePtr, unsigned char *BaseGen
 	// Special case: CR0&0x3f
 	case L_CR0:
 		// movl Ofs_CR0(%%ebx),%%eax
-		G3M(0x8b,0x43,Ofs_CR0,Cp);
+		G2M(0x8b,0x83,Cp); G4(Ofs_CR0,Cp);
 		// andl $0x3f,%%eax
 		G3(0x3fe083,Cp);
 		break;

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -108,8 +108,7 @@
 
 static unsigned char *CodeGen_x86(unsigned char *CodePtr, unsigned char *BaseGenBuf, const IGen *IG);
 static unsigned Exec_x86(unsigned *mem_ref, unsigned long *flg,
-			 unsigned char *ecpu, void *SeqStart,
-			 unsigned *seqbase);
+			 unsigned char *ecpu, void *SeqStart);
 
 /////////////////////////////////////////////////////////////////////////////
 
@@ -124,7 +123,7 @@ static unsigned Exec_x86(unsigned *mem_ref, unsigned long *flg,
  */
 
 static unsigned char TailCode[TAILSIZE+1] =
-	{ 0xb8,0,0,0,0,0x89,0xc1,0x5a,0xc3,0xf4 };
+	{ 0xb8,0,0,0,0,0x89,0x43,Ofs_KEY,0x5a,0xc3,0xf4 };
 
 /*
  * This function is only here for looking at the generated binary code
@@ -279,8 +278,10 @@ static unsigned char *CodeGen_x86(unsigned char *CodePtr, unsigned char *BaseGen
 		G4M(0x83,0x7b,Ofs_ERR,0x00,Cp);
 		// jz skip
 		G2M(JE_JZ,TAILSIZE,Cp);
-		// movl {exit_addr},%%eax; movl %%eax, %%ecx; pop %%edx; ret
-		G1(0xb8,Cp); G4(IG->p1,Cp); G4M(0x89,0xc1,0x5a,0xc3,Cp);
+		// movl {exit_addr},%%eax; movl %%eax, %%Ofs_KEY(%%ebx)
+		G1(0xb8,Cp); G4(IG->p1,Cp); G3M(0x89,0x43,Ofs_EBX,Cp);
+		// pop %%edx; ret
+		G2M(0x5a,0xc3,Cp);
 		}
 		break;
 	case L_NOP:
@@ -1275,8 +1276,10 @@ shrot0:
 		G2M(0x73,TAILSIZE+7,Cp);
 		// movb EXCP0D_GPF, Ofs_ERR(%%ebx)
 		G2M(0xc6,0x83,Cp); G4(Ofs_ERR,Cp); G1(EXCP0D_GPF,Cp);
-		// movl {exit_addr},%%eax; mov %%eax, %%ecx; pop %%edx; ret
-		G1(0xb8,Cp); G4(jpc,Cp); G4M(0x89,0xc1,0x5a,0xc3,Cp);
+		// movl {exit_addr},%%eax; mov %%eax, Ofs_KEY(%%ebx);
+		G1(0xb8,Cp); G4(jpc,Cp); G3M(0x89,0x43,Ofs_KEY,Cp);
+		// pop %%edx; ret
+		G2M(0x5a,0xc3,Cp);
 		// address to call in edi
 		// movl $(inum*4), %edi
 		G1(0xbf,Cp); G4(intno*4, Cp);
@@ -1296,8 +1299,10 @@ shrot0:
 		G4M(0x83,0x7b,Ofs_ERR,0x00,Cp);
 		// je skip
 		G2M(JE_JZ,TAILSIZE,Cp);
-		// movl {exit_addr},%%eax; movl %eax,%ecx;  pop %%edx; ret
-		G1(MOViax,Cp); G4(IG->p2,Cp); G4M(0x89,0xc1,POPdx,RET,Cp);
+		// movl {exit_addr},%%eax; movl %eax,Ofs_KEY(%ebx);
+		G1(MOViax,Cp); G4(IG->p2,Cp); G3M(0x89,0x43,Ofs_KEY,Cp);
+		// pop %%edx; ret
+		G2M(POPdx,RET,Cp);
 
 	case O_MOVS_SetA: {
 		/* use edi for loads unless MOVSDST or REP is set */
@@ -1871,8 +1876,8 @@ shrot0:
 			G3M(0x0f,0xb7,0xc0,Cp);
 		// addl Ofs_XCS(%%ebx),%%eax
 		G3M(0x03,0x43,Ofs_XCS,Cp);
-		// movl %%eax, %%ecx // signals indirect
-		G2M(0x89,0xc1,Cp);
+		// movl %%eax, Ofs_KEY(%%ecx) // signals indirect
+		G3M(0x89,0x43,Ofs_KEY,Cp);
 		// pop %%edx; ret
 		G2M(0x5a,0xc3,Cp);
 		}
@@ -1913,14 +1918,15 @@ shrot0:
 		    G4M(0x0f,0xb7,0x4b,Ofs_EXITPEND,Cp);
 		    // jecxz {continue}: exit if exitpend not 0
 		    G2M(0xe3,TAILSIZE,Cp);
-		    // movl {exit_addr},%%eax; pop %%edx; movl %%eax, %%ecx; ret
-		    G1(0xb8,Cp); G4(dspt,Cp); G4M(0x89,0xc1,0x5a,0xc3,Cp);
+		    // movl {exit_addr},%%eax; movl %%eax,Ofs_KEY(%%ebx)
+		    G1(0xb8,Cp); G4(dspt,Cp); G3M(0x89,0x43,Ofs_KEY,Cp);
+		    // pop %%edx; ret
+		    G2M(0x5a,0xc3,Cp);
 	        }
-		// mov [node_pc], %%ecx
-		G1(0xb9,Cp); G4(IG->p1,Cp);
 		// t:	b8 [exit_pc] 5a c3
 		G1(0xb8,Cp);
 		G4(dspt,Cp); G2(0xc35a,Cp);
+		G5(0x9090909090,Cp); // padding for 64-bit jump
 		if (debug_level('e')>2) e_printf("JMP_Link %08x %08x\n", dspt, IG->p1);
 		}
 		break;
@@ -2044,8 +2050,7 @@ shrot0:
 #define EXEC_CLOBBERS
 #endif
 static unsigned Exec_x86(unsigned *mem_ref, unsigned long *flg,
-		unsigned char *ecpu, void *SeqStart,
-		unsigned int *seqbase)
+		unsigned char *ecpu, void *SeqStart)
 {
 	unsigned ePC;
 	void *jb;
@@ -2066,14 +2071,14 @@ static unsigned Exec_x86(unsigned *mem_ref, unsigned long *flg,
 		"call	1f\n"		/* save return addr		*/
 		"jmp	2f\n"
 		"1:\n"
-		"push	%5\n"
-		"jmp	*%6\n"
+		"push	%4\n"
+		"jmp	*%5\n"
 		"2:\n"
 #ifdef __x86_64__
 		"movq	%%r12,%%rsp\n"
 #endif
 		"pop	"RE_REG(bp)"\n"
-		: "=d"(*flg),"=a"(ePC),"=D"(*mem_ref),"=c"(*seqbase)
+		: "=d"(*flg),"=a"(ePC),"=D"(*mem_ref)
 		: "b"(ecpu),"d"(*flg),"a"(GetExecCodeBuf(SeqStart)),
 		  [mb]"D"(jb)  // don't use "r" or can assign to %rbp
 		/* Note: we need to clobber "class-less" regs (like %rbp) even

--- a/src/base/emu-i386/simx86/codegen-x86.h
+++ b/src/base/emu-i386/simx86/codegen-x86.h
@@ -37,10 +37,10 @@
 
 #include "codegen.h"
 
-#define TAILSIZE	9
+#define TAILSIZE	10
 #define JMPTAILSIZE	12
 #define TAILFIX		1
-#define CKSIGNSIZE	15
+#define CKSIGNSIZE	16
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -59,8 +59,7 @@
 
 unsigned char * (*CodeGen)(unsigned char *CodePtr, unsigned char *BaseGenBuf, const IGen *IG);
 unsigned (*Exec)(unsigned *mem_ref, unsigned long *flg,
-		 unsigned char *ecpu, void *SeqStart,
-		 unsigned *seqbase);
+		 unsigned char *ecpu, void *SeqStart);
 
 int UseLinker = 0;
 hitimer_u TimeStartExec;
@@ -358,7 +357,6 @@ void Gen(int op, int mode, ...)
 
 	case JMP_LINK:		// dspt
 		IG->p0 = va_arg(ap,unsigned int);	// dspt
-		IG->p1 = va_arg(ap,unsigned int);	// PC of node
 		break;
 
 	case JLOOP_LINK:
@@ -587,7 +585,7 @@ static void Exec_post(unsigned long flg, unsigned int mem_ref)
 }
 
 static unsigned ExecOne(TNode *G, unsigned *mem_ref, unsigned long *flg,
-		unsigned char *ecpu, unsigned int *pLastXKey)
+		unsigned char *ecpu)
 {
 	unsigned int ePC;
 	/*
@@ -605,13 +603,13 @@ static unsigned ExecOne(TNode *G, unsigned *mem_ref, unsigned long *flg,
 	 * A complication here is that the previous node may already
 	 * be linked, so an unlinked exit will return the start PC
 	 * of the original (unlinked) block in seqbase.
-	 * Unlinkable exits are flagged using ePC==LastXKey; self-links
+	 * Unlinkable exits are flagged using ePC==TheCPU.key; self-links
 	 * are already handled at the compile stage.
 	 */
 	/* check links FROM LastXNode TO current node */
-	if (*pLastXKey != G->key)
-		NodeLinker(FindTree(*pLastXKey), G);
-	ePC = Exec(mem_ref, flg, ecpu, G->addr, pLastXKey);
+	if (TheCPU.key != G->key)
+		NodeLinker(FindTree(TheCPU.key), G);
+	ePC = Exec(mem_ref, flg, ecpu, G->addr);
 #ifdef SKIP_EMU_VBIOS
 	if ((TheCPU.cs&0xf000)==config.vbios_seg && !TheCPU.err)
 		TheCPU.err = EXCP_GOBACK;
@@ -646,7 +644,7 @@ static void HandleEmuSignals(void)
 	}
 }
 
-unsigned int DoExec(TNode *G, unsigned *pLastXKey)
+unsigned int DoExec(TNode *G)
 {
 	unsigned long flg;
 	unsigned char *ecpu;
@@ -679,7 +677,7 @@ unsigned int DoExec(TNode *G, unsigned *pLastXKey)
 	/* try fast inner loop if nothing special is going on */
 	if (!(seqflg & (F_SPEC|F_LEAV)) && !debug_level('e')) {
 		while (1) {
-			ePC = ExecOne(G, &mem_ref, &flg, ecpu, pLastXKey);
+			ePC = ExecOne(G, &mem_ref, &flg, ecpu);
 			if (TheCPU.err || exit_pending())
 				break;
 			G = FindTree(ePC);
@@ -688,7 +686,7 @@ unsigned int DoExec(TNode *G, unsigned *pLastXKey)
 		}
 	} else
 #endif
-		ePC = ExecOne(G, &mem_ref, &flg, ecpu, pLastXKey);
+		ePC = ExecOne(G, &mem_ref, &flg, ecpu);
 	// G is unreliable (maybe deleted) past this point!
 	Exec_post(flg, mem_ref);
 
@@ -697,8 +695,8 @@ unsigned int DoExec(TNode *G, unsigned *pLastXKey)
 	    ExecTime += GETTSC() - TimeStartExec;
 #endif
 	    if (debug_level('e')>1) {
-		if (debug_level('e')>2 && *pLastXKey != ePC)
-			e_printf("New LastXKey=%08x\n",*pLastXKey);
+		if (debug_level('e')>2 && TheCPU.key != ePC)
+			e_printf("New TheCPU.key=%08x\n",TheCPU.key);
 		e_printf("** End code, PC=%08x sig=%x\n",ePC,
 		    exit_pending());
 		if ((debug_level('e')>3) && (seqflg & F_FPOP)) {

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -716,11 +716,11 @@ unsigned int DoExec(TNode *G, unsigned *pLastXKey)
 	 */
 	if (!TheCPU.err && exit_pending()) {
 		/* checking for infinite loops, flagged in JumpGen() */
-		/* TheCPU.eip points to the first instruction of the last
-		   executed block, except for real-mode retf, which cannot
+		/* TheCPU.key points to the first instruction of the last
+		   executed block, except for indirect jumps, which cannot
 		   cause forever loops */
 		if (!(EFLAGS & (VIF|IF|TF))) {
-			TNode *LastG = FindTree(LONG_CS + TheCPU.eip);
+			TNode *LastG = FindTree(TheCPU.key);
 			seqflg = LastG ? LastG->flags : 0;
 			if (seqflg & F_SLFJ) {
 				error("!Forever loop!\n");

--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -224,9 +224,8 @@ TNode *Close(unsigned int PC, unsigned int Interp_LONGCS, int mode, int flags);
 extern unsigned char * (*CodeGen)(unsigned char *CodePtr,
 				  unsigned char *BaseGenBuf, const IGen *IG);
 extern unsigned (*Exec)(unsigned *mem_ref, unsigned long *flg,
-			unsigned char *ecpu, void *SeqStart,
-			unsigned *seqbase);
-unsigned int DoExec(TNode *G, unsigned *LastXKey);
+			unsigned char *ecpu, void *SeqStart);
+unsigned int DoExec(TNode *G);
 void EndGen(void);
 extern void fp87_save_except(void);
 //

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -642,7 +642,7 @@ static unsigned int InterpOne(unsigned int PC, unsigned int Interp_LONG_CS,
 	}
 
 	if (CurrIMeta == 0)
-		Gen(L_IMM, basemode&~DATA16, Ofs_EIP, PC - Interp_LONG_CS);
+		Gen(L_IMM, basemode&~DATA16, Ofs_KEY, PC);
 
 override:
 	switch ((opc=Fetch(PC))) {
@@ -1644,11 +1644,11 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			int dr = (signed short)FetchW(PC+1);
 			if (REALADDR()) {
 				Gen(O_POP1, _mode|MOPT);
-				Gen(O_POP2, _mode, Ofs_EIP);
+				Gen(O_POP2, _mode, Ofs_TEMP);
 				Gen(O_POP2, _mode|MNOREG|SEGREG|MRETISP, dr);
 				AddrGen(A_SR_SH4, _mode, Ofs_CS, Ofs_XCS);
 				Gen(O_POP3, _mode);
-				Gen(L_REG, _mode, Ofs_EIP);
+				Gen(L_REG, _mode, Ofs_TEMP);
 			}
 			else {
 				Gen(O_SIM, _mode, opc, dr, P0);
@@ -1726,11 +1726,11 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			/* pop from stack without adjusting esp before A_SR_* */
 			if (REALADDR()) {
 				Gen(O_POP1, _mode|MOPT);
-				Gen(O_POP2, _mode, Ofs_EIP);
+				Gen(O_POP2, _mode, Ofs_TEMP);
 				Gen(O_POP2, _mode|MNOREG|SEGREG);
 				AddrGen(A_SR_SH4, _mode, Ofs_CS, Ofs_XCS);
 				Gen(O_POP3, _mode);
-				Gen(L_REG, _mode, Ofs_EIP);
+				Gen(L_REG, _mode, Ofs_TEMP);
 			}
 			else {
 				Gen(O_SIM, _mode, opc, 0, P0);

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -166,7 +166,6 @@ static void JMPGen(int op, int mode, ...)
 		Gen(L_IMM, mode, Ofs_ERR, EXCP01_SSTP);
 
 	va_start(ap, mode);
-	unsigned int P0 = InstrMeta[0].npc;
 	switch(op) {
 	case JMP_TAILCODE:
 		Gen(op, mode, va_arg(ap, unsigned int));
@@ -175,23 +174,23 @@ static void JMPGen(int op, int mode, ...)
 		Gen(op, mode);
 		break;
 	case JMP_LINK:
-		Gen(op, mode, va_arg(ap, unsigned int), P0);
+		Gen(op, mode, va_arg(ap, unsigned int));
 		break;
 	case JB_LINK:
 		Gen(op, mode, va_arg(ap, unsigned int));
-		Gen(JMP_LINK, mode, va_arg(ap, unsigned int), P0);
-		Gen(JMP_LINK, mode|CKSIGN, va_arg(ap, unsigned int), P0);
+		Gen(JMP_LINK, mode, va_arg(ap, unsigned int));
+		Gen(JMP_LINK, mode|CKSIGN, va_arg(ap, unsigned int));
 		break;
 	case JF_LINK:
 		Gen(op, mode, va_arg(ap, unsigned int));
-		Gen(JMP_LINK, mode, va_arg(ap, unsigned int), P0);
-		Gen(JMP_LINK, mode&~CKSIGN, va_arg(ap, unsigned int), P0);
+		Gen(JMP_LINK, mode, va_arg(ap, unsigned int));
+		Gen(JMP_LINK, mode&~CKSIGN, va_arg(ap, unsigned int));
 		break;
 	case JLOOP_LINK:
 		Gen(op, mode, va_arg(ap, unsigned int));
 		/* CKSIGN is likely not needed for loops */
-		Gen(JMP_LINK, mode, va_arg(ap, unsigned int), P0);
-		Gen(JMP_LINK, mode, va_arg(ap, unsigned int), P0);
+		Gen(JMP_LINK, mode, va_arg(ap, unsigned int));
+		Gen(JMP_LINK, mode, va_arg(ap, unsigned int));
 		break;
 	}
 	va_end(ap);
@@ -424,7 +423,7 @@ static TNode *_Interp86(unsigned int PC, unsigned int Interp_LONG_CS,
 static unsigned int FindExecCode(unsigned int PC)
 {
 	TNode *G;
-	unsigned LastXKey = PC;
+	TheCPU.key = PC;
 
 	/* for a sequence to be found, it must begin with
 	 * an allowable opcode. Look into table.
@@ -497,7 +496,7 @@ static unsigned int FindExecCode(unsigned int PC)
 		if (seqflg & F_SPEC)
 			prejit_run(G);
 #endif
-		PC = DoExec(G, &LastXKey);
+		PC = DoExec(G);
 		// G is unreliable (maybe deleted) past this point!
 #if SPEC_PREJIT
 		if (seqflg & F_SPEC)

--- a/src/base/emu-i386/simx86/syncpu.h
+++ b/src/base/emu-i386/simx86/syncpu.h
@@ -56,7 +56,7 @@ typedef struct {
 /*20*/	unsigned int edx;
 /*24*/	unsigned int ecx;
 /*28*/	unsigned int eax;
-/*2c*/	unsigned int eip;
+/*2c*/	unsigned int key;
 /*30*/	unsigned int eflags;
 /*34*/	unsigned short es, cs, ss, ds, fs, gs;
 /*40*/	SDTR es_cache;
@@ -71,11 +71,13 @@ typedef struct {
 /*72*/	/*sig_atomic_t*/unsigned short exit_pending;
 /*74*/	unsigned int StackMask;
 /*78*/ 	unsigned int df_increments; /* either 0x040201 or 0xfcfeff */
+/*7c*/	unsigned int temp;
 	/* begin of cr array */
-/*7c*/	unsigned int cr[5]; /* only cr[0] is used in compiled code */
 /* ------------------------------------------------ */
-/*80*/	//unsigned int end_mark[0] = cr[1]
+/*80*/	unsigned int cr[5]; /* only cr[0] is used in compiled code */
 	unsigned int tr[2];
+
+	unsigned int eip;
 
 	unsigned int mode;
 	unsigned int sreg1;
@@ -128,8 +130,8 @@ typedef struct {
 	emu_fpregset_t fpstate;
 } SynCPU;
 
-/* JIT uses byte offsets, make sure cr[0] is still ok */
-static_assert(offsetof(SynCPU,cr[1]) == 128);
+/* JIT uses byte offsets, make sure temp is still ok */
+static_assert(offsetof(SynCPU,temp) == 124);
 
 struct _SynCPU {
 #ifdef X86_JIT
@@ -170,7 +172,7 @@ extern struct _SynCPU TheCPU_struct;
 #define Ofs_ESI		(offsetof(SynCPU,esi))
 #define rEDI		TheCPU.edi
 #define Ofs_EDI		(offsetof(SynCPU,edi))
-#define Ofs_EIP		(offsetof(SynCPU,eip))
+#define Ofs_KEY		(offsetof(SynCPU,key))
 
 #define Ofs_CS		(offsetof(SynCPU,cs))
 #define Ofs_DS		(offsetof(SynCPU,ds))
@@ -196,6 +198,7 @@ extern struct _SynCPU TheCPU_struct;
 #define Ofs_XFS		(offsetof(SynCPU,fs_cache))
 #define Ofs_XGS		(offsetof(SynCPU,gs_cache))
 
+#define Ofs_TEMP	(offsetof(SynCPU,temp))
 #define Ofs_ERR		(offsetof(SynCPU,err))
 #define Ofs_SCP_ERR		(offsetof(SynCPU,scp_err))
 #define Ofs_int_revectored	(offsetof(SynCPU,int_revectored))

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -661,7 +661,7 @@ unsigned int FindPC(const unsigned char *addr)
   Addr2Pc *AP;
   int i;
 
-  G = FindTree(LONG_CS + TheCPU.eip);
+  G = FindTree(TheCPU.key);
   if (!G)
     return 0;
   AP = G->meta;


### PR DESCRIPTION
There was some redundancy in each block setting `TheCPU.eip`, and it also returning the start of the block in `%ecx`.
I thought it nicer to let it set the PC instead (as in @stsp 's original patch for FindPC), but under a different name, `TheCPU.key`. Then we can also use that instead of `LastXKey`.

Using the key is not appropriate for the then remaining users of `TheCPU.eip` in compiled code: RM `RETl` and `RETlisp`, for which I introduced a new general-use temp field, and kicked CR0 out of the byte-offsetable fields, as SMSW is rarely used.