### PR TITLE
cpu/simx86: introduce _CPU_VM_CURRENT(), use for FPE handling

### DIFF
--- a/src/base/emu-i386/cpu.c
+++ b/src/base/emu-i386/cpu.c
@@ -275,7 +275,7 @@ static void fpu_reset(void)
   vm86_fpu_state.cwd = 0x0040;
   vm86_fpu_state.swd = 0;
 //  vm86_fpu_state.ftw = 0x5555;       //bochs
-  if (config.cpu_vm == CPUVM_KVM || config.cpu_vm_dpmi == CPUVM_KVM)
+  if (_CPU_VM_CURRENT() == CPUVM_KVM)
     kvm_update_fpu();
 }
 
@@ -291,6 +291,8 @@ static void fpu_io_write(ioport_t port, Bit8u val, void *arg)
   switch (port) {
   case 0xf0:
     pic_untrigger(13);
+    if (_CPU_VM_CURRENT() == CPUVM_KVM)
+      kvm_get_fpu();
     fpu_ignne = !!(vm86_fpu_state.swd & 0x80);
     /* Note: we emuate the "unrecommended" (by Intel) design where the
      * untriggering of IGNNE requires an extra write to 0xf0 after fnclex */
@@ -304,10 +306,8 @@ static void fpu_io_write(ioport_t port, Bit8u val, void *arg)
       fpu_ignne = 0;
       /* fnclex */
       vm86_fpu_state.swd &= 0x7f00;
-      if (config.cpu_vm == CPUVM_KVM || config.cpu_vm_dpmi == CPUVM_KVM)
+      if (_CPU_VM_CURRENT() == CPUVM_KVM)
         kvm_update_fpu();
-      if (config.cpu_vm == CPUVM_EMU || config.cpu_vm_dpmi == CPUVM_EMU)
-        cpuemu_update_fpu();
     }
     break;
   }
@@ -368,10 +368,8 @@ int fpu_fpe_handler (unsigned char *csp)
       case 0x29: //fldcw
 	dbug_printf("coprocessor exception, disabling CW load exception because of IGNNE#\n");
 	vm86_fpu_state.cwd = 0x37f;
-	if (config.cpu_vm == CPUVM_KVM || config.cpu_vm_dpmi == CPUVM_KVM)
+	if (_CPU_VM_CURRENT() == CPUVM_KVM)
 	  kvm_update_fpu();
-	if (config.cpu_vm == CPUVM_EMU || config.cpu_vm_dpmi == CPUVM_EMU)
-	  cpuemu_update_fpu();
 	return 0;
       }
     }

--- a/src/base/emu-i386/kvm.c
+++ b/src/base/emu-i386/kvm.c
@@ -1581,9 +1581,6 @@ int true_kvm_dpmi(cpuctx_t *scp)
 	_eip -= 2;
     }
 
-    if (_trapno == 0x10) {
-        kvm_get_fpu(); // needed for the swd check in the port f0 handler
-    }
 #if 0
         struct kvm_fpu fpu;
         ioctl(vcpufd, KVM_GET_FPU, &fpu);

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -1585,6 +1585,11 @@ int _CPU_VM_DPMI(void)
     return config.cpu_vm_dpmi;
 }
 
+int _CPU_VM_CURRENT(void)
+{
+    return in_dpmi_pm() ? _CPU_VM_DPMI() : _CPU_VM();
+}
+
 static int lockcnt;
 
 void prejit_lock(void)

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -1486,10 +1486,8 @@ static void finish_clnt_switch(void)
   assert(in_dpmi);
   if (config.cpu_vm_dpmi == CPUVM_KVM)
     update_kvm_idt();
-  if (config.cpu_vm == CPUVM_KVM || config.cpu_vm_dpmi == CPUVM_KVM)
+  if (_CPU_VM_CURRENT() == CPUVM_KVM)
     kvm_update_fpu();
-  if (_CPU_VM() == CPUVM_EMU || _CPU_VM_DPMI() == CPUVM_EMU)
-    cpuemu_update_fpu();
 }
 
 static int do_ldt_write(unsigned short ldt_entry, unsigned int *lp)
@@ -1540,7 +1538,7 @@ static int ldt_write_low(unsigned short ldt_entry, unsigned int *lp)
 
 static void save_prev_clnt_state(void)
 {
-  if (_CPU_VM() == CPUVM_KVM || _CPU_VM_DPMI() == CPUVM_KVM)
+  if (_CPU_VM_CURRENT() == CPUVM_KVM)
     kvm_get_fpu();
   memcpy(&DPMI_CLIENT.saved_fpu_state, &vm86_fpu_state,
     sizeof(vm86_fpu_state));
@@ -4380,7 +4378,7 @@ void dpmi_init(void)
 
   in_dpmi++;
   memset(&DPMIclient[in_dpmi - 1], 0, sizeof(DPMI_CLIENT));
-  if (config.cpu_vm == CPUVM_KVM || config.cpu_vm_dpmi == CPUVM_KVM)
+  if (_CPU_VM_CURRENT() == CPUVM_KVM)
     kvm_get_fpu();
   memcpy(&DPMIclient[in_dpmi - 1].saved_fpu_state, &vm86_fpu_state,
     sizeof(vm86_fpu_state));

--- a/src/include/cpu-emu.h
+++ b/src/include/cpu-emu.h
@@ -111,6 +111,7 @@ int EMU_V86(void);
 int EMU_DPMI(void);
 int _CPU_VM(void);
 int _CPU_VM_DPMI(void);
+int _CPU_VM_CURRENT(void);
 #else
 #define e_gen_sigalrm()
 #define e_gen_sigalrm_from_thread()


### PR DESCRIPTION
We weren't always getting the correct FPU state with KVM as sometimes the 0xf0 port handler was called via instremu. Introducing _CPU_VM_CURRENT() deals with that correctly.

Also there is no need to call cpuemu_update_fpu() as FPU state is already synchronized when entering and leaving cpu-emu.

Observed when debugging #2708