### PR TITLE
simx86: move codegen part of Move2Tree() to ProduceCode()

### DIFF
--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -401,11 +401,28 @@ static void OptimizeCode(IMeta *I)
 	}
 }
 
-static unsigned char *ProduceCode(unsigned int PC, IMeta *I0)
+/*
+ * The intermediate code and its associated structures are in the InstrMeta
+ * array. We allocate a buffer and generate the code, then
+ * we copy the sequence data from the head element of InstrMeta. In this
+ * process we lose all the correspondences between original code and compiled
+ * code addresses. At the end, we reset InstrMeta to prepare for a new
+ * sequence.
+ */
+static TNode *ProduceCode(unsigned int PC, IMeta *I0)
 {
 	int i,j,mall_req;
 	unsigned char *cp, *cp1, *BaseGenBuf, *CodePtr;
 	size_t GenBufSize;
+	Addr2Pc *ap;
+	int nap = CurrIMeta + 2;
+
+	TNode *G = calloc(1, sizeof(TNode) + sizeof(Addr2Pc) * nap);
+	assert(G);
+
+	/* transfer info from first node of the Meta list to our new node */
+	G->key = I0->npc;
+	G->seqnum = nap - 1;
 
 	if (debug_level('e')>1) {
 	    e_printf("---------------------------------------------\n");
@@ -426,20 +443,34 @@ static unsigned char *ProduceCode(unsigned int PC, IMeta *I0)
 	BaseGenBuf = AllocGenCodeBuf(mall_req);
 	/* actual code buffer starts from here */
 	CodePtr = BaseGenBuf;
-	I0->daddr = 0;
 	if (debug_level('e')>1)
 	    e_printf("CodeBuf=%p siz %zd\n",BaseGenBuf,GenBufSize);
 
-	for (i=0; i<=CurrIMeta; i++) {
+	/* setup structures for inter-node linking */
+	G->clink_nt.link = G->clink_t.link = 0;
+	/* setup source/xlated instruction offsets in G->meta */
+	for (i=0, ap=G->meta; i<=CurrIMeta; i++, ap++) {
 	    IMeta *I = &I0[i];
 	    if (i < CurrIMeta)
 		OptimizeCode(I);
 	    cp = cp1 = CodePtr;
-	    I->daddr = cp - BaseGenBuf;
 	    for (j=0; j<I->ngen; j++) {
 		IGen *IG = &I->gen[j];
-		if (IG->op == JMP_LINK)
-			IG->p2 = CodePtr - BaseGenBuf;
+		if (IG->op == JMP_LINK) {
+		    unsigned int link = CodePtr - BaseGenBuf;
+		    assert(link); // because TheCPU.eip is set first, this can never be 0
+		    if (j < I->ngen - 1) {
+			G->clink_nt.link = link;
+			G->clink_nt.target = IG->p0;
+		    }
+		    else {
+			assert(j == I->ngen - 1);
+			G->clink_t.link = link;
+			G->clink_t.target = IG->p0;
+		    }
+		    if ((debug_level('e')>3))
+			dbug_printf("Link %d: %x:%08x\n",IG->op,link,IG->p0);
+		}
 		CodePtr = CodeGen(CodePtr, BaseGenBuf, IG);
 		if (CodePtr-cp1 > MAX_GEND_BYTES_PER_OP) {
 		    dosemu_error("Generated code (%zd bytes) overflowed into buffer, please "
@@ -455,33 +486,43 @@ static unsigned char *ProduceCode(unsigned int PC, IMeta *I0)
 		}
 		cp1 = CodePtr;
 	    }
-	    I->len = CodePtr - cp;
-	    I0->flags |= I->flags;
+	    G->flags |= I->flags;
 	    if (debug_level('e')>3) {
 		if (debug_level('e')>4) {
 		    e_printf("Metadata %03d PC=%08x flags=%x(%x) ng=%d\n",
-			     i,I->npc,I->flags,I0->flags,I->ngen);
+			     i,I->npc,I->flags,G->flags,I->ngen);
 		}
-		GCPrint(cp, BaseGenBuf, I->len);
+		GCPrint(cp, BaseGenBuf, CodePtr - cp);
 	    }
+	    ap->daddr = cp - BaseGenBuf;
+	    ap->dnpc  = I->npc - I0->npc;
+	    if (debug_level('e')>8)
+		e_printf("Pmeta %03d: %p(%04x):%08x(%04x)\n",i,
+			 cp,ap->daddr,I->npc,ap->dnpc);
 	}
+	G->len = ap->daddr = CodePtr - BaseGenBuf;
+	if (debug_level('e')>8) e_printf("Pmeta %03d:         (%04x)\n",i,G->len);
+
+	CurrIMeta = -1;
+	memset(I0,0,sizeof(IMeta));
+
 	if (debug_level('e')>1)
 	    e_printf("Size=%td guess=%zd\n",(CodePtr-BaseGenBuf),GenBufSize);
 /**/ if ((CodePtr-BaseGenBuf) > GenBufSize) leavedos_main(0x535347);
-	I0->seqlen  = PC - I0->npc;
+	G->seqlen = PC - G->key;
 
 	if (debug_level('e')>1)
 	    e_printf("---------------------------------------------\n");
 
-	I0->totlen = CodePtr - BaseGenBuf;
-
 	/* shrink buffer to what is actually needed */
-	mall_req = I0->totlen;
+	mall_req = G->len;
 	ShrinkGenCodeBuf(BaseGenBuf, mall_req);
-	if (debug_level('e')>3)
-		e_printf("Seq len %#x:%#x\n",I0->seqlen,I0->totlen);
 
-	return BaseGenBuf;
+	if (debug_level('e')>3)
+		e_printf("Seq len %#x:%#x\n",G->seqlen,G->len);
+
+	G->addr = BaseGenBuf;
+	return G;
 }
 
 
@@ -513,7 +554,6 @@ TNode *Close(unsigned int PC, unsigned int Interp_LONG_CS, int mode,
 {
 	IMeta *I0;
 	TNode *G;
-	unsigned char *GenCodeBuf;
 
 	assert (CurrIMeta >= 0);
 
@@ -524,13 +564,13 @@ TNode *Close(unsigned int PC, unsigned int Interp_LONG_CS, int mode,
 		e_printf("==== Closing sequence at %08x\n", PC);
 	}
 
-	GenCodeBuf = ProduceCode(PC, I0);
+	G = ProduceCode(PC, I0);
 
 	NodesParsed++;
 #if PROFILE
 	if (debug_level('e')) TotalNodesParsed++;
 #endif
-	G = Move2Tree(I0, GenCodeBuf);		/* when is G==NULL? */
+	Move2Tree(G);
 	/* InstrMeta will be zeroed at this point */
 	/* mprotect the page here; a page fault will be triggered
 	 * if some other code tries to write over the page including

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -103,7 +103,7 @@ static TNode *DoClose(unsigned int PC, unsigned int Interp_LONG_CS, int mode,
 	unsigned int P0 = InstrMeta[0].npc;
 	TNode *G, *nextG = NULL;
 
-	assert(InstrMeta[0].ncount > 0);
+	assert(CurrIMeta >= 0);
 	/* If the code doesn't terminate with a jump/loop instruction
 	 * it still lacks the tail code; add it here */
 	IMeta *GL = &InstrMeta[CurrIMeta];

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -1072,34 +1072,16 @@ static int TraverseAndClean(void)
 
 /*
  * Add a node to the collector tree.
- * The code is linearly stored in the CodeBuf and its associated structures
- * are in the InstrMeta array. We allocate a buffer and copy the code, then
- * we copy the sequence data from the head element of InstrMeta. In this
- * process we lose all the correspondences between original code and compiled
- * code addresses. At the end, we reset both CodeBuf and InstrMeta to prepare
- * for a new sequence.
  */
-TNode *Move2Tree(IMeta *I0, unsigned char *GenCodeBuf)
+void Move2Tree(TNode *nG)
 {
 #if PROFILE >= 2
   hitimer_t t0 = 0;
   if (debug_level('e')) t0 = GETTSC();
 #endif
-  int key;
-  int nap;
   TNode **found;
-  IMeta *I;
-  IGen *IG;
-  int i, apl=0;
-  Addr2Pc *ap;
-  unsigned int op;
 
-  key = I0->npc;
-
-  nap = I0->ncount + 1;
-  TNode *nG = calloc(1, sizeof(TNode) + sizeof(Addr2Pc) * nap);
-  assert(nG);
-  nG->key = key;
+  nG->alive = NODELIFE(G);
   pthread_mutex_lock(&trees_mtx);
   found = avltr_probe(nG);
   /* since existing code was invalidated in DoClose(),
@@ -1108,73 +1090,24 @@ TNode *Move2Tree(IMeta *I0, unsigned char *GenCodeBuf)
 #if !defined(SINGLESTEP)&&!defined(SINGLEBLOCK)
   if (debug_level('e')>2) {
 		e_printf("New TNode %d at=%p key=%08x\n",
-			ninodes,nG,key);
+			ninodes,nG,nG->key);
 		if (debug_level('e')>3)
 			e_printf("Header: len=%d n_ops=%d PC=%08x\n",
-				I0->totlen, I0->ncount, I0->npc);
+				nG->len, nG->seqnum, nG->key);
   }
 #endif
-  nG = *found;
-  nG->alive = NODELIFE(nG);
-  pthread_mutex_unlock(&trees_mtx);
-
-  /* transfer info from first node of the Meta list to our new node */
-  nG->seqlen = I0->seqlen;
-  nG->seqnum = I0->ncount;
 #if PROFILE
   if (debug_level('e')) if (nG->len > MaxNodeSize) MaxNodeSize = nG->len;
 #endif
-  nG->len = I0->totlen;
-  nG->flags = I0->flags;
-  __atomic_store_n(&findtree_cache[key&FINDTREE_CACHE_HASH_MASK], nG,
-		   __ATOMIC_RELAXED);
-
-  nG->addr = GenCodeBuf;
-
-  /* setup structures for inter-node linking */
-  nG->clink_nt.link = nG->clink_t.link = 0;
-  IG = &I0[CurrIMeta].gen[I0[CurrIMeta].ngen-1];
-  op = IG->op;
-  if (op == JMP_LINK) {
-    assert(IG->p2); // because TheCPU.eip is set first, this can never be 0
-    nG->clink_t.link = IG->p2;
-    nG->clink_t.target = IG->p0;
-    if (I0[CurrIMeta].ngen > 1 && (IG-1)->op == JMP_LINK) {
-      IG--;
-      assert(IG->p2);
-      nG->clink_nt.link = IG->p2;
-      nG->clink_nt.target = IG->p0;
-    }
-    if ((debug_level('e')>3))
-	dbug_printf("Link %d: %x:%08x\n",op,
-		nG->clink_nt.link,
-		(nG->clink_nt.link? nG->clink_nt.target:0));
-  }
-
-  /* setup source/xlated instruction offsets */
-  ap = nG->meta;
-  I = I0;
-  for (i=0; i<nG->seqnum; i++) {
-	ap->daddr = I->daddr;
-	apl = ap->daddr + I->len;
-	ap->dnpc  = I->npc - I0->npc;
-	if (debug_level('e')>8)
-	    e_printf("Pmeta %03d: %p(%04x):%08x(%04x)\n",i,
-		nG->addr+ap->daddr,ap->daddr,I->npc,ap->dnpc);
-	ap++, I++;
-  }
-  ap->daddr = apl;
-  if (debug_level('e')>8) e_printf("Pmeta %03d:         (%04x)\n",i,apl);
-
 #ifdef DEBUG_LINKER
   CheckLinks();
 #endif
-  CurrIMeta = -1;
-  memset(&InstrMeta[0],0,sizeof(IMeta));
+  pthread_mutex_unlock(&trees_mtx);
+  __atomic_store_n(&findtree_cache[nG->key&FINDTREE_CACHE_HASH_MASK], nG,
+		   __ATOMIC_RELAXED);
 #if PROFILE >= 2
   if (debug_level('e')) AddTime += (GETTSC() - t0);
 #endif
-  return nG;
 }
 
 void tree_gc(void)
@@ -1536,21 +1469,15 @@ int NewIMeta(int npc, int override)
 	   we allow one more for the instruction following STI/POPss/MOVss */
 	if (CurrIMeta < MAXINODES-2+override) {
 		// add new opcode metadata
-		IMeta *I,*I0;
+		IMeta *I;
 
 		CurrIMeta++;
 		I = &InstrMeta[CurrIMeta];
 		if (CurrIMeta==0) {		// no open code sequences
 			if (debug_level('e')>2) e_printf("============ Opening sequence at %08x\n",npc);
-			I0 = I;
-		}
-		else {
-			I0 = &InstrMeta[0];
 		}
 
-		I0->ncount += 1;
 		I->npc = npc;
-
 		I->ngen = 0;
 		I->flags = 0;
 		ret = 1;

--- a/src/base/emu-i386/simx86/trees.h
+++ b/src/base/emu-i386/simx86/trees.h
@@ -80,8 +80,7 @@ typedef struct _ianpc {
 
 typedef struct _imeta {
 	int npc;
-	unsigned short ncount, flags, seqlen;
-	unsigned int len, totlen, daddr;
+	unsigned short flags;
 	int ngen;
 	IGen gen[NUMGENS];
 } IMeta;
@@ -148,7 +147,7 @@ typedef struct avltr_tree
 #define MINUS -1
 
 TNode *FindTree(int key);
-TNode *Move2Tree(IMeta *I0, unsigned char *GenCodeBuf);
+void Move2Tree(TNode *G);
 void tree_gc(void);
 
 void InitTrees(void);


### PR DESCRIPTION
This way many fields of IMeta are no longer needed, since we can directly use a newly allocated TNode * in ProduceCode().