### PR TITLE
simx86: use a BrokenCodePtr variable to only keep JIT code alive for …

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -2800,7 +2800,7 @@ static void emu_pagefault_handler(dosaddr_t addr, int err, uint32_t op, int len)
 	   to intermediate ops */
 	if (err == -1) {
 		if (e_querymark(addr, len))
-			TryInvalidateNodeRange(addr, len, currentIG);
+			InvalidateNodeRangeFromFault(addr, len, currentIG);
 		return;
 	}
 	if ((err & 2) && msdos_ldt_access(addr)) {

--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -625,6 +625,10 @@ static unsigned ExecOne(TNode *G)
 #endif
 		prefetch(CPUOFFS(0));
 	ePC = Exec(G->addr);
+	if (BrokenCodePtr) {
+		FreeGenCodeBuf(BrokenCodePtr);
+		BrokenCodePtr = NULL;
+	}
 #ifdef SKIP_EMU_VBIOS
 	if ((TheCPU.cs&0xf000)==config.vbios_seg && !TheCPU.err)
 		TheCPU.err = EXCP_GOBACK;

--- a/src/base/emu-i386/simx86/codegen.h
+++ b/src/base/emu-i386/simx86/codegen.h
@@ -240,8 +240,6 @@ static __inline__ int GoodNode(TNode *G)
 					G->key, G->mode, TheCPU.mode);
 		return 0;
 	}
-	if (G->alive <= 0)
-		return 0;
 	return 1;
 }
 

--- a/src/base/emu-i386/simx86/cpatch.c
+++ b/src/base/emu-i386/simx86/cpatch.c
@@ -70,7 +70,7 @@ static void m_munprotect(unsigned int addr, unsigned int len, unsigned char *eip
 		return;
 	// no need to invalidate the whole page here,
 	// as the page does not need to be unprotected
-	TryInvalidateNodeRange(addr, len, eip);
+	InvalidateNodeRangeFromFault(addr, len, eip);
 #if PROFILE
 	CpatchInvalidates++;
 #endif
@@ -262,7 +262,7 @@ void stk_32(dosaddr_t addr, Bit32u value)
 static void wri8_slow(dosaddr_t addr, Bit8u value, unsigned char *eip)
 {
 	if (e_querymark(addr, 1)) {
-		TryInvalidateNodeRange(addr, 1, eip);
+		InvalidateNodeRangeFromFault(addr, 1, eip);
 #if PROFILE
 		CpatchInvalidates++;
 #endif
@@ -273,7 +273,7 @@ static void wri8_slow(dosaddr_t addr, Bit8u value, unsigned char *eip)
 static void wri16_slow(dosaddr_t addr, Bit16u value, unsigned char *eip)
 {
 	if (e_querymark(addr, 2)) {
-		TryInvalidateNodeRange(addr, 2, eip);
+		InvalidateNodeRangeFromFault(addr, 2, eip);
 #if PROFILE
 		CpatchInvalidates++;
 #endif
@@ -284,7 +284,7 @@ static void wri16_slow(dosaddr_t addr, Bit16u value, unsigned char *eip)
 static void wri32_slow(dosaddr_t addr, Bit32u value, unsigned char *eip)
 {
 	if (e_querymark(addr, 4)) {
-		TryInvalidateNodeRange(addr, 4, eip);
+		InvalidateNodeRangeFromFault(addr, 4, eip);
 #if PROFILE
 		CpatchInvalidates++;
 #endif

--- a/src/base/emu-i386/simx86/sigsegv.c
+++ b/src/base/emu-i386/simx86/sigsegv.c
@@ -320,7 +320,7 @@ int e_emu_fault(sigcontext_t *scp, int in_vm86)
 int e_handle_pagefault(dosaddr_t addr, unsigned err, sigcontext_t *scp)
 {
 	int v;
-	unsigned char *p;
+	unsigned char *p, *pjit;
 	int in_dosemu;
 
 	/* err:
@@ -366,12 +366,14 @@ int e_handle_pagefault(dosaddr_t addr, unsigned err, sigcontext_t *scp)
 	if (debug_level('e')) PageFaults++;
 #endif
 	in_dosemu = !(InCompiledCode || in_vm86 || DPMIValidSelector(_scp_cs));
+	p = (unsigned char *) _scp_rip;
+	pjit = InCompiledCode ? GetGenCodeBuf(p) : NULL;
 	if (in_vm86)
 		p = SEG_ADR((unsigned char *), cs, ip);
 	else if (DPMIValidSelector(_scp_cs))
 		p = (unsigned char *)EMU_BASE32(GetSegmentBase(_scp_cs) + _scp_rip);
-	else
-		p = GetGenCodeBuf((unsigned char *) _scp_rip);
+	else if (InCompiledCode)
+		p = pjit;
 	if (debug_level('e')>1 || in_dosemu) {
 		v = *((int *)p);
 		__asm__("bswap %0" : "=r" (v) : "0" (v));
@@ -404,7 +406,8 @@ int e_handle_pagefault(dosaddr_t addr, unsigned err, sigcontext_t *scp)
 	/* We HAVE to invalidate all the code in the page
 	 * if the page is going to be unprotected */
 	addr &= _PAGE_MASK;
-	return TryInvalidateNodeRange(addr, PAGE_SIZE, p);
+	InvalidateNodeRangeFromFault(addr, PAGE_SIZE, pjit);
+	return 1;
 }
 
 int e_handle_fault(sigcontext_t *scp)

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -46,6 +46,7 @@
 
 IMeta	InstrMeta[MAXINODES];
 int	CurrIMeta;
+unsigned char *BrokenCodePtr;
 
 /* Tree structure to store collected code sequences */
 static avltr_tree CollectTree;
@@ -1162,8 +1163,7 @@ static TNode *FindTree_tail(int key)
 	G = *I;
 	assert(G && G->addr);
 	if (debug_level('e')>3) e_printf("Found key %08x\n",key);
-	if (G->alive > 0)
-	    G->alive = NODELIFE(G);
+	G->alive = NODELIFE(G);
 #if PROFILE
 	if (debug_level('e')) {
 	    NodesFound++;
@@ -1209,8 +1209,7 @@ TNode *FindTree(int key)
 	    NodesFastFound++;
 #endif
 	}
-	if (I->alive > 0)
-	    I->alive = NODELIFE(I);
+	I->alive = NODELIFE(I);
 	return I;
   }
   if (!e_querymark(key, 1))
@@ -1241,8 +1240,7 @@ TNode *FindTree_unlocked(int key)
 	    NodesFastFound++;
 #endif
 	}
-	if (I->alive > 0)
-	    I->alive = NODELIFE(I);
+	I->alive = NODELIFE(I);
 	return I;
   }
 
@@ -1302,7 +1300,6 @@ static void RemoveNode_unlocked(TNode *G)
   e_unmarkpage(G->key, G->seqlen);
   NodeUnlinker(G);
   assert(!G->bkr && !G->clink_t.ref && !G->clink_nt.ref && G->addr);
-  FreeGenCodeBuf(G->addr);
   __atomic_store_n(&findtree_cache[G->key&FINDTREE_CACHE_HASH_MASK],
 		   NULL, __ATOMIC_RELAXED);
   TNode *deleted = avltr_delete(G->key);
@@ -1313,11 +1310,13 @@ static void RemoveNode_unlocked(TNode *G)
 void RemoveNode(TNode *G)
 {
   pthread_mutex_lock_trees();
+  unsigned char *p = G->addr;
   RemoveNode_unlocked(G);
+  FreeGenCodeBuf(p);
   pthread_mutex_unlock_trees();
 }
 
-static int BreakNodeHook(TNode *G, unsigned char *eip)
+static unsigned char *BreakNodeHook(TNode *G, unsigned char *eip)
 {
     unsigned char *ahE;
     /* if the current eip is in *any* chunk of code that is deleted
@@ -1328,6 +1327,7 @@ static int BreakNodeHook(TNode *G, unsigned char *eip)
        call returns to may write to the current unprotected page.
     */
     ahE = G->addr + G->len;
+    e_printf("BreakNodeHook %p ahE=%p eip=%p\n", G->addr, ahE, eip);
     if (ADDR_IN_RANGE(eip,G->addr,ahE)) {
 	/* Exclude last instruction, as there is no need to break
 	 * node after last instruction (it ends there anyway). */
@@ -1337,20 +1337,19 @@ static int BreakNodeHook(TNode *G, unsigned char *eip)
 		     eip,G->addr,ahE);
 	if (ADDR_IN_RANGE(eip,G->addr,ahE1))
 	    BreakNode(G, eip);
-	/* we can only call RemoveNode in codegen.c */
-	NodeUnlinker(G);
-	G->alive = 0;
-	return -1;
+	/* return pointer to JIT code that can only be freed in codegen.c
+	   because we are returning to it */
+	return G->addr;
     }
-    return 0;
+    return NULL;
 }
 
-static int DoInvalidateNodeRange(int al, int len, unsigned char *eip,
-    int (*hook)(TNode *, unsigned char *))
+static unsigned char *DoInvalidateNodeRange(int al, int len, unsigned char *eip,
+    unsigned char * (*hook)(TNode *, unsigned char *))
 {
   TNode *G;
   int ah;
-  int rc = 0;
+  unsigned char *rc = NULL;
 #if PROFILE >= 2
   hitimer_t t0 = 0;
 
@@ -1373,14 +1372,19 @@ static int DoInvalidateNodeRange(int al, int len, unsigned char *eip,
       ahG = G->key + G->seqlen;
       assert (G->addr);
       if (RANGE_INTERSECT(G->key,ahG,al,ah)) {
+	    unsigned char *p = NULL;
 	    if (debug_level('e')>1)
 		dbug_printf("Invalidated node %p at %08x\n",G,G->key);
-	    if (eip && hook)
-		rc = hook(G, eip);
-	    if (rc == -1)
-		return rc;
+	    if (eip && hook) {
+		p = hook(G, eip);
+		if (p)
+		    rc = p;
+	    }
 	    if (debug_level('e')>2) e_printf("Delete node %08x\n",G->key);
+	    unsigned char *q = G->addr;
 	    RemoveNode_unlocked(G);
+	    if (p == NULL)
+		FreeGenCodeBuf(q);
       }
       if (ahG >= ah)
         break;
@@ -1399,9 +1403,9 @@ void InvalidateNodeRange(int al, int len)
   DoInvalidateNodeRange(al, len, NULL, NULL);
 }
 
-int TryInvalidateNodeRange(int al, int len, unsigned char *eip)
+void InvalidateNodeRangeFromFault(int al, int len, unsigned char *eip)
 {
-  return DoInvalidateNodeRange(al, len, eip, BreakNodeHook);
+  BrokenCodePtr = DoInvalidateNodeRange(al, len, eip, BreakNodeHook);
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/base/emu-i386/simx86/trees.h
+++ b/src/base/emu-i386/simx86/trees.h
@@ -161,9 +161,10 @@ static inline unsigned int FindPC_X(const unsigned char *addr)
     return FindPC(GetGenCodeBuf(addr));
 }
 void InvalidateNodeRange(int addr, int len);
-int TryInvalidateNodeRange(int addr, int len, unsigned char *eip);
+void InvalidateNodeRangeFromFault(int addr, int len, unsigned char *eip);
 void RemoveNode(TNode *G);
 void NodeLinker(TNode *LG, TNode *G);
+extern unsigned char *BrokenCodePtr;
 
 #ifdef DEBUG_TREE
 extern FILE *tLog;


### PR DESCRIPTION
…a bit

This way all the rest for the node can be deleted, and there is no need for dead nodes any more.

Also pass the correct jit pointer from sigsegv.c to TryInvalidateNodeRange()

Fixes #2708