### PR TITLE
Revert "dpmi: respect int revect for msdos translations"

### DIFF
--- a/src/base/core/int.c
+++ b/src/base/core/int.c
@@ -4100,29 +4100,3 @@ static int msdos_remap_extended_open(void)
     CARRY;
   return ret;
 }
-
-far_t get_int_vector(int vec)
-{
-    far_t addr;
-
-    if (test_bit(vec, &vm86s.int_revectored)) {
-	addr.segment = INT_RVC_SEG;
-	switch (vec) {
-	case 0x21:
-	    int21_rvc_setup();
-	    addr.offset = INT_RVC_21_OFF;
-	    return addr;
-	case 0x2f:
-	    int2f_rvc_setup();
-	    addr.offset = INT_RVC_2f_OFF;
-	    return addr;
-	case 0x33:
-	    int33_rvc_setup();
-	    addr.offset = INT_RVC_33_OFF;
-	    return addr;
-	}
-    }
-    addr.segment = ISEG(vec);
-    addr.offset = IOFF(vec);
-    return addr;
-}

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -2016,7 +2016,11 @@ int DPMI_allocate_specific_ldt_descriptor(unsigned short selector)
 
 far_t DPMI_get_real_mode_interrupt_vector(int vec)
 {
-    return get_int_vector(vec);
+    far_t addr;
+
+    addr.segment = ISEG(vec);
+    addr.offset = IOFF(vec);
+    return addr;
 }
 
 int DPMIAllocateShared(struct SHM_desc *shm)

--- a/src/include/int.h
+++ b/src/include/int.h
@@ -35,7 +35,6 @@ void int_try_disable_revect(void);
 enum { I_NOT_HANDLED, I_HANDLED, I_SECOND_REVECT };
 
 extern int can_revector(int i);
-far_t get_int_vector(int vec);
 
 void update_xtitle(void);
 


### PR DESCRIPTION
This reverts commit 7bf53376ba1c1fde18e54520609686cd8b1d41f1.

Fixes #2790

This patch mostly predates fdpp and inthandling redesign, and is likely not needed now, at least sure not for fdpp.

The problem is that we must not reveal our revect addr even in DPMI, as then libi86 sets it back to IVT. But if revect is still enabled, we expect some DOSish handler in IVT, and we read its addr and put to our revect addr. Now as libi86 wrote our own address to IVT, we put it to revect addr and get a loop.