### PR TITLE
Add interrupt 24 handler to share open test

### DIFF
--- a/.github/workflows/create-packages-emscripten.yml
+++ b/.github/workflows/create-packages-emscripten.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     name: "build"
     runs-on: ubuntu-24.04
-    if: (github.repository_owner == 'dosemu2')
+    if: (github.repository_owner == 'dosemu2' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false))
     steps:
     - uses: actions/checkout@v4
     - name: Setup Emscripten

--- a/test/func_ds3_share_open_twice.py
+++ b/test/func_ds3_share_open_twice.py
@@ -530,12 +530,56 @@ OPEN_HYBRID = fixup_matrix(OPEN_622, [
     ("SH_DENYNO", "R" , "SH_COMPAT", "R" , "ALLOW"), # File RO success, W fails INT24. For MS-DOS-7: always success.
 ])
 
+# Choosing to not support Int24 on MFS. It should have no effect on
+# most DJGPP compiled programs as the default Int24 handler always
+# returns failure anyway, see discussion here:
+# https://github.com/dosemu2/dosemu2/pull/2759#issuecomment-3794907783
+OPEN_HYBRID_NO_INT24 = fixup_matrix(OPEN_HYBRID, [
+    ("SH_DENYRW", "R" , "SH_COMPAT", "R" , "DENY"),
+    ("SH_DENYRW", "R" , "SH_COMPAT", "W" , "DENY"),
+    ("SH_DENYRW", "R" , "SH_COMPAT", "RW", "DENY"),
+    ("SH_DENYRW", "W" , "SH_COMPAT", "R" , "DENY"),
+    ("SH_DENYRW", "W" , "SH_COMPAT", "W" , "DENY"),
+    ("SH_DENYRW", "W" , "SH_COMPAT", "RW", "DENY"),
+    ("SH_DENYRW", "RW", "SH_COMPAT", "R" , "DENY"),
+    ("SH_DENYRW", "RW", "SH_COMPAT", "W" , "DENY"),
+    ("SH_DENYRW", "RW", "SH_COMPAT", "RW", "DENY"),
+    ("SH_DENYWR", "R" , "SH_COMPAT", "W" , "DENY"),
+    ("SH_DENYWR", "R" , "SH_COMPAT", "RW", "DENY"),
+    ("SH_DENYWR", "W" , "SH_COMPAT", "R" , "DENY"),
+    ("SH_DENYWR", "W" , "SH_COMPAT", "W" , "DENY"),
+    ("SH_DENYWR", "W" , "SH_COMPAT", "RW", "DENY"),
+    ("SH_DENYWR", "RW", "SH_COMPAT", "R" , "DENY"),
+    ("SH_DENYWR", "RW", "SH_COMPAT", "W" , "DENY"),
+    ("SH_DENYWR", "RW", "SH_COMPAT", "RW", "DENY"),
+    ("SH_DENYRD", "R" , "SH_COMPAT", "R" , "DENY"),
+    ("SH_DENYRD", "R" , "SH_COMPAT", "W" , "DENY"),
+    ("SH_DENYRD", "R" , "SH_COMPAT", "RW", "DENY"),
+    ("SH_DENYRD", "W" , "SH_COMPAT", "R" , "DENY"),
+    ("SH_DENYRD", "W" , "SH_COMPAT", "W" , "DENY"),
+    ("SH_DENYRD", "W" , "SH_COMPAT", "RW", "DENY"),
+    ("SH_DENYRD", "RW", "SH_COMPAT", "R" , "DENY"),
+    ("SH_DENYRD", "RW", "SH_COMPAT", "W" , "DENY"),
+    ("SH_DENYRD", "RW", "SH_COMPAT", "RW", "DENY"),
+    ("SH_DENYNO", "R" , "SH_COMPAT", "W" , "DENY"),
+    ("SH_DENYNO", "R" , "SH_COMPAT", "RW", "DENY"),
+    ("SH_DENYNO", "W" , "SH_COMPAT", "R" , "DENY"),
+    ("SH_DENYNO", "W" , "SH_COMPAT", "W" , "DENY"),
+    ("SH_DENYNO", "W" , "SH_COMPAT", "RW", "DENY"),
+    ("SH_DENYNO", "RW", "SH_COMPAT", "R" , "DENY"),
+    ("SH_DENYNO", "RW", "SH_COMPAT", "W" , "DENY"),
+    ("SH_DENYNO", "RW", "SH_COMPAT", "RW", "DENY"),
+])
+
 
 def ds3_share_open_twice(self, fstype):
-    if 'FDPP' in self.version or fstype == 'MFS':
-        tests = OPEN_HYBRID
+    if fstype == 'MFS':
+        tests = OPEN_HYBRID_NO_INT24
     else:
-        tests = OPEN_622
+        if 'FDPP' in self.version:
+            tests = OPEN_HYBRID
+        else:
+            tests = OPEN_622
 
     results = _run_all(self, fstype, tests)
     self.assertIn("rem tests complete", results)

--- a/test/func_ds3_share_open_twice.py
+++ b/test/func_ds3_share_open_twice.py
@@ -6,13 +6,37 @@ def _run_all(self, fstype, tests):
 
     share = "rem Internal share" if self.version == "FDPP kernel" else "c:\\share"
 
-    tfile = "set LFN=n\r\n" + "d:\r\n" + share + "\r\n"
+    tfile = f"echo off\r\nset LFN=n\r\nd:\r\n{share}\r\n"
     for t in tests:
         tfile += ("c:\\sharopen primary %s %s %s %s %s\r\n" % t)
+    tfile += "echo on\r\n"
     tfile += "rem tests complete\r\n"
     tfile += "rem end\r\n"
-
     self.mkfile("testit.bat", tfile)
+
+    # assemble handler
+    handler_S = self.workdir / 'handler.S'
+    handler_S.write_text("""
+.code32
+
+.text
+.global _int24_handler
+_int24_handler:
+    movw $1, _int24_received
+
+/* Values for critical error handler action code:
+      00h ignore error and continue processing request;
+      01h retry operation
+      02h terminate program as though INT 21/AH=4Ch called (INT 20h for DOS 1.x)
+      03h fail system call in progress (DOS 3+) */
+    movb $3, %al
+    iret
+
+.data
+.global _int24_received
+_int24_received:
+    .word 0
+""")
 
     # compile sources
     self.mkexe_with_djgpp("sharopen", r"""
@@ -22,10 +46,37 @@ def _run_all(self, fstype, tests):
 #include <io.h>
 #include <process.h>
 #include <share.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include <dpmi.h>
+#include <go32.h>
 
 #define FNAME "FOO.DAT"
+
+extern void *int24_handler;
+extern volatile uint16_t int24_received;
+
+static __dpmi_paddr old_vec;
+
+int install_int24(void)
+{
+  __dpmi_paddr new_vec;
+
+  __dpmi_get_protected_mode_interrupt_vector(0x24, &old_vec);
+
+  new_vec.selector = _go32_my_cs();
+  new_vec.offset32 = (uintptr_t)&int24_handler;
+  if (__dpmi_set_protected_mode_interrupt_vector(0x24, &new_vec) == -1)
+    return -1;
+
+  return 0;
+}
+
+void restore_int24(void)
+{
+  __dpmi_set_protected_mode_interrupt_vector(0x24, &old_vec);
+}
 
 unsigned short sharemode(const char *s) {
   if (strcmp(s, "SH_COMPAT") == 0)
@@ -116,15 +167,32 @@ int main(int argc, char *argv[]) {
 
   } else { // secondary
     unsigned short mode = secsmode | secomode;
+    int rc;
+
+    if ((rc = install_int24()) != 0) {
+        printf("FAIL: Failed to install int24 handler (%d)\n", rc);
+        return 1;
+    }
+
     ret = _dos_open(FNAME, mode, &handle);
     if (ret != 0) {
-      if (strcmp(argv[6], "DENY") == 0 || strcmp(argv[6], "INT24") == 0) {
+      if (strcmp(argv[6], "DENY") == 0) {
         printf("PASS:('%s', '%s', '%s', '%s', '%s')[secondary denied]\n",
             argv[2], argv[3], argv[4], argv[5], argv[6]);
+      } else if (strcmp(argv[6], "INT24") == 0) {
+//      printf("INFO: int24_received = 0x%04x\n", int24_received);
+        if (int24_received) {
+          printf("PASS:('%s', '%s', '%s', '%s', '%s')[secondary denied]\n",
+              argv[2], argv[3], argv[4], argv[5], argv[6]);
+        } else {
+          printf("FAIL:('%s', '%s', '%s', '%s', '%s')[secondary denied]\n",
+              argv[2], argv[3], argv[4], argv[5], argv[6]);
+        }
       } else {
         printf("FAIL:('%s', '%s', '%s', '%s', '%s')[secondary denied]\n",
             argv[2], argv[3], argv[4], argv[5], argv[6]);
       }
+      restore_int24();
       return -1;
     }
     if (strcmp(argv[6], "ALLOW") == 0) {
@@ -134,12 +202,13 @@ int main(int argc, char *argv[]) {
       printf("FAIL:('%s', '%s', '%s', '%s', '%s')[secondary allowed]\n",
           argv[2], argv[3], argv[4], argv[5], argv[6]);
     }
+    restore_int24();
   }
 
   _dos_close(handle);
   return 0;
 }
-""")
+""", extraargs=[f'{handler_S}',])
 
     self.mkfile("FOO.DAT", "some data", dname=testdir)
 
@@ -701,11 +770,6 @@ OPEN_HYBRID = (
     ("SH_DENYNO", "RW", "SH_DENYNO", "RW", "ALLOW"),
 )
 
-def _check_single_result(self, results, t):
-    m = re.search(r"FAIL:\('%s', '%s', '%s', '%s', '%s'\)\[.*\]" % t, results)
-    if m:
-        self.fail(msg=m.group(0))
-
 
 def ds3_share_open_twice(self, fstype):
     if 'FDPP' in self.version or fstype == 'MFS':
@@ -714,7 +778,5 @@ def ds3_share_open_twice(self, fstype):
         tests = OPEN_622
 
     results = _run_all(self, fstype, tests)
-    for t in tests:
-        with self.subTest(t=t):
-            _check_single_result(self, results, t)
     self.assertIn("rem tests complete", results)
+    self.assertNotIn("FAIL:", results)

--- a/test/func_ds3_share_open_twice.py
+++ b/test/func_ds3_share_open_twice.py
@@ -1,4 +1,4 @@
-import re
+from copy import deepcopy
 
 
 def _run_all(self, fstype, tests):
@@ -256,7 +256,7 @@ int main(int argc, char *argv[]) {
 # 1 = open succeeds if file read-only, else fails with error code.
 # 2 = open succeeds if file read-only, else fails with INT 24
 
-OPEN_622 = (
+OPEN_622 = [
 # Compat R |Y Y Y  N N N  1 N N  N N N  1 N N.
     ("SH_COMPAT", "R" , "SH_COMPAT", "R" , "ALLOW"),
     ("SH_COMPAT", "R" , "SH_COMPAT", "W" , "ALLOW"),
@@ -511,264 +511,24 @@ OPEN_622 = (
     ("SH_DENYNO", "RW", "SH_DENYNO", "R" , "ALLOW"),
     ("SH_DENYNO", "RW", "SH_DENYNO", "W" , "ALLOW"),
     ("SH_DENYNO", "RW", "SH_DENYNO", "RW", "ALLOW"),
-)
+]
 
-OPEN_HYBRID = (
-# Compat R |Y Y Y  N N N  1 N N  N N N  1 N N.
-    ("SH_COMPAT", "R" , "SH_COMPAT", "R" , "ALLOW"),
-    ("SH_COMPAT", "R" , "SH_COMPAT", "W" , "ALLOW"),
-    ("SH_COMPAT", "R" , "SH_COMPAT", "RW", "ALLOW"),
-    ("SH_COMPAT", "R" , "SH_DENYRW", "R" , "DENY"),
-    ("SH_COMPAT", "R" , "SH_DENYRW", "W" , "DENY"),
-    ("SH_COMPAT", "R" , "SH_DENYRW", "RW", "DENY"),
+
+def fixup_matrix(orig, fixups):
+    newl = deepcopy(orig)
+    for fx in fixups:
+        for i, r in enumerate(newl):
+            if fx[0:4] == r[0:4]:
+                newl[i] = fx
+    return newl
+
+
+OPEN_HYBRID = fixup_matrix(OPEN_622, [
     ("SH_COMPAT", "R" , "SH_DENYWR", "R" , "ALLOW"), # File RO success, W fails. For MS-DOS-7: always success.
-    ("SH_COMPAT", "R" , "SH_DENYWR", "W" , "DENY"),
-    ("SH_COMPAT", "R" , "SH_DENYWR", "RW", "DENY"),
-    ("SH_COMPAT", "R" , "SH_DENYRD", "R" , "DENY"),
-    ("SH_COMPAT", "R" , "SH_DENYRD", "W" , "DENY"),
-    ("SH_COMPAT", "R" , "SH_DENYRD", "RW", "DENY"),
     ("SH_COMPAT", "R" , "SH_DENYNO", "R" , "ALLOW"), # File RO success, W fails. For MS-DOS-7: always success.
-    ("SH_COMPAT", "R" , "SH_DENYNO", "W" , "DENY"),
-    ("SH_COMPAT", "R" , "SH_DENYNO", "RW", "DENY"),
-
-#        W |Y Y Y  N N N  N N N  N N N  N N N.
-    ("SH_COMPAT", "W" , "SH_COMPAT", "R" , "ALLOW"),
-    ("SH_COMPAT", "W" , "SH_COMPAT", "W" , "ALLOW"),
-    ("SH_COMPAT", "W" , "SH_COMPAT", "RW", "ALLOW"),
-    ("SH_COMPAT", "W" , "SH_DENYRW", "R" , "DENY"),
-    ("SH_COMPAT", "W" , "SH_DENYRW", "W" , "DENY"),
-    ("SH_COMPAT", "W" , "SH_DENYRW", "RW", "DENY"),
-    ("SH_COMPAT", "W" , "SH_DENYWR", "R" , "DENY"),
-    ("SH_COMPAT", "W" , "SH_DENYWR", "W" , "DENY"),
-    ("SH_COMPAT", "W" , "SH_DENYWR", "RW", "DENY"),
-    ("SH_COMPAT", "W" , "SH_DENYRD", "R" , "DENY"),
-    ("SH_COMPAT", "W" , "SH_DENYRD", "W" , "DENY"),
-    ("SH_COMPAT", "W" , "SH_DENYRD", "RW", "DENY"),
-    ("SH_COMPAT", "W" , "SH_DENYNO", "R" , "DENY"),
-    ("SH_COMPAT", "W" , "SH_DENYNO", "W" , "DENY"),
-    ("SH_COMPAT", "W" , "SH_DENYNO", "RW", "DENY"),
-
-#        RW|Y Y Y  N N N  N N N  N N N  N N N
-    ("SH_COMPAT", "RW", "SH_COMPAT", "R" , "ALLOW"),
-    ("SH_COMPAT", "RW", "SH_COMPAT", "W" , "ALLOW"),
-    ("SH_COMPAT", "RW", "SH_COMPAT", "RW", "ALLOW"),
-    ("SH_COMPAT", "RW", "SH_DENYRW", "R" , "DENY"),
-    ("SH_COMPAT", "RW", "SH_DENYRW", "W" , "DENY"),
-    ("SH_COMPAT", "RW", "SH_DENYRW", "RW", "DENY"),
-    ("SH_COMPAT", "RW", "SH_DENYWR", "R" , "DENY"),
-    ("SH_COMPAT", "RW", "SH_DENYWR", "W" , "DENY"),
-    ("SH_COMPAT", "RW", "SH_DENYWR", "RW", "DENY"),
-    ("SH_COMPAT", "RW", "SH_DENYRD", "R" , "DENY"),
-    ("SH_COMPAT", "RW", "SH_DENYRD", "W" , "DENY"),
-    ("SH_COMPAT", "RW", "SH_DENYRD", "RW", "DENY"),
-    ("SH_COMPAT", "RW", "SH_DENYNO", "R" , "DENY"),
-    ("SH_COMPAT", "RW", "SH_DENYNO", "W" , "DENY"),
-    ("SH_COMPAT", "RW", "SH_DENYNO", "RW", "DENY"),
-
-# Deny   R |C C C  N N N  N N N  N N N  N N N
-    ("SH_DENYRW", "R" , "SH_COMPAT", "R" , "INT24"),
-    ("SH_DENYRW", "R" , "SH_COMPAT", "W" , "INT24"),
-    ("SH_DENYRW", "R" , "SH_COMPAT", "RW", "INT24"),
-    ("SH_DENYRW", "R" , "SH_DENYRW", "R" , "DENY"),
-    ("SH_DENYRW", "R" , "SH_DENYRW", "W" , "DENY"),
-    ("SH_DENYRW", "R" , "SH_DENYRW", "RW", "DENY"),
-    ("SH_DENYRW", "R" , "SH_DENYWR", "R" , "DENY"),
-    ("SH_DENYRW", "R" , "SH_DENYWR", "W" , "DENY"),
-    ("SH_DENYRW", "R" , "SH_DENYWR", "RW", "DENY"),
-    ("SH_DENYRW", "R" , "SH_DENYRD", "R" , "DENY"),
-    ("SH_DENYRW", "R" , "SH_DENYRD", "W" , "DENY"),
-    ("SH_DENYRW", "R" , "SH_DENYRD", "RW", "DENY"),
-    ("SH_DENYRW", "R" , "SH_DENYNO", "R" , "DENY"),
-    ("SH_DENYRW", "R" , "SH_DENYNO", "W" , "DENY"),
-    ("SH_DENYRW", "R" , "SH_DENYNO", "RW", "DENY"),
-
-# All    W |C C C  N N N  N N N  N N N  N N N.
-    ("SH_DENYRW", "W" , "SH_COMPAT", "R" , "INT24"),
-    ("SH_DENYRW", "W" , "SH_COMPAT", "W" , "INT24"),
-    ("SH_DENYRW", "W" , "SH_COMPAT", "RW", "INT24"),
-    ("SH_DENYRW", "W" , "SH_DENYRW", "R" , "DENY"),
-    ("SH_DENYRW", "W" , "SH_DENYRW", "W" , "DENY"),
-    ("SH_DENYRW", "W" , "SH_DENYRW", "RW", "DENY"),
-    ("SH_DENYRW", "W" , "SH_DENYWR", "R" , "DENY"),
-    ("SH_DENYRW", "W" , "SH_DENYWR", "W" , "DENY"),
-    ("SH_DENYRW", "W" , "SH_DENYWR", "RW", "DENY"),
-    ("SH_DENYRW", "W" , "SH_DENYRD", "R" , "DENY"),
-    ("SH_DENYRW", "W" , "SH_DENYRD", "W" , "DENY"),
-    ("SH_DENYRW", "W" , "SH_DENYRD", "RW", "DENY"),
-    ("SH_DENYRW", "W" , "SH_DENYNO", "R" , "DENY"),
-    ("SH_DENYRW", "W" , "SH_DENYNO", "W" , "DENY"),
-    ("SH_DENYRW", "W" , "SH_DENYNO", "RW", "DENY"),
-
-#        RW|C C C  N N N  N N N  N N N  N N N
-    ("SH_DENYRW", "RW", "SH_COMPAT", "R" , "INT24"),
-    ("SH_DENYRW", "RW", "SH_COMPAT", "W" , "INT24"),
-    ("SH_DENYRW", "RW", "SH_COMPAT", "RW", "INT24"),
-    ("SH_DENYRW", "RW", "SH_DENYRW", "R" , "DENY"),
-    ("SH_DENYRW", "RW", "SH_DENYRW", "W" , "DENY"),
-    ("SH_DENYRW", "RW", "SH_DENYRW", "RW", "DENY"),
-    ("SH_DENYRW", "RW", "SH_DENYWR", "R" , "DENY"),
-    ("SH_DENYRW", "RW", "SH_DENYWR", "W" , "DENY"),
-    ("SH_DENYRW", "RW", "SH_DENYWR", "RW", "DENY"),
-    ("SH_DENYRW", "RW", "SH_DENYRD", "R" , "DENY"),
-    ("SH_DENYRW", "RW", "SH_DENYRD", "W" , "DENY"),
-    ("SH_DENYRW", "RW", "SH_DENYRD", "RW", "DENY"),
-    ("SH_DENYRW", "RW", "SH_DENYNO", "R" , "DENY"),
-    ("SH_DENYRW", "RW", "SH_DENYNO", "W" , "DENY"),
-    ("SH_DENYRW", "RW", "SH_DENYNO", "RW", "DENY"),
-
-# Deny   R |2 C C  N N N  Y N N  N N N  Y N N
     ("SH_DENYWR", "R" , "SH_COMPAT", "R" , "ALLOW"), # File RO success, W fails INT24. For MS-DOS-7: always success.
-    ("SH_DENYWR", "R" , "SH_COMPAT", "W" , "INT24"),
-    ("SH_DENYWR", "R" , "SH_COMPAT", "RW", "INT24"),
-    ("SH_DENYWR", "R" , "SH_DENYRW", "R" , "DENY"),
-    ("SH_DENYWR", "R" , "SH_DENYRW", "W" , "DENY"),
-    ("SH_DENYWR", "R" , "SH_DENYRW", "RW", "DENY"),
-    ("SH_DENYWR", "R" , "SH_DENYWR", "R" , "ALLOW"),
-    ("SH_DENYWR", "R" , "SH_DENYWR", "W" , "DENY"),
-    ("SH_DENYWR", "R" , "SH_DENYWR", "RW", "DENY"),
-    ("SH_DENYWR", "R" , "SH_DENYRD", "R" , "DENY"),
-    ("SH_DENYWR", "R" , "SH_DENYRD", "W" , "DENY"),
-    ("SH_DENYWR", "R" , "SH_DENYRD", "RW", "DENY"),
-    ("SH_DENYWR", "R" , "SH_DENYNO", "R" , "ALLOW"),
-    ("SH_DENYWR", "R" , "SH_DENYNO", "W" , "DENY"),
-    ("SH_DENYWR", "R" , "SH_DENYNO", "RW", "DENY"),
-
-# Write  W |C C C  N N N  N N N  Y N N  Y N N.
-    ("SH_DENYWR", "W" , "SH_COMPAT", "R" , "INT24"),
-    ("SH_DENYWR", "W" , "SH_COMPAT", "W" , "INT24"),
-    ("SH_DENYWR", "W" , "SH_COMPAT", "RW", "INT24"),
-    ("SH_DENYWR", "W" , "SH_DENYRW", "R" , "DENY"),
-    ("SH_DENYWR", "W" , "SH_DENYRW", "W" , "DENY"),
-    ("SH_DENYWR", "W" , "SH_DENYRW", "RW", "DENY"),
-    ("SH_DENYWR", "W" , "SH_DENYWR", "R" , "DENY"),
-    ("SH_DENYWR", "W" , "SH_DENYWR", "W" , "DENY"),
-    ("SH_DENYWR", "W" , "SH_DENYWR", "RW", "DENY"),
-    ("SH_DENYWR", "W" , "SH_DENYRD", "R" , "ALLOW"),
-    ("SH_DENYWR", "W" , "SH_DENYRD", "W" , "DENY"),
-    ("SH_DENYWR", "W" , "SH_DENYRD", "RW", "DENY"),
-    ("SH_DENYWR", "W" , "SH_DENYNO", "R" , "ALLOW"),
-    ("SH_DENYWR", "W" , "SH_DENYNO", "W" , "DENY"),
-    ("SH_DENYWR", "W" , "SH_DENYNO", "RW", "DENY"),
-
-#        RW|C C C  N N N  N N N  N N N  Y N N
-    ("SH_DENYWR", "RW", "SH_COMPAT", "R" , "INT24"),
-    ("SH_DENYWR", "RW", "SH_COMPAT", "W" , "INT24"),
-    ("SH_DENYWR", "RW", "SH_COMPAT", "RW", "INT24"),
-    ("SH_DENYWR", "RW", "SH_DENYRW", "R" , "DENY"),
-    ("SH_DENYWR", "RW", "SH_DENYRW", "W" , "DENY"),
-    ("SH_DENYWR", "RW", "SH_DENYRW", "RW", "DENY"),
-    ("SH_DENYWR", "RW", "SH_DENYWR", "R" , "DENY"),
-    ("SH_DENYWR", "RW", "SH_DENYWR", "W" , "DENY"),
-    ("SH_DENYWR", "RW", "SH_DENYWR", "RW", "DENY"),
-    ("SH_DENYWR", "RW", "SH_DENYRD", "R" , "DENY"),
-    ("SH_DENYWR", "RW", "SH_DENYRD", "W" , "DENY"),
-    ("SH_DENYWR", "RW", "SH_DENYRD", "RW", "DENY"),
-    ("SH_DENYWR", "RW", "SH_DENYNO", "R" , "ALLOW"),
-    ("SH_DENYWR", "RW", "SH_DENYNO", "W" , "DENY"),
-    ("SH_DENYWR", "RW", "SH_DENYNO", "RW", "DENY"),
-
-# Deny   R |C C C  N N N  N Y N  N N N  N Y N
-    ("SH_DENYRD", "R" , "SH_COMPAT", "R" , "INT24"),
-    ("SH_DENYRD", "R" , "SH_COMPAT", "W" , "INT24"),
-    ("SH_DENYRD", "R" , "SH_COMPAT", "RW", "INT24"),
-    ("SH_DENYRD", "R" , "SH_DENYRW", "R" , "DENY"),
-    ("SH_DENYRD", "R" , "SH_DENYRW", "W" , "DENY"),
-    ("SH_DENYRD", "R" , "SH_DENYRW", "RW", "DENY"),
-    ("SH_DENYRD", "R" , "SH_DENYWR", "R" , "DENY"),
-    ("SH_DENYRD", "R" , "SH_DENYWR", "W" , "ALLOW"),
-    ("SH_DENYRD", "R" , "SH_DENYWR", "RW", "DENY"),
-    ("SH_DENYRD", "R" , "SH_DENYRD", "R" , "DENY"),
-    ("SH_DENYRD", "R" , "SH_DENYRD", "W" , "DENY"),
-    ("SH_DENYRD", "R" , "SH_DENYRD", "RW", "DENY"),
-    ("SH_DENYRD", "R" , "SH_DENYNO", "R" , "DENY"),
-    ("SH_DENYRD", "R" , "SH_DENYNO", "W" , "ALLOW"),
-    ("SH_DENYRD", "R" , "SH_DENYNO", "RW", "DENY"),
-
-# Read   W |C C C  N N N  N N N  N Y N  N Y N.
-    ("SH_DENYRD", "W" , "SH_COMPAT", "R" , "INT24"),
-    ("SH_DENYRD", "W" , "SH_COMPAT", "W" , "INT24"),
-    ("SH_DENYRD", "W" , "SH_COMPAT", "RW", "INT24"),
-    ("SH_DENYRD", "W" , "SH_DENYRW", "R" , "DENY"),
-    ("SH_DENYRD", "W" , "SH_DENYRW", "W" , "DENY"),
-    ("SH_DENYRD", "W" , "SH_DENYRW", "RW", "DENY"),
-    ("SH_DENYRD", "W" , "SH_DENYWR", "R" , "DENY"),
-    ("SH_DENYRD", "W" , "SH_DENYWR", "W" , "DENY"),
-    ("SH_DENYRD", "W" , "SH_DENYWR", "RW", "DENY"),
-    ("SH_DENYRD", "W" , "SH_DENYRD", "R" , "DENY"),
-    ("SH_DENYRD", "W" , "SH_DENYRD", "W" , "ALLOW"),
-    ("SH_DENYRD", "W" , "SH_DENYRD", "RW", "DENY"),
-    ("SH_DENYRD", "W" , "SH_DENYNO", "R" , "DENY"),
-    ("SH_DENYRD", "W" , "SH_DENYNO", "W" , "ALLOW"),
-    ("SH_DENYRD", "W" , "SH_DENYNO", "RW", "DENY"),
-
-#        RW|C C C  N N N  N N N  N N N  N Y N
-    ("SH_DENYRD", "RW", "SH_COMPAT", "R" , "INT24"),
-    ("SH_DENYRD", "RW", "SH_COMPAT", "W" , "INT24"),
-    ("SH_DENYRD", "RW", "SH_COMPAT", "RW", "INT24"),
-    ("SH_DENYRD", "RW", "SH_DENYRW", "R" , "DENY"),
-    ("SH_DENYRD", "RW", "SH_DENYRW", "W" , "DENY"),
-    ("SH_DENYRD", "RW", "SH_DENYRW", "RW", "DENY"),
-    ("SH_DENYRD", "RW", "SH_DENYWR", "R" , "DENY"),
-    ("SH_DENYRD", "RW", "SH_DENYWR", "W" , "DENY"),
-    ("SH_DENYRD", "RW", "SH_DENYWR", "RW", "DENY"),
-    ("SH_DENYRD", "RW", "SH_DENYRD", "R" , "DENY"),
-    ("SH_DENYRD", "RW", "SH_DENYRD", "W" , "DENY"),
-    ("SH_DENYRD", "RW", "SH_DENYRD", "RW", "DENY"),
-    ("SH_DENYRD", "RW", "SH_DENYNO", "R" , "DENY"),
-    ("SH_DENYRD", "RW", "SH_DENYNO", "W" , "ALLOW"),
-    ("SH_DENYRD", "RW", "SH_DENYNO", "RW", "DENY"),
-
-# Deny   R |2 C C  N N N  Y Y Y  N N N  Y Y Y
     ("SH_DENYNO", "R" , "SH_COMPAT", "R" , "ALLOW"), # File RO success, W fails INT24. For MS-DOS-7: always success.
-    ("SH_DENYNO", "R" , "SH_COMPAT", "W" , "INT24"),
-    ("SH_DENYNO", "R" , "SH_COMPAT", "RW", "INT24"),
-    ("SH_DENYNO", "R" , "SH_DENYRW", "R" , "DENY"),
-    ("SH_DENYNO", "R" , "SH_DENYRW", "W" , "DENY"),
-    ("SH_DENYNO", "R" , "SH_DENYRW", "RW", "DENY"),
-    ("SH_DENYNO", "R" , "SH_DENYWR", "R" , "ALLOW"),
-    ("SH_DENYNO", "R" , "SH_DENYWR", "W" , "ALLOW"),
-    ("SH_DENYNO", "R" , "SH_DENYWR", "RW", "ALLOW"),
-    ("SH_DENYNO", "R" , "SH_DENYRD", "R" , "DENY"),
-    ("SH_DENYNO", "R" , "SH_DENYRD", "W" , "DENY"),
-    ("SH_DENYNO", "R" , "SH_DENYRD", "RW", "DENY"),
-    ("SH_DENYNO", "R" , "SH_DENYNO", "R" , "ALLOW"),
-    ("SH_DENYNO", "R" , "SH_DENYNO", "W" , "ALLOW"),
-    ("SH_DENYNO", "R" , "SH_DENYNO", "RW", "ALLOW"),
-
-# None   W |C C C  N N N  N N N  Y Y Y  Y Y Y.
-    ("SH_DENYNO", "W" , "SH_COMPAT", "R" , "INT24"),
-    ("SH_DENYNO", "W" , "SH_COMPAT", "W" , "INT24"),
-    ("SH_DENYNO", "W" , "SH_COMPAT", "RW", "INT24"),
-    ("SH_DENYNO", "W" , "SH_DENYRW", "R" , "DENY"),
-    ("SH_DENYNO", "W" , "SH_DENYRW", "W" , "DENY"),
-    ("SH_DENYNO", "W" , "SH_DENYRW", "RW", "DENY"),
-    ("SH_DENYNO", "W" , "SH_DENYWR", "R" , "DENY"),
-    ("SH_DENYNO", "W" , "SH_DENYWR", "W" , "DENY"),
-    ("SH_DENYNO", "W" , "SH_DENYWR", "RW", "DENY"),
-    ("SH_DENYNO", "W" , "SH_DENYRD", "R" , "ALLOW"),
-    ("SH_DENYNO", "W" , "SH_DENYRD", "W" , "ALLOW"),
-    ("SH_DENYNO", "W" , "SH_DENYRD", "RW", "ALLOW"),
-    ("SH_DENYNO", "W" , "SH_DENYNO", "R" , "ALLOW"),
-    ("SH_DENYNO", "W" , "SH_DENYNO", "W" , "ALLOW"),
-    ("SH_DENYNO", "W" , "SH_DENYNO", "RW", "ALLOW"),
-
-#        RW|C C C  N N N  N N N  N N N  Y Y Y
-    ("SH_DENYNO", "RW", "SH_COMPAT", "R" , "INT24"),
-    ("SH_DENYNO", "RW", "SH_COMPAT", "W" , "INT24"),
-    ("SH_DENYNO", "RW", "SH_COMPAT", "RW", "INT24"),
-    ("SH_DENYNO", "RW", "SH_DENYRW", "R" , "DENY"),
-    ("SH_DENYNO", "RW", "SH_DENYRW", "W" , "DENY"),
-    ("SH_DENYNO", "RW", "SH_DENYRW", "RW", "DENY"),
-    ("SH_DENYNO", "RW", "SH_DENYWR", "R" , "DENY"),
-    ("SH_DENYNO", "RW", "SH_DENYWR", "W" , "DENY"),
-    ("SH_DENYNO", "RW", "SH_DENYWR", "RW", "DENY"),
-    ("SH_DENYNO", "RW", "SH_DENYRD", "R" , "DENY"),
-    ("SH_DENYNO", "RW", "SH_DENYRD", "W" , "DENY"),
-    ("SH_DENYNO", "RW", "SH_DENYRD", "RW", "DENY"),
-    ("SH_DENYNO", "RW", "SH_DENYNO", "R" , "ALLOW"),
-    ("SH_DENYNO", "RW", "SH_DENYNO", "W" , "ALLOW"),
-    ("SH_DENYNO", "RW", "SH_DENYNO", "RW", "ALLOW"),
-)
+])
 
 
 def ds3_share_open_twice(self, fstype):

--- a/test/test_dosemu.py
+++ b/test/test_dosemu.py
@@ -5156,6 +5156,7 @@ MSDOS700TestCase = msdos700(OurTestCase, {
     "test_command_com_cmdline_length_old_dos01": UNSUPPORTED,
     "test_command_com_cmdline_length_old_dos02": UNSUPPORTED,
     "test_fat32_img_d_writable": UNSUPPORTED,
+    "test_fat_ds3_share_open_twice": UNSUPPORTED,
     "test_fat_label_create_bpb32": UNSUPPORTED,
     "test_lfn_volume_info_fat16": KNOWNFAIL,
     "test_lfn_volume_info_fat32": UNSUPPORTED,
@@ -5168,6 +5169,7 @@ MSDOS710TestCase = msdos710(OurTestCase, {
     "test_comcom_r200fix_protected": UNSUPPORTED,
     "test_command_com_cmdline_length_old_dos01": UNSUPPORTED,
     "test_command_com_cmdline_length_old_dos02": UNSUPPORTED,
+    "test_fat_ds3_share_open_twice": UNSUPPORTED,
 })
 
 PPDOSGITTestCase = ppdosgit(OurTestCase, {


### PR DESCRIPTION
Some entries in the test matrix for share open twice specify that the open() should cause an Int24 to be generated. Add a handler to the test and see if we got called.