### PR TITLE
simx86: stop using e_querymark to stop codegen (except prejit)

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -3359,6 +3359,22 @@ stack_return_from_vm86:
 			    }
 			break;
 			}
+/*101*/	case 0x101: { /* GRP7 - Extended Opcode 21 */
+			unsigned char opm = arg;
+			switch (opm) {
+			case 0: /* SGDT */
+			    /* Store Global Descriptor Table Register */
+			    sim_write_word(mem_ref, TheCPU.GDTR.Limit);
+			    sim_write_dword(mem_ref+2, TheCPU.GDTR.Base);
+			    break;
+			case 1: /* SIDT */
+			    /* Store Interrupt Descriptor Table Register */
+			    sim_write_word(mem_ref, TheCPU.IDTR.Limit);
+			    sim_write_dword(mem_ref+2, TheCPU.IDTR.Base);
+			    break;
+			}
+			break;
+			}
 /*102*/	case 0x102:   /* LAR */ /* Load Access Rights Byte */
 /*103*/	case 0x103: { /* LSL */ /* Load Segment Limit */
 			unsigned short sv = data; int tmp;

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -501,13 +501,11 @@ static TNode *ProduceCode(unsigned int PC, IMeta *I0)
 			 cp,ap->daddr,I->npc,ap->dnpc);
 	}
 	G->len = ap->daddr = CodePtr - BaseGenBuf;
-	if (debug_level('e')>8) e_printf("Pmeta %03d:         (%04x)\n",i,G->len);
 
-	CurrIMeta = -1;
-	memset(I0,0,sizeof(IMeta));
-
-	if (debug_level('e')>1)
+	if (debug_level('e')>1) {
+	    if (debug_level('e')>8) e_printf("Pmeta %03d:         (%04x)\n",i,G->len);
 	    e_printf("Size=%td guess=%zd\n",(CodePtr-BaseGenBuf),GenBufSize);
+	}
 /**/ if ((CodePtr-BaseGenBuf) > GenBufSize) leavedos_main(0x535347);
 	G->seqlen = PC - G->key;
 

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -95,23 +95,20 @@ static char R1Tab_l[14] =
  * by the next DoExec.
  */
 static TNode *DoClose(unsigned int PC, unsigned int Interp_LONG_CS, int mode,
-		int flags)
+		int flags, TNode *nextG)
 {
 	unsigned int P0 = InstrMeta[0].npc;
-	TNode *G, *nextG = NULL;
+	TNode *G;
 
 	assert(CurrIMeta >= 0);
 	/* If the code doesn't terminate with a jump/loop instruction
 	 * it still lacks the tail code; add it here */
 	IMeta *GL = &InstrMeta[CurrIMeta];
 	if (GL->gen[GL->ngen-1].op < JMP_TAILCODE) {
-		/* almost always we get here because e_querymark() in
-		   _Interp86() found code. If there is no overlap
-		   and the node is compatible we can generate a jump
+		/* we get here because _Interp86() found code or in
+		   single-step mode. For code we can generate a jump
 		   to it and link as well */
-		nextG = FindTree(PC);
-		if (nextG && nextG->mode == mode &&
-		    nextG->cs == Interp_LONG_CS)
+		if (nextG)
 			JMPGen(JMP_LINK, mode, PC);
 		else
 			JMPGen(JMP_TAILCODE, mode, PC);
@@ -125,7 +122,7 @@ static TNode *DoClose(unsigned int PC, unsigned int Interp_LONG_CS, int mode,
 
 		/* in case of prejit, the page content could
 		 * be altered, so we better re-jit */
-		if (flags & (F_PREJ | F_SPRJ))
+		if (flags & F_PREJ)
 			return NULL;
 		abeg = P0 & _PAGE_MASK;
 		aend = PC & _PAGE_MASK;
@@ -464,10 +461,6 @@ static unsigned int FindExecCode(unsigned int PC)
 			else if (debug_level('e')>2)
 				e_printf("** Found compiled code at %08x\n",PC);
 		}
-		else if (e_querymark(PC, 1)) {
-			/* slow path */
-			InvalidateNodeRange(PC, 1, NULL);
-		}
 		/* future proofing: _Interp86() can't fail now in non-prejit mode
 		   but if it ever does, retry */
 		while (!G) {
@@ -475,12 +468,6 @@ static unsigned int FindExecCode(unsigned int PC)
 				TheCPU.err = EXCP_GOBACK;
 				return PC;
 			}
-#if 0
-			/* this obviously can't happen with current code, but
-			 * slows down execution under debug a lot */
-			if (debug_level('e') && e_querymark(PC, 1))
-				error("simx86: code nodes clashed at %x\n", PC);
-#endif
 			if (debug_level('e')>=9)
 				dbug_printf("\n%s",e_print_regs(LONG_CS));
 			G = _Interp86(PC, LONG_CS, TheCPU.cs, TheCPU.mode, 0);
@@ -554,10 +541,6 @@ void Interp86(void)
     TheCPU.eip = PC - LONG_CS;
 }
 
-/* safety gap should be definitely longer than 1 instruction to not
- * overwrite something unintentionally */
-#define SAFE_PRJ_GAP 16
-
 static void sprj_deep(TNode *G, unsigned int Interp_LONG_CS,
 		unsigned short ocs, int basemode, int flags)
 {
@@ -567,8 +550,8 @@ static void sprj_deep(TNode *G, unsigned int Interp_LONG_CS,
 	while (G->clink_t.link && !(G->flags & F_LJMP)) {
 		TNode *oldG = G;
 		unsigned int PC = G->clink_t.target;
-		if (e_querymark(PC, SAFE_PRJ_GAP)) break;
 		G = _Interp86(PC, Interp_LONG_CS, ocs, basemode, flags);
+		if (!G) break;
 		i++;
 		NodesPrejitted++;
 		NodeLinker(oldG, G);
@@ -581,23 +564,39 @@ static void sprj_deep(TNode *G, unsigned int Interp_LONG_CS,
 static TNode *_Interp86(unsigned int PC, unsigned int Interp_LONG_CS,
 			unsigned short ocs, int basemode, int flags)
 {
-	int gap = (flags & F_SPRJ) ? SAFE_PRJ_GAP : 1;
+	TNode *nextG = NULL;
 	CurrIMeta = -1;
 	if (debug_level('e')>2) e_printf("============ Opening sequence at %08x\n",PC);
 	for (;;) {
-		PC = InterpOne(PC, Interp_LONG_CS, ocs, basemode);
+		unsigned int newPC = InterpOne(PC, Interp_LONG_CS, ocs, basemode);
 		assert (CurrIMeta>=0);
+#ifdef SPEC_PREJIT
+		/* let SPEC_PREJIT give up if it overwrites */
+		if ((flags & F_SPRJ) && e_querymark(PC, newPC - PC))
+			return NULL;
+#endif
+		PC = newPC;
 
 #ifndef SINGLEBLOCK
 		IMeta *GL = &InstrMeta[CurrIMeta];
 		if ((basemode & MSSTP) ||
-		    GL->gen[GL->ngen-1].op >= JMP_TAILCODE ||
-		    e_querymark(PC, gap))
-#endif
+		    GL->gen[GL->ngen-1].op >= JMP_TAILCODE)
 			break;
+
+		/* if we find compatible code, stop compiling and let
+		   DoClose() generate a jump to it */
+		nextG = FindTree(PC);
+		if (nextG) {
+			if (nextG->mode == basemode && nextG->cs == Interp_LONG_CS)
+				break;
+			nextG = NULL;
+		}
+#else
+		break;
+#endif
 	}
 	InstrMeta[0].flags |= flags;
-	return DoClose(PC, Interp_LONG_CS, basemode, flags);
+	return DoClose(PC, Interp_LONG_CS, basemode, flags, nextG);
 }
 
 static unsigned int InterpOne(unsigned int PC, unsigned int Interp_LONG_CS,
@@ -2780,7 +2779,7 @@ static void prejit_run(TNode *G)
     ds = e_emu_disasm(EMU_BASE32(PC),basemode&MBIGCS,ocs);
     e_printf("prejit at  %s\n", ds);
   }
-  if (e_querymark(PC, SAFE_PRJ_GAP))
+  if (e_querymark(PC, 1))
     return;
 #if PROFILE
   SpecPrejits++;

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -414,8 +414,8 @@ static unsigned int ExceptionGen(unsigned int PC, int basemode, int trapno,
 
 /////////////////////////////////////////////////////////////////////////////
 
-static unsigned int _Interp86(unsigned int PC, unsigned int Interp_LONG_CS,
-			      unsigned short ocs, int basemode, int flags);
+static TNode *_Interp86(unsigned int PC, unsigned int Interp_LONG_CS,
+			unsigned short ocs, int basemode, int flags);
 
 static int leave_instremu(void)
 {
@@ -483,11 +483,10 @@ static unsigned int FindExecCode(unsigned int PC)
 #endif
 			if (debug_level('e')>=9)
 				dbug_printf("\n%s",e_print_regs(LONG_CS));
-			PC = _Interp86(PC, LONG_CS, TheCPU.cs, TheCPU.mode, 0);
+			G = _Interp86(PC, LONG_CS, TheCPU.cs, TheCPU.mode, 0);
 #if SPEC_PREJIT
 			speculate = can_speculate();
 #endif
-			G = DoClose(PC, LONG_CS, TheCPU.mode, 0);
 		}
 		if (debug_level('e') &&
 				/* check for codemarks inconsistency */
@@ -578,7 +577,7 @@ static int interp_post(unsigned int PC, unsigned int Interp_LONG_CS,
 		return ret;
 }
 
-static void sprj_deep(TNode *G, unsigned PC, unsigned int Interp_LONG_CS,
+static void sprj_deep(TNode *G, unsigned int Interp_LONG_CS,
 		unsigned short ocs, int basemode, int flags)
 {
 #ifdef SPEC_PREJIT
@@ -586,10 +585,9 @@ static void sprj_deep(TNode *G, unsigned PC, unsigned int Interp_LONG_CS,
 
 	while (G->clink_t.link && !(G->flags & F_LJMP)) {
 		TNode *oldG = G;
-		PC = G->clink_t.target;
+		unsigned int PC = G->clink_t.target;
 		if (e_querymark(PC, SAFE_PRJ_GAP)) break;
-		PC = _Interp86(PC, Interp_LONG_CS, ocs, basemode, flags);
-		G = DoClose(PC, Interp_LONG_CS, basemode, flags);
+		G = _Interp86(PC, Interp_LONG_CS, ocs, basemode, flags);
 		i++;
 		NodesPrejitted++;
 		NodeLinker(oldG, G);
@@ -599,15 +597,15 @@ static void sprj_deep(TNode *G, unsigned PC, unsigned int Interp_LONG_CS,
 #endif
 }
 
-static unsigned int _Interp86(unsigned int PC, unsigned int Interp_LONG_CS,
-			      unsigned short ocs, int basemode, int flags)
+static TNode *_Interp86(unsigned int PC, unsigned int Interp_LONG_CS,
+			unsigned short ocs, int basemode, int flags)
 {
 	CurrIMeta = -1;
 	if (debug_level('e')>2) e_printf("============ Opening sequence at %08x\n",PC);
 	do {
 		PC = InterpOne(PC, Interp_LONG_CS, ocs, basemode);
 	} while (!interp_post(PC, Interp_LONG_CS, basemode, flags));
-	return PC;
+	return DoClose(PC, Interp_LONG_CS, basemode, flags);
 }
 
 static unsigned int InterpOne(unsigned int PC, unsigned int Interp_LONG_CS,
@@ -2749,11 +2747,10 @@ void instr_emu_sim_reset_count(void)
 static void _PreJit86(unsigned int PC, unsigned int Interp_LONG_CS,
 		      unsigned short ocs, int basemode, int flags)
 {
-	PC = _Interp86(PC, Interp_LONG_CS, ocs, basemode, flags);
-	TNode *G = DoClose(PC, Interp_LONG_CS, basemode, flags);
+	TNode *G = _Interp86(PC, Interp_LONG_CS, ocs, basemode, flags);
 	if (G && (flags & F_SPRJ)) {
 		NodesPrejitted++;
-		sprj_deep(G, PC, Interp_LONG_CS, ocs, basemode, flags);
+		sprj_deep(G, Interp_LONG_CS, ocs, basemode, flags);
 	}
 }
 

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -2318,14 +2318,11 @@ repag0:
 				unsigned char opm = D_MO(Fetch(PC+2));
 				switch (opm) {
 				case 0: /* SGDT */
-				    /* Store Global Descriptor Table Register */
-				    PC++; PC += ModRM(opc, PC, _mode|DATA16|MSTORE);
-				    error("SGDT not implemented\n");
-				    break;
 				case 1: /* SIDT */
+				    /* Store Global Descriptor Table Register */
 				    /* Store Interrupt Descriptor Table Register */
-				    PC++; PC += ModRM(opc, PC, _mode|DATA16|MSTORE);
-				    error("SIDT not implemented\n");
+				    PC++; PC += ModRM(opc, PC, _mode);
+				    Gen(O_SIM, _mode, 0x100+opc2, opm, P0);
 				    break;
 				case 2: /* LGDT */ /* PM privileged AND real _mode */
 				    /* Load Global Descriptor Table Register */

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -551,9 +551,7 @@ void Interp86(void)
     }
 
     PC = LONG_CS + TheCPU.eip;
-    assert(CurrIMeta < 0);
     PC = FindExecCode(PC);
-    assert(CurrIMeta < 0);
     TheCPU.eip = PC - LONG_CS;
 }
 
@@ -604,6 +602,8 @@ static void sprj_deep(TNode *G, unsigned PC, unsigned int Interp_LONG_CS,
 static unsigned int _Interp86(unsigned int PC, unsigned int Interp_LONG_CS,
 			      unsigned short ocs, int basemode, int flags)
 {
+	CurrIMeta = -1;
+	if (debug_level('e')>2) e_printf("============ Opening sequence at %08x\n",PC);
 	do {
 		PC = InterpOne(PC, Interp_LONG_CS, ocs, basemode);
 	} while (!interp_post(PC, Interp_LONG_CS, basemode, flags));

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -106,7 +106,7 @@ static TNode *DoClose(unsigned int PC, unsigned int Interp_LONG_CS, int mode,
 	IMeta *GL = &InstrMeta[CurrIMeta];
 	if (GL->gen[GL->ngen-1].op < JMP_TAILCODE) {
 		/* almost always we get here because e_querymark() in
-		   interp_post() found code. If there is no overlap
+		   _Interp86() found code. If there is no overlap
 		   and the node is compatible we can generate a jump
 		   to it and link as well */
 		nextG = FindTree(PC);
@@ -558,25 +558,6 @@ void Interp86(void)
  * overwrite something unintentionally */
 #define SAFE_PRJ_GAP 16
 
-static int interp_post(unsigned int PC, unsigned int Interp_LONG_CS,
-		       const int mode, int flags)
-{
-		int ret = 0;
-		int gap = (flags & F_SPRJ) ? SAFE_PRJ_GAP : 1;
-		assert (CurrIMeta>=0);
-
-#ifndef SINGLEBLOCK
-		IMeta *GL = &InstrMeta[CurrIMeta];
-		if ((mode & MSSTP) ||
-		    GL->gen[GL->ngen-1].op >= JMP_TAILCODE ||
-		    e_querymark(PC, gap))
-#endif
-			ret = 1;
-		InstrMeta[0].flags |= flags;
-
-		return ret;
-}
-
 static void sprj_deep(TNode *G, unsigned int Interp_LONG_CS,
 		unsigned short ocs, int basemode, int flags)
 {
@@ -600,11 +581,22 @@ static void sprj_deep(TNode *G, unsigned int Interp_LONG_CS,
 static TNode *_Interp86(unsigned int PC, unsigned int Interp_LONG_CS,
 			unsigned short ocs, int basemode, int flags)
 {
+	int gap = (flags & F_SPRJ) ? SAFE_PRJ_GAP : 1;
 	CurrIMeta = -1;
 	if (debug_level('e')>2) e_printf("============ Opening sequence at %08x\n",PC);
-	do {
+	for (;;) {
 		PC = InterpOne(PC, Interp_LONG_CS, ocs, basemode);
-	} while (!interp_post(PC, Interp_LONG_CS, basemode, flags));
+		assert (CurrIMeta>=0);
+
+#ifndef SINGLEBLOCK
+		IMeta *GL = &InstrMeta[CurrIMeta];
+		if ((basemode & MSSTP) ||
+		    GL->gen[GL->ngen-1].op >= JMP_TAILCODE ||
+		    e_querymark(PC, gap))
+#endif
+			break;
+	}
+	InstrMeta[0].flags |= flags;
 	return DoClose(PC, Interp_LONG_CS, basemode, flags);
 }
 
@@ -1935,7 +1927,7 @@ repag0:
 					op = (realrepmod&MREP) ? LOOPZ_LOOPE : LOOPNZ_LOOPNE;
 				JMPGen(JLOOP_LINK, _mode, op, PC, P0);
 				/* code will be flushed immediately
-				   in interp_post because TF is set */
+				   in _Interp86() because TF is set */
 				break;
 			} }
 			break;

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -50,7 +50,7 @@
 #include "codegen.h"
 
 IMeta	InstrMeta[MAXINODES];
-int	CurrIMeta = -1;
+int	CurrIMeta;
 
 /* Tree structure to store collected code sequences */
 static avltr_tree CollectTree;
@@ -563,7 +563,6 @@ static void avltr_init(void)
   G->link[0] = TNodePool;
 
   g_printf("avltr_init\n");
-  CurrIMeta = -1;
   ninodes = 0;
 }
 
@@ -1480,10 +1479,6 @@ int NewIMeta(int npc, int override)
 
 		CurrIMeta++;
 		I = &InstrMeta[CurrIMeta];
-		if (CurrIMeta==0) {		// no open code sequences
-			if (debug_level('e')>2) e_printf("============ Opening sequence at %08x\n",npc);
-		}
-
 		I->npc = npc;
 		I->ngen = 0;
 		I->flags = 0;
@@ -1598,7 +1593,6 @@ void EndGen(void)
 	int i;
 	int csm = config.CPUSpeedInMhz*1000;
 #endif
-	CurrIMeta = -1;
 	avltr_destroy();
 	free(TNodePool); TNodePool=NULL;
 #ifdef SHOW_STAT


### PR DESCRIPTION
Only stop if
1. there's a jump op generated, or
2. we're in single step mode (SINGLEBLOCK or TF), or
3. we encounter a compatible block we can jump into
other existing code is going to be invalidated in DoClose(), we're just going to bulldoze over it here.

SPEC_PREJIT should avoid overwriting, but instead of using a gap, I let it give up, by not calling Close() and resetting CurrIMeta, thereby throwing away the prejitted code, instead of generating an early tailcode.

While testing with prejit I saw a bunch of SIDT errors passing by, I've just converted those (and SGDT) into GPFs, and the existing UMIP code in dpmi.c/cpu.c can deal with them.

Putting as draft since this needs some careful testing.

Random note: our strict no-overlap policy isn't universal among JITters, when I looked at QEMU they'll happily generate multiple sequences for the same PC, or overlapping bits. It seems not to matter much in terms of performance though.
Here's an example
```
100 mov bx,10
103 dec bx
104 jnz 103
106 ...
```
dosemu2 will generate a block for 100-106, then invalidate it and regenerate 103-106. If later it gets there again via 100 it generates a block for 100-103 with a jump link at 103, and after that it's done.
QEMU instead generates a block for 100-106 and another one for 103-106, if I understand it correctly.