### PR TITLE
CI: Remove attempt to tidy up assert messages

### DIFF
--- a/ci_test.sh
+++ b/ci_test.sh
@@ -24,7 +24,6 @@ export TEST_DOSEMU=/usr/local/bin/dosemu
 export TEST_CMDDIR=/usr/local/share/dosemu/commands
 
 if [ "${BLDTYPE}" = "packaged" ] ; then
-  export SKIP_UNCERTAIN=1
   if [ "${OS}" = "ubuntu-22.04" ] ; then
     export SKIP_NATIVE_DPMI=1
   fi
@@ -34,10 +33,7 @@ fi
 
 if [ "${RUNTYPE}" = "simple" ] ; then
   export SKIP_EXPENSIVE=1
-  export SKIP_UNCERTAIN=1
-elif [ "${RUNTYPE}" = "normal" ] ; then
-  export SKIP_UNCERTAIN=1
-else
+elif [ "${RUNTYPE}" = "full" ] ; then
   export NO_FAILFAST=1
 fi
 

--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -17,7 +17,7 @@ from ptyprocess import PtyProcessError
 from shutil import copy, rmtree
 from subprocess import (Popen, call, check_call, check_output,
                         DEVNULL, STDOUT, TimeoutExpired, CalledProcessError)
-from sys import argv, exit, stdout, stderr, version_info
+from sys import argv, exc_info, exit, stdout, stderr, version_info
 from tarfile import open as topen
 from time import sleep
 from unittest.util import strclass
@@ -67,6 +67,7 @@ RED = "\x1b[31m"
 GREEN = "\x1b[32m"
 YELLOW = "\x1b[33m"
 LIGHT_BLUE = "\x1b[94m"
+ORANGE = "\x1b[38;5;214m"  # requires 24 bit terminal support
 RESET = "\x1b[0m"
 
 
@@ -147,6 +148,48 @@ def mark(attr_names):
             setattr(wrapper, n, True)
         return wrapper
     return decorator
+
+
+def maybeFailure(func):
+    """
+    Docorator used to mark a test that may fail without stopping the test run
+    """
+
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        try:
+            return func(self, *args, **kwargs)
+
+        except self.failureException:
+            if environ.get("NO_MAYBEFAILURES", '0') == '1':
+                raise
+
+            # 1. Get raw traceback info
+            etype, value, tb = exc_info()
+
+            # 2. Filter the traceback frames
+            # Keep frames from our file, and skip the decorator/unittest internals
+            clean_frames = []
+            for frame, lineno in traceback.walk_tb(tb):
+                filename = frame.f_code.co_filename
+                # Skip the decorator itself and the unittest library internals
+                if "unittest/case.py" in filename or "unittest/suite.py" in filename:
+                    continue
+                if frame.f_code.co_name == "wrapper": # Skip our own decorator frame
+                    continue
+                clean_frames.append((frame, lineno))
+
+            # 3. Format only the relevant frames manually
+            # This mimics the "Traceback (most recent call last):" header
+            formatted_lines = ["Traceback (most recent call last):\n"]
+            for frame, lineno in clean_frames:
+                formatted_lines.extend(traceback.format_stack(frame, limit=1))
+
+            # Add the actual exception message at the end
+            formatted_lines.extend(traceback.format_exception_only(etype, value))
+
+            self.skipTest(f"MAYFAIL\n{''.join(formatted_lines)}")
+    return wrapper
 
 
 class BaseTestCase(object):
@@ -727,6 +770,7 @@ class MyTestResult(unittest.TextTestResult):
         super().__init__(*args, **kwargs)
         if (self.stream.isatty() or environ.get("CI")) and not environ.get("NO_COLOR"):
             self.with_color_terminal = True
+        self.mayfails = []
 
     def getDescription(self, test):
         if 'SubTest' in strclass(test.__class__):
@@ -818,7 +862,7 @@ class MyTestResult(unittest.TextTestResult):
                 continue
 
             if l[0].stat().st_size > 16*1024:
-                msgLines.append(f" '{l[0].name}' file too large for CI, see job artifacts\n")
+                msgLines.append(f"'{l[0].name}' file too large for CI, see job artifacts\n")
                 continue
 
             msgLines.append(f"::group::{l[0].name}\n")
@@ -861,6 +905,25 @@ class MyTestResult(unittest.TextTestResult):
         if getattr(self, 'failfast', False):
             self.stop()
 
+    def addSkip(self, test, reason):
+        if reason.startswith("MAYFAIL\n"):
+            if self.showAll:
+                if self.with_color_terminal:
+                    self.stream.writeln(f"{ORANGE}FAIL{RESET} (acceptable)")
+                else:
+                    self.stream.writeln("FAIL (acceptable)")
+            elif self.dots:
+                self.stream.write('M')
+                self.stream.flush()
+            # Store the test and the reason (which now contains the traceback)
+            self.mayfails.append((test, reason[len("MAYFAIL\n"):]))
+
+            for _, l in test.logfiles.items():
+                l[0].unlink(missing_ok=True)
+            test.logfiles = {}
+        else:
+            super().addSkip(test, reason)
+
     def addSuccess(self, test):
         super(unittest.TextTestResult, self).addSuccess(test)
         if self.showAll:
@@ -884,6 +947,20 @@ class MyTestResult(unittest.TextTestResult):
                 test.firstsub = False
                 self.stream.writeln("FAIL (one or more subtests)")
             self.stream.writeln("    %-76s ... FAIL" % subtest._subDescription())
+
+    def printErrors(self):
+        # 1. Print standard Errors/Failures first
+        super().printErrors()
+
+        # 2. Print our custom "MAYFAIL" details
+        if self.mayfails:
+            for test, reason in self.mayfails:
+                self.stream.writeln("\n" + "=" * 70)
+                self.stream.writeln(f"FAIL (acceptable): {self.getDescription(test)}")
+                self.stream.writeln("-" * 70)
+                # The 'reason' string now holds the traceback we captured in the decorator
+                self.stream.writeln(reason)
+            self.stream.flush()
 
 
 class MyTestRunner(unittest.TextTestRunner):
@@ -915,6 +992,7 @@ def main_setup(cases):
                   "  NO_COLOR=1          Override the terminal detection and disable colour printing of PASS|FAIL etc\n" +
                   "  NO_FAILFAST=1       Don't quit on the first test failure, run all specified\n" +
                   "  NO_KVM=1            Disables KVM, equivalent to autodetection not finding /dev/kvm\n" +
+                  "  NO_MAYBEFAILURES=1  Disables the maybeFailure mechanism so promoting test failures to FAIL\n" +
                   "  NO_TESTRUN=1        Exit the test runner after setting up the test environment and print the command line to be used\n" +
                   "  SKIP_EXPENSIVE=1    Tests that have been marked as expensive are not run\n" +
                   "  SKIP_NATIVE_DPMI=1  Tests that use native DPMI are not run\n" +

--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -614,13 +614,13 @@ class BaseTestCase(object):
                     child.expect(resp[0])
                     child.send(resp[1])
                     if outfile is None:
-                        ret += child.before.decode('ASCII', 'replace')
+                        ret += child.before.decode('cp437', 'replace')
                 trms = ['rem end',]
                 if eofisok:
                     trms += [pexpect.EOF,]
                 child.expect(trms, timeout=timeout)
                 if outfile is None:
-                    ret += child.before.decode('ASCII', 'replace')
+                    ret += child.before.decode('cp437', 'replace')
                 else:
                     ret = outfile.read_text()
             except pexpect.TIMEOUT:
@@ -786,13 +786,12 @@ class MyTestResult(unittest.TextTestResult):
         if maxLineLen > 120:
             n = list()
             for l in msgLines:
-                lf = l.encode('utf-8').decode('unicode_escape')
                 if self.with_color_terminal:
-                    lf = re.sub(r'(?m)^FAIL:', f"{RED}FAIL{RESET}:", lf)
-                    lf = re.sub(r'(?m)^PASS:', f"{GREEN}PASS{RESET}:", lf)
-                    lf = re.sub(r'(?m)^OKAY:', f"{YELLOW}OKAY{RESET}:", lf)
-                    lf = re.sub(r'(?m)^INFO:', f"{LIGHT_BLUE}INFO{RESET}:", lf)
-                n += [ lf, ]
+                    l = re.sub(r'(?m)^FAIL:', f"{RED}FAIL{RESET}:", l)
+                    l = re.sub(r'(?m)^PASS:', f"{GREEN}PASS{RESET}:", l)
+                    l = re.sub(r'(?m)^OKAY:', f"{YELLOW}OKAY{RESET}:", l)
+                    l = re.sub(r'(?m)^INFO:', f"{LIGHT_BLUE}INFO{RESET}:", l)
+                n += [ l, ]
             msgLines = n
 
         # Stdout, Stderr

--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -995,8 +995,7 @@ def main_setup(cases):
                   "  NO_MAYBEFAILURES=1  Disables the maybeFailure mechanism so promoting test failures to FAIL\n" +
                   "  NO_TESTRUN=1        Exit the test runner after setting up the test environment and print the command line to be used\n" +
                   "  SKIP_EXPENSIVE=1    Tests that have been marked as expensive are not run\n" +
-                  "  SKIP_NATIVE_DPMI=1  Tests that use native DPMI are not run\n" +
-                  "  SKIP_UNCERTAIN=1    Tests that have non-deterministic behaviour are not run\n")
+                  "  SKIP_NATIVE_DPMI=1  Tests that use native DPMI are not run\n")
             exit(0)
 
         if argv[1] == "--get-test-binaries":

--- a/test/func_libi86_testsuite.py
+++ b/test/func_libi86_testsuite.py
@@ -6,9 +6,11 @@ from shutil import copy
 from subprocess import check_call, check_output, CalledProcessError, DEVNULL, TimeoutExpired
 from sys import stderr
 
-from common_framework import DOSEMU_CONF_DEFAULT
+from common_framework import DOSEMU_CONF_DEFAULT, maybeFailure
 
 TESTSUITE = "/usr/ia16-elf/libexec/libi86/tests/testsuite"
+
+WHITELIST = [104, 105, 106, 107, 108, 109, 110]
 
 
 def libi86_create_items(testcase):
@@ -31,23 +33,28 @@ def libi86_create_items(testcase):
         if t:
             tests += [t.groups(),]
 
-    def create_test(test):
+    def create_test(num, oname):
         def do_test_libi86(self):
-            libi86_test_item(self, test[0])
-        docstring = """libi86 item % 3s %s""" % (test[0], test[2])
+            libi86_test_item(self, num)
+        docstring = f"""libi86 item {num: 3d} {oname}"""
         setattr(do_test_libi86, '__doc__', docstring)
         setattr(do_test_libi86, 'libi86test', True)
-        return do_test_libi86
+        if num in WHITELIST:
+            return maybeFailure(do_test_libi86)
+        else:
+            return do_test_libi86
 
     # Insert each test into the testcase
     for test in tests:
-        name = 'test_libi86_item_%03d' % int(test[0])
-        setattr(testcase, name, create_test(test))
+        num = int(test[0])
+        tname = f'test_libi86_item_{num:03d}'
+        oname = test[2]
+        setattr(testcase, tname, create_test(num, oname))
 
     testcase.attrs.add('libi86test')
 
 
-def libi86_test_item(self, test):
+def libi86_test_item(self, num):
     self.mkfile("dosemu.conf", DOSEMU_CONF_DEFAULT, dname=self.imagedir)
 
     os.umask(0)
@@ -68,16 +75,28 @@ def libi86_test_item(self, test):
     # Do just one
     try:
         starttime = self.utcnow()
-        check_call([TESTSUITE, *args, test[0]], cwd=build, timeout=60, stdout=DEVNULL, stderr=DEVNULL)
+        check_call([TESTSUITE, *args, str(num)], cwd=build, timeout=120, stdout=DEVNULL, stderr=DEVNULL)
         self.duration = self.utcnow() - starttime
-    except CalledProcessError:
-        raise self.failureException("Test error") from None
-    except TimeoutExpired:
-        raise self.failureException("Test timeout") from None
-    finally:
+
+    except (TimeoutExpired, CalledProcessError) as e:
         #  The libi86 test suite has its own log file called 'testsuite.log',
         #  so we will present it as our usual expect log
         logfile = build / "tests" / "testsuite.log"
         if logfile.is_file():
             copy(logfile, self.logfiles['xpt'][0])
             self.logfiles['xpt'][1] = "testsuite.log"
+
+        #  It also has some test directory specific files
+        for tup in (
+                ("a.c", "c"),
+                ("a.log", "out")):
+            fil = build / "tests" / "testsuite.dir" / f"{num:03d}" / tup[0]
+            ext = tup[1]
+            if fil.is_file():
+                self.logfiles[ext] = [self.topdir / f"{self.id()}.{ext}", f"{fil.parent.name}/{fil.name}"]
+                copy(fil, self.logfiles[ext][0])
+
+        if isinstance(e, TimeoutExpired):
+            raise self.failureException("Test timed out, output files may be truncated") from None
+        elif isinstance(e, CalledProcessError):
+            raise self.failureException(f"Test failed with return code {e.returncode}") from None

--- a/test/func_pit_mode_2.py
+++ b/test/func_pit_mode_2.py
@@ -4,8 +4,6 @@ from os import environ
 def pit_mode_2(self):
     if environ.get("SKIP_EXPENSIVE"):
         self.skipTest("expensive test")
-    if environ.get("SKIP_UNCERTAIN"):
-        self.skipTest("uncertain test")
 
     self.mkfile("testit.bat", """\
 pitmode2

--- a/test/test_dosemu.py
+++ b/test/test_dosemu.py
@@ -4,7 +4,7 @@ import unittest
 
 from sys import argv
 
-from common_framework import (BaseTestCase, main, main_setup, mark,
+from common_framework import (BaseTestCase, main, main_setup, mark, maybeFailure,
                               KNOWNFAIL, UNSUPPORTED)
 
 from common_os import (drdos701, frdos120, frdos130, frdosgit, msdos622,
@@ -1469,6 +1469,7 @@ class OurTestCase(BaseTestCase):
         """Passing DOS Errorlevel back"""
         passing_dos_errorlevel_back(self)
 
+    @maybeFailure
     def test_pit_mode_2(self):
         """PIT Mode 2"""
         pit_mode_2(self)

--- a/test/test_processor.py
+++ b/test/test_processor.py
@@ -2,7 +2,7 @@
 
 from subprocess import check_call
 
-from common_framework import (BaseTestCase, main, main_setup, mark,
+from common_framework import (BaseTestCase, main, main_setup, mark, maybeFailure,
                               KNOWNFAIL, UNSUPPORTED)
 from common_os import ppdosgit
 
@@ -32,11 +32,6 @@ class OurTestCase(BaseTestCase):
         """Build PC-MOS"""
         build_pcmos(self)
 
-    @mark('cputest')
-    def test_cpu_trap_flag(self):
-        """CPU Trap Flag"""
-        cpu_trap_flag(self)
-
     @mark('fputest')
     def test_fpu_bart_exceptions_fpex(self):
         """FPU Exceptions (Bart) (fpex)"""
@@ -59,6 +54,12 @@ class KVMTestCase(ppdosgit(OurTestCase, {
     })):
     use_cpu = 'kvm'
 
+    @mark('cputest')
+    @maybeFailure
+    def test_cpu_trap_flag(self):
+        """CPU Trap Flag"""
+        cpu_trap_flag(self)
+
 
 class EMUTestCase(ppdosgit(OurTestCase, {
         "test_fpu_f2xm1_sim_sim": KNOWNFAIL,
@@ -70,6 +71,11 @@ class EMUTestCase(ppdosgit(OurTestCase, {
         "test_fpu_fyl2xp1_sim_sim": KNOWNFAIL,
     })):
     use_cpu = 'emu'
+
+    @mark('cputest')
+    def test_cpu_trap_flag(self):
+        """CPU Trap Flag"""
+        cpu_trap_flag(self)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The assert messages show the results content on one single line, so previously an attempt was made to fold these to make them more readable on the CI web interface. Unfortunately when the assert is a regex, it can have seemingly invalid escape codes within, for example '\d+'. The previous code has now started to trigger a Python deprecation warning when it encounters these and emits them in the middle of the runner output. Remove this and if the output is confusing, consult the bundled artifacts for the raw log files.