### PR TITLE
Priv

### DIFF
--- a/src/base/core/emu.c
+++ b/src/base/core/emu.c
@@ -309,6 +309,8 @@ int emulate(int argc, char **argv, char * const *envp)
 #ifdef USE_MHPDBG
     mhp_early_init();           /* before mfs_post_config() */
 #endif
+    dos2tty_init();             /* before mfs_post_config() */
+    /* this seals FS ops */
     mfs_post_config();		/* called after config and all config_scrubs */
 #ifdef X86_EMULATOR
 #ifdef DONT_DEBUG_BOOT		/* cpuemu only */
@@ -372,7 +374,6 @@ int emulate(int argc, char **argv, char * const *envp)
 #ifdef USE_MHPDBG
     mhp_init();
 #endif
-    dos2tty_init();
     priv_drop_total();
     init_all_DOS_tables();	/* longest init function! needs to be optimized */
     signal_init();              /* initialize sig's & sig handlers */

--- a/src/base/core/emu.c
+++ b/src/base/core/emu.c
@@ -372,8 +372,8 @@ int emulate(int argc, char **argv, char * const *envp)
 #ifdef USE_MHPDBG
     mhp_init();
 #endif
-    priv_drop_total();
     dos2tty_init();
+    priv_drop_total();
     init_all_DOS_tables();	/* longest init function! needs to be optimized */
     signal_init();              /* initialize sig's & sig handlers */
     if (config.exitearly) {

--- a/src/base/core/priv.c
+++ b/src/base/core/priv.c
@@ -331,17 +331,18 @@ static void start_landlock(void)
   int i;
   int err;
   const char **p;
+  /* most of the below is needed for exec'ed children, not for dosemu */
   static const char *allow_rw[] = {
     "/dev/shm",
     "/dev/pts",
     "/tmp",
-    "/var",
     "/run/lock",
     "/proc",
     NULL
   };
   static const char *allow_ro[] = {
     "/usr",
+    "/var",
     "/sys",
     "/etc",
     NULL

--- a/src/base/core/priv.c
+++ b/src/base/core/priv.c
@@ -337,13 +337,11 @@ static void start_landlock(void)
     "/dev/pts",
     "/tmp",
     "/run/lock",
-    "/proc",
     NULL
   };
   static const char *allow_ro[] = {
     "/usr",
     "/var",
-    "/sys",
     "/etc",
     NULL
   };

--- a/src/base/core/priv.c
+++ b/src/base/core/priv.c
@@ -348,7 +348,6 @@ static void start_landlock(void)
   };
   static const char *allow_files_rw[] = {
     "/dev/null",
-    "/dev/ptmx",
     NULL
   };
 

--- a/src/base/core/priv.c
+++ b/src/base/core/priv.c
@@ -336,7 +336,7 @@ static void start_landlock(void)
     "/dev/pts",
     "/tmp",
     "/var",
-    "/run",
+    "/run/lock",
     "/proc",
     NULL
   };

--- a/src/base/core/priv.c
+++ b/src/base/core/priv.c
@@ -332,7 +332,8 @@ static void start_landlock(void)
   int err;
   const char **p;
   static const char *allow_rw[] = {
-    "/dev",
+    "/dev/shm",
+    "/dev/pts",
     "/tmp",
     "/var",
     "/run",
@@ -343,6 +344,11 @@ static void start_landlock(void)
     "/usr",
     "/sys",
     "/etc",
+    NULL
+  };
+  static const char *allow_files_rw[] = {
+    "/dev/null",
+    "/dev/ptmx",
     NULL
   };
 
@@ -383,6 +389,14 @@ static void start_landlock(void)
     err = landlock_allow_fd(fd, 0);
     if (err) {
       error("landlock_allow_rw(%i) failed\n", fd);
+      leavedos(3);
+      return;
+    }
+  }
+  for (p = allow_files_rw; *p; p++) {
+    err = landlock_allow_file(*p, 0);
+    if (err) {
+      error("landlock_allow_rw(%s) failed\n", *p);
       leavedos(3);
       return;
     }

--- a/src/base/core/priv.c
+++ b/src/base/core/priv.c
@@ -334,7 +334,6 @@ static void start_landlock(void)
   /* most of the below is needed for exec'ed children, not for dosemu */
   static const char *allow_rw[] = {
     "/dev/shm",
-    "/dev/pts",
     "/tmp",
     "/run/lock",
     NULL

--- a/src/base/lib/fslib/fslib.c
+++ b/src/base/lib/fslib/fslib.c
@@ -30,19 +30,22 @@ int mfs_define_drive(const char *path)
   int ret;
 
   ret = fssvc->add_path(path);
-  if (ret == -1)
-    return ret;
+  assert(ret != -1);
   return ret + 1;
 }
 
 int fslib_add_path_list(const char *list)
 {
-  return fssvc->add_path_list(list);
+  int ret = fssvc->add_path_list(list);
+  assert(ret == 0);
+  return ret;
 }
 
 int fslib_add_path_ex(const char *path)
 {
-  return fssvc->add_path_ex(path);
+  int ret = fssvc->add_path_ex(path);
+  assert(ret == 0);
+  return ret;
 }
 
 int mfs_open_file(int mfs_idx, const char *path, int flags)

--- a/src/base/misc/dos2linux.c
+++ b/src/base/misc/dos2linux.c
@@ -110,6 +110,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <libgen.h>
 #include <unistd.h>
 #ifdef HAVE_LIBBSD
 #include <bsd/unistd.h>
@@ -187,6 +188,7 @@ void misc_e6_store_options(const char *str)
 
 
 static int pty_fd;
+static int mfs_idx;
 static int cbrk;
 static pthread_t reader;
 struct rd_args {
@@ -272,18 +274,49 @@ static void pty_worker(struct rd_args *args)
 
 void dos2tty_init(void)
 {
+    char pts[PATH_MAX], *dn;
+    int err;
+
     pty_fd = posix_openpt(O_RDWR);
     if (pty_fd == -1)
     {
-        error("openpt failed %s\n", strerror(errno));
+        error("openpt() failed %s\n", strerror(errno));
         return;
     }
     unlockpt(pty_fd);
+    err = ptsname_r(pty_fd, pts, sizeof(pts));
+    if (err) {
+        error("ptsname() failed %s\n", strerror(errno));
+        return;
+    }
+    dn = dirname(pts);
+    assert(dn && dn[0] != '\0' && dn == pts);
+    if (dn[strlen(dn) - 1] != '/')
+        strlcat(pts, "/", sizeof(pts));
+    mfs_idx = mfs_define_drive(pts);
 }
 
 void dos2tty_done(void)
 {
     close(pty_fd);
+}
+
+static int pts_open(void)
+{
+    int err, pts_fd;
+
+    err = grantpt(pty_fd);
+    if (err) {
+	error("grantpt failed: %s\n", strerror(errno));
+	return err;
+    }
+    /* set ctty in child later */
+    pts_fd = mfs_open_file(mfs_idx, ptsname(pty_fd), O_RDWR | O_NOCTTY);
+    if (pts_fd == -1) {
+	error("pts open failed: %s\n", strerror(errno));
+	return -1;
+    }
+    return pts_fd;
 }
 
 static void dos2tty_start(struct rd_args *args)
@@ -365,7 +398,7 @@ int run_unix_command(int argc, const char **argv, int bg)
     }
 
     g_printf("UNIX: run %s, %i args\n", path, argc);
-    pid = run_external_command(path, argc, argv, !bg, -1, pty_fd);
+    pid = run_external_command(path, argc, argv, !bg, -1, pts_open);
     if (bg) {
 	sigchld_enable_cleanup(pid);
 	return 0;

--- a/src/base/misc/dos2linux.c
+++ b/src/base/misc/dos2linux.c
@@ -431,6 +431,12 @@ static int do_wait_custom(pid_t pid, int fd)
     return WEXITSTATUS(status);
 }
 
+static void chld_crash(int sig)
+{
+    error("secure child crashed with %i\n", sig);
+    exit(7);
+}
+
 int unix_run_secure(const char *path, int pos, struct popen2 *file)
 {
     int close_from = STDERR_FILENO + 1;
@@ -439,7 +445,13 @@ int unix_run_secure(const char *path, int pos, struct popen2 *file)
     sigset_t set, oset;
     int outp[2];
     const char *argv[2];
+    pshared_sem_t init_sem, crit_sem;
+    struct sigaction act;
 
+    retval = pshared_sem_init(&init_sem, 0);
+    assert(!retval);
+    retval = pshared_sem_init(&crit_sem, 0);
+    assert(!retval);
     assert(pos < strlen(path));
     argv[0] = path + pos;
     argv[1] = NULL;	/* no args allowed */
@@ -454,11 +466,13 @@ int unix_run_secure(const char *path, int pos, struct popen2 *file)
 	g_printf("run_unix_command(): fork() failed\n");
 	return -1;
     case 0: /* child */
+	pshared_sem_wait(crit_sem);
 	retval = priv_drop();
-	if (retval) {
-	    kill(dosemu_pid, SIGTERM);
+	if (retval)
 	    _exit(EXIT_FAILURE);
-	}
+	pshared_sem_post(init_sem);
+	pshared_sem_destroy(&init_sem);
+	pshared_sem_destroy(&crit_sem);
 	close(0);
 	open("/dev/null", O_RDONLY);
 	close(1);
@@ -502,7 +516,13 @@ int unix_run_secure(const char *path, int pos, struct popen2 *file)
 	_exit(retval);
 	break;
     }
+    sigchld_set_critical(chld_crash, &act);
+    pshared_sem_post(crit_sem);
+    pshared_sem_wait(init_sem);
+    sigchld_unset_critical(&act);
     sigprocmask(SIG_SETMASK, &oset, NULL);
+    pshared_sem_destroy(&init_sem);
+    pshared_sem_destroy(&crit_sem);
     close(outp[1]);
     file->from_child = outp[0];
     file->to_child = -1;

--- a/src/base/misc/utilities.c
+++ b/src/base/misc/utilities.c
@@ -1081,24 +1081,6 @@ FILE *fstream_tee(FILE *orig)
 }
 #endif
 
-static int pts_open(int pty_fd)
-{
-    int err, pts_fd;
-
-    err = grantpt(pty_fd);
-    if (err) {
-	error("grantpt failed: %s\n", strerror(errno));
-	return err;
-    }
-    /* set ctty in child later */
-    pts_fd = open(ptsname(pty_fd), O_RDWR | O_NOCTTY);
-    if (pts_fd == -1) {
-	error("pts open failed: %s\n", strerror(errno));
-	return -1;
-    }
-    return pts_fd;
-}
-
 int pshared_sem_init(pshared_sem_t *sem, unsigned int value)
 {
     char sem_name[] = "/dosemu2_psem_%PXXXXXX";
@@ -1136,7 +1118,7 @@ int pshared_sem_destroy(pshared_sem_t *sem)
 }
 
 pid_t run_external_command(const char *path, int argc, const char **argv,
-        int use_stdin, int close_from, int pty_fd)
+        int use_stdin, int close_from, int (*pts_open)(void))
 {
     pid_t pid;
     int wt, retval;
@@ -1148,7 +1130,7 @@ pid_t run_external_command(const char *path, int argc, const char **argv,
     assert(!retval);
     signal_block_async_nosig(&oset);
     sigprocmask(SIG_SETMASK, NULL, &set);
-    pts_fd = pts_open(pty_fd);
+    pts_fd = pts_open();
     /* fork child */
     switch ((pid = fork())) {
     case -1: /* failed */
@@ -1184,7 +1166,7 @@ pid_t run_external_command(const char *path, int argc, const char **argv,
 	dup(pts_fd);
 	dup(pts_fd);
 	close(pts_fd);
-	close(pty_fd);
+	/* can close pty_fd, but its closed in close_from anyway */
 	if (close_from != -1)
 #ifdef HAVE_CLOSEFROM
 	    closefrom(close_from);

--- a/src/base/misc/utilities.c
+++ b/src/base/misc/utilities.c
@@ -1117,20 +1117,31 @@ int pshared_sem_destroy(pshared_sem_t *sem)
     return ret;
 }
 
+static void chld_crash(int sig)
+{
+    error("child crashed with %i\n", sig);
+    exit(7);
+}
+
 pid_t run_external_command(const char *path, int argc, const char **argv,
         int use_stdin, int close_from, int (*pts_open)(void))
 {
     pid_t pid;
     int wt, retval;
     sigset_t set, oset;
+    struct sigaction act;
     int pts_fd;
-    pshared_sem_t pty_sem;
+    pshared_sem_t init_sem, crit_sem;
 
-    retval = pshared_sem_init(&pty_sem, 0);
+    retval = pshared_sem_init(&init_sem, 0);
+    assert(!retval);
+    retval = pshared_sem_init(&crit_sem, 0);
     assert(!retval);
     signal_block_async_nosig(&oset);
     sigprocmask(SIG_SETMASK, NULL, &set);
     pts_fd = pts_open();
+    if (pts_fd == -1)
+	return -1;
     /* fork child */
     switch ((pid = fork())) {
     case -1: /* failed */
@@ -1138,24 +1149,18 @@ pid_t run_external_command(const char *path, int argc, const char **argv,
 	g_printf("run_unix_command(): fork() failed\n");
 	return -1;
     case 0: /* child */
+	pshared_sem_wait(crit_sem);
 	retval = priv_drop();
-	if (retval) {
-	    pshared_sem_post(pty_sem);
-	    pshared_sem_destroy(&pty_sem);
-	    kill(dosemu_pid, SIGTERM);
+	if (retval)
 	    _exit(EXIT_FAILURE);
-	}
 	setsid();	// will have ctty
 	/* if opening tty before setsid(), needs to force ctty with ioctl() */
 	ioctl(pts_fd, TIOCSCTTY, 0);
 	/* Reading master side before slave opened, results in EOF.
 	 * Notify user that reads are now safe. */
-	pshared_sem_post(pty_sem);
-	pshared_sem_destroy(&pty_sem);
-	if (pts_fd == -1) {
-	    kill(dosemu_pid, SIGTERM);
-	    _exit(EXIT_FAILURE);
-	}
+	pshared_sem_post(init_sem);
+	pshared_sem_destroy(&init_sem);
+	pshared_sem_destroy(&crit_sem);
 	close(0);
 	close(1);
 	close(2);
@@ -1202,10 +1207,14 @@ pid_t run_external_command(const char *path, int argc, const char **argv,
 	_exit(retval);
 	break;
     }
-    sigprocmask(SIG_SETMASK, &oset, NULL);
     /* wait until its safe to read from pty_fd */
-    pshared_sem_wait(pty_sem);
-    pshared_sem_destroy(&pty_sem);
+    sigchld_set_critical(chld_crash, &act);
+    pshared_sem_post(crit_sem);
+    pshared_sem_wait(init_sem);
+    sigchld_unset_critical(&act);
+    sigprocmask(SIG_SETMASK, &oset, NULL);
+    pshared_sem_destroy(&init_sem);
+    pshared_sem_destroy(&crit_sem);
     close(pts_fd);
     return pid;
 }

--- a/src/base/misc/utilities.c
+++ b/src/base/misc/utilities.c
@@ -880,6 +880,9 @@ int popen2_custom(const char *cmdline, struct popen2 *childinfo)
     p = fork();
     assert(p >= 0);
     if(p == 0) { /* child */
+	int err = priv_drop();
+	if (err)
+	    _exit(EXIT_FAILURE);
         setsid();	// escape ctty
         close(pipe_stdin[1]);
         dup2(pipe_stdin[0], 0);

--- a/src/base/misc/utilities.c
+++ b/src/base/misc/utilities.c
@@ -14,6 +14,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/socket.h>
+#include <sys/ioctl.h>
 #include <fcntl.h>
 #include <string.h>
 #include <ctype.h>
@@ -1081,15 +1082,13 @@ static int pts_open(int pty_fd)
 {
     int err, pts_fd;
 
-    setsid();	// will have ctty
-    /* open pts _after_ setsid, or it won't became a ctty */
     err = grantpt(pty_fd);
     if (err) {
 	error("grantpt failed: %s\n", strerror(errno));
 	return err;
     }
-    /* don't set O_CLOEXEC here */
-    pts_fd = open(ptsname(pty_fd), O_RDWR);
+    /* set ctty in child later */
+    pts_fd = open(ptsname(pty_fd), O_RDWR | O_NOCTTY);
     if (pts_fd == -1) {
 	error("pts open failed: %s\n", strerror(errno));
 	return -1;
@@ -1146,6 +1145,7 @@ pid_t run_external_command(const char *path, int argc, const char **argv,
     assert(!retval);
     signal_block_async_nosig(&oset);
     sigprocmask(SIG_SETMASK, NULL, &set);
+    pts_fd = pts_open(pty_fd);
     /* fork child */
     switch ((pid = fork())) {
     case -1: /* failed */
@@ -1160,7 +1160,9 @@ pid_t run_external_command(const char *path, int argc, const char **argv,
 	    kill(dosemu_pid, SIGTERM);
 	    _exit(EXIT_FAILURE);
 	}
-	pts_fd = pts_open(pty_fd);
+	setsid();	// will have ctty
+	/* if opening tty before setsid(), needs to force ctty with ioctl() */
+	ioctl(pts_fd, TIOCSCTTY, 0);
 	/* Reading master side before slave opened, results in EOF.
 	 * Notify user that reads are now safe. */
 	pshared_sem_post(pty_sem);
@@ -1219,6 +1221,7 @@ pid_t run_external_command(const char *path, int argc, const char **argv,
     /* wait until its safe to read from pty_fd */
     pshared_sem_wait(pty_sem);
     pshared_sem_destroy(&pty_sem);
+    close(pts_fd);
     return pid;
 }
 

--- a/src/base/serial/tty_io.c
+++ b/src/base/serial/tty_io.c
@@ -32,6 +32,7 @@
 #include "ser_defs.h"
 #include "tty_io.h"
 
+static int pty_fd;
 static void async_serial_run(int fd, void *arg);
 
 /* This function flushes the internal unix receive buffer [num = port] */
@@ -652,17 +653,34 @@ static void pty_exit(void *arg)
   tty_close(c);
 }
 
+static int pts_open(void)
+{
+    int err, pts_fd;
+
+    err = grantpt(pty_fd);
+    if (err) {
+       error("grantpt failed: %s\n", strerror(errno));
+       return err;
+    }
+    /* set ctty in child later */
+    pts_fd = open(ptsname(pty_fd), O_RDWR | O_NOCTTY);
+    if (pts_fd == -1) {
+       error("pts open failed: %s\n", strerror(errno));
+       return -1;
+    }
+    return pts_fd;
+}
+
 static int pty_open(com_t *c, const char *cmd)
 {
   struct termios t;
   const char *argv[] = { "sh", "-c", cmd, NULL };
   const int argc = 4;
-  int pty_fd;
 
   pty_fd = pty_init(c);
   cfmakeraw(&t);
   tcsetattr(pty_fd, TCSANOW, &t);
-  pid_t pid = run_external_command("/bin/sh", argc, argv, 1, -1, pty_fd);
+  pid_t pid = run_external_command("/bin/sh", argc, argv, 1, -1, pts_open);
   if (pid == -1) {
     close(pty_fd);
     return -1;

--- a/src/include/utilities.h
+++ b/src/include/utilities.h
@@ -178,7 +178,7 @@ void create_thread(pthread_t *restrict thread,
 
 pid_t run_external_command(const char *path, int argc,
         const char **argv,
-        int use_stdin, int close_from, int pty_fd);
+        int use_stdin, int close_from, int (*pts_open)(void));
 
 #ifdef HAVE_OPTRESET
 /* needs to set both to 1, no idea why optreset alone isn't enough! */

--- a/src/plugin/searpc/util.c
+++ b/src/plugin/searpc/util.c
@@ -93,25 +93,20 @@ SearpcClient *clnt_init(int *sock_rx, init_cb_t init_cb,
             /* child */
             close(socks[0]);
             close(transp[0]);
+            pshared_sem_wait(svc_sem2);
             err = priv_drop();
-            if (err) {
-                pshared_sem_post(svc_sem);
-                pshared_sem_wait(svc_sem2);
-                pshared_sem_destroy(&svc_sem);
-                pshared_sem_destroy(&svc_sem2);
+            if (err)
                 _exit(1);
-            }
             setsid();
             prctl(PR_SET_PDEATHSIG, SIGQUIT);
             err = init_cb(svc_name, socks[1], init_arg);
-            pshared_sem_post(svc_sem);
-            pshared_sem_wait(svc_sem2);
-            pshared_sem_destroy(&svc_sem);
-            pshared_sem_destroy(&svc_sem2);
             if (err) {
                 fprintf(stderr, "%s service failed\n", svc_name);
                 _exit(1);
             }
+            pshared_sem_post(svc_sem);
+            pshared_sem_destroy(&svc_sem);
+            pshared_sem_destroy(&svc_sem2);
             svc_run(svc_name, transp[1], svc_ex);
             _exit(1);  // not reached
             break;
@@ -119,17 +114,17 @@ SearpcClient *clnt_init(int *sock_rx, init_cb_t init_cb,
 
     close(socks[1]);
     close(transp[1]);
+    sigchld_register_handler(pid, ex_cb, NULL);
     sigchld_set_critical(chld_crash, &act);
+    pshared_sem_post(svc_sem2);
     pshared_sem_wait(svc_sem);
     sigchld_unset_critical(&act);
-    pshared_sem_post(svc_sem2);
     pshared_sem_destroy(&svc_sem);
     pshared_sem_destroy(&svc_sem2);
 
     clnt = searpc_client_new();
     clnt->send = transport_callback;
     clnt->arg = (void *)(uintptr_t)transp[0];
-    sigchld_register_handler(pid, ex_cb, NULL);
     *sock_rx = socks[0];
     if (r_pid)
         *r_pid = pid;


### PR DESCRIPTION
These are the very tight restrictions.
If they work, the suid/setcap games
can just be removed.

TODO: remove silly SIGTERM from
child processes when they crash
due to insufficient privs.