### PR TITLE
mapping: implement softmmu for fullsim (POC, #2772)

### DIFF
--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -412,7 +412,8 @@ void map_memory_space(void)
     perror("LOWRAM alloc");
     leavedos(98);
   }
-  mem_reserve(memsize);
+  if (!EMU_FULLSIM())
+    mem_reserve(memsize);
   register_hardware_ram_virtual('L', 0, LOWMEM_SIZE + HMASIZE, 0);
   result = alias_mapping_high(MAPPING_INIT_LOWRAM, 0, memsize,
 			      PROT_READ | PROT_WRITE, lowmem);
@@ -427,7 +428,8 @@ void map_memory_space(void)
     perror ("LOWRAM mmap");
     exit(EXIT_FAILURE);
   }
-  c_printf("Conventional memory mapped from %p to %p\n", lowmem, mem_base);
+  if (!EMU_FULLSIM())
+    c_printf("Conventional memory mapped from %p to %p\n", lowmem, mem_base);
 
   if (config.xms_size) {
     memcheck_addtype('x', "XMS");

--- a/src/base/lib/mapping/mapfile.c
+++ b/src/base/lib/mapping/mapfile.c
@@ -36,6 +36,7 @@
 #include "dosemu_debug.h"
 #include "mapping.h"
 #include "mpriv.h"
+#include "emu.h"
 
 /* ------------------------------------------------------------ */
 
@@ -207,7 +208,8 @@ static int open_mapping_mshm(int cap)
 static void do_free_mapping(struct file_mapping *p)
 {
   munmap(p->addr, p->size);
-  close(p->fd);
+  if (p->fd != -1)
+    close(p->fd);
   p->size = 0;
 }
 
@@ -228,8 +230,10 @@ static void *alloc_tail(int fd, size_t mapsize, int prot, void *target)
 {
   int i, fixed = 0;
   struct file_mapping *p;
-  int rc = ftruncate(fd, mapsize);
-  assert(rc != -1);
+  if (fd != -1) {
+    int rc = ftruncate(fd, mapsize);
+    assert(rc != -1);
+  }
 
   for (i = 0, p = file_mappings; i < MAX_FILE_MAPPINGS; i++, p++)
     if (p->size == 0)
@@ -239,7 +243,16 @@ static void *alloc_tail(int fd, size_t mapsize, int prot, void *target)
     fixed = MAP_FIXED;
   else
     target = NULL;
-  target = mmap(target, mapsize, prot, MAP_SHARED | fixed, fd, 0);
+  if (fd == -1) {
+    if (fixed)
+      /* on emscripten mprotect is a no-op, elsewhere this just
+	 overrides the protection from do_huge_page */
+      mprotect(target, mapsize, prot);
+    else
+      target = mmap(target, mapsize, prot, MAP_PRIVATE | MAP_ANONYMOUS, fd, 0);
+  } else {
+    target = mmap(target, mapsize, prot, MAP_SHARED | fixed, fd, 0);
+  }
   if (target == MAP_FAILED) {
     error("mapping: mmap(%x) failed: %s\n", fixed, strerror(errno));
     return MAP_FAILED;
@@ -314,10 +327,12 @@ static void *resize_mapping_file(int cap, void *addr, size_t oldsize, size_t new
     /* ensure page-aligned */
     assert(!(oldsize & (PAGE_SIZE - 1)));
     assert(!(newsize & (PAGE_SIZE - 1)));
+    /* partial unmapping not supported by emscripten, but this will simply
+       fail there and not hurt */
     munmap(addr + newsize, oldsize - newsize);
 #endif
   } else {
-    if (newsize > p->fsize) {
+    if (p->fd != -1 && newsize > p->fsize) {
       int rc = ftruncate(p->fd, newsize);
       assert(rc != -1);
       p->fsize = newsize;
@@ -326,11 +341,28 @@ static void *resize_mapping_file(int cap, void *addr, size_t oldsize, size_t new
 #if defined(HAVE_MREMAP) && HAVE_DECL_MREMAP_MAYMOVE
     p->addr = mremap(addr, oldsize, newsize, MREMAP_MAYMOVE);
 #else
-    p->addr = mmap(NULL, newsize, p->prot, MAP_SHARED, p->fd, 0);
+    if (p->fd == -1) {
+      p->addr = mmap(NULL, newsize, p->prot, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+      if (p->addr != MAP_FAILED)
+	memcpy(p->addr, addr, oldsize);
+    } else {
+      p->addr = mmap(NULL, newsize, p->prot, MAP_SHARED, p->fd, 0);
+    }
     munmap(addr, oldsize);
 #endif
   }
   return p->addr;
+}
+
+static int open_mapping_softmmu(int cap)
+{
+  return EMU_FULLSIM();
+}
+
+static void *alloc_mapping_softmmu(int cap, size_t mapsize, void *target)
+{
+  Q__printf("MAPPING: alloc, cap=%s, mapsize=%zx\n", cap, mapsize);
+  return alloc_tail(-1, mapsize, PROT_READ | PROT_WRITE, target);
 }
 
 #ifdef HAVE_SHM_OPEN
@@ -374,6 +406,19 @@ struct mappingdrivers mappingdriver_file = {
   free_mapping_file,
   resize_mapping_file,
   alias_mapping_file,
+  attach_mapping_file,
+  detach_mapping_file,
+};
+
+struct mappingdrivers mappingdriver_softmmu = {
+  "softmmu",
+  "softmmu mapping",
+  open_mapping_softmmu,
+  close_mapping_file,
+  alloc_mapping_softmmu,
+  free_mapping_file,
+  resize_mapping_file,
+  NULL,
   attach_mapping_file,
   detach_mapping_file,
 };

--- a/src/base/lib/mapping/mapping.c
+++ b/src/base/lib/mapping/mapping.c
@@ -97,9 +97,10 @@ unsigned char *_jit_base(void)
 uint8_t *lowmem_base;
 
 static struct mappingdrivers *mappingdrv[] = {
+  &mappingdriver_softmmu, /* first try softmmu (fullsim only!) */
 #ifdef HAVE_MEMFD_CREATE
 #if HAVE_DECL_MEMFD_CREATE
-  &mappingdriver_mshm,  /* first try memfd mmap */
+  &mappingdriver_mshm,  /* then try memfd mmap */
 #endif
 #endif
 #ifdef HAVE_SHM_OPEN

--- a/src/base/lib/mapping/mapping.c
+++ b/src/base/lib/mapping/mapping.c
@@ -86,10 +86,12 @@ static struct {
 } mem_bases[MAX_BASES];
 unsigned char *_mem_base(void)
 {
+  assert(mem_bases[MEM_BASE].base != MAP_FAILED);
   return mem_bases[MEM_BASE].base;
 }
 unsigned char *_jit_base(void)
 {
+  assert(mem_bases[JIT_BASE].base != MAP_FAILED);
   return mem_bases[JIT_BASE].base;
 }
 uint8_t *lowmem_base;
@@ -159,7 +161,7 @@ void *dosaddr_to_unixaddr(dosaddr_t addr)
   off = addr - hw->vbase;
   if (hw->aliasmap[off >> PAGE_SHIFT].ptr)
     return hw->aliasmap[off >> PAGE_SHIFT].ptr + (off & (PAGE_SIZE - 1));
-  return MEM_BASE32(addr);
+  return LOWMEM(addr);
 }
 
 void *physaddr_to_unixaddr(unsigned int addr)
@@ -255,8 +257,10 @@ static void kmem_map_single(int cap, int idx, dosaddr_t targ)
         MREMAP_MAYMOVE | MREMAP_FIXED, dst);
     }
   } else {
-    mremap(kmem_map[idx].base[MEM_BASE], kmem_map[idx].len, kmem_map[idx].len,
-        MREMAP_MAYMOVE | MREMAP_FIXED, MEM_BASE32(targ));
+    void *dst = MEM_BASE32x(targ, MEM_BASE);
+    if (dst != MAP_FAILED)
+      mremap(kmem_map[idx].base[MEM_BASE], kmem_map[idx].len, kmem_map[idx].len,
+	     MREMAP_MAYMOVE | MREMAP_FIXED, dst);
   }
   kmem_map[idx].dst = targ;
   update_aliasmap(targ, kmem_map[idx].len, kmem_map[idx].bkp_base);
@@ -285,6 +289,9 @@ int alias_mapping_high(int cap, dosaddr_t targ, size_t mapsize, int protect,
     void *source)
 {
   void *addr;
+
+  if (mem_bases[MEM_BASE].base == MAP_FAILED)
+    return 0;
 
   Q__printf("MAPPING: alias, cap=%s, targ=%#x, size=%zx, protect=%x, source=%p\n",
 	cap, targ, mapsize, protect, source);
@@ -547,7 +554,7 @@ int restore_mapping_pa(unsigned int addr, size_t mapsize)
 
 static int do_mprot(dosaddr_t targ, size_t mapsize, int protect)
 {
-  int i, ret = -1;
+  int i, ret;
 
   for (i = 0; i < MAX_BASES; i++) {
     void *addr = MEM_BASE32x(targ, i);
@@ -562,7 +569,7 @@ static int do_mprot(dosaddr_t targ, size_t mapsize, int protect)
       return ret;
     }
   }
-  return ret;
+  return 0;
 }
 
 int mprotect_mapping(int cap, dosaddr_t targ, size_t mapsize, int protect)
@@ -574,8 +581,7 @@ int mprotect_mapping(int cap, dosaddr_t targ, size_t mapsize, int protect)
 	cap, targ, mapsize, protect);
   invalidate_unprotected_page_cache(targ, mapsize);
   if (cap & MAPPING_CPUEMU) {
-    /* no need to mprotect with fullsim */
-    if (EMU_FULLSIM())
+    if (mem_bases[JIT_BASE].base == MAP_FAILED)
       return 0;
     /* for cpuemu only mprotect JIT_BASE */
     ret = mprotect(MEM_BASE32x(targ, JIT_BASE), mapsize, protect);
@@ -588,6 +594,8 @@ int mprotect_mapping(int cap, dosaddr_t targ, size_t mapsize, int protect)
     return ret;
   if (is_kvm_map(cap))
     mprotect_kvm(cap, targ, mapsize, protect);
+  if (mem_bases[MEM_BASE].base == MAP_FAILED)
+    return ret;
   addr = MEM_BASE32(targ);
   if ((unsigned char *)addr < mem_bases[MEM_BASE].base ||
       (unsigned char *)addr + mapsize > mem_bases[MEM_BASE].base +
@@ -1154,7 +1162,7 @@ void *get_hardware_uaddr(unsigned addr)
       int off = addr - hw->base;
       if (hw->aliasmap[off >> PAGE_SHIFT].ptr)
         return hw->aliasmap[off >> PAGE_SHIFT].ptr + (off & (PAGE_SIZE - 1));
-      return MEM_BASE32(addr);
+      return LOWMEM(addr);
     }
   }
   return MAP_FAILED;
@@ -1399,7 +1407,6 @@ void munmap_shm_mapping(void *addr)
 
 int mprotect_vga(int idx, dosaddr_t targ, size_t mapsize, int protect)
 {
-  void *addr = MEM_BASE32(targ);
   int wp = !(protect & PROT_WRITE);
   int err;
 
@@ -1407,7 +1414,7 @@ int mprotect_vga(int idx, dosaddr_t targ, size_t mapsize, int protect)
   if (err)
     return err;
   if (mapping_hook)
-    err = mapping_hook->wp_vga(idx, addr, mapsize, wp);
+    err = mapping_hook->wp_vga(idx, MEM_BASE32(targ), mapsize, wp);
   return err;
 }
 

--- a/src/base/lib/mapping/mapping.h
+++ b/src/base/lib/mapping/mapping.h
@@ -156,6 +156,7 @@ struct mappingdrivers {
 };
 char *decode_mapping_cap(int cap);
 
+extern struct mappingdrivers mappingdriver_softmmu;
 extern struct mappingdrivers mappingdriver_shm;
 extern struct mappingdrivers mappingdriver_mshm;
 extern struct mappingdrivers mappingdriver_file;

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -3352,13 +3352,13 @@ err:
      * to check that the entire area belongs to this client.
      * Fortunately DPMI spec doesn't demand the 0x703 pages to be
      * zeroed out. */
-    int rc;
+    int rc = 0;
     dosaddr_t addr = (_LWORD_(ebx) << 16) | (_LWORD_(ecx));
     unsigned size = (_LWORD_(esi) << 16) | (_LWORD_(edi));
     if (addr + size > config.dpmi_base + dpmi_mem_size()) {
       D_printf("DPMI: Failing bad paging call\n");
       rc = -1;
-    } else {
+    } else if (!EMU_FULLSIM()) {
       rc = madvise(MEM_BASE32(addr), size, MADV_COLD);
     }
     if (rc == -1) {

--- a/src/dosext/dpmi/memory.c
+++ b/src/dosext/dpmi/memory.c
@@ -225,7 +225,10 @@ int dpmi_alloc_pool(void)
     dpmi_base = config.dpmi_base;
     c_printf("DPMI: mem init, mpool is %d bytes at %#x\n", memsize, dpmi_base);
     /* Create DPMI pool */
-    sminit_com(&mem_pool, dpmi_base, memsize, commit, uncommit, 0);
+    if (EMU_FULLSIM())
+      sminit(&mem_pool, dpmi_base, memsize);
+    else
+      sminit_com(&mem_pool, dpmi_base, memsize, commit, uncommit, 0);
     dpmi_total_memory = config.dpmi * 1024;
     fh_init(&shmap, shms, SHSIZE, -1,
             (int)offsetof(struct shm_fhm, fd) -


### PR DESCRIPTION
A new softmmu mapping driver was added, which does not alias memory, but allocates it via aligned_alloc; all mprotect() calls on it are skipped. This is then used in full sim mode.

There is then only one main chunk of memory, and is mapped from DOS memory only via `lowmem_aliasmap` (using the unprotected page cache for speed). `mem_bases[MEM_BASE].base` and
`mem_bases[JIT_BASE].base` both refer to this same chunk.

This is more of a proof of concept then something that is ready: there are some things to be sorted out:
* conditional compilation for unused mapping drivers on non-x86?
* ldt and comcom64 still use file-based mapping via `mmap_shm_mapping`. I think I can simplify ldt for fullsim, but comcom64 is harder (as mentioned in #2772)
* does emscripten support plain anonymous private mmap()s? If so we could still use them there, for simpler code (e.g. `src/base/core/coopth.c` also uses `mmap` this way).
* the difference between softmmu and non-softmmu in mapping.c is fairly small, but for mapfile.c perhaps we need a mapsoftmmu.c to get it better seperated. And a fair chunk of mapping.c is about kmem, which I haven't touched either -- it's probably not very useful on non-x86 but this will need some changes on x86 with fullsim+softmmu.