### PR TITLE
Packaging: Debian packaging for 32bit RaspiOS

### DIFF
--- a/debian/dosemu2-dev.install
+++ b/debian/dosemu2-dev.install
@@ -1,2 +1,2 @@
 usr/include/dosemu2/*
-usr/lib/*-linux-gnu/*.so
+usr/lib/*-linux-gnu*/*.so

--- a/debian/dosemu2.install
+++ b/debian/dosemu2.install
@@ -1,6 +1,6 @@
 etc/dosemu2.alias etc/X11/fonts/misc/
 usr/bin/*
-usr/lib/*-linux-gnu/*.so.*
+usr/lib/*-linux-gnu*/*.so.*
 usr/lib/sysusers.d/dosemu2.conf
 usr/libexec/dosemu2/dosemu2.bin
 usr/share/man/man1/*


### PR DESCRIPTION
On RaspiOS 32 bit the library install path is
/usr/lib/arm-linux-gnueabihf so we need to wildcard the packaging to accommodate.