### PR TITLE
int: delimit scope of force_revect to inte6 [fixes #2790]

### DIFF
--- a/src/base/core/int.c
+++ b/src/base/core/int.c
@@ -275,10 +275,6 @@ static void revect_helper(int stk_offs)
 	int start = (ah == 0xff ? 0 : ah + 1);
 	int i;
 
-	if (config.force_revect) {
-	    set_ZF();
-	    break;
-	}
 	for (i = start; i < 256; i++) {
 	    if (int_handlers[i].interrupt_function[REVECT])
 		break;
@@ -1824,7 +1820,7 @@ RVC_SETUP(x) \
 static far_t int##x##_unrevect(uint16_t seg, uint16_t offs) \
 { \
   far_t ret = {}; \
-  if (int##x##_hooked || config.force_revect) \
+  if (int##x##_hooked || (config.force_revect && 0x##x == DOS_HELPER_INT)) \
     return ret; \
   int##x##_hooked = 1; \
   di_printf("int_rvc: unrevect 0x%s\n", #x); \
@@ -1844,7 +1840,7 @@ static far_t int##x##_unrevect(uint16_t seg, uint16_t offs) \
 static int int##x##_unrevect_simple(void) \
 { \
   if (int##x##_hooked || !int_handlers[0x##x].interrupt_function[REVECT] || \
-        config.force_revect) \
+        (config.force_revect && 0x##x == DOS_HELPER_INT)) \
     return 0; \
   int##x##_hooked = 1; \
   di_printf("int_rvc: unrevect 0x%s\n", #x); \


### PR DESCRIPTION
260b283fc allowed for ints to remain revected after boot. Limit that to intE6 only, as this is enough for having Borland Basic still working. Otherwise the patch was too risky.

See also #2785