### PR TITLE
simx86: only use TheCPU.key for first PC of block

### DIFF
--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -122,7 +122,7 @@ static unsigned Exec_x86(void *SeqStart);
  */
 
 static unsigned char TailCode[TAILSIZE+1] =
-	{ 0xb8,0,0,0,0,0x89,0x43,Ofs_KEY,0x5a,0xc3,0xf4 };
+	{ 0xb8,0,0,0,0,0x5a,0xc3,0xf4 };
 
 /*
  * This function is only here for looking at the generated binary code
@@ -277,8 +277,8 @@ static unsigned char *CodeGen_x86(unsigned char *CodePtr, unsigned char *BaseGen
 		G4M(0x83,0x7b,Ofs_ERR,0x00,Cp);
 		// jz skip
 		G2M(JE_JZ,TAILSIZE,Cp);
-		// movl {exit_addr},%%eax; movl %%eax, %%Ofs_KEY(%%ebx)
-		G1(0xb8,Cp); G4(IG->p1,Cp); G3M(0x89,0x43,Ofs_KEY,Cp);
+		// movl {exit_addr},%%eax
+		G1(0xb8,Cp); G4(IG->p1,Cp)
 		// pop %%edx; ret
 		G2M(0x5a,0xc3,Cp);
 		}
@@ -1275,8 +1275,8 @@ shrot0:
 		G2M(0x73,TAILSIZE+7,Cp);
 		// movb EXCP0D_GPF, Ofs_ERR(%%ebx)
 		G2M(0xc6,0x83,Cp); G4(Ofs_ERR,Cp); G1(EXCP0D_GPF,Cp);
-		// movl {exit_addr},%%eax; mov %%eax, Ofs_KEY(%%ebx);
-		G1(0xb8,Cp); G4(jpc,Cp); G3M(0x89,0x43,Ofs_KEY,Cp);
+		// movl {exit_addr},%%eax
+		G1(0xb8,Cp); G4(jpc,Cp)
 		// pop %%edx; ret
 		G2M(0x5a,0xc3,Cp);
 		// address to call in edi
@@ -1298,8 +1298,8 @@ shrot0:
 		G4M(0x83,0x7b,Ofs_ERR,0x00,Cp);
 		// je skip
 		G2M(JE_JZ,TAILSIZE,Cp);
-		// movl {exit_addr},%%eax; movl %eax,Ofs_KEY(%ebx);
-		G1(MOViax,Cp); G4(IG->p2,Cp); G3M(0x89,0x43,Ofs_KEY,Cp);
+		// movl {exit_addr},%%eax
+		G1(MOViax,Cp); G4(IG->p2,Cp)
 		// pop %%edx; ret
 		G2M(POPdx,RET,Cp);
 
@@ -1867,9 +1867,6 @@ shrot0:
 		/* copy tail instructions to the end of the code block */
 		unsigned char *p = Cp;
 		GNX(Cp, TailCode, TAILSIZE);
-		/* Keep TheCPU.eip for BreakNode */
-		if (mode & MPATCH)
-			p[5] = p[6] = p[7] = NOP;
 		*((unsigned int *)(p + TAILFIX)) = IG->p0;
 		}
 		break;
@@ -1880,8 +1877,8 @@ shrot0:
 			G3M(0x0f,0xb7,0xc0,Cp);
 		// addl Ofs_XCS(%%ebx),%%eax
 		G3M(0x03,0x43,Ofs_XCS,Cp);
-		// movl %%eax, Ofs_KEY(%%ebx) // signals indirect
-		G3M(0x89,0x43,Ofs_KEY,Cp);
+		// movl %%eax, Ofs_TEMP(%%ebx) // new PC
+		G3M(0x89,0x43,Ofs_TEMP,Cp);
 #ifdef __x86_64__
 		// movl %%eax,%%edi
 		G2M(0x89,0xc7,Cp);
@@ -1903,8 +1900,8 @@ shrot0:
 		// otherwise to the tail code
 		// jmp *%rax
 		G2M(0xff,0xe0,Cp);
-		// movl Ofs_KEY(%%ebx),%%eax
-		G3M(0x8b,0x43,Ofs_KEY,Cp);
+		// movl Ofs_TEMP(%%ebx),%%eax
+		G3M(0x8b,0x43,Ofs_TEMP,Cp);
 		// pop %%edx; ret
 		G2M(0x5a,0xc3,Cp);
 		}
@@ -1945,8 +1942,8 @@ shrot0:
 		    G4M(0x0f,0xb7,0x4b,Ofs_EXITPEND,Cp);
 		    // jecxz {continue}: exit if exitpend not 0
 		    G2M(0xe3,TAILSIZE,Cp);
-		    // movl {exit_addr},%%eax; movl %%eax,Ofs_KEY(%%ebx)
-		    G1(0xb8,Cp); G4(dspt,Cp); G3M(0x89,0x43,Ofs_KEY,Cp);
+		    // movl {exit_addr},%%eax
+		    G1(0xb8,Cp); G4(dspt,Cp)
 		    // pop %%edx; ret
 		    G2M(0x5a,0xc3,Cp);
 	        }

--- a/src/base/emu-i386/simx86/codegen-x86.h
+++ b/src/base/emu-i386/simx86/codegen-x86.h
@@ -37,10 +37,10 @@
 
 #include "codegen.h"
 
-#define TAILSIZE	10
+#define TAILSIZE	7
 #define JMPTAILSIZE	12
 #define TAILFIX		1
-#define CKSIGNSIZE	16
+#define CKSIGNSIZE	13
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -614,10 +614,9 @@ static unsigned ExecOne(TNode *G)
 	 * A complication here is that the previous node may already
 	 * be linked, so an unlinked exit will return the start PC
 	 * of the original (unlinked) block in seqbase.
-	 * Unlinkable exits are flagged using ePC==TheCPU.key; self-links
+	 * check links FROM LastXNode TO current node, if different: self-links
 	 * are already handled at the compile stage.
 	 */
-	/* check links FROM LastXNode TO current node */
 	if (TheCPU.key != G->key)
 		NodeLinker(FindTree(TheCPU.key), G);
 #ifdef __i386__

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -716,14 +716,10 @@ static void linknode(TNode *LG, TNode *G, linkdesc *L, char branch)
 	backref *B;
 
 	// points to current node, which can't be a forever loop?
-	if (L->target!=G->key || !L->link ||
+	if (L->target!=G->key || !L->link || L->ref!=0 ||
 	    (G->mode & MTRAP) || (LG->mode & MTRAP))
 		return;
 
-	if (L->ref!=0) {
-		dbug_printf("Linker: ref at %08x busy\n",LG->key);
-		leavedos_main(0x8102 + (branch == 'N'));
-	}
 	IGen IG = (IGen){.op = JMP_LINK, .mode = MPATCH|MLINK,
 			 .p0 = L->target, .link = G->addr};
 	CodeGen(LG->addr + L->link, LG->addr, &IG);
@@ -1352,14 +1348,18 @@ int InvalidateNodeRange(int al, int len, unsigned char *eip)
 	       not officially exist anymore) that the SIGSEGV or patched
 	       call returns to may write to the current unprotected page.
 	    */
-	    /* Exclude last instruction, as there is no need to break
-	     * node after last instruction (it ends there anyway). */
-	    ahE = G->addr + G->meta[G->seqnum - 1].daddr;
+	    ahE = G->addr + G->len;
 	    if (eip && ADDR_IN_RANGE(eip,G->addr,ahE)) {
 		if (debug_level('e')>1)
 		    e_printf("### Node self hit %p->%p..%p\n",
 			     eip,G->addr,ahE);
-		BreakNode(G, eip);
+		/* Exclude last instruction, as there is no need to break
+		 * node after last instruction (it ends there anyway), but
+		 * we must still delay deletion until AFTER returning from JIT!,
+		 * or otherwise we'd return into free()ed code. */
+		ahE = G->addr + G->meta[G->seqnum - 1].daddr;
+		if (ADDR_IN_RANGE(eip,G->addr,ahE))
+		    BreakNode(G, eip);
 		TheCPU.err = EXCP_BREAKNODE;
 		/* we can only call RemoveNode in codegen.c */
 	    }


### PR DESCRIPTION
The dual use to signal non-linkable exits was confusing for BreakNode, which relies on TheCPU.key to always be the first PC of the block.

We can instead check in NodeLinker if the node is linkable. Note that already linked jumps can exit because of signals, in which case L->ref is already set, so this is no longer fatal, but became a check that it doesn't need linking again.

The reversal of part of dd01a3594 in d08026d is otherwise correct and needed, just with TheCPU.key being potentially wrong ExecOne could delete the wrong node.

tested with zx_emul.