### PR TITLE
simx86: don't start prejit threads and neither use mutexes when not needed

### DIFF
--- a/src/base/emu-i386/simx86/cpatch.c
+++ b/src/base/emu-i386/simx86/cpatch.c
@@ -53,7 +53,7 @@ int CpatchInvalidates;
 /*
  * Return address of the stub function is passed into eip
  */
-void m_munprotect(unsigned int addr, unsigned int len, unsigned char *eip)
+static void m_munprotect(unsigned int addr, unsigned int len, unsigned char *eip)
 {
 	/* Shut down prejitter before invalidating, or it may crash.
 	 * Also since mprot API currently lacks mutex, shut down prejitter
@@ -241,7 +241,8 @@ void rep_movs_stos(struct rep_stack *stack)
 
 void stk_16(dosaddr_t addr, Bit16u value)
 {
-	e_invalidate(addr, 2);
+	prejit_sync();
+	e_invalidate_unlocked(addr, 2);
 	WRITE_WORD(addr, value);
 #if PROFILE
 	CpatchStkWrites++;
@@ -250,7 +251,8 @@ void stk_16(dosaddr_t addr, Bit16u value)
 
 void stk_32(dosaddr_t addr, Bit32u value)
 {
-	e_invalidate(addr, 4);
+	prejit_sync();
+	e_invalidate_unlocked(addr, 4);
 	WRITE_DWORD(addr, value);
 #if PROFILE
 	CpatchStkWrites++;
@@ -325,6 +327,7 @@ void wri_8(dosaddr_t addr, Bit8u value, unsigned char *rip)
 #if PROFILE
 	CpatchWrites++;
 #endif
+	prejit_sync();
 	if (e_querymprot(addr)) {
 		wri8_slow(addr, value, eip);
 		return;
@@ -354,6 +357,7 @@ void wri_16(dosaddr_t addr, Bit16u value, unsigned char *rip)
 #if PROFILE
 	CpatchWrites++;
 #endif
+	prejit_sync();
 	if (e_querymprotrange(addr, 2)) {
 		wri16_slow(addr, value, eip);
 		return;
@@ -383,6 +387,7 @@ void wri_32(dosaddr_t addr, Bit32u value, unsigned char *rip)
 #if PROFILE
 	CpatchWrites++;
 #endif
+	prejit_sync();
 	if (e_querymprotrange(addr, 4)) {
 		wri32_slow(addr, value, eip);
 		return;

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -1590,6 +1590,10 @@ static int lockcnt;
 void prejit_lock(void)
 {
     prejit_sync();
+#if !PREJIT_TEST
+    if (config.cpu_vm != CPUVM_KVM && config.cpu_vm_dpmi != CPUVM_KVM)
+	return;
+#endif
     /* No actual locking: just wait til prejit stops. */
     pthread_mutex_lock(&run_mtx);
     lockcnt++;
@@ -1600,6 +1604,10 @@ void prejit_lock(void)
 
 void prejit_unlock(void)
 {
+#if !PREJIT_TEST
+    if (config.cpu_vm != CPUVM_KVM && config.cpu_vm_dpmi != CPUVM_KVM)
+	return;
+#endif
     pthread_mutex_lock(&run_mtx);
     assert(lockcnt > 0);
     lockcnt--;

--- a/src/base/emu-i386/simx86/econfig.h
+++ b/src/base/emu-i386/simx86/econfig.h
@@ -76,6 +76,9 @@
 #define KEEP_ESP 1
 #define STACK_WRAP_MP 1
 
+/* speculative prejit: this is probably unsafe with cpatch */
+#define SPEC_PREJIT 0
+
 /////////////////////////////////////////////////////////////////////////////
 
 #endif

--- a/src/base/emu-i386/simx86/emu86.h
+++ b/src/base/emu-i386/simx86/emu86.h
@@ -748,7 +748,6 @@ int e_querymprotrange(unsigned int addr, size_t len);
 int e_querymprotrange_full(unsigned int addr, size_t len);
 int e_markpage(unsigned int addr, size_t len);
 int e_unmarkpage(unsigned int addr, size_t len);
-void m_munprotect(unsigned int addr, unsigned int len, unsigned char *eip);
 
 void InitGenCodeBuf(void);
 void EndGenCodeBuf(void);
@@ -773,7 +772,11 @@ int64_t m_findnode(unsigned int addr, size_t len);
 int64_t m_findnodestart(unsigned int addr);
 void mprot_init(void);
 void mprot_end(void);
+#if SPEC_PREJIT
 void prejit_sync(void);
+#else
+#define prejit_sync()
+#endif
 void init_emu_npu(void);
 
 unsigned int Sim_helper(unsigned int mem_ref, unsigned int data, int mode,

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -50,9 +50,6 @@ int EmuSignals = 0;
 
 static void JMPGen(int op, int mode, ...);
 
-/* this is probably unsafe with cpatch */
-#define SPEC_PREJIT 0
-
 #if SPEC_PREJIT
 static pthread_cond_t run_cnd = PTHREAD_COND_INITIALIZER;
 static int prejit_running;

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -2809,15 +2809,15 @@ static void prejit_run(TNode *G)
 }
 #endif
 
+#if SPEC_PREJIT
 void prejit_sync(void)
 {
-#if SPEC_PREJIT
   pthread_mutex_lock(&run_mtx);
   while (prejit_running)
     cond_wait(&run_cnd, &run_mtx);
   pthread_mutex_unlock(&run_mtx);
-#endif
 }
+#endif
 
 void prejit_init(void)
 {

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -53,20 +53,20 @@ static void JMPGen(int op, int mode, ...);
 /* this is probably unsafe with cpatch */
 #define SPEC_PREJIT 0
 
+#if SPEC_PREJIT
 static pthread_cond_t run_cnd = PTHREAD_COND_INITIALIZER;
 static int prejit_running;
 static pthread_mutex_t run_mtx = PTHREAD_MUTEX_INITIALIZER;
 static pthread_t prejit_thr;
 static sem_t prejit_sem;
 static void *prejit_thread(void *arg);
-#if SPEC_PREJIT
 static int can_speculate(void);
 static void prejit_run(TNode *G);
+static TNode *prejit_G;
+static unsigned short prejit_cs;
 #else
 #define can_speculate() 0
 #endif
-static TNode *prejit_G;
-static unsigned short prejit_cs;
 #if PROFILE
 int SpecPrejits;
 #endif
@@ -2771,6 +2771,7 @@ void PreJit86(unsigned int PC, int basemode)
 	e_mdrop();
 }
 
+#if SPEC_PREJIT
 static void *prejit_thread(void *arg)
 {
   while (1) {
@@ -2786,7 +2787,6 @@ static void *prejit_thread(void *arg)
   return NULL;
 }
 
-#if SPEC_PREJIT
 static void prejit_run(TNode *G)
 {
   unsigned int PC = G->key + G->seqlen;
@@ -2814,21 +2814,27 @@ static void prejit_run(TNode *G)
 
 void prejit_sync(void)
 {
+#if SPEC_PREJIT
   pthread_mutex_lock(&run_mtx);
   while (prejit_running)
     cond_wait(&run_cnd, &run_mtx);
   pthread_mutex_unlock(&run_mtx);
+#endif
 }
 
 void prejit_init(void)
 {
+#if SPEC_PREJIT
   sem_init(&prejit_sem, 0, 0);
   pthread_create(&prejit_thr, NULL, prejit_thread, NULL);
+#endif
 }
 
 void prejit_done(void)
 {
+#if SPEC_PREJIT
   pthread_cancel(prejit_thr);
   pthread_join(prejit_thr, NULL);
   sem_destroy(&prejit_sem);
+#endif
 }

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -1398,7 +1398,7 @@ static void do_invalidate(unsigned data, int cnt)
 	InvalidateNodeRange(data, cnt, NULL);
 }
 
-static void _e_invalidate(unsigned data, int cnt)
+void e_invalidate_unlocked(unsigned data, int cnt)
 {
 	/* nothing to invalidate if there are no page protections */
 	if (!e_querymprotrange(data, cnt))
@@ -1413,7 +1413,7 @@ static void _e_invalidate(unsigned data, int cnt)
 void e_invalidate(unsigned data, int cnt)
 {
 	prejit_lock();
-	_e_invalidate(data, cnt);
+	e_invalidate_unlocked(data, cnt);
 	prejit_unlock();
 }
 

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -56,7 +56,14 @@ int	CurrIMeta = -1;
 static avltr_tree CollectTree;
 static avltr_traverser Traverser;
 static int ninodes = 0;
+#if SPEC_PREJIT
 static pthread_mutex_t trees_mtx = PTHREAD_MUTEX_INITIALIZER;
+#define pthread_mutex_lock_trees() pthread_mutex_lock(&trees_mtx)
+#define pthread_mutex_unlock_trees() pthread_mutex_unlock(&trees_mtx)
+#else
+#define pthread_mutex_lock_trees()
+#define pthread_mutex_unlock_trees()
+#endif
 
 int NodesParsed = 0;
 int NodesExecd = 0;
@@ -128,7 +135,7 @@ static inline avltr_node *Tmalloc(void)
   avltr_node *G  = TNodePool->link[0];
   avltr_node *G1 = G->link[0];
   if (G1==TNodePool) {
-    pthread_mutex_unlock(&trees_mtx);
+    pthread_mutex_unlock_trees();
     leavedos_main(0x4c4c); // return NULL;
   }
   TNodePool->link[0] = G1; G->link[0]=NULL;
@@ -204,7 +211,7 @@ static TNode **avltr_probe (TNode *item)
       p = q;
       k++;
 /**/if (k>=AVL_MAX_HEIGHT) {
-      pthread_mutex_unlock(&trees_mtx);
+      pthread_mutex_unlock_trees();
       leavedos_main(0x777);
     }
 #if PROFILE
@@ -345,7 +352,7 @@ static TNode *avltr_delete(const int key)
       }
       k++;
 /**/  if (k>=AVL_MAX_HEIGHT) {
-        pthread_mutex_unlock(&trees_mtx);
+        pthread_mutex_unlock_trees();
         leavedos_main(0x777);
       }
   }
@@ -1082,7 +1089,7 @@ void Move2Tree(TNode *nG)
   TNode **found;
 
   nG->alive = NODELIFE(G);
-  pthread_mutex_lock(&trees_mtx);
+  pthread_mutex_lock_trees();
   found = avltr_probe(nG);
   /* since existing code was invalidated in DoClose(),
      we must find a new node */
@@ -1102,7 +1109,7 @@ void Move2Tree(TNode *nG)
 #ifdef DEBUG_LINKER
   CheckLinks();
 #endif
-  pthread_mutex_unlock(&trees_mtx);
+  pthread_mutex_unlock_trees();
   __atomic_store_n(&findtree_cache[nG->key&FINDTREE_CACHE_HASH_MASK], nG,
 		   __ATOMIC_RELAXED);
 #if PROFILE >= 2
@@ -1215,9 +1222,9 @@ TNode *FindTree(int key)
   if (!e_querymark(key, 1))
 	return NULL;
 
-  pthread_mutex_lock(&trees_mtx);
+  pthread_mutex_lock_trees();
   I = FindTree_tail(key);
-  pthread_mutex_unlock(&trees_mtx);
+  pthread_mutex_unlock_trees();
   if (I) {
 	__atomic_store_n(&findtree_cache[key&FINDTREE_CACHE_HASH_MASK], I,
 			 __ATOMIC_RELAXED);
@@ -1310,9 +1317,9 @@ static void RemoveNode_unlocked(TNode *G)
 
 void RemoveNode(TNode *G)
 {
-  pthread_mutex_lock(&trees_mtx);
+  pthread_mutex_lock_trees();
   RemoveNode_unlocked(G);
-  pthread_mutex_unlock(&trees_mtx);
+  pthread_mutex_unlock_trees();
 }
 
 int InvalidateNodeRange(int al, int len, unsigned char *eip)
@@ -1328,7 +1335,7 @@ int InvalidateNodeRange(int al, int len, unsigned char *eip)
   ah = al + len;
   if (debug_level('e')>1) dbug_printf("Invalidate area %08x..%08x\n",al,ah);
 
-  pthread_mutex_lock(&trees_mtx);
+  pthread_mutex_lock_trees();
   /* find crossing-or-in-range node */
   G = find_node_start(al, len);
   if (G == NULL) goto quit;
@@ -1372,7 +1379,7 @@ int InvalidateNodeRange(int al, int len, unsigned char *eip)
       G = find_node(ahG, ah - ahG);
   }
 quit:
-  pthread_mutex_unlock(&trees_mtx);
+  pthread_mutex_unlock_trees();
   if (debug_level('e') && e_querymark(al, len))
     error("simx86: InvalidateNodeRange did not clear all code for %#08x, len=%x\n",
 	  al, len);

--- a/src/base/lib/misc/dlmalloc.h
+++ b/src/base/lib/misc/dlmalloc.h
@@ -1,4 +1,7 @@
+#include "../../../base/emu-i386/simx86/econfig.h"
+#if SPEC_PREJIT
 #define USE_LOCKS 1
+#endif
 #define INSECURE 1
 #define HAVE_MORECORE 0
 #define HAVE_MMAP 0

--- a/src/include/cpu-emu.h
+++ b/src/include/cpu-emu.h
@@ -64,6 +64,7 @@ char *e_scp_disasm(cpuctx_t *scp, int pmode);
 
 /* called from mfs.c, fatfs.c and some places that memcpy */
 void e_invalidate(unsigned data, int cnt);
+void e_invalidate_unlocked(unsigned data, int cnt);
 void e_invalidate_full(unsigned data, int cnt);
 void e_invalidate_full_pa(unsigned data, int cnt);
 int e_invalidate_page_full(unsigned data);


### PR DESCRIPTION
I measured locking overhead in pure JIT mode at ~3.6%, and this brings it back to 1.1%. The biggest overhead came from `stk16()/stk32()` in cpatch.c calling `e_invalidate` which then called `prejit_lock()`, and then `prejit_lock()` called `prejit_sync()`.

KVM prejit is now only used if KVM is used (also in mixed vm86/dpmi=JIT-KVM or KVM-JIT mode, I haven't touched the locks for that case), and speculative prejit only with SPEC_PREJIT -- if I understood things correctly the tree locks are only relevant for SPEC_PREJIT, but if not I'll have to adapt one of the patches in here.