### PR TITLE
simx86: handle indirect jumps and ret via helper

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -2625,11 +2625,18 @@ static unsigned int Gen_sim(IGen *IG, unsigned int *pmem_ref)
 		} }
 		break;
 
-	case JMP_INDIRECT:
-		P0 = LONG_CS + ((mode & DATA16) ? DR1.w.l : DR1.d);
-		TheCPU.key = P0;
+	case JMP_INDIRECT: {
+		unsigned ePC = LONG_CS + ((mode & DATA16) ? DR1.w.l : DR1.d);
+		TheCPU.key = ePC;
+		TNode *G = FindTree(ePC);
+		if (G && GoodNode(G)) {
+			IG = (IGen *)G->addr;
+			continue;
+		}
+		P0 = ePC;
 		if (debug_level('e')>2)
 			dbug_printf("** Jump taken to %08x\n",P0);
+		}
 		break;
 
 	case JMP_LINK:		// dspt

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -1878,6 +1878,29 @@ shrot0:
 		G3M(0x03,0x43,Ofs_XCS,Cp);
 		// movl %%eax, Ofs_KEY(%%ecx) // signals indirect
 		G3M(0x89,0x43,Ofs_KEY,Cp);
+#ifdef __x86_64__
+		// movl %%eax,%%edi
+		G2M(0x89,0xc7,Cp);
+		// lea 3+2(%%rip), %%rsi // tailcode
+		G3M(0x48,0x8d,0x35,Cp); G4(3+2,Cp);
+#else
+		// push address of tailcode
+		G1(PUSHwi,Cp); G4((uintptr_t)GetExecCodeBuf(Cp+4+1+3+2+2),Cp);
+		// push ePC
+		G1(PUSHax,Cp);
+#endif
+		// call Ofs_JmpIndirect(%%ebx)
+		G3M(0xff,0x53,Ofs_JmpIndirect(),Cp);
+#ifndef __x86_64__
+		// need to pop arguments for i386
+		G2M(POPdx,POPdx,Cp);
+#endif
+		// jump to next block if a compatible one exists
+		// otherwise to the tail code
+		// jmp *%rax
+		G2M(0xff,0xe0,Cp);
+		// movl Ofs_KEY(%%ebx),%%eax
+		G3M(0x8b,0x43,Ofs_KEY,Cp);
 		// pop %%edx; ret
 		G2M(0x5a,0xc3,Cp);
 		}

--- a/src/base/emu-i386/simx86/cpatch.c
+++ b/src/base/emu-i386/simx86/cpatch.c
@@ -614,6 +614,7 @@ enum {
 	STUB_READ_32,
 	STUB_SETSEGPROT,
 	STUB_SIMHELPER,
+	STUB_JMP_INDIRECT,
 	STUBS_LEN
 };
 static_assert(STUBS_LEN <= STUBS_LEN_MAX);
@@ -640,6 +641,11 @@ int Ofs_SetSegProt(void)
 int Ofs_SimHelper(void)
 {
 	return Ofs_stub(STUB_SIMHELPER);
+}
+
+int Ofs_JmpIndirect(void)
+{
+	return Ofs_stub(STUB_JMP_INDIRECT);
 }
 
 /* call N(%ebx) */
@@ -842,6 +848,21 @@ unsigned int Sim_helper_jit(unsigned int mem_ref, unsigned int data,
     return ret;
 }
 
+unsigned char *Jmp_indirect_helper(unsigned int ePC,
+				   unsigned char *tailcode)
+{
+    unsigned char *ret;
+    TNode *G;
+
+    InCompiledCode--;
+
+    G = FindTree(ePC);
+    ret = G && GoodNode(G) ? GetExecCodeBuf(G->addr) : tailcode;
+
+    InCompiledCode++;
+    return ret;
+}
+
 void Cpatch_init(void)
 {
     TheCPU_struct.stub_func[STUB_REP] = stub_rep;
@@ -855,6 +876,8 @@ void Cpatch_init(void)
     TheCPU_struct.stub_func[STUB_READ_32] = stub_read_32;
     TheCPU_struct.stub_func[STUB_SETSEGPROT] = stub_setsegprot;
     TheCPU_struct.stub_func[STUB_SIMHELPER] = stub_simhelper;
+    TheCPU_struct.stub_func[STUB_JMP_INDIRECT] = (stubfunc_t)
+        Jmp_indirect_helper;
 }
 
 /* ======================================================================= */

--- a/src/base/emu-i386/simx86/cpatch.h
+++ b/src/base/emu-i386/simx86/cpatch.h
@@ -25,9 +25,12 @@ ASMLINKAGE(void,SetSegProt_helper,(unsigned short sel, int ofs));
 ASMLINKAGE(unsigned int,Sim_helper_jit,(unsigned int mem_ref, \
 					unsigned int data, \
 					struct sim_stack *s));
+ASMLINKAGE(unsigned char *,Jmp_indirect_helper,(unsigned int ePC, \
+						unsigned char *tailcode));
 
 int Cpatch(sigcontext_t *scp);
 int UnCpatch(unsigned char *eip);
 void Cpatch_init(void);
 int Ofs_SetSegProt(void);
 int Ofs_SimHelper(void);
+int Ofs_JmpIndirect(void);


### PR DESCRIPTION
This way we can don't have to leave the JIT if the next block is valid, and the number of exits goes down significantly (by a factor > 15).

This gives a modest performance boost, and it will also allow simplifying DoExec() as there is no more need for a fast loop there: almost all remaining exits are either with TheCPU.err set or if some new code needs to be compiled. 