### PR TITLE
simx86: delete nodes as soon as possible

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -2618,7 +2618,8 @@ static unsigned int Gen_sim(IGen *IG, unsigned int *pmem_ref)
 
 	case JMP_TAILCODE: {	// retaddr
 		P0 = (unsigned int)IG->p0;
-		TheCPU.key = P0;
+		if (!(mode & MPATCH))
+			TheCPU.key = P0;
 		if (debug_level('e')>2) {
 			dbug_printf("** Tail code: return from %08x\n",P0);
 		} }
@@ -2784,7 +2785,7 @@ static unsigned Exec_sim(void *SeqStart)
 	P0 = Gen_sim(SeqStart, &TheCPU.mem_ref);
 	currentIG = NULL;
 	EFLAGS = (EFLAGS & ~EFLAGS_CC) | FlagSync_All();
-	if (TheCPU.err) TheCPU.key = P0;
+	if (TheCPU.err && TheCPU.err != EXCP_BREAKNODE) TheCPU.key = P0;
 
 	return P0;
 }

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -1863,10 +1863,15 @@ shrot0:
 		}
 		break;
 
-	case JMP_TAILCODE:
+	case JMP_TAILCODE: {
 		/* copy tail instructions to the end of the code block */
+		unsigned char *p = Cp;
 		GNX(Cp, TailCode, TAILSIZE);
-		*((unsigned int *)(Cp - TAILSIZE + TAILFIX)) = IG->p0;
+		/* Keep TheCPU.eip for BreakNode */
+		if (mode & MPATCH)
+			p[5] = p[6] = p[7] = NOP;
+		*((unsigned int *)(p + TAILFIX)) = IG->p0;
+		}
 		break;
 
 	case JMP_INDIRECT: {	// input: %%{e}ax = %%{e}ip

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -587,6 +587,12 @@ static unsigned ExecOne(TNode *G)
 #endif
 		prefetch(CPUOFFS(0));
 	ePC = Exec(G->addr);
+	if (TheCPU.err == EXCP_BREAKNODE) {
+		if (debug_level('e')>2)
+			e_printf("Delete broken node %08x\n",TheCPU.key);
+		avltr_delete(TheCPU.key);
+		TheCPU.err = 0;
+	}
 #ifdef SKIP_EMU_VBIOS
 	if ((TheCPU.cs&0xf000)==config.vbios_seg && !TheCPU.err)
 		TheCPU.err = EXCP_GOBACK;
@@ -687,7 +693,6 @@ unsigned int DoExec(TNode *G)
 
 #if defined(SINGLESTEP)
 	InvalidateNodeRange(key, 1, NULL);
-	avltr_delete(key);
 #endif
 
 	return ePC;

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -590,7 +590,9 @@ static unsigned ExecOne(TNode *G)
 	if (TheCPU.err == EXCP_BREAKNODE) {
 		if (debug_level('e')>2)
 			e_printf("Delete broken node %08x\n",TheCPU.key);
-		avltr_delete(TheCPU.key);
+		G = FindTree(TheCPU.key);
+		assert(G);
+		RemoveNode(G);
 		TheCPU.err = 0;
 	}
 #ifdef SKIP_EMU_VBIOS
@@ -692,7 +694,8 @@ unsigned int DoExec(TNode *G)
 	}
 
 #if defined(SINGLESTEP)
-	InvalidateNodeRange(key, 1, NULL);
+	G = FindTree(key);
+	if (G) RemoveNode(G);
 #endif
 
 	return ePC;

--- a/src/base/emu-i386/simx86/emu86.h
+++ b/src/base/emu-i386/simx86/emu86.h
@@ -680,6 +680,7 @@ extern int SpecPrejits;
 #define EXCP_STISIGNAL	67
 #define EXCP_MODESWITCH	68
 #define EXCP_EMULEAVE	69
+#define EXCP_BREAKNODE	70
 
 #define exit_SIGPEND	0x01	/* signal pending mask */
 #define exit_RPIC	0x02	/* pic asks for interruption */

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -461,7 +461,7 @@ static unsigned int FindExecCode(unsigned int PC)
 		G = FindTree(PC);
 		if (G) {
 			if (!GoodNode(G)) {
-				InvalidateNodeRange(G->key, G->seqlen, NULL);
+				RemoveNode(G);
 				G = NULL;
 			}
 			else if (debug_level('e')>2)

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -800,7 +800,7 @@ void NodeLinker(TNode *LG, TNode *G)
 #endif
 	if (debug_level('e')>8 && LG) e_printf("NodeLinker: %08x->%08x\n",LG->key,G->key);
 
-	if (LG && LG->alive>0) {
+	if (LG) {
 		linknode(LG, G, &LG->clink_t, 'T');
 		linknode(LG, G, &LG->clink_nt, 'N');
 	}
@@ -953,10 +953,6 @@ static void CheckLinks(void)
 	return;
     }
     G = p->data;
-    if (G->alive <= 0) {
-	e_printf("Node %p invalidated\n",G);
-	continue;
-    }
     if (debug_level('e')>5) e_printf("Node %p at %08x\n",G,G->key);
     checklink(G, &G->clink_t, 'T');
     checklink(G, &G->clink_nt, 'N');
@@ -990,11 +986,6 @@ static void DumpTree (FILE *fd)
     }
     fprintf(fd,"\n-----------------------------------------------------------\n");
     G = p->data;
-    if (G->alive <= 0) {
-	fprintf(fd,"%04d Node %p invalidated\n",nn,G);
-	nn++;
-	continue;
-    }
     fprintf(fd,"%04d Node %p at %08x..%08x addr=%p flags=%#x\n",
 	nn,G,G->key,(G->key+G->seqlen-1),G->addr,G->flags);
     fprintf(fd,"     AVL (%p:%p),%d,%d,%d,%d\n",p->link[0],p->link[1],
@@ -1019,7 +1010,8 @@ static void DumpTree (FILE *fd)
 	    B = B->next;
 	}
     }
-    if (G->addr) {
+    assert(G->addr);
+    {
 	int i, j, k;
 	unsigned char *p = G->addr;
 	Addr2Pc *AP = G->meta;
@@ -1079,15 +1071,11 @@ static int TraverseAndClean(void)
   }
 
   G = p->data;
-  if ((G->addr != NULL) && (G->alive>0)) {
-      G->alive -= AGENODE;
-      if (G->alive <= 0) {
-	if (debug_level('e')>2) e_printf("TraverseAndClean: node at %08x decayed\n",G->key);
-	e_unmarkpage(G->key, G->seqlen);
-	NodeUnlinker(G);
-      }
-  }
-  if ((G->addr == NULL) || (G->alive<=0)) {
+  G->alive -= AGENODE;
+  if (G->alive <= 0) {
+      if (debug_level('e')>2) e_printf("TraverseAndClean: node at %08x decayed\n",G->key);
+      e_unmarkpage(G->key, G->seqlen);
+      NodeUnlinker(G);
       if (debug_level('e')>2) e_printf("Delete node %08x\n",G->key);
       avltr_delete(G->key);
       cnt++;
@@ -1275,10 +1263,9 @@ static TNode *FindTree_tail(int key)
 #endif
 
   I = avltr_find(key);
-  if (!I) goto endsrch;
-  G = *I;
-  assert(G);
-  if (G->addr && (G->alive>0)) {
+  if (I) {
+	G = *I;
+	assert(G && G->addr);
 	if (debug_level('e')>3) e_printf("Found key %08x\n",key);
 	G->alive = NODELIFE(G);
 #if PROFILE
@@ -1292,7 +1279,6 @@ static TNode *FindTree_tail(int key)
 	return G;
   }
 
-endsrch:
 #if PROFILE >= 2
   if (debug_level('e')) SearchTime += (GETTSC() - t0);
 #endif
@@ -1319,7 +1305,7 @@ TNode *FindTree(int key)
      ~99.99% success rate */
   I = __atomic_load_n(&findtree_cache[key&FINDTREE_CACHE_HASH_MASK],
 		      __ATOMIC_RELAXED);
-  if (I && (I->alive>0) && (I->key==key)) {
+  if (I && (I->key==key)) {
 	if (debug_level('e')) {
 	    if (debug_level('e')>4)
 		e_printf("Found key %08x via cache\n", key);
@@ -1350,7 +1336,7 @@ TNode *FindTree_unlocked(int key)
   /* fast path: using cache indexed by low 12 bits of PC:
      ~99.99% success rate */
   I = findtree_cache[key&FINDTREE_CACHE_HASH_MASK];
-  if (I && (I->alive>0) && (I->key==key)) {
+  if (I && (I->key==key)) {
 	if (debug_level('e')) {
 	    if (debug_level('e')>4)
 		e_printf("Found key %08x via cache\n", key);
@@ -1438,12 +1424,11 @@ int InvalidateNodeRange(int al, int len, unsigned char *eip)
       if (!G || G->key >= ah)
         break;
       ahG = G->key + G->seqlen;
-      if (G->addr && (G->alive>0)) {
-	if (RANGE_INTERSECT(G->key,ahG,al,ah)) {
+      assert (G->addr);
+      if (RANGE_INTERSECT(G->key,ahG,al,ah)) {
 	    unsigned char *ahE;
 	    if (debug_level('e')>1)
 		dbug_printf("Invalidated node %p at %08x\n",G,G->key);
-	    G->alive = 0;
 	    e_unmarkpage(G->key, G->seqlen);
 	    NodeUnlinker(G);
 	    cleaned++;
@@ -1467,7 +1452,6 @@ int InvalidateNodeRange(int al, int len, unsigned char *eip)
 		if (debug_level('e')>2) e_printf("Delete node %08x\n",G->key);
 		avltr_delete(G->key);
 	    }
-	}
       }
       if (ahG >= ah)
         break;

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -58,7 +58,6 @@ static avltr_traverser Traverser;
 static int ninodes = 0;
 static pthread_mutex_t trees_mtx = PTHREAD_MUTEX_INITIALIZER;
 
-int NodesCleaned = 0;
 int NodesParsed = 0;
 int NodesExecd = 0;
 int NodesPrejitted = 0;
@@ -577,7 +576,6 @@ static void avltr_init(void)
 
   g_printf("avltr_init\n");
   CurrIMeta = -1;
-  NodesCleaned = 0;
   ninodes = 0;
 }
 
@@ -1271,7 +1269,6 @@ static TNode *FindTree_tail(int key)
 {
   TNode **I;
   TNode *G;
-  static int tccount=0;
 #if PROFILE >= 2
   hitimer_t t0 = 0;
   if (debug_level('e')) t0 = GETTSC();
@@ -1299,13 +1296,6 @@ endsrch:
 #if PROFILE >= 2
   if (debug_level('e')) SearchTime += (GETTSC() - t0);
 #endif
-  if ((ninodes>500) && (((++tccount) >= CleanFreq) || NodesCleaned)) {
-	while (NodesCleaned > 0) {
-	    (void)TraverseAndClean();
-	    if (NodesCleaned) NodesCleaned--;
-	}
-	tccount=0;
-  }
 
   if (debug_level('e')) {
     if (debug_level('e')>4) e_printf("Not found key %08x\n",key);
@@ -1409,7 +1399,8 @@ static void BreakNode(TNode *G, unsigned char *eip)
   ebase = eip - G->addr;
   for (i=0; i<G->seqnum; i++) {
     if (A->daddr >= ebase) {		// found following instr
-	IGen IG = (IGen){.op = JMP_TAILCODE, .p0 = G->key + A->dnpc};
+	IGen IG = (IGen){.op = JMP_TAILCODE, .mode = MPATCH,
+			 .p0 = G->key + A->dnpc};
 	p = G->addr + A->daddr;		// translated IP of following instr
 	CodeGen(p, G->addr, &IG);
 	if (debug_level('e')>1)
@@ -1456,7 +1447,6 @@ int InvalidateNodeRange(int al, int len, unsigned char *eip)
 	    e_unmarkpage(G->key, G->seqlen);
 	    NodeUnlinker(G);
 	    cleaned++;
-	    NodesCleaned++;
 	    /* if the current eip is in *any* chunk of code that is deleted
 	        (not just the one written to)
 	       then we need to break the node immediately to go back to
@@ -1464,14 +1454,18 @@ int InvalidateNodeRange(int al, int len, unsigned char *eip)
 	       not officially exist anymore) that the SIGSEGV or patched
 	       call returns to may write to the current unprotected page.
 	    */
-	    /* Exclude last instruction, as there is no need to break
-	     * node after last instruction (it ends there anyway). */
-	    ahE = G->addr + G->meta[G->seqnum - 1].daddr;
+	    ahE = G->addr + G->len;
 	    if (eip && ADDR_IN_RANGE(eip,G->addr,ahE)) {
 		if (debug_level('e')>1)
 		    e_printf("### Node self hit %p->%p..%p\n",
 			     eip,G->addr,ahE);
 		BreakNode(G, eip);
+		TheCPU.err = EXCP_BREAKNODE;
+		/* we can only call avltr_delete in codegen.c */
+	    }
+	    else {
+		if (debug_level('e')>2) e_printf("Delete node %08x\n",G->key);
+		avltr_delete(G->key);
 	    }
 	}
       }

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -316,7 +316,7 @@ static TNode **avltr_probe (TNode *item)
 }
 
 
-void avltr_delete(const int key)
+static TNode *avltr_delete(const int key)
 {
   avltr_tree *tree = &CollectTree;
   avltr_node *pa[AVL_MAX_HEIGHT];	/* Stack P: Nodes. */
@@ -328,7 +328,7 @@ void avltr_delete(const int key)
   a[0] = 0;
   pa[0] = &tree->root;
   p = tree->root.link[0];
-  if (p == NULL) return;
+  if (p == NULL) return NULL;
 
   for (;;) {
       int diff = (key - p->data->key);
@@ -336,11 +336,11 @@ void avltr_delete(const int key)
       if (diff==0) break;
       pa[k] = p;
       if (diff < 0) {
-	  if (p->link[0] == NULL) return;
+	  if (p->link[0] == NULL) return NULL;
 	  p = p->link[0]; a[k] = 0;
       }
       else if (diff > 0) {
-	  if (p->rtag != PLUS) return;
+	  if (p->rtag != PLUS) return NULL;
 	  p = p->link[1]; a[k] = 1;
       }
       k++;
@@ -423,26 +423,6 @@ void avltr_delete(const int key)
 #if !defined(SINGLESTEP)&&!defined(SINGLEBLOCK)
   if (debug_level('e')>2) e_printf("Remove node %p\n",p);
 #endif
-#ifdef DEBUG_LINKER
-	if (G->bkr) {
-	    dbug_printf("Cannot delete - bkr busy\n");
-	    pthread_mutex_unlock(&trees_mtx);
-	    leavedos_main(0x9141);
-	}
-	if (G->clink_t.ref || G->clink_nt.ref) {
-	    dbug_printf("Cannot delete - ref busy\n");
-	    pthread_mutex_unlock(&trees_mtx);
-	    leavedos_main(0x9142);
-	}
-#endif
-/**/ if (G->addr==NULL) {
-      pthread_mutex_unlock(&trees_mtx);
-      leavedos_main(0x8130);
-  }
-  FreeGenCodeBuf(G->addr);
-  __atomic_store_n(&findtree_cache[G->key&FINDTREE_CACHE_HASH_MASK],
-		   NULL, __ATOMIC_RELAXED);
-  free(G);
   Tfree(p);
 
   while (--k) {
@@ -551,6 +531,7 @@ void avltr_delete(const int key)
 	  }
       }
   }
+  return G;
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -1073,11 +1054,8 @@ static int TraverseAndClean(void)
   G = p->data;
   G->alive -= AGENODE;
   if (G->alive <= 0) {
-      if (debug_level('e')>2) e_printf("TraverseAndClean: node at %08x decayed\n",G->key);
-      e_unmarkpage(G->key, G->seqlen);
-      NodeUnlinker(G);
-      if (debug_level('e')>2) e_printf("Delete node %08x\n",G->key);
-      avltr_delete(G->key);
+      if (debug_level('e')>2) e_printf("TraverseAndClean: node at %08x decayed, delete\n",G->key);
+      RemoveNode(G);
       cnt++;
   }
   else {
@@ -1103,7 +1081,6 @@ static int TraverseAndClean(void)
  */
 TNode *Move2Tree(IMeta *I0, unsigned char *GenCodeBuf)
 {
-  TNode *nG = NULL;
 #if PROFILE >= 2
   hitimer_t t0 = 0;
   if (debug_level('e')) t0 = GETTSC();
@@ -1120,37 +1097,23 @@ TNode *Move2Tree(IMeta *I0, unsigned char *GenCodeBuf)
   key = I0->npc;
 
   nap = I0->ncount + 1;
-  TNode *G = calloc(1, sizeof(TNode) + sizeof(Addr2Pc) * nap);
-  if (G==NULL) {
-    leavedos_main(0x8201);
-  }
-  G->key = key;
+  TNode *nG = calloc(1, sizeof(TNode) + sizeof(Addr2Pc) * nap);
+  assert(nG);
+  nG->key = key;
   pthread_mutex_lock(&trees_mtx);
-  found = avltr_probe(G);
-  if (*found != G) {
-	nG = *found;
-	*found = G;
-	if (debug_level('e')>2) {
-		e_printf("Equal keys: replace node %p at %08x\n",
-			nG,key);
-	}
-	/* ->REPLACE the code of the node found with the latest
-	   compiled version */
-	NodeUnlinker(nG);
-	FreeGenCodeBuf(nG->addr);
-	free(nG);
-  }
-  else {
+  found = avltr_probe(nG);
+  /* since existing code was invalidated in DoClose(),
+     we must find a new node */
+  assert(*found == nG);
 #if !defined(SINGLESTEP)&&!defined(SINGLEBLOCK)
-	if (debug_level('e')>2) {
+  if (debug_level('e')>2) {
 		e_printf("New TNode %d at=%p key=%08x\n",
 			ninodes,nG,key);
 		if (debug_level('e')>3)
 			e_printf("Header: len=%d n_ops=%d PC=%08x\n",
 				I0->totlen, I0->ncount, I0->npc);
-	}
-#endif
   }
+#endif
   nG = *found;
   nG->alive = NODELIFE(nG);
   pthread_mutex_unlock(&trees_mtx);
@@ -1399,6 +1362,26 @@ static void BreakNode(TNode *G, unsigned char *eip)
   e_printf("============ Node %08x break failed\n",G->key);
 }
 
+static void RemoveNode_unlocked(TNode *G)
+{
+  e_unmarkpage(G->key, G->seqlen);
+  NodeUnlinker(G);
+  assert(!G->bkr && !G->clink_t.ref && !G->clink_nt.ref && G->addr);
+  FreeGenCodeBuf(G->addr);
+  __atomic_store_n(&findtree_cache[G->key&FINDTREE_CACHE_HASH_MASK],
+		   NULL, __ATOMIC_RELAXED);
+  TNode *deleted = avltr_delete(G->key);
+  assert(deleted == G);
+  free(G);
+}
+
+void RemoveNode(TNode *G)
+{
+  pthread_mutex_lock(&trees_mtx);
+  RemoveNode_unlocked(G);
+  pthread_mutex_unlock(&trees_mtx);
+}
+
 int InvalidateNodeRange(int al, int len, unsigned char *eip)
 {
   TNode *G;
@@ -1429,8 +1412,6 @@ int InvalidateNodeRange(int al, int len, unsigned char *eip)
 	    unsigned char *ahE;
 	    if (debug_level('e')>1)
 		dbug_printf("Invalidated node %p at %08x\n",G,G->key);
-	    e_unmarkpage(G->key, G->seqlen);
-	    NodeUnlinker(G);
 	    cleaned++;
 	    /* if the current eip is in *any* chunk of code that is deleted
 	        (not just the one written to)
@@ -1446,11 +1427,11 @@ int InvalidateNodeRange(int al, int len, unsigned char *eip)
 			     eip,G->addr,ahE);
 		BreakNode(G, eip);
 		TheCPU.err = EXCP_BREAKNODE;
-		/* we can only call avltr_delete in codegen.c */
+		/* we can only call RemoveNode in codegen.c */
 	    }
 	    else {
 		if (debug_level('e')>2) e_printf("Delete node %08x\n",G->key);
-		avltr_delete(G->key);
+		RemoveNode_unlocked(G);
 	    }
       }
       if (ahG >= ah)

--- a/src/base/emu-i386/simx86/trees.h
+++ b/src/base/emu-i386/simx86/trees.h
@@ -159,7 +159,7 @@ static inline unsigned int FindPC_X(const unsigned char *addr)
     return FindPC(GetGenCodeBuf(addr));
 }
 int InvalidateNodeRange(int addr, int len, unsigned char *eip);
-void avltr_delete(const int key);
+void RemoveNode(TNode *G);
 void NodeLinker(TNode *LG, TNode *G);
 
 #ifdef DEBUG_TREE


### PR DESCRIPTION
The goal of this PR is to eliminate "dead" nodes and do some related cleanups, that is have a `RemoveNode()` function to delete the node with all the related work, and have only one place left to do GC.

Some of this I did in the interval-tree branch -- this doesn't touch the trees, but would make it easier to swap it for something else (whether a different kind of tree or a hash table etc, as discussed before). And with TheCPU.key BreakNode() could be handled more elegantly in codegen.c.

I'm not 100% sure if we should disable GC, certainly with limited amounts of DPMI memory and no more dead nodes there can't be uncontrolled growth, but at some point the tree may be too big and slower.

