### PR TITLE
CI: FPU disable FISTTP in tests as they require SSE3

### DIFF
--- a/test/fpu/test-i386-fp-exceptions.c
+++ b/test/fpu/test-i386-fp-exceptions.c
@@ -537,133 +537,135 @@ int main(void)
         ret = 1;
     }
 
-    __asm__ volatile ("fnclex");
-    __asm__ volatile ("fisttps %0" : "=m" (res_16) : "t" (1.5L) : "st");
-    __asm__ volatile ("fnstsw" : "=a" (sw));
-    if ((sw & EXC) != PE) {
-        printf("FAIL: fisttp inexact\n");
-        ret = 1;
-    }
-    __asm__ volatile ("fnclex");
-    __asm__ volatile ("fisttps %0" : "=m" (res_16) : "t" (32768.0L) : "st");
-    __asm__ volatile ("fnstsw" : "=a" (sw));
-    if ((sw & EXC) != IE) {
-        printf("FAIL: fisttp 32768\n");
-        ret = 1;
-    }
-    __asm__ volatile ("fnclex");
-    __asm__ volatile ("fisttps %0" : "=m" (res_16) : "t" (32768.5L) : "st");
-    __asm__ volatile ("fnstsw" : "=a" (sw));
-    if ((sw & EXC) != IE) {
-        printf("FAIL: fisttp 32768.5\n");
-        ret = 1;
-    }
-    __asm__ volatile ("fnclex");
-    __asm__ volatile ("fisttps %0" : "=m" (res_16) : "t" (-32769.0L) : "st");
-    __asm__ volatile ("fnstsw" : "=a" (sw));
-    if ((sw & EXC) != IE) {
-        printf("FAIL: fisttp -32769\n");
-        ret = 1;
-    }
-    __asm__ volatile ("fnclex");
-    __asm__ volatile ("fisttps %0" : "=m" (res_16) : "t" (-32769.5L) : "st");
-    __asm__ volatile ("fnstsw" : "=a" (sw));
-    if ((sw & EXC) != IE) {
-        printf("FAIL: fisttp -32769.5\n");
-        ret = 1;
-    }
-    __asm__ volatile ("fnclex");
-    __asm__ volatile ("fisttps %0" : "=m" (res_16) : "t" (ld_nan) : "st");
-    __asm__ volatile ("fnstsw" : "=a" (sw));
-    if ((sw & EXC) != IE) {
-        printf("FAIL: fisttp nan\n");
-        ret = 1;
-    }
-    __asm__ volatile ("fnclex");
-    __asm__ volatile ("fisttps %0" : "=m" (res_16) : "t" (ld_invalid_1.ld) :
-                      "st");
-    __asm__ volatile ("fnstsw" : "=a" (sw));
-    if ((sw & EXC) != IE) {
-        printf("FAIL: fisttp invalid\n");
-        ret = 1;
-    }
+    if (__builtin_cpu_supports("sse3")) {
+        __asm__ volatile ("fnclex");
+        __asm__ volatile ("fisttps %0" : "=m" (res_16) : "t" (1.5L) : "st");
+        __asm__ volatile ("fnstsw" : "=a" (sw));
+        if ((sw & EXC) != PE) {
+            printf("FAIL: fisttp inexact\n");
+            ret = 1;
+        }
+        __asm__ volatile ("fnclex");
+        __asm__ volatile ("fisttps %0" : "=m" (res_16) : "t" (32768.0L) : "st");
+        __asm__ volatile ("fnstsw" : "=a" (sw));
+        if ((sw & EXC) != IE) {
+            printf("FAIL: fisttp 32768\n");
+            ret = 1;
+        }
+        __asm__ volatile ("fnclex");
+        __asm__ volatile ("fisttps %0" : "=m" (res_16) : "t" (32768.5L) : "st");
+        __asm__ volatile ("fnstsw" : "=a" (sw));
+        if ((sw & EXC) != IE) {
+            printf("FAIL: fisttp 32768.5\n");
+            ret = 1;
+        }
+        __asm__ volatile ("fnclex");
+        __asm__ volatile ("fisttps %0" : "=m" (res_16) : "t" (-32769.0L) : "st");
+        __asm__ volatile ("fnstsw" : "=a" (sw));
+        if ((sw & EXC) != IE) {
+            printf("FAIL: fisttp -32769\n");
+            ret = 1;
+        }
+        __asm__ volatile ("fnclex");
+        __asm__ volatile ("fisttps %0" : "=m" (res_16) : "t" (-32769.5L) : "st");
+        __asm__ volatile ("fnstsw" : "=a" (sw));
+        if ((sw & EXC) != IE) {
+            printf("FAIL: fisttp -32769.5\n");
+            ret = 1;
+        }
+        __asm__ volatile ("fnclex");
+        __asm__ volatile ("fisttps %0" : "=m" (res_16) : "t" (ld_nan) : "st");
+        __asm__ volatile ("fnstsw" : "=a" (sw));
+        if ((sw & EXC) != IE) {
+            printf("FAIL: fisttp nan\n");
+            ret = 1;
+        }
+        __asm__ volatile ("fnclex");
+        __asm__ volatile ("fisttps %0" : "=m" (res_16) : "t" (ld_invalid_1.ld) :
+                          "st");
+        __asm__ volatile ("fnstsw" : "=a" (sw));
+        if ((sw & EXC) != IE) {
+            printf("FAIL: fisttp invalid\n");
+            ret = 1;
+        }
 
-    __asm__ volatile ("fnclex");
-    __asm__ volatile ("fisttpl %0" : "=m" (res_32) : "t" (1.5L) : "st");
-    __asm__ volatile ("fnstsw" : "=a" (sw));
-    if ((sw & EXC) != PE) {
-        printf("FAIL: fisttpl inexact\n");
-        ret = 1;
-    }
-    __asm__ volatile ("fnclex");
-    __asm__ volatile ("fisttpl %0" : "=m" (res_32) : "t" (2147483648.0L) :
-                      "st");
-    __asm__ volatile ("fnstsw" : "=a" (sw));
-    if ((sw & EXC) != IE) {
-        printf("FAIL: fisttpl 2147483648\n");
-        ret = 1;
-    }
-    __asm__ volatile ("fnclex");
-    __asm__ volatile ("fisttpl %0" : "=m" (res_32) : "t" (-2147483649.0L) :
-                      "st");
-    __asm__ volatile ("fnstsw" : "=a" (sw));
-    if ((sw & EXC) != IE) {
-        printf("FAIL: fisttpl -2147483649\n");
-        ret = 1;
-    }
-    __asm__ volatile ("fnclex");
-    __asm__ volatile ("fisttpl %0" : "=m" (res_32) : "t" (ld_nan) : "st");
-    __asm__ volatile ("fnstsw" : "=a" (sw));
-    if ((sw & EXC) != IE) {
-        printf("FAIL: fisttpl nan\n");
-        ret = 1;
-    }
-    __asm__ volatile ("fnclex");
-    __asm__ volatile ("fisttpl %0" : "=m" (res_32) : "t" (ld_invalid_1.ld) :
-                      "st");
-    __asm__ volatile ("fnstsw" : "=a" (sw));
-    if ((sw & EXC) != IE) {
-        printf("FAIL: fisttpl invalid\n");
-        ret = 1;
-    }
+        __asm__ volatile ("fnclex");
+        __asm__ volatile ("fisttpl %0" : "=m" (res_32) : "t" (1.5L) : "st");
+        __asm__ volatile ("fnstsw" : "=a" (sw));
+        if ((sw & EXC) != PE) {
+            printf("FAIL: fisttpl inexact\n");
+            ret = 1;
+        }
+        __asm__ volatile ("fnclex");
+        __asm__ volatile ("fisttpl %0" : "=m" (res_32) : "t" (2147483648.0L) :
+                          "st");
+        __asm__ volatile ("fnstsw" : "=a" (sw));
+        if ((sw & EXC) != IE) {
+            printf("FAIL: fisttpl 2147483648\n");
+            ret = 1;
+        }
+        __asm__ volatile ("fnclex");
+        __asm__ volatile ("fisttpl %0" : "=m" (res_32) : "t" (-2147483649.0L) :
+                          "st");
+        __asm__ volatile ("fnstsw" : "=a" (sw));
+        if ((sw & EXC) != IE) {
+            printf("FAIL: fisttpl -2147483649\n");
+            ret = 1;
+        }
+        __asm__ volatile ("fnclex");
+        __asm__ volatile ("fisttpl %0" : "=m" (res_32) : "t" (ld_nan) : "st");
+        __asm__ volatile ("fnstsw" : "=a" (sw));
+        if ((sw & EXC) != IE) {
+            printf("FAIL: fisttpl nan\n");
+            ret = 1;
+        }
+        __asm__ volatile ("fnclex");
+        __asm__ volatile ("fisttpl %0" : "=m" (res_32) : "t" (ld_invalid_1.ld) :
+                          "st");
+        __asm__ volatile ("fnstsw" : "=a" (sw));
+        if ((sw & EXC) != IE) {
+            printf("FAIL: fisttpl invalid\n");
+            ret = 1;
+        }
 
-    __asm__ volatile ("fnclex");
-    __asm__ volatile ("fisttpll %0" : "=m" (res_64) : "t" (1.5L) : "st");
-    __asm__ volatile ("fnstsw" : "=a" (sw));
-    if ((sw & EXC) != PE) {
-        printf("FAIL: fisttpll inexact\n");
-        ret = 1;
-    }
-    __asm__ volatile ("fnclex");
-    __asm__ volatile ("fisttpll %0" : "=m" (res_64) : "t" (0x1p63) :
-                      "st");
-    __asm__ volatile ("fnstsw" : "=a" (sw));
-    if ((sw & EXC) != IE) {
-        printf("FAIL: fisttpll 0x1p63\n");
-        ret = 1;
-    }
-    __asm__ volatile ("fnclex");
-    __asm__ volatile ("fisttpll %0" : "=m" (res_64) : "t" (-0x1.1p63L) :
-                      "st");
-    __asm__ volatile ("fnstsw" : "=a" (sw));
-    if ((sw & EXC) != IE) {
-        printf("FAIL: fisttpll -0x1.1p63\n");
-        ret = 1;
-    }
-    __asm__ volatile ("fnclex");
-    __asm__ volatile ("fisttpll %0" : "=m" (res_64) : "t" (ld_nan) : "st");
-    __asm__ volatile ("fnstsw" : "=a" (sw));
-    if ((sw & EXC) != IE) {
-        printf("FAIL: fisttpll nan\n");
-        ret = 1;
-    }
-    __asm__ volatile ("fnclex");
-    __asm__ volatile ("fisttpll %0" : "=m" (res_64) : "t" (ld_invalid_1.ld) :
-                      "st");
-    __asm__ volatile ("fnstsw" : "=a" (sw));
-    if ((sw & EXC) != IE) {
-        printf("FAIL: fisttpll invalid\n");
-        ret = 1;
+        __asm__ volatile ("fnclex");
+        __asm__ volatile ("fisttpll %0" : "=m" (res_64) : "t" (1.5L) : "st");
+        __asm__ volatile ("fnstsw" : "=a" (sw));
+        if ((sw & EXC) != PE) {
+            printf("FAIL: fisttpll inexact\n");
+            ret = 1;
+        }
+        __asm__ volatile ("fnclex");
+        __asm__ volatile ("fisttpll %0" : "=m" (res_64) : "t" (0x1p63) :
+                          "st");
+        __asm__ volatile ("fnstsw" : "=a" (sw));
+        if ((sw & EXC) != IE) {
+            printf("FAIL: fisttpll 0x1p63\n");
+            ret = 1;
+        }
+        __asm__ volatile ("fnclex");
+        __asm__ volatile ("fisttpll %0" : "=m" (res_64) : "t" (-0x1.1p63L) :
+                          "st");
+        __asm__ volatile ("fnstsw" : "=a" (sw));
+        if ((sw & EXC) != IE) {
+            printf("FAIL: fisttpll -0x1.1p63\n");
+            ret = 1;
+        }
+        __asm__ volatile ("fnclex");
+        __asm__ volatile ("fisttpll %0" : "=m" (res_64) : "t" (ld_nan) : "st");
+        __asm__ volatile ("fnstsw" : "=a" (sw));
+        if ((sw & EXC) != IE) {
+            printf("FAIL: fisttpll nan\n");
+            ret = 1;
+        }
+        __asm__ volatile ("fnclex");
+        __asm__ volatile ("fisttpll %0" : "=m" (res_64) : "t" (ld_invalid_1.ld) :
+                          "st");
+        __asm__ volatile ("fnstsw" : "=a" (sw));
+        if ((sw & EXC) != IE) {
+            printf("FAIL: fisttpll invalid\n");
+            ret = 1;
+        }
     }
 
     __asm__ volatile ("fnclex");

--- a/test/test_processor.py
+++ b/test/test_processor.py
@@ -2,7 +2,8 @@
 
 from subprocess import check_call
 
-from common_framework import BaseTestCase, main, main_setup, mark, KNOWNFAIL
+from common_framework import (BaseTestCase, main, main_setup, mark,
+                              KNOWNFAIL, UNSUPPORTED)
 from common_os import ppdosgit
 
 from func_build_freecom import build_freecom
@@ -38,9 +39,8 @@ class OurTestCase(BaseTestCase):
 
 class KVMTestCase(ppdosgit(OurTestCase, {
         "test_fpu_f2xm1_kvm_sim": KNOWNFAIL,
-        "test_fpu_fisttp_kvm_jit": KNOWNFAIL,
-        "test_fpu_fisttp_kvm_sim": KNOWNFAIL,
-        "test_fpu_fp_exceptions_kvm_jit": KNOWNFAIL,
+        "test_fpu_fisttp_kvm_jit": UNSUPPORTED,  # Requires Pentium 4 (SSE3)
+        "test_fpu_fisttp_kvm_sim": UNSUPPORTED,  # Requires Pentium 4 (SSE3)
         "test_fpu_fp_exceptions_kvm_sim": KNOWNFAIL,
         "test_fpu_fyl2x_kvm_sim": KNOWNFAIL,
         "test_fpu_fyl2xp1_kvm_sim": KNOWNFAIL,
@@ -51,9 +51,8 @@ class KVMTestCase(ppdosgit(OurTestCase, {
 
 class EMUTestCase(ppdosgit(OurTestCase, {
         "test_fpu_f2xm1_sim_sim": KNOWNFAIL,
-        "test_fpu_fisttp_jit_jit": KNOWNFAIL,
-        "test_fpu_fisttp_sim_sim": KNOWNFAIL,
-        "test_fpu_fp_exceptions_jit_jit": KNOWNFAIL,
+        "test_fpu_fisttp_jit_jit": UNSUPPORTED,  # Requires Pentium 4 (SSE3)
+        "test_fpu_fisttp_sim_sim": UNSUPPORTED,  # Requires Pentium 4 (SSE3)
         "test_fpu_fp_exceptions_sim_sim": KNOWNFAIL,
         "test_fpu_fyl2x_sim_sim": KNOWNFAIL,
         "test_fpu_fyl2xp1_sim_sim": KNOWNFAIL,


### PR DESCRIPTION
Disabled because we don't emulate a Pentium 4, and it's not likely anytime soon as there are better candidates for improvement such as MMX. See comments in [closes #2738].