### PR TITLE
CI: Remove maybeFailure from libi86 tests

### DIFF
--- a/test/func_libi86_testsuite.py
+++ b/test/func_libi86_testsuite.py
@@ -10,7 +10,7 @@ from common_framework import DOSEMU_CONF_DEFAULT, maybeFailure
 
 TESTSUITE = "/usr/ia16-elf/libexec/libi86/tests/testsuite"
 
-WHITELIST = [104, 105, 106, 107, 108, 109, 110]
+WHITELIST = []
 
 
 def libi86_create_items(testcase):


### PR DESCRIPTION
This removes the maybeFailure decorator from the failing tests so that a fix may be developed. However since those tests are autotest based, it may be better to run the test in question outside of the usual test framework. Here's an example:

##### Just use the framework to set things up
~~~
$ test/test_dosemu.py PPDOSGITTestCase.test_libi86_item_110

Usable KVM found
Test PP-DOS-GIT  libi86 item  110 system                                         ... FAIL

======================================================================
FAIL: Test PP-DOS-GIT  libi86 item  110 system                                        
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/func_libi86_testsuite.py", line 38, in do_test_libi86
    libi86_test_item(self, num)
  File "test/func_libi86_testsuite.py", line 102, in libi86_test_item
    raise self.failureException(f"Test failed with return code {e.returncode}") from None
AssertionError: Test failed with return code 1
Further info in file 'test_dosemu.PPDOSGITTestCase.test_libi86_item_110.log'
Further info in file 'test_dosemu.PPDOSGITTestCase.test_libi86_item_110.xpt'
Further info in file 'test_dosemu.PPDOSGITTestCase.test_libi86_item_110.c'

----------------------------------------------------------------------
Ran 1 test in 3.030s

FAILED (failures=1)
~~~

##### Now run the test directly
~~~
HERE=$(pwd) ; (cd ${HERE}/test-imagedir/libi86-test && \
    /usr/ia16-elf/libexec/libi86/tests/testsuite --x-installcheck --x-test-underlying \
    --x-with-dosemu=${HERE}/bin/dosemu \
    --x-with-dosemu-options="-f ${HERE}/test-imagedir/dosemu.conf -n \
    --Fimagedir ${HERE}/test-imagedir -o ${HERE}/dosemu.log" 110)
testsuite: WARNING: running tests in test-imagedir/libi86-test/tests
## ----------------------------------- ##
## libi86 20250921 test suite: libi86. ##
## ----------------------------------- ##
110: system                                          FAILED (process.h.at:400)

## ------------- ##
## Test results. ##
## ------------- ##

ERROR: 1 test was run,
1 failed unexpectedly.
## -------------------------- ##
## testsuite.log was created. ##
## -------------------------- ##

Please send `tests/testsuite.log' and all information you think might help:

   To: <https://gitlab.com/tkchia/libi86/-/issues>
   Subject: [libi86 20250921] testsuite: 110 failed

You may investigate any problem if you feel able to do so, in which
case the test suite provides a good starting point.  Its output may
be found below `tests/testsuite.dir'.
~~~

##### Check the output
~~~
$ ls test-imagedir/libi86-test/tests/testsuite.dir/110/
a.c  a.exe  a.map  expout  run	testsuite.log  w00t  w00t.bat

$ cat test-imagedir/libi86-test/tests/testsuite.dir/110/testsuite.log 
#                             -*- compilation -*-
110. process.h.at:399: testing system ...
/usr/ia16-elf/libexec/libi86/tests/../tests/process.h.at:400: $CC -o a.exe $CPPFLAGS -Wall -Werror=strict-prototypes -Werror=missing-prototypes -Werror=unused -Werror=deprecated -Werror=uninitialized -Werror=maybe-uninitialized -Os -mregparmcall -mcmodel=small a.c -li86 -Wl,-Map=a.map
stderr:
a.c: In function 'main':
a.c:10:3: warning: implicit declaration of function 'puts' [-Wimplicit-function-declaration]
   const char *cmd_line = BAT_FILE_MINUS_EXT " /foo victor --bar ::hugo";
   ^~~~
stdout:
/usr/ia16-elf/libexec/libi86/tests/../tests/process.h.at:400: ( \
  set +e; \
  if test x = x"$TERM" -o xdumb = x"$TERM"; then \
    TERM=vt220 && LINES=25 && COLUMNS=80 && export TERM LINES COLUMNS; \
  fi && \
  rm -f a.log && \
  ulimit -t 60 && \
  if test yes = "$DOSEMU_IS_1"; then \
    "$DOSEMU" $DOSEMU_OPTS $DOSEMUDUMB >a.log \
      ./a.exe; \
  else \
    "$DOSEMU" $DOSEMU_OPTS $DOSEMUDUMB >a.log \
      -K . -E a.exe; \
  fi </dev/null; \
  res=$?; \
  test -f a.log && \
    "$abs_srcdir"/postproc-stdout.sh <a.log && \
    rm a.log; \
  test 0 -ne $res && \
    DOSEMULOG="$HOME"/.dosemu/boot.log && \
    test -f "$DOSEMULOG" && \
    echo === "$DOSEMULOG" === >&2 && \
    cat "$DOSEMULOG" >&2; \
  exit $res \
)
stderr:
--- expout	2026-03-12 19:10:47.616282014 +0000
+++ test-imagedir/libi86-test/tests/testsuite.dir/at-groups/110/stdout	2026-03-12 19:10:48.043282537 +0000
@@ -1,6 +1,6 @@
-/foo
-victor
---bar
-::hugo
-""
+/foo
+victor
+--bar
+::hugo
+""
 yo
110. process.h.at:399: 110. system (process.h.at:399): FAILED (process.h.at:400)
~~~