### PR TITLE
simx86: unlink forward refs changing code (remove direct jumps)

### DIFF
--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -812,6 +812,13 @@ static void unlinknode(TNode *G, linkdesc *T, char branch)
 		dbug_printf("Unlinker: FW %c ref error\n", branch);
 		leavedos_main(0x8111 + (branch == 'N'));
 	}
+	/* we must unlink the forward ref code since the node we linked to
+	   may also get deleted, and we may currently be executing G,
+	   where in BreakNodeHook the last instruction is excluded from
+	   tail code patching */
+	IGen IG = (IGen){.op = JMP_LINK, .mode = MPATCH,
+			 .p0 = T->target, .p1 = G->key};
+	CodeGen(G->addr + T->link, G->addr, &IG);
 	T->ref = NULL;
 }
 


### PR DESCRIPTION
So far NodeUnlinker only undid direct jumps for references *to* the node that was removed, but for forward references *from* the node it wasn't needed since the node would be deleted anyway.

However with BreakNodeHook excluding the last instruction the linking jump instruction could still be kept and jump into a node that was also deleted. We must therefore also undo the jump for forward references!

Fixes #2708