### PR TITLE
Use HOST_PAGE_* instead of PAGE_* in DPMI and simx86

### DIFF
--- a/src/base/emu-i386/simx86/codegen.c
+++ b/src/base/emu-i386/simx86/codegen.c
@@ -730,18 +730,18 @@ unsigned int DoExec(TNode *G)
 	return ePC;
 }
 
-#define fB(c,x) (((uint8_t *)(c))[(x) & ~_PAGE_MASK])
+#define fB(c,x) (((uint8_t *)(c))[(x) & ~HOST_PAGE_MASK])
 static inline uint16_t fW(void *c, dosaddr_t x)
 {
 	if (x & 1)
 		return ((fB(c, x + 1) << 8) | fB(c, x));
-	return (((uint16_t *)(c))[(x & ~_PAGE_MASK) >> 1]);
+	return (((uint16_t *)(c))[(x & ~HOST_PAGE_MASK) >> 1]);
 }
 static inline uint32_t fD(void *c, dosaddr_t x)
 {
 	if (x & 3)
 		return (((uint32_t)fW(c, x + 2) << 16) | fW(c, x));
-	return (((uint32_t *)(c))[(x & ~_PAGE_MASK) >> 2]);
+	return (((uint32_t *)(c))[(x & ~HOST_PAGE_MASK) >> 2]);
 }
 
 uint8_t jit_fetch_byte(dosaddr_t x)
@@ -759,7 +759,7 @@ uint16_t jit_fetch_word(dosaddr_t x)
 	if ((x & ~CGRMASK) != ((x + 1) & ~CGRMASK))
 		return ((jit_fetch_byte(x + 1) << 8) | jit_fetch_byte(x));
 	e_fetch(x, 2, cache);
-	if ((x & _PAGE_MASK) != ((x + 1) & _PAGE_MASK))
+	if ((x & HOST_PAGE_MASK) != ((x + 1) & HOST_PAGE_MASK))
 		return ((fB(cache[1], x + 1) << 8) | fB(cache[0], x));
 	return fW(cache[0], x);
 }
@@ -772,7 +772,7 @@ uint32_t jit_fetch_dword(dosaddr_t x)
 		return (((uint32_t)jit_fetch_word(x + 2) << 16) |
 				jit_fetch_word(x));
 	e_fetch(x, 4, cache);
-	if ((x & _PAGE_MASK) != ((x + 3) & _PAGE_MASK)) {
+	if ((x & HOST_PAGE_MASK) != ((x + 3) & HOST_PAGE_MASK)) {
 		if (!(x & 1))
 			return (((uint32_t)fW(cache[1], x + 2) << 16) |
 					fW(cache[0], x));

--- a/src/base/emu-i386/simx86/emu86.h
+++ b/src/base/emu-i386/simx86/emu86.h
@@ -694,13 +694,6 @@ extern int SpecPrejits;
 #ifndef max
 #define max(a,b)	((a)>(b)?(a):(b))
 #endif
-#ifndef PAGE_SHIFT
-#define PAGE_SHIFT		12
-#endif
-#ifndef PAGE_SIZE
-#define PAGE_SIZE		(1UL << PAGE_SHIFT)
-#endif
-#define _PAGE_MASK		(~(PAGE_SIZE-1))
 #define CGRAN		0		/* 2^n */
 #define CGRMASK		(0xfffff>>CGRAN)
 

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -124,10 +124,10 @@ static TNode *DoClose(unsigned int PC, unsigned int Interp_LONG_CS, int mode,
 		 * be altered, so we better re-jit */
 		if (flags & F_PREJ)
 			return NULL;
-		abeg = P0 & _PAGE_MASK;
-		aend = PC & _PAGE_MASK;
+		abeg = P0 & HOST_PAGE_MASK;
+		aend = PC & HOST_PAGE_MASK;
 		/* re-populate cache */
-		for (; abeg <= aend; abeg += PAGE_SIZE)
+		for (; abeg <= aend; abeg += HOST_PAGE_SIZE)
 			Fetch(abeg);
 	    }
 	}

--- a/src/base/emu-i386/simx86/memory.c
+++ b/src/base/emu-i386/simx86/memory.c
@@ -60,12 +60,13 @@ int MaxCPages;
 
 typedef struct _mpmap {
 	struct _mpmap *next;
-	int mega;
-	void *pagemap[256];	/* 256 pages *4096 = 1M */
+	int mega, pages;
 	uint64_t subpage[(0x100000>>CGRAN)/UINT64_WIDTH];	/* 2^CGRAN-byte granularity, 1M/2^CGRAN bits */
 	uint64_t nodemap[0x100000/UINT64_WIDTH];
+	void *pagemap[];	/* pages=1M/HOST_PAGE_SIZE entries */
 } tMpMap;
 #define NM_MASK (0x100000/UINT64_WIDTH - 1)
+#define MEGA_SHIFT 20
 
 static tMpMap *MpH = NULL;
 int PageFaults = 0;
@@ -88,7 +89,7 @@ static void *FindC(unsigned int addr, int remove);
 
 static inline tMpMap *FindM(unsigned int addr)
 {
-	int a2l = addr >> (PAGE_SHIFT+8);
+	int a2l = addr >> MEGA_SHIFT;
 	tMpMap *M = LastMp;
 
 	if (M && (M->mega==a2l)) return M;
@@ -106,22 +107,25 @@ static void AddMpMap(unsigned int addr, unsigned int aend)
 {
 	int bs;
 	int page;
+	int pagespermega = (1<<MEGA_SHIFT) / HOST_PAGE_SIZE;
 	tMpMap *M;
 
 	M = FindM(addr);
 	if (M == NULL) {
-	    M = (tMpMap *)calloc(1,sizeof(tMpMap));
+	    M = (tMpMap *)calloc(1,sizeof(tMpMap) + pagespermega * sizeof(void *));
+	    M->pages = pagespermega;
 	    M->next = MpH; MpH = M;
-	    M->mega = addr >> 20;
+	    M->mega = addr >> MEGA_SHIFT;
 	}
-	page = (addr >> PAGE_SHIFT) & 255;
-	for (; addr <= aend; addr += PAGE_SIZE, page++) {
-	    if (page == 256) {
+	page = (addr / HOST_PAGE_SIZE) & (pagespermega - 1);
+	for (; addr <= aend; addr += HOST_PAGE_SIZE, page++) {
+	    if (page == pagespermega) {
 		M = FindM(addr);
 		if (M == NULL) {
-		    M = (tMpMap *)calloc(1,sizeof(tMpMap));
+		    M = (tMpMap *)calloc(1,sizeof(tMpMap) + (pagespermega * sizeof(void *)));
+		    M->pages = pagespermega;
 		    M->next = MpH; MpH = M;
-		    M->mega = addr >> 20;
+		    M->mega = addr >> MEGA_SHIFT;
 		}
 		page = 0;
 	    }
@@ -140,12 +144,12 @@ static int do_rm_page(tMpMap *P, tMpMap *M, int page)
 
 	free(M->pagemap[page]);
 	M->pagemap[page] = NULL;
-	for (i = 0; i < ARRAY_SIZE(M->pagemap); i++) {
+	for (i = 0; i < M->pages; i++) {
 	    if (M->pagemap[i])
 		break;
 	}
 	/* completely empty, remove */
-	if (i == ARRAY_SIZE(M->pagemap)) {
+	if (i == M->pages) {
 	    if (debug_level('e')>1)
 		dbug_printf("MPMAP: removing 0x%x\n", M->mega);
 	    if (P)
@@ -167,17 +171,17 @@ static void RmMpMap(unsigned int addr, unsigned int aend)
 	tMpMap *M, *P;
 	void *p;
 
-	for (; addr <= aend; addr += PAGE_SIZE) {
-	    page = addr >> PAGE_SHIFT;
+	for (; addr <= aend; addr += HOST_PAGE_SIZE) {
+	    page = addr / HOST_PAGE_SIZE;
 	    P = NULL;
 	    M = MpH;
 	    while (M) {
-		if (M->mega==(page>>8)) break;
+		if (M->mega==(page/M->pages)) break;
 		P = M;
 		M = M->next;
 	    }
 	    if (M==NULL) continue;
-	    page &= 255;
+	    page &= M->pages - 1;
 	    p = M->pagemap[page];
 	    bs = !!p;
 	    if (p)
@@ -189,33 +193,34 @@ static void RmMpMap(unsigned int addr, unsigned int aend)
 
 int e_querymprot(dosaddr_t addr)
 {
-	int a2 = addr >> PAGE_SHIFT;
+	int a2 = addr / HOST_PAGE_SIZE;
 	tMpMap *M = FindM(addr);
 
 	if (M==NULL) return 0;
-	return !!M->pagemap[a2&255];
+	return !!M->pagemap[a2&(M->pages-1)];
 }
 
 int e_querymprotrange(unsigned int addr, size_t len)
 {
 	int a2l, a2h;
+	int pagespermega = (1<<MEGA_SHIFT) / HOST_PAGE_SIZE;
 	tMpMap *M = FindM(addr);
 
-	a2l = addr >> PAGE_SHIFT;
-	a2h = (addr+len-1) >> PAGE_SHIFT;
+	a2l = addr / HOST_PAGE_SIZE;
+	a2h = (addr+len-1) / HOST_PAGE_SIZE;
 
 	if (!M)
-		a2l &= ~0xff;
+		a2l &= ~(pagespermega-1);
 	while (a2l <= a2h) {
 		if (M) {
-			if (M->pagemap[a2l&255])
+			if (M->pagemap[a2l&(M->pages-1)])
 				return 1;
 			a2l++;
-			if ((a2l&255)==0)
-				M = FindM(a2l << PAGE_SHIFT);
+			if ((a2l&(M->pages-1))==0)
+				M = FindM(a2l * HOST_PAGE_SIZE);
 		} else {
-			a2l += 256;
-			M = FindM(a2l << PAGE_SHIFT);
+			a2l += pagespermega;
+			M = FindM(a2l * HOST_PAGE_SIZE);
 		}
 	}
 	return 0;
@@ -226,15 +231,15 @@ int e_querymprotrange_full(unsigned int addr, size_t len)
 	int a2l, a2h;
 	tMpMap *M = FindM(addr);
 
-	a2l = addr >> PAGE_SHIFT;
-	a2h = (addr+len-1) >> PAGE_SHIFT;
+	a2l = addr / HOST_PAGE_SIZE;
+	a2h = (addr+len-1) / HOST_PAGE_SIZE;
 
 	while (M && a2l <= a2h) {
-		if (!M->pagemap[a2l&255])
+		if (!M->pagemap[a2l&(M->pages-1)])
 			return 0;
 		a2l++;
-		if ((a2l&255)==0)
-			M = FindM(a2l << PAGE_SHIFT);
+		if ((a2l&(M->pages-1))==0)
+			M = FindM(a2l * HOST_PAGE_SIZE);
 	}
 	if (!M)
 		return 0;
@@ -298,14 +303,14 @@ int e_unmarkpage(unsigned int addr, size_t len)
 	}
 
 	/* check if unmarked pages have no more code, and if so, unprotect */
-	abeg = addr & _PAGE_MASK;
-	aend = PAGE_ALIGN(addr + len);
+	abeg = addr & HOST_PAGE_MASK;
+	aend = HOST_PAGE_ALIGN(addr + len);
 	/* don't unprotect partial first page with code */
 	if (abeg != addr && e_querymark(abeg, addr - abeg))
-		abeg += PAGE_SIZE;
+		abeg += HOST_PAGE_SIZE;
 	/* don't unprotect partial last page with code */
 	if (aend != addr + len && e_querymark(addr + len, aend - (addr + len)))
-		aend -= PAGE_SIZE;
+		aend -= HOST_PAGE_SIZE;
 
 	if (aend > abeg)
 		e_munprotect(abeg, aend - abeg);
@@ -429,7 +434,7 @@ static void *NewC(unsigned int abeg)
 
 	assert(num_clist < CLIST_MAX);
 	ce = &clist[num_clist++];
-	p = malloc(PAGE_SIZE);
+	p = malloc(HOST_PAGE_SIZE);
 	ce->addr = abeg;
 	ce->data = p;
 	ce->alive_cnt = CALIVE_CNT;
@@ -499,17 +504,18 @@ void e_mdrop(void)
 void e_fetch(unsigned int addr, size_t len, void **ret)
 {
 	unsigned int abeg, aend, page, off, l;
+	int pagespermega = (1<<MEGA_SHIFT) / HOST_PAGE_SIZE;
 	void *p0 = NULL, *p1 = NULL;
 	tMpMap *M = NULL;
 
 	/* cover only 2 pages max */
-	assert(len && len <= PAGE_SIZE);
-	abeg = addr & _PAGE_MASK;
-	aend = (addr+len-1) & _PAGE_MASK;
+	assert(len && len <= HOST_PAGE_SIZE);
+	abeg = addr & HOST_PAGE_MASK;
+	aend = (addr+len-1) & HOST_PAGE_MASK;
 	/* we do not support MB-crossing transactions */
 	assert((abeg & ~CGRMASK) == (aend & ~CGRMASK));
-	page = (abeg >> PAGE_SHIFT) & 255;
-	off = addr & ~_PAGE_MASK;
+	page = (abeg / HOST_PAGE_SIZE) & (pagespermega - 1);
+	off = addr & ~HOST_PAGE_MASK;
 	p0 = FindC(abeg, 0);
 	if (!p0 && (M = FindM(abeg)))
 	    p0 = M->pagemap[page];  // may be NULL
@@ -540,10 +546,10 @@ static void do_mprotect(unsigned int addr, size_t len)
 	unsigned a;
 
 	assert(len);
-	abeg = addr & _PAGE_MASK;
-	aend = (addr+len-1) & _PAGE_MASK;
+	abeg = addr & HOST_PAGE_MASK;
+	aend = (addr+len-1) & HOST_PAGE_MASK;
 	/* only protect ranges that were not already protected by e_mprotect */
-	for (a = abeg; a <= aend; a += PAGE_SIZE) {
+	for (a = abeg; a <= aend; a += HOST_PAGE_SIZE) {
 	    int qp = e_querymprot(a);
 	    if (!qp) {
 		if (abeg1 == (unsigned)-1)
@@ -551,13 +557,13 @@ static void do_mprotect(unsigned int addr, size_t len)
 		aend1 = a;
 	    }
 	    if ((a == aend || qp) && abeg1 != (unsigned)-1) {
-		e = mprotect_mapping(MAPPING_CPUEMU, abeg1, aend1-abeg1+PAGE_SIZE,
+		e = mprotect_mapping(MAPPING_CPUEMU, abeg1, aend1-abeg1+HOST_PAGE_SIZE,
 			    PROT_READ | _PROT_EXEC);
 		if (e<0) {
 		    error("MPMAP: %s\n",strerror(errno));
 		    exit(1);
 		}
-		AddMpMap(abeg1, aend1+PAGE_SIZE-1);
+		AddMpMap(abeg1, aend1+HOST_PAGE_SIZE-1);
 		abeg1 = (unsigned)-1;
 	    }
 	}
@@ -576,15 +582,15 @@ static void e_munprotect(unsigned int addr, size_t len)
 	unsigned int abeg1 = (unsigned)-1;
 	unsigned a;
 
-	abeg = addr & _PAGE_MASK;
+	abeg = addr & HOST_PAGE_MASK;
 	if (len==0) {
 	    aend = abeg;
 	}
 	else {
-	    aend = (addr+len-1) & _PAGE_MASK;
+	    aend = (addr+len-1) & HOST_PAGE_MASK;
 	}
 	/* only unprotect ranges that were protected by e_mprotect */
-	for (a = abeg; a <= aend; a += PAGE_SIZE) {
+	for (a = abeg; a <= aend; a += HOST_PAGE_SIZE) {
 	    int qp = e_querymprot(a);
 	    if (qp) {
 		if (abeg1 == (unsigned)-1)
@@ -592,13 +598,13 @@ static void e_munprotect(unsigned int addr, size_t len)
 		aend1 = a;
 	    }
 	    if ((a == aend || !qp) && abeg1 != (unsigned)-1) {
-		e = mprotect_mapping(MAPPING_CPUEMU, abeg1, aend1-abeg1+PAGE_SIZE,
+		e = mprotect_mapping(MAPPING_CPUEMU, abeg1, aend1-abeg1+HOST_PAGE_SIZE,
 			     PROT_RWX);
 		if (e<0) {
 		    e_printf("MPUNMAP: %s\n",strerror(errno));
 		    exit(1);
 		}
-		RmMpMap(abeg1, aend1+PAGE_SIZE-1);
+		RmMpMap(abeg1, aend1+HOST_PAGE_SIZE-1);
 		abeg1 = (unsigned)-1;
 	    }
 	}
@@ -608,13 +614,13 @@ static void e_munprotect(unsigned int addr, size_t len)
 static int subpage_dirty(uint8_t *p, uint8_t *p1, tMpMap *M, int page)
 {
     int i, n;
-    uint64_t *bitmask = &M->subpage[page << (PAGE_SHIFT - 6)];
-    for (i = 0; i < PAGE_SIZE >> 6 /*64*/; i++) {
+    uint64_t *bitmask = &M->subpage[page * (HOST_PAGE_SIZE >> 6)];
+    for (i = 0; i < HOST_PAGE_SIZE >> 6; i++) {
 	n = -1;
 	while ((n = find_bit64_from(bitmask[i], n + 1)) != -1) {
 	    int bnum = i * 64 + n;
 #if MPMAP_DEBUG
-	    dosaddr_t addr = (M->mega << 20) | (page << PAGE_SHIFT) | bnum;
+	    dosaddr_t addr = (M->mega << MEGA_SHIFT) | (page * HOST_PAGE_SIZE) | bnum;
 	    if (test_bit(addr&CGRMASK, M->nodemap))
 		assert(FindTree(addr));
 #endif
@@ -630,21 +636,22 @@ void e_invalidate_dirty(unsigned int addr, unsigned int aend)
 {
 	int bs=0;
 	int page;
+	int pagespermega = (1<<MEGA_SHIFT) / HOST_PAGE_SIZE;
 	tMpMap *M = NULL;
 	void *p;
 
-	page = (addr >> PAGE_SHIFT) & 255;
-	for (; addr <= aend; addr += PAGE_SIZE, page++) {
-	    if (page == 256) {
+	page = (addr / HOST_PAGE_SIZE) & (pagespermega - 1);
+	for (; addr <= aend; addr += HOST_PAGE_SIZE, page++) {
+	    if (page == pagespermega) {
 		M = NULL;
 		page = 0;
 	    }
 	    if (!M) {
 		M = FindM(addr);
 		if (!M) {
-		    int inc = 255 - page;
-		    page = 255;
-		    addr += inc * PAGE_SIZE;
+		    int inc = pagespermega - 1 - page;
+		    page = pagespermega - 1;
+		    addr += inc * HOST_PAGE_SIZE;
 		    continue;
 		}
 	    }
@@ -669,7 +676,7 @@ void e_invalidate_page_dirty(unsigned int addr)
 
 	M = FindM(addr);
 	if (M==NULL) return;
-	page = (addr >> PAGE_SHIFT) & 255;
+	page = (addr / HOST_PAGE_SIZE) & (M->pages - 1);
 	p = M->pagemap[page];
 	bs = 0;
 	if (p && subpage_dirty(p, EMU_BASE32(addr), M, page)) {
@@ -688,9 +695,9 @@ void e_invalidate_dirty_full(void)
 again:
 	M = MpH;
 	while (M) {
-	    for (i=0; i<ARRAY_SIZE(M->pagemap); i++) {
+	    for (i=0; i<M->pages; i++) {
 		void *p = M->pagemap[i];
-		dosaddr_t addr = (M->mega<<20) | (i<<PAGE_SHIFT);
+		dosaddr_t addr = (M->mega<<MEGA_SHIFT) | (i*HOST_PAGE_SIZE);
 		void *p1 = EMU_BASE32(addr);
 		if (p && subpage_dirty(p, p1, M, i)) {
 		    if (debug_level('e')>1)
@@ -810,11 +817,11 @@ again:
 	M = MpH;
 	M2 = NULL;
 	while (M) {
-	    for (i=0; i<ARRAY_SIZE(M->pagemap); i++) if (M->pagemap[i]) {
-		unsigned int addr = (M->mega<<20) | (i<<PAGE_SHIFT);
+	    for (i=0; i<M->pages; i++) if (M->pagemap[i]) {
+		unsigned int addr = (M->mega<<MEGA_SHIFT) | (i*HOST_PAGE_SIZE);
 		if (debug_level('e')>1)
 		    dbug_printf("MP_END %08x = RWX\n",addr);
-		mprotect_mapping(MAPPING_CPUEMU, addr, PAGE_SIZE, PROT_RWX);
+		mprotect_mapping(MAPPING_CPUEMU, addr, HOST_PAGE_SIZE, PROT_RWX);
 		if (do_rm_page(M2, M, i))
 		    goto again;
 	    }

--- a/src/base/emu-i386/simx86/sigsegv.c
+++ b/src/base/emu-i386/simx86/sigsegv.c
@@ -413,8 +413,8 @@ int e_handle_pagefault(dosaddr_t addr, unsigned err, sigcontext_t *scp)
 #endif
 	/* We HAVE to invalidate all the code in the page
 	 * if the page is going to be unprotected */
-	addr &= _PAGE_MASK;
-	InvalidateNodeRangeFromFault(addr, PAGE_SIZE, pjit);
+	addr &= HOST_PAGE_MASK;
+	InvalidateNodeRangeFromFault(addr, HOST_PAGE_SIZE, pjit);
 	return 1;
 }
 

--- a/src/base/emu-i386/simx86/trees.c
+++ b/src/base/emu-i386/simx86/trees.c
@@ -735,8 +735,8 @@ void InvalidateNodeRangeFromFault(int al, int len, unsigned char *eip)
 /////////////////////////////////////////////////////////////////////////////
 static void do_invalidate(unsigned data, int cnt)
 {
-	cnt = PAGE_ALIGN(data + cnt) - (data & _PAGE_MASK);
-	data &= _PAGE_MASK;
+	cnt = PAGE_ALIGN(data + cnt) - (data & HOST_PAGE_MASK);
+	data &= HOST_PAGE_MASK;
 	InvalidateNodeRange(data, cnt);
 }
 
@@ -795,8 +795,8 @@ void e_invalidate_full(unsigned data, int cnt)
 
 int e_invalidate_page_full(unsigned data)
 {
-	int cnt = PAGE_SIZE;
-	data &= _PAGE_MASK;
+	int cnt = HOST_PAGE_SIZE;
+	data &= HOST_PAGE_MASK;
 	/* nothing to invalidate if there are no page protections */
 	if (!e_querymprotrange(data, cnt))
 		return 0;

--- a/src/base/lib/mapping/mapping.c
+++ b/src/base/lib/mapping/mapping.c
@@ -579,6 +579,9 @@ int mprotect_mapping(int cap, dosaddr_t targ, size_t mapsize, int protect)
 	cap, targ, mapsize, protect);
   invalidate_unprotected_page_cache(targ, mapsize);
   if (cap & MAPPING_CPUEMU) {
+    /* no need to mprotect with fullsim */
+    if (EMU_FULLSIM())
+      return 0;
     /* for cpuemu only mprotect JIT_BASE */
     ret = mprotect(MEM_BASE32x(targ, JIT_BASE), mapsize, protect);
     if (ret)

--- a/src/base/misc/mmio_tracing.c
+++ b/src/base/misc/mmio_tracing.c
@@ -15,7 +15,7 @@ static struct mmio_tracing_config mmio_tracing_config;
 
 static void mmio_tracing_scrub(void)
 {
-  if (!EMU_FULL())
+  if (!EMU_FULLSIM())
     error("MMIO: tracing is only only working for fully simulated cpu. "
           "Config must be set to '$_cpu_vm=\"emulated\"', '$_cpu_vm_dpmi=\"emulated\"' and '$_cpu_emu=\"fullsim\"'\n");
 }

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -4159,7 +4159,7 @@ void dpmi_setup(void)
     MEMCPY_2DOS(block->base, _binary_dpmisel_o_bin_start,
 		_binary_dpmisel_o_bin_end - _binary_dpmisel_o_bin_start);
     mprotect_mapping(MAPPING_DPMI, block->base,
-	    PAGE_ALIGN(DPMI_sel_code_end-DPMI_sel_code_start),
+	    HOST_PAGE_ALIGN(DPMI_sel_code_end-DPMI_sel_code_start),
 	    PROT_READ | DPMI_PROT_EXEC);
     err = SetSelector(_dpmi_sel16, block->base,
 		    DPMI_SEL_OFF(DPMI_sel_code_end)-1, 0,

--- a/src/dosext/dpmi/memory.c
+++ b/src/dosext/dpmi/memory.c
@@ -145,6 +145,7 @@ dpmi_pm_block *lookup_pm_block_by_shmname(dpmi_pm_block_root *root,
 static int commit(void *ptr, size_t size)
 {
   dosaddr_t targ = DOSADDR_REL(ptr);
+  size = HOST_PAGE_ALIGN(size);
   if (mprotect_mapping(MAPPING_DPMI, targ, size,
 	PROT_READ | PROT_WRITE | DPMI_PROT_EXEC) == -1)
     return 0;
@@ -154,6 +155,7 @@ static int commit(void *ptr, size_t size)
 
 static int uncommit(void *ptr, size_t size)
 {
+  size = HOST_PAGE_ALIGN(size);
   if (mprotect_mapping(MAPPING_DPMI, DOSADDR_REL(ptr), size, PROT_NONE) == -1)
     return 0;
   return 1;
@@ -163,12 +165,12 @@ unsigned dpmi_mem_size(void)
 {
     if (!config.dpmi)
 	return 0;
-    return PAGE_ALIGN(config.dpmi * 1024) +
-      PAGE_ALIGN(DPMI_pm_stack_size * DPMI_MAX_CLIENTS) +
-      PAGE_ALIGN(LDT_ENTRIES*LDT_ENTRY_SIZE) +
-      PAGE_ALIGN(DPMI_sel_code_end-DPMI_sel_code_start) +
+    return HOST_PAGE_ALIGN(config.dpmi * 1024) +
+      HOST_PAGE_ALIGN(DPMI_pm_stack_size * DPMI_MAX_CLIENTS) +
+      HOST_PAGE_ALIGN(LDT_ENTRIES*LDT_ENTRY_SIZE) +
+      HOST_PAGE_ALIGN(DPMI_sel_code_end-DPMI_sel_code_start) +
       dpmi_reserved_space +
-      (5 * DPMI_page_size); /* 5 extra pages */
+      HOST_PAGE_ALIGN(5 * DPMI_page_size); /* 5 extra pages */
 }
 
 void dump_maps(void)

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -154,7 +154,8 @@ typedef struct config_info {
        uint64_t boot_dos;
 
 #ifdef X86_EMULATOR
-       #define EMU_FULL() (EMU_V86() && EMU_DPMI())
+       #define EMU_FULL() (config.cpu_vm == CPUVM_EMU && config.cpu_vm_dpmi == CPUVM_EMU)
+       #define EMU_FULLSIM() (EMU_FULL() && config.cpusim)
        #define IS_EMU() (EMU_V86() || EMU_DPMI())
        boolean cpusim;
 #endif


### PR DESCRIPTION
This avoids calling mprotect with addresses and sizes not being a multiple of the host page size which could be 16k on RPi5.
I tested this by setting the HOST_PAGE_SIZE to 16384 on x86_64 and putting an assert on mprotect_mapping.

Should fix #2768 (to be confirmed)