### PR TITLE
simx86: Eliminate EMUADDR_REL and EMU_BASE32 outside JIT-specific code (#2772)

### DIFF
--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -317,14 +317,13 @@ char *e_print_scp_regs(cpuctx_t *scp, int pmode)
 }
 
 
-char *e_emu_disasm(unsigned char *org, int is32, unsigned int refseg)
+char *e_emu_disasm(dosaddr_t code, int is32, unsigned int refseg)
 {
    static char buf[512];
    static char frmtbuf[256];
    int rc = 0;
    int i;
    char *p = buf, *p1;
-   dosaddr_t code;
    dosaddr_t org2;
    unsigned int segbase;
 #ifdef USE_MHPDBG
@@ -335,7 +334,6 @@ char *e_emu_disasm(unsigned char *org, int is32, unsigned int refseg)
      segbase = GetSegmentBase(refseg);
    else
      segbase = refseg * 16;
-   code = EMUADDR_REL(org);
    org2 = code - segbase;
 #ifdef USE_MHPDBG
    rc = dis_8086(code, frmtbuf, is32, &ref, segbase);
@@ -363,7 +361,7 @@ char *e_scp_disasm(cpuctx_t *scp, int pmode)
    static unsigned int lasta = 0;
    int rc;
    int i;
-   unsigned char *p, *pb, *org2;
+   unsigned char *p, *pb;
    dosaddr_t org, csp2;
    unsigned int refseg, seg;
    unsigned int ref;
@@ -387,9 +385,8 @@ char *e_scp_disasm(cpuctx_t *scp, int pmode)
    	&ref, (pmode? csp2 : refseg * 16));
 
    pb = buf;
-   org2 = EMU_BASE32(org);
-   while ((*org2&0xfc)==0x64) org2++;	/* skip most prefixes */
-   if ((debug_level('t')>3)||(InterOps[*org2]&2))
+   while ((READ_BYTE(org)&0xfc)==0x64) org++;	/* skip most prefixes */
+   if ((debug_level('t')>3)||(InterOps[READ_BYTE(org)]&2))
 	pb += sprintf(pb,"%s",e_print_scp_regs(scp,pmode));
 
    p = pb + sprintf(pb,"  %08x: ",org);

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -355,13 +355,12 @@ char *e_emu_disasm(dosaddr_t code, int is32, unsigned int refseg)
 #ifdef TRACE_DPMI
 char *e_scp_disasm(cpuctx_t *scp, int pmode)
 {
-   static char insrep = 0;
-   static unsigned char buf[1024];
-   static unsigned char frmtbuf[256];
+   static char buf[1024];
+   static char frmtbuf[256];
    static unsigned int lasta = 0;
    int rc;
    int i;
-   unsigned char *p, *pb;
+   char *p, *pb;
    dosaddr_t org, csp2;
    unsigned int refseg, seg;
    unsigned int ref;
@@ -369,17 +368,11 @@ char *e_scp_disasm(cpuctx_t *scp, int pmode)
    *buf = 0;
    seg = _cs;
    refseg = seg;
-   if (!(seg & 0x0004)) {
-      csp2 = org = EMUADDR_REL(LINP(_rip)); /* XXX bogus for x86_64 */
-   }
-   else {
-      csp2 = 0;
-      if (scp->cs <= 0xffff)
-         csp2 = GetSegmentBase(seg);
-      org = csp2 + _eip;
-   }
-   if (org==lasta) { insrep=1; return buf; } /* skip 'rep xxx' steps */
-   lasta = org; insrep = 0;
+   assert(DPMIValidSelector(seg));
+   csp2 = GetSegmentBase(seg);
+   org = csp2 + _eip;
+   if (org==lasta) { return buf; } /* skip 'rep xxx' steps */
+   lasta = org;
 
    rc = dis_8086(org, frmtbuf, pmode&&IsSegment32(seg),
    	&ref, (pmode? csp2 : refseg * 16));

--- a/src/base/emu-i386/simx86/cpu-emu.c
+++ b/src/base/emu-i386/simx86/cpu-emu.c
@@ -264,15 +264,13 @@ char *e_print_regs(unsigned int Interp_LONG_CS)
 		dosaddr_t csp = Interp_LONG_CS+TheCPU.eip;
 		dosaddr_t st = LONG_SS+TheCPU.esp;
 		if (csp < 0xa0000 - 256 || dpmi_is_valid_range(csp, 256)) {
-			unsigned char *op = EMU_BASE32(csp);
 			for (i=(ERB_L5+ERB_LEFTM); i<(ERB_L6); i+=3) {
-			   exprintb(*op++,buf,i);
+			   exprintb(READ_BYTE(csp),buf,i); csp++;
 			}
 		}
 		if (st < 0xa0000 - 256 || dpmi_is_valid_range(st, 256)) {
-			unsigned short *stk = (unsigned short *)EMU_BASE32(st);
 			for (i=(ERB_L6+ERB_LEFTM); i<(ERB_L7-2); i+=5) {
-			   exprintw(*stk++,buf,i);
+			   exprintw(READ_WORD(st),buf,i); st += 2;
 			}
 		}
 	}

--- a/src/base/emu-i386/simx86/emu86.h
+++ b/src/base/emu-i386/simx86/emu86.h
@@ -726,7 +726,7 @@ int _ModRM(unsigned char opc, unsigned int PC, int mode, signed char overr_ds, s
 })
 int ModGetReg1(unsigned int PC, int mode);
 //
-char *e_emu_disasm(unsigned char *org, int is32, unsigned int refseg);
+char *e_emu_disasm(dosaddr_t code, int is32, unsigned int refseg);
 char *e_print_regs(unsigned int Interp_LONGCS);
 char *e_print_scp_regs(cpuctx_t *scp, int pmode);
 const char *e_trace_fp(void);

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -382,7 +382,7 @@ static int can_speculate(void)
 	if (debug_level('e')) {
 		unsigned short ocs = TheCPU.cs;
 		unsigned int P2 = GL->npc;
-		char *ds = e_emu_disasm(EMU_BASE32(P2),IG->mode&MBIGCS,ocs);
+		char *ds = e_emu_disasm(P2,IG->mode&MBIGCS,ocs);
 		e_printf("prejit after  %s\n", ds);
 	}
 	return 1;
@@ -622,7 +622,7 @@ static unsigned int InterpOne(unsigned int PC, unsigned int Interp_LONG_CS,
 
 	if (debug_level('e')>2) {
 		char *ds;
-		ds = e_emu_disasm(EMU_BASE32(PC),basemode&MBIGCS,ocs);
+		ds = e_emu_disasm(PC,basemode&MBIGCS,ocs);
 		e_printf("  %s\n", ds);
 	}
 
@@ -2771,7 +2771,7 @@ static void prejit_run(TNode *G)
     char *ds;
     unsigned short ocs = TheCPU.cs;
     unsigned int basemode = G->mode;
-    ds = e_emu_disasm(EMU_BASE32(PC),basemode&MBIGCS,ocs);
+    ds = e_emu_disasm(PC,basemode&MBIGCS,ocs);
     e_printf("prejit at  %s\n", ds);
   }
   if (e_querymark(PC, 1))

--- a/src/base/emu-i386/simx86/memory.c
+++ b/src/base/emu-i386/simx86/memory.c
@@ -522,7 +522,7 @@ void e_fetch(unsigned int addr, size_t len, void **ret)
 	if (!p0)
 	    p0 = NewC(abeg);
 	l = (abeg == aend ? len : aend - addr);
-	memcpy(&((uint8_t *)p0)[off], EMU_BASE32(addr), l);
+	MEMCPY_2UNIX(&((uint8_t *)p0)[off], addr, l);
 	ret[0] = p0;
 	if (abeg == aend)
 	    return;
@@ -534,7 +534,7 @@ void e_fetch(unsigned int addr, size_t len, void **ret)
 	if (!p1)
 	    p1 = NewC(aend);
 	/* not offsetting as aend is page_aligned */
-	memcpy(p1, EMU_BASE32(aend), addr + len - aend);
+	MEMCPY_2UNIX(p1, aend, addr + len - aend);
 	ret[1] = p1;
 }
 
@@ -611,7 +611,7 @@ static void e_munprotect(unsigned int addr, size_t len)
 }
 
 /* check code hits on sub-page level */
-static int subpage_dirty(uint8_t *p, uint8_t *p1, tMpMap *M, int page)
+static int subpage_dirty(uint8_t *p, dosaddr_t p1, tMpMap *M, int page)
 {
     int i, n;
     uint64_t *bitmask = &M->subpage[page * (HOST_PAGE_SIZE >> 6)];
@@ -624,7 +624,7 @@ static int subpage_dirty(uint8_t *p, uint8_t *p1, tMpMap *M, int page)
 	    if (test_bit(addr&CGRMASK, M->nodemap))
 		assert(FindTree(addr));
 #endif
-	    if (p[bnum] != p1[bnum]) {
+	    if (p[bnum] != READ_BYTE(p1+bnum)) {
 		return 1;
 	    }
 	}
@@ -657,7 +657,7 @@ void e_invalidate_dirty(unsigned int addr, unsigned int aend)
 	    }
 	    p = M->pagemap[page];
 	    bs = 0;
-	    if (p && subpage_dirty(p, EMU_BASE32(addr), M, page)) {
+	    if (p && subpage_dirty(p, addr, M, page)) {
 		e_invalidate_page_full(addr);
 		bs = 1;
 		M = NULL;
@@ -679,7 +679,7 @@ void e_invalidate_page_dirty(unsigned int addr)
 	page = (addr / HOST_PAGE_SIZE) & (M->pages - 1);
 	p = M->pagemap[page];
 	bs = 0;
-	if (p && subpage_dirty(p, EMU_BASE32(addr), M, page)) {
+	if (p && subpage_dirty(p, addr, M, page)) {
 	    e_invalidate_page_full(addr);
 	    bs = 1;
 	}
@@ -698,8 +698,7 @@ again:
 	    for (i=0; i<M->pages; i++) {
 		void *p = M->pagemap[i];
 		dosaddr_t addr = (M->mega<<MEGA_SHIFT) | (i*HOST_PAGE_SIZE);
-		void *p1 = EMU_BASE32(addr);
-		if (p && subpage_dirty(p, p1, M, i)) {
+		if (p && subpage_dirty(p, addr, M, i)) {
 		    if (debug_level('e')>1)
 			dbug_printf("MP_INV %08x = RWX\n",addr);
 		    e_invalidate_page_full(addr);


### PR DESCRIPTION
If I understand things well, reading a byte from EMU_BASE32(x) gives the same contents as READ_BYTE(x), it's just a bit quicker without the aliasmap lookups, but these aren't critical paths.

We still need to use EMU_BASE32/EMUADDR_REL in cpatch.c and sigsegv.c to convert pointers from scp (cr2) and passed registers to and from dosaddr_t but that code is JIT specific.

So this eliminates the use of jit_base outside JIT.