### PR TITLE
smalloc: convert from void * to dosaddr_t (#2772)

### DIFF
--- a/src/base/core/lowmem.c
+++ b/src/base/core/lowmem.c
@@ -51,35 +51,38 @@ static void do_sm_error(int prio, const char *fmt, ...)
 
 int lowmem_init(void)
 {
-    dosemu_lmheap_base = MK_FP32(DOSEMU_LMHEAP_SEG, DOSEMU_LMHEAP_OFF);
-    sminit(&mp, dosemu_lmheap_base, DOSEMU_LMHEAP_SIZE);
+    dosaddr_t base = SEGOFF2LINEAR(DOSEMU_LMHEAP_SEG, DOSEMU_LMHEAP_OFF);
+    sminit(&mp, base, DOSEMU_LMHEAP_SIZE);
+    dosemu_lmheap_base = LINEAR2UNIX(base);
     smregister_error_notifier(&mp, do_sm_error);
     return 1;
 }
 
 void * lowmem_alloc(int size)
 {
-	char *ptr = smalloc(&mp, size);
-	if (!ptr) {
+	dosaddr_t ptr = smalloc(&mp, size);
+	if (ptr == (dosaddr_t)-1) {
 		error("lowmem_heap: OOM, size=%i\n", size);
 		leavedos(86);
 	}
-	return ptr;
+	return LINEAR2UNIX(ptr);
 }
 
 void * lowmem_alloc_aligned(int align, int size)
 {
-	char *ptr = smalloc_aligned(&mp, align, size);
-	if (!ptr) {
+	dosaddr_t ptr = smalloc_aligned(&mp, align, size);
+	if (ptr == (dosaddr_t)-1) {
 		error("lowmem_heap: OOM, size=%i\n", size);
 		leavedos(86);
 	}
-	return ptr;
+	return LINEAR2UNIX(ptr);
 }
 
 void lowmem_free(void *p)
 {
-	smfree(&mp, p);
+	if (!p) return;
+	smfree(&mp, SEGOFF2LINEAR(DOSEMU_LMHEAP_SEG,
+				  DOSEMU_LMHEAP_OFFS_OF(p)));
 }
 
 void lowmem_reset(void)

--- a/src/base/dev/vga/vgaemu.c
+++ b/src/base/dev/vga/vgaemu.c
@@ -1602,7 +1602,7 @@ static int vga_emu_post_init(void);
 int vga_emu_pre_init(void)
 {
   int i;
-  void *base;
+  dosaddr_t base;
   vga_mapping_type vmt = {0, 0, 0};
 
   if (config.dumb_video) {
@@ -1634,8 +1634,8 @@ int vga_emu_pre_init(void)
   vga.mem.size = (vga.mem.size + ((1 << 18) - 1)) & ~((1 << 18) - 1);
   vga.mem.pages = vga.mem.size / HOST_PAGE_SIZE;
 
-  base = smalloc_aligned_topdown(&main_pool, NULL, HOST_PAGE_SIZE, vga.mem.size);
-  if(!base) {
+  base = smalloc_aligned_topdown(&main_pool, (dosaddr_t)-1, HOST_PAGE_SIZE, vga.mem.size);
+  if(base == (dosaddr_t)-1) {
     error("vga_emu_init: not enough memory (%u k)\n", vga.mem.size >> 10);
     config.exitearly = 1;
     return 1;
@@ -1684,7 +1684,7 @@ int vga_emu_pre_init(void)
     }
   }
 
-  vga.mem.lfb_base = DOSADDR_REL(base);
+  vga.mem.lfb_base = base;
   vga.mem.base = dosaddr_to_unixaddr(vga.mem.lfb_base);
   memcheck_addtype('e', "VGAEMU LFB");
   register_hardware_ram_virtual('e', VGAEMU_PHYS_LFB_BASE, vga.mem.size,
@@ -1732,7 +1732,7 @@ void vga_emu_done(void)
 {
   if (vga.mem.lfb_base) {
     unalias_mapping_pa(MAPPING_DPMI, VGAEMU_PHYS_LFB_BASE, vga.mem.size);
-    smfree(&main_pool, MEM_BASE32(vga.mem.lfb_base));
+    smfree(&main_pool, vga.mem.lfb_base);
     vga.mem.lfb_base = 0;
   }
 }

--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -391,7 +391,8 @@ static void do_sm_error(int prio, const char *fmt, ...)
 
 void map_memory_space(void)
 {
-  unsigned char *lowmem, *ptr, *ptr2;
+  unsigned char *lowmem;
+  dosaddr_t ptr, ptr2;
   int result;
   uint32_t memsize;
   int32_t phys_rsv, phys_low;
@@ -433,23 +434,23 @@ void map_memory_space(void)
     memcheck_reserve('x', LOWMEM_SIZE + EXTMEM_SIZE, XMS_SIZE);
   }
 
-  sminit_f(&main_pool, mem_base, memsize, SMFLG_NOMEMSET);
+  sminit_f(&main_pool, 0, memsize, SMFLG_NOMEMSET);
   ptr = smalloc(&main_pool, LOWMEM_SIZE + HMASIZE);
-  assert(ptr == mem_base);
+  assert(ptr == 0);
   /* we have an uncommitted hole up to phys_low */
   ptr += phys_low;
   phys_rsv = phys_low - (LOWMEM_SIZE + HMASIZE);
   /* create non-identity mapping up to phys_low */
   ptr2 = smalloc_topdown(&main_pool, config.dpmi ? phys_low : phys_rsv);
-  assert(ptr2);
+  assert(ptr2 != (dosaddr_t)-1);
   if (config.dpmi) {
-    void *dptr = smalloc_fixed(&main_pool, MEM_BASE32(config.dpmi_base),
+    dosaddr_t dptr = smalloc_fixed(&main_pool, config.dpmi_base,
         dpmi_mem_size());
-    assert(dptr);
+    assert(dptr != (dosaddr_t)-1);
     if (config.cpu_vm_dpmi == CPUVM_KVM) {
       /* map dpmi+uncommitted space to kvm */
       int prot = KVM_PROT_RWX;
-      mmap_kvm(MAPPING_INIT_LOWRAM, phys_low, ptr2 - ptr, ptr, phys_low, prot);
+      mmap_kvm(MAPPING_INIT_LOWRAM, phys_low, ptr2 - ptr, MEM_BASE32(ptr), phys_low, prot);
     }
     /* unused hole for alignment */
     ptr2 += LOWMEM_SIZE + HMASIZE;
@@ -462,12 +463,12 @@ void map_memory_space(void)
       LOWMEM_SIZE + HMASIZE);
 
   /* establish ext_mem alias access for int15 within 32Mb window above dpmi */
-  ext_va = DOSADDR_REL(ptr2);
+  ext_va = ptr2;
   /* Note: can't map directly to lowmem_base here because XMS uses the
    * same window with different source. */
   register_hardware_ram_virtual('X', LOWMEM_SIZE + HMASIZE, phys_rsv, ext_va);
   if (config.dpmi && config.cpu_vm_dpmi == CPUVM_KVM)
-    mmap_kvm(MAPPING_LOWMEM, DOSADDR_REL(ptr2), phys_rsv,
+    mmap_kvm(MAPPING_LOWMEM, ptr2, phys_rsv,
         MEM_BASE32(LOWMEM_SIZE + HMASIZE), LOWMEM_SIZE + HMASIZE,
         KVM_PROT_RWX);
 

--- a/src/base/init/memcheck.c
+++ b/src/base/init/memcheck.c
@@ -294,15 +294,3 @@ void memcheck_dump(void)
   c_printf(".:  (unused)\n");
   c_printf("CONF:  End dump\n");
 }
-
-#if 0
-void *lowmemp(const unsigned char *ptr)
-{
-  dosaddr_t addr = DOSADDR_REL(ptr);
-#ifdef __x86_64__
-  if (addr > 0xffffffff)
-    return (void *)ptr;
-#endif
-  return dosaddr_to_unixaddr(addr);
-}
-#endif

--- a/src/base/lib/mapping/mapping.c
+++ b/src/base/lib/mapping/mapping.c
@@ -342,11 +342,10 @@ int alias_mapping(int cap, dosaddr_t targ, size_t mapsize, int protect, void *so
 }
 
 #ifdef __linux__
-static void *mmap_mapping_kmem(int cap, dosaddr_t targ, size_t mapsize,
+static dosaddr_t mmap_mapping_kmem(int cap, dosaddr_t targ, size_t mapsize,
 	off_t source)
 {
   int i;
-  void *target;
 
   Q__printf("MAPPING: map kmem, cap=%s, target=%x, size=%zx, source=%#jx\n",
 	cap, targ, mapsize, (intmax_t)source);
@@ -354,27 +353,24 @@ static void *mmap_mapping_kmem(int cap, dosaddr_t targ, size_t mapsize,
   i = map_find_idx(kmem_map, kmem_mappings, source);
   if (i == -1) {
 	error("KMEM mapping for %#jx was not allocated!\n", (intmax_t)source);
-	return MAP_FAILED;
+	return (dosaddr_t)-1;
   }
   if (kmem_map[i].len != mapsize) {
 	error("KMEM mapping for %#jx allocated for size %#x, but %#zx requested\n",
 	      (intmax_t)source, kmem_map[i].len, mapsize);
-	return MAP_FAILED;
+	return (dosaddr_t)-1;
   }
 
   if (targ == (dosaddr_t)-1) {
-    target = smalloc_aligned_topdown(&main_pool, NULL, PAGE_SIZE, mapsize);
-    if (!target) {
+    targ = smalloc_aligned_topdown(&main_pool, (dosaddr_t)-1, PAGE_SIZE, mapsize);
+    if (targ == (dosaddr_t)-1) {
       error("OOM for mmap_mapping_kmem, %s\n", strerror(errno));
-      return MAP_FAILED;
+      return targ;
     }
-    targ = DOSADDR_REL(target);
-  } else {
-    target = MEM_BASE32(targ);
   }
   kmem_map_single(cap, i, targ);
 
-  return target;
+  return targ;
 }
 #endif
 
@@ -923,18 +919,18 @@ static struct hardware_ram *hardware_ram;
 static int do_map_hwram(struct hardware_ram *hw)
 {
 #ifdef __linux__
-  unsigned char *p;
+  dosaddr_t p;
   int cap = MAPPING_KMEM;
   if (hw->default_vbase != (dosaddr_t)-1)
     cap |= MAPPING_LOWMEM;
   else if (!config.dpmi)
     return 0;
   p = mmap_mapping_kmem(cap, hw->default_vbase, hw->size, hw->base);
-  if (p == MAP_FAILED) {
+  if (p == (dosaddr_t)-1) {
     error("mmap error in map_hardware_ram %s\n", strerror (errno));
     return -1;
   }
-  hw->vbase = DOSADDR_REL(p);
+  hw->vbase = p;
   g_printf("mapped hardware ram at 0x%08zx .. 0x%08zx at %#x\n",
 	     hw->base, hw->base+hw->size-1, hw->vbase);
   return 0;

--- a/src/base/lib/misc/smalloc.c
+++ b/src/base/lib/misc/smalloc.c
@@ -114,25 +114,25 @@ static int get_oom_pr(struct mempool *mp, size_t size)
     return 0;
 }
 
-static void sm_uncommit(struct mempool *mp, void *addr, size_t comb_size)
+static void sm_uncommit(struct mempool *mp, dosaddr_t addr, size_t comb_size)
 {
     /* align address up and align down size */
-    uintptr_t a = (uintptr_t)addr;
-    uintptr_t aa = PAGE_ALIGN(a);
+    dosaddr_t a = addr;
+    dosaddr_t aa = PAGE_ALIGN(a);
     size_t aligned_size = (comb_size - (aa - a)) & _PAGE_MASK;
-    void *aligned_addr = (void *)aa;
+    dosaddr_t aligned_addr = aa;
     if (!mp->uncommit || !aligned_size)
       return;
     mp->uncommit(aligned_addr, aligned_size);
 }
 
-static int __sm_commit(struct mempool *mp, void *addr, size_t size,
-	void *e_addr, size_t e_size)
+static int __sm_commit(struct mempool *mp, dosaddr_t addr, size_t size,
+	dosaddr_t e_addr, size_t e_size)
 {
   if (!mp->commit)
     return 1;
   if (!mp->commit(addr, size)) {
-    smerror(mp, "SMALLOC: failed to commit %p %zi\n", addr, size);
+    smerror(mp, "SMALLOC: failed to commit %#x %zi\n", addr, size);
     if (e_size) {
       mp->avail += e_size;
       sm_uncommit(mp, e_addr, e_size);
@@ -142,14 +142,14 @@ static int __sm_commit(struct mempool *mp, void *addr, size_t size,
   return 1;
 }
 
-static int sm_commit(struct mempool *mp, void *addr, size_t size,
-	void *e_addr, size_t e_size)
+static int sm_commit(struct mempool *mp, dosaddr_t addr, size_t size,
+	dosaddr_t e_addr, size_t e_size)
 {
     /* align address down and align up size */
-    uintptr_t a = (uintptr_t)addr;
-    uintptr_t aa = a & _PAGE_MASK;
+    dosaddr_t a = addr;
+    dosaddr_t aa = a & _PAGE_MASK;
     size_t aligned_size = PAGE_ALIGN(size + (a - aa));
-    void *aligned_addr = (void *)aa;
+    dosaddr_t aligned_addr = aa;
     int ok = __sm_commit(mp, aligned_addr, aligned_size, e_addr, e_size);
     if (ok) {
 	assert(mp->avail >= size);
@@ -158,9 +158,9 @@ static int sm_commit(struct mempool *mp, void *addr, size_t size,
     return ok;
 }
 
-static int sm_commit_simple(struct mempool *mp, void *addr, size_t size)
+static int sm_commit_simple(struct mempool *mp, dosaddr_t addr, size_t size)
 {
-  return sm_commit(mp, addr, size, NULL, 0);
+  return sm_commit(mp, addr, size, (dosaddr_t)-1, 0);
 }
 
 static void mntruncate(struct memnode *pmn, size_t size)
@@ -199,7 +199,7 @@ static void mntruncate(struct memnode *pmn, size_t size)
   }
 }
 
-static struct memnode *find_mn(struct mempool *mp, unsigned char *ptr,
+static struct memnode *find_mn(struct mempool *mp, dosaddr_t ptr,
     struct memnode **prev)
 {
   struct memnode *pmn, *mn;
@@ -219,7 +219,7 @@ static struct memnode *find_mn(struct mempool *mp, unsigned char *ptr,
   return NULL;
 }
 
-static struct memnode *find_mn_at(struct mempool *mp, unsigned char *ptr)
+static struct memnode *find_mn_at(struct mempool *mp, dosaddr_t ptr)
 {
   struct memnode *mn;
   for (mn = &mp->mn; mn; mn = mn->next) {
@@ -242,12 +242,12 @@ static struct memnode *smfind_free_area(struct mempool *mp, size_t size)
 }
 
 static struct memnode *smfind_free_area_topdown(struct mempool *mp,
-    unsigned char *top, size_t size)
+    dosaddr_t top, size_t size)
 {
   struct memnode *mn;
   struct memnode *mn1 = NULL;
   for (mn = &mp->mn; mn; mn = mn->next) {
-    if (top && mn->mem_area + size > top)
+    if (top != (dosaddr_t)-1 && mn->mem_area + size > top)
       break;
     if (!mn->used && mn->size >= size)
       mn1 = mn;
@@ -255,7 +255,7 @@ static struct memnode *smfind_free_area_topdown(struct mempool *mp,
   return mn1;
 }
 
-static struct memnode *sm_alloc_fixed(struct mempool *mp, void *ptr,
+static struct memnode *sm_alloc_fixed(struct mempool *mp, dosaddr_t ptr,
     size_t size)
 {
   struct memnode *mn;
@@ -264,21 +264,21 @@ static struct memnode *sm_alloc_fixed(struct mempool *mp, void *ptr,
     smerror(mp, "SMALLOC: zero-sized allocation attempted\n");
     return NULL;
   }
-  if (!(mn = find_mn_at(mp, (unsigned char *)ptr))) {
-    smerror(mp, "SMALLOC: invalid address %p on alloc_fixed\n", ptr);
+  if (!(mn = find_mn_at(mp, ptr))) {
+    smerror(mp, "SMALLOC: invalid address %#x on alloc_fixed\n", ptr);
     return NULL;
   }
   if (mn->used) {
-    do_smerror(0, mp, "SMALLOC: address %p already allocated\n", ptr);
+    do_smerror(0, mp, "SMALLOC: address %#x already allocated\n", ptr);
     return NULL;
   }
-  delta = (uint8_t *)ptr - mn->mem_area;
+  delta = ptr - mn->mem_area;
   assert(delta >= 0);
   if (size + delta > mn->size) {
     int pr = get_oom_pr(mp, size);
     if (pr < 0)
       pr = 0;
-    do_smerror(pr, mp, "SMALLOC: no space %zi at address %p\n", size, ptr);
+    do_smerror(pr, mp, "SMALLOC: no space %zi at address %#x\n", size, ptr);
     return NULL;
   }
   if (delta) {
@@ -292,7 +292,7 @@ static struct memnode *sm_alloc_fixed(struct mempool *mp, void *ptr,
   mntruncate(mn, size);
   assert(mn->size == size);
   if (!(mp->flags & SMFLG_NOMEMSET))
-    memset(mn->mem_area, 0, size);
+    MEMSET_DOS(mn->mem_area, 0, size);
   return mn;
 }
 
@@ -301,7 +301,7 @@ static struct memnode *sm_alloc_aligned(struct mempool *mp, size_t align,
 {
   struct memnode *mn;
   int delta;
-  uintptr_t iptr;
+  dosaddr_t iptr;
   if (!size) {
     smerror(mp, "SMALLOC: zero-sized allocation attempted\n");
     return NULL;
@@ -315,7 +315,7 @@ static struct memnode *sm_alloc_aligned(struct mempool *mp, size_t align,
     return NULL;
   }
   /* insert small node to align the start */
-  iptr = (uintptr_t)mn->mem_area;
+  iptr = mn->mem_area;
   delta = ((iptr | align) - iptr + 1) & align;
   if (delta) {
     mntruncate(mn, delta);
@@ -328,7 +328,7 @@ static struct memnode *sm_alloc_aligned(struct mempool *mp, size_t align,
   mntruncate(mn, size);
   assert(mn->size == size);
   if (!(mp->flags & SMFLG_NOMEMSET))
-    memset(mn->mem_area, 0, size);
+    MEMSET_DOS(mn->mem_area, 0, size);
   return mn;
 }
 
@@ -338,13 +338,13 @@ static struct memnode *sm_alloc_mn(struct mempool *mp, size_t size)
 }
 
 static struct memnode *sm_alloc_aligned_topdown(struct mempool *mp,
-    unsigned char *top, size_t align, size_t size)
+    dosaddr_t top, size_t align, size_t size)
 {
   struct memnode *mn;
   int delta;
-  uintptr_t iptr;
-  uintptr_t min_top;
-  uintptr_t iend;
+  dosaddr_t iptr;
+  dosaddr_t min_top;
+  dosaddr_t iend;
   if (!size) {
     smerror(mp, "SMALLOC: zero-sized allocation attempted\n");
     return NULL;
@@ -358,16 +358,16 @@ static struct memnode *sm_alloc_aligned_topdown(struct mempool *mp,
     return NULL;
   }
   /* use top part of the found area */
-  min_top = (uintptr_t)mn->mem_area + mn->size;
-  if (top)
-    min_top = _min(min_top, (uintptr_t)top);
+  min_top = mn->mem_area + mn->size;
+  if (top != (dosaddr_t)-1)
+    min_top = _min(min_top, top);
   iptr = (min_top - size) & ~align;
   iend = iptr + size;
-  delta = (uintptr_t)mn->mem_area + mn->size - iend;
+  delta = mn->mem_area + mn->size - iend;
   if (delta)
     mntruncate(mn, mn->size - delta);
-  assert(iptr >= (uintptr_t)mn->mem_area);
-  delta = iptr - (uintptr_t)mn->mem_area;
+  assert(iptr >= mn->mem_area);
+  delta = iptr - mn->mem_area;
   if (delta) {
     mntruncate(mn, delta);
     mn = mn->next;
@@ -379,65 +379,65 @@ static struct memnode *sm_alloc_aligned_topdown(struct mempool *mp,
   mntruncate(mn, size);
   assert(mn->size == size);
   if (!(mp->flags & SMFLG_NOMEMSET))
-    memset(mn->mem_area, 0, size);
+    MEMSET_DOS(mn->mem_area, 0, size);
   return mn;
 }
 
 static struct memnode *sm_alloc_topdown(struct mempool *mp, size_t size)
 {
-  return sm_alloc_aligned_topdown(mp, NULL, 1, size);
+  return sm_alloc_aligned_topdown(mp, (dosaddr_t)-1, 1, size);
 }
 
-void *smalloc(struct mempool *mp, size_t size)
+dosaddr_t smalloc(struct mempool *mp, size_t size)
 {
   struct memnode *mn = sm_alloc_mn(mp, size);
   if (!mn)
-    return NULL;
+    return (dosaddr_t)-1;
   return mn->mem_area;
 }
 
-void *smalloc_fixed(struct mempool *mp, void *ptr, size_t size)
+dosaddr_t smalloc_fixed(struct mempool *mp, dosaddr_t ptr, size_t size)
 {
   struct memnode *mn = sm_alloc_fixed(mp, ptr, size);
   if (!mn)
-    return NULL;
+    return (dosaddr_t)-1;
   assert(mn->mem_area == ptr);
   return mn->mem_area;
 }
 
-void *smalloc_aligned(struct mempool *mp, size_t align, size_t size)
+dosaddr_t smalloc_aligned(struct mempool *mp, size_t align, size_t size)
 {
   struct memnode *mn = sm_alloc_aligned(mp, align, size);
   if (!mn)
-    return NULL;
-  assert(((uintptr_t)mn->mem_area & (align - 1)) == 0);
+    return (dosaddr_t)-1;
+  assert((mn->mem_area & (align - 1)) == 0);
   return mn->mem_area;
 }
 
-void *smalloc_topdown(struct mempool *mp, size_t size)
+dosaddr_t smalloc_topdown(struct mempool *mp, size_t size)
 {
   struct memnode *mn = sm_alloc_topdown(mp, size);
   if (!mn)
-    return NULL;
+    return (dosaddr_t)-1;
   return mn->mem_area;
 }
 
-void *smalloc_aligned_topdown(struct mempool *mp, unsigned char *top,
+dosaddr_t smalloc_aligned_topdown(struct mempool *mp, dosaddr_t top,
     size_t align, size_t size)
 {
   struct memnode *mn = sm_alloc_aligned_topdown(mp, top, align, size);
   if (!mn)
-    return NULL;
-  assert(((uintptr_t)mn->mem_area & (align - 1)) == 0);
+    return (dosaddr_t)-1;
+  assert((mn->mem_area & (align - 1)) == 0);
   return mn->mem_area;
 }
 
-int smfree(struct mempool *mp, void *ptr)
+int smfree(struct mempool *mp, dosaddr_t ptr)
 {
   struct memnode *mn, *pmn;
-  if (!ptr)
+  if (ptr == (dosaddr_t)-1)
     return -1;
-  if (!(mn = find_mn(mp, (unsigned char *)ptr, &pmn))) {
+  if (!(mn = find_mn(mp, ptr, &pmn))) {
     smerror(mp, "SMALLOC: bad pointer passed to smfree()\n");
     return -1;
   }
@@ -485,9 +485,9 @@ static struct memnode *sm_realloc_alloc_mn(struct mempool *mp,
         return NULL;
     }
     pmn->used = 1;
-    memmove(pmn->mem_area, mn->mem_area, mn->size);
+    MEMMOVE_DOS2DOS(pmn->mem_area, mn->mem_area, mn->size);
     if (!(mp->flags & SMFLG_NOMEMSET))
-      memset(pmn->mem_area + mn->size, 0, size - mn->size);
+      MEMSET_DOS(pmn->mem_area + mn->size, 0, size - mn->size);
     mn->used = 0;
     if (size < pmn->size + mn->size) {
       size_t overl = size > pmn->size ? size - pmn->size : 0;
@@ -511,28 +511,28 @@ static struct memnode *sm_realloc_alloc_mn(struct mempool *mp,
 	    "SMALLOC: Out Of Memory on realloc, requested=%zu\n", size);
       return NULL;
     }
-    memcpy(new_mn->mem_area, mn->mem_area, mn->size);
+    MEMCPY_DOS2DOS(new_mn->mem_area, mn->mem_area, mn->size);
     smfree(mp, mn->mem_area);
   }
   return new_mn;
 }
 
-void *smrealloc(struct mempool *mp, void *ptr, size_t size)
+dosaddr_t smrealloc(struct mempool *mp, dosaddr_t ptr, size_t size)
 {
   struct memnode *mn, *pmn, *nmn;
   if (!ptr)
     return smalloc(mp, size);
-  if (!(mn = find_mn(mp, (unsigned char *)ptr, &pmn))) {
+  if (!(mn = find_mn(mp, ptr, &pmn))) {
     smerror(mp, "SMALLOC: bad pointer passed to smrealloc()\n");
-    return NULL;
+    return (dosaddr_t)-1;
   }
   if (!mn->used) {
     smerror(mp, "SMALLOC: attempt to realloc the not allocated region\n");
-    return NULL;
+    return (dosaddr_t)-1;
   }
   if (size == 0) {
     smfree(mp, ptr);
-    return NULL;
+    return (dosaddr_t)-1;
   }
   if (size == mn->size)
     return ptr;
@@ -550,44 +550,44 @@ void *smrealloc(struct mempool *mp, void *ptr, size_t size)
     if (nmn && !nmn->used && mn->size + nmn->size >= size) {
       /* expand by shrinking next memnode */
       if (!sm_commit_simple(mp, nmn->mem_area, size - mn->size))
-        return NULL;
+        return (dosaddr_t)-1;
       if (!(mp->flags & SMFLG_NOMEMSET))
-        memset(nmn->mem_area, 0, size - mn->size);
+        MEMSET_DOS(nmn->mem_area, 0, size - mn->size);
       mntruncate(mn, size);
     } else {
       /* need to allocate new memnode */
       mn = sm_realloc_alloc_mn(mp, pmn, mn, nmn, size);
       if (!mn)
-        return NULL;
+        return (dosaddr_t)-1;
     }
   }
   assert(mn->size == size);
   return mn->mem_area;
 }
 
-void *smrealloc_aligned(struct mempool *mp, void *ptr, int align, size_t size)
+dosaddr_t smrealloc_aligned(struct mempool *mp, dosaddr_t ptr, int align, size_t size)
 {
   struct memnode *mn, *pmn, *nmn;
   assert(__builtin_popcount(align) == 1);
   if (!ptr)
     return smalloc_aligned(mp, align, size);
-  if (!(mn = find_mn(mp, (unsigned char *)ptr, &pmn))) {
+  if (!(mn = find_mn(mp, ptr, &pmn))) {
     smerror(mp, "SMALLOC: bad pointer passed to smrealloc()\n");
-    return NULL;
+    return (dosaddr_t)-1;
   }
   if (!mn->used) {
     smerror(mp, "SMALLOC: attempt to realloc the not allocated region\n");
-    return NULL;
+    return (dosaddr_t)-1;
   }
   if (size == 0) {
     smfree(mp, ptr);
-    return NULL;
+    return (dosaddr_t)-1;
   }
   if (size == mn->size)
     return ptr;
-  if ((uintptr_t)mn->mem_area & (align - 1)) {
+  if (mn->mem_area & (align - 1)) {
     smerror(mp, "SMALLOC: unaligned pointer passed to smrealloc_aligned()\n");
-    return NULL;
+    return (dosaddr_t)-1;
   }
   if (size < mn->size) {
     /* shrink */
@@ -603,16 +603,16 @@ void *smrealloc_aligned(struct mempool *mp, void *ptr, int align, size_t size)
     if (nmn && !nmn->used && mn->size + nmn->size >= size) {
       /* expand by shrinking next memnode */
       if (!sm_commit_simple(mp, nmn->mem_area, size - mn->size))
-        return NULL;
+        return (dosaddr_t)-1;
       if (!(mp->flags & SMFLG_NOMEMSET))
-        memset(nmn->mem_area, 0, size - mn->size);
+        MEMSET_DOS(nmn->mem_area, 0, size - mn->size);
       mntruncate(mn, size);
     } else {
       /* lazy impl */
       struct memnode *new_mn = sm_alloc_aligned(mp, align, size);
       if (!new_mn)
-        return NULL;
-      memcpy(new_mn->mem_area, mn->mem_area, mn->size);
+        return (dosaddr_t)-1;
+      MEMCPY_DOS2DOS(new_mn->mem_area, mn->mem_area, mn->size);
       smfree(mp, mn->mem_area);
     }
   }
@@ -620,13 +620,13 @@ void *smrealloc_aligned(struct mempool *mp, void *ptr, int align, size_t size)
   return mn->mem_area;
 }
 
-static int do_sminit(struct mempool *mp, void *start, size_t size, int flags)
+static int do_sminit(struct mempool *mp, dosaddr_t start, size_t size, int flags)
 {
   mp->size = size;
   mp->mn.size = size;
   mp->mn.used = 0;
   mp->mn.next = NULL;
-  mp->mn.mem_area = (unsigned char *)start;
+  mp->mn.mem_area = start;
   mp->avail = size;
   mp->flags = flags;
   mp->commit = NULL;
@@ -635,19 +635,19 @@ static int do_sminit(struct mempool *mp, void *start, size_t size, int flags)
   return 0;
 }
 
-int sminit(struct mempool *mp, void *start, size_t size)
+int sminit(struct mempool *mp, dosaddr_t start, size_t size)
 {
   return do_sminit(mp, start, size, 0);
 }
 
-int sminit_f(struct mempool *mp, void *start, size_t size, int flags)
+int sminit_f(struct mempool *mp, dosaddr_t start, size_t size, int flags)
 {
   return do_sminit(mp, start, size, flags);
 }
 
-static int do_sminit_com(struct mempool *mp, void *start, size_t size,
-    int (*commit)(void *area, size_t size),
-    int (*uncommit)(void *area, size_t size), int do_uncommit,
+static int do_sminit_com(struct mempool *mp, dosaddr_t start, size_t size,
+    int (*commit)(dosaddr_t area, size_t size),
+    int (*uncommit)(dosaddr_t area, size_t size), int do_uncommit,
     int flags)
 {
   do_sminit(mp, start, size, flags);
@@ -658,17 +658,17 @@ static int do_sminit_com(struct mempool *mp, void *start, size_t size,
   return 0;
 }
 
-int sminit_com(struct mempool *mp, void *start, size_t size,
-    int (*commit)(void *area, size_t size),
-    int (*uncommit)(void *area, size_t size),
+int sminit_com(struct mempool *mp, dosaddr_t start, size_t size,
+    int (*commit)(dosaddr_t area, size_t size),
+    int (*uncommit)(dosaddr_t area, size_t size),
     int flags)
 {
   return do_sminit_com(mp, start, size, commit, uncommit, 1, flags);
 }
 
-int sminit_comu(struct mempool *mp, void *start, size_t size,
-    int (*commit)(void *area, size_t size),
-    int (*uncommit)(void *area, size_t size),
+int sminit_comu(struct mempool *mp, dosaddr_t start, size_t size,
+    int (*commit)(dosaddr_t area, size_t size),
+    int (*uncommit)(dosaddr_t area, size_t size),
     int flags)
 {
   return do_sminit_com(mp, start, size, commit, uncommit, 0, flags);
@@ -702,7 +702,7 @@ size_t smget_free_space(struct mempool *mp)
   return mp->avail;
 }
 
-size_t smget_free_space_upto(struct mempool *mp, unsigned char *top)
+size_t smget_free_space_upto(struct mempool *mp, dosaddr_t top)
 {
   struct memnode *mn;
   int cnt = 0;
@@ -729,17 +729,17 @@ size_t smget_largest_free_area(struct mempool *mp)
   return size;
 }
 
-int smget_area_size(struct mempool *mp, void *ptr)
+int smget_area_size(struct mempool *mp, dosaddr_t ptr)
 {
   struct memnode *mn;
-  if (!(mn = find_mn(mp, (unsigned char *)ptr, NULL))) {
+  if (!(mn = find_mn(mp, ptr, NULL))) {
     smerror(mp, "SMALLOC: bad pointer passed to smget_area_size()\n");
     return -1;
   }
   return mn->size;
 }
 
-void *smget_base_addr(struct mempool *mp)
+dosaddr_t smget_base_addr(struct mempool *mp)
 {
   return mp->mn.mem_area;
 }

--- a/src/base/lib/misc/smalloc.h
+++ b/src/base/lib/misc/smalloc.h
@@ -18,6 +18,7 @@
 #define __SMALLOC_H
 
 #include <stddef.h>
+#include "memory.h"
 
 #ifndef FORMAT
 #define FORMAT(T,A,B) __attribute__((format(T,A,B)))
@@ -27,7 +28,7 @@ struct memnode {
   struct memnode *next;
   size_t size;
   int used;
-  unsigned char *mem_area;
+  dosaddr_t mem_area;
 };
 
 typedef struct mempool {
@@ -35,39 +36,39 @@ typedef struct mempool {
   size_t avail;
   int flags;
   struct memnode mn;
-  int (*commit)(void *area, size_t size);
-  int (*uncommit)(void *area, size_t size);
+  int (*commit)(dosaddr_t area, size_t size);
+  int (*uncommit)(dosaddr_t area, size_t size);
   void (*smerr)(int prio, const char *fmt, ...) FORMAT(printf, 2, 3);
 } smpool;
 
 #define SMFLG_NOMEMSET 1
 
-void *smalloc(struct mempool *mp, size_t size);
-void *smalloc_fixed(struct mempool *mp, void *ptr, size_t size);
-int smfree(struct mempool *mp, void *ptr);
-void *smalloc_aligned(struct mempool *mp, size_t align, size_t size);
-void *smalloc_topdown(struct mempool *mp, size_t size);
-void *smalloc_aligned_topdown(struct mempool *mp, unsigned char *top,
+dosaddr_t smalloc(struct mempool *mp, size_t size);
+dosaddr_t smalloc_fixed(struct mempool *mp, dosaddr_t ptr, size_t size);
+int smfree(struct mempool *mp, dosaddr_t ptr);
+dosaddr_t smalloc_aligned(struct mempool *mp, size_t align, size_t size);
+dosaddr_t smalloc_topdown(struct mempool *mp, size_t size);
+dosaddr_t smalloc_aligned_topdown(struct mempool *mp, dosaddr_t top,
     size_t align, size_t size);
-void *smrealloc(struct mempool *mp, void *ptr, size_t size);
-void *smrealloc_aligned(struct mempool *mp, void *ptr, int align, size_t size);
-int sminit(struct mempool *mp, void *start, size_t size);
-int sminit_f(struct mempool *mp, void *start, size_t size, int flags);
-int sminit_com(struct mempool *mp, void *start, size_t size,
-    int (*commit)(void *area, size_t size),
-    int (*uncommit)(void *area, size_t size),
+dosaddr_t smrealloc(struct mempool *mp, dosaddr_t ptr, size_t size);
+dosaddr_t smrealloc_aligned(struct mempool *mp, dosaddr_t ptr, int align, size_t size);
+int sminit(struct mempool *mp, dosaddr_t start, size_t size);
+int sminit_f(struct mempool *mp, dosaddr_t start, size_t size, int flags);
+int sminit_com(struct mempool *mp, dosaddr_t start, size_t size,
+    int (*commit)(dosaddr_t area, size_t size),
+    int (*uncommit)(dosaddr_t area, size_t size),
     int flags);
-int sminit_comu(struct mempool *mp, void *start, size_t size,
-    int (*commit)(void *area, size_t size),
-    int (*uncommit)(void *area, size_t size),
+int sminit_comu(struct mempool *mp, dosaddr_t start, size_t size,
+    int (*commit)(dosaddr_t area, size_t size),
+    int (*uncommit)(dosaddr_t area, size_t size),
     int flags);
 void smfree_all(struct mempool *mp);
 int smdestroy(struct mempool *mp);
 size_t smget_free_space(struct mempool *mp);
-size_t smget_free_space_upto(struct mempool *mp, unsigned char *top);
+size_t smget_free_space_upto(struct mempool *mp, dosaddr_t top);
 size_t smget_largest_free_area(struct mempool *mp);
-int smget_area_size(struct mempool *mp, void *ptr);
-void *smget_base_addr(struct mempool *mp);
+int smget_area_size(struct mempool *mp, dosaddr_t ptr);
+dosaddr_t smget_base_addr(struct mempool *mp);
 void smregister_error_notifier(struct mempool *mp,
   void (*func)(int prio, const char *fmt, ...) FORMAT(printf, 2, 3));
 void smregister_default_error_notifier(

--- a/src/dosext/dpmi/dpmi_api.c
+++ b/src/dosext/dpmi/dpmi_api.c
@@ -31,10 +31,10 @@
 short __dpmi_int_ss, __dpmi_int_sp, __dpmi_int_flags;
 
 static uint16_t data_sel;
-static unsigned char *pool_base;
+static dosaddr_t pool_base;
 static smpool apool;
 
-#define POOL_OFS(p) ((unsigned char *)(p) - pool_base)
+#define POOL_OFS(p) ((p) - pool_base)
 
 static void do_callf(cpuctx_t *scp, int is_32, struct pmaddr_s pma)
 {
@@ -446,18 +446,18 @@ int _dpmi_set_extended_exception_handler_vector_rm(cpuctx_t *scp, int is_32, int
 int _dpmi_simulate_real_mode_interrupt(cpuctx_t *scp, int is_32, int _vector, __dpmi_regs *__regs)
 {			/* DPMI 0.9 AX=0300 */
     cpuctx_t sa = *scp;
-    __dpmi_regs *regs = smalloc(&apool, sizeof(*regs));
+    dosaddr_t regs = smalloc(&apool, sizeof(*__regs));
 
     _eax = 0x300;
     _ebx = _vector;
     _ecx = 0;
     _es = data_sel;
     _edi = POOL_OFS(regs);
-    memcpy(regs, __regs, sizeof(*regs));
+    MEMCPY_2DOS(regs, __regs, sizeof(*__regs));
     D_printf("MSDOS: sched to dos thread for int 0x%x\n", _vector);
     do_dpmi_callf(scp, is_32);
     D_printf("MSDOS: return from dos thread\n");
-    memcpy(__regs, regs, sizeof(*regs));
+    MEMCPY_2UNIX(__regs, regs, sizeof(*__regs));
     smfree(&apool, regs);
     *scp = sa;
     return 0;
@@ -466,7 +466,7 @@ int _dpmi_simulate_real_mode_interrupt(cpuctx_t *scp, int is_32, int _vector, __
 int _dpmi_int(cpuctx_t *scp, int is_32, int _vector, __dpmi_regs *__regs)
 { /* like above, but sets ss sp fl */	/* DPMI 0.9 AX=0300 */
     cpuctx_t sa = *scp;
-    __dpmi_regs *regs = smalloc(&apool, sizeof(*regs));
+    dosaddr_t regs = smalloc(&apool, sizeof(*__regs));
 
     _eax = 0x300;
     _ebx = _vector;
@@ -476,11 +476,11 @@ int _dpmi_int(cpuctx_t *scp, int is_32, int _vector, __dpmi_regs *__regs)
     __regs->x.ss = __dpmi_int_ss;
     __regs->x.sp = __dpmi_int_sp;
     __regs->x.flags = __dpmi_int_flags;
-    memcpy(regs, __regs, sizeof(*regs));
+    MEMCPY_2DOS(regs, __regs, sizeof(*__regs));
     D_printf("MSDOS: sched to dos thread for int 0x%x\n", _vector);
     do_dpmi_callf(scp, is_32);
     D_printf("MSDOS: return from dos thread\n");
-    memcpy(__regs, regs, sizeof(*regs));
+    MEMCPY_2UNIX(__regs, regs, sizeof(*__regs));
     smfree(&apool, regs);
     *scp = sa;
     return 0;
@@ -498,19 +498,19 @@ static void do_procedure_retf(cpuctx_t *scp,
 	.selector = dpmi_sel(),
     };
     cpuctx_t sa = *scp;
-    __dpmi_regs *regs = smalloc(&apool, sizeof(*regs));
+    dosaddr_t regs = smalloc(&apool, sizeof(*__regs));
 
     _eax = 0x301;
     _ebx = 0;
     _ecx = words;
     _es = data_sel;
     _edi = POOL_OFS(regs);
-    memcpy(regs, __regs, sizeof(*regs));
+    MEMCPY_2DOS(regs, __regs, sizeof(*__regs));
     D_printf("MSDOS: sched to dos thread for call to %x:%x\n",
 	    __regs->x.cs, __regs->x.ip);
     do_callf(scp, is_32, is_32 ? pma : pma16);
     D_printf("MSDOS: return from dos thread\n");
-    memcpy(__regs, regs, sizeof(*regs));
+    MEMCPY_2UNIX(__regs, regs, sizeof(*__regs));
     smfree(&apool, regs);
     *scp = sa;
 }
@@ -546,19 +546,19 @@ int _dpmi_simulate_real_mode_procedure_retf_stack(cpuctx_t *scp, int is_32,
 int _dpmi_simulate_real_mode_procedure_iret(cpuctx_t *scp, int is_32, __dpmi_regs *__regs)
 {				/* DPMI 0.9 AX=0302 */
     cpuctx_t sa = *scp;
-    __dpmi_regs *regs = smalloc(&apool, sizeof(*regs));
+    dosaddr_t regs = smalloc(&apool, sizeof(*__regs));
 
     _eax = 0x302;
     _ebx = 0;
     _ecx = 0;
     _es = data_sel;
     _edi = POOL_OFS(regs);
-    memcpy(regs, __regs, sizeof(*regs));
+    MEMCPY_2DOS(regs, __regs, sizeof(*__regs));
     D_printf("MSDOS: sched to dos thread for call to %x:%x\n",
 	    __regs->x.cs, __regs->x.ip);
     do_dpmi_callf(scp, is_32);
     D_printf("MSDOS: return from dos thread\n");
-    memcpy(__regs, regs, sizeof(*regs));
+    MEMCPY_2UNIX(__regs, regs, sizeof(*__regs));
     smfree(&apool, regs);
     *scp = sa;
     return 0;
@@ -896,15 +896,15 @@ int _dpmi_set_coprocessor_emulation(cpuctx_t *scp, int is_32, int _flags)
 void dpmi_api_init(uint16_t selector, dosaddr_t pool, int pool_size)
 {
     data_sel = selector;
-    pool_base = MEM_BASE32(pool);
+    pool_base = pool;
     sminit(&apool, pool_base, pool_size);
 }
 
 __dpmi_paddr dapi_alloc(int len)
 {
     __dpmi_paddr ret = {};
-    void *ptr = smalloc(&apool, len);
-    if (ptr) {
+    dosaddr_t ptr = smalloc(&apool, len);
+    if (ptr != (dosaddr_t)-1) {
         ret.selector = data_sel;
         ret.offset32 = POOL_OFS(ptr);
     }

--- a/src/dosext/dpmi/memory.c
+++ b/src/dosext/dpmi/memory.c
@@ -49,8 +49,8 @@ static unsigned int mem_allocd;           /* how many bytes memory client */
 unsigned int pm_block_handle_used;       /* tracking handle */
 
 static smpool mem_pool;
-static unsigned char *dpmi_lin_rsv_base;
-static unsigned char *dpmi_base;
+static dosaddr_t dpmi_lin_rsv_base;
+static dosaddr_t dpmi_base;
 static const int dpmi_reserved_space = 4 * 1024 * 1024; // reserve 4Mb
 
 #define SHSIZE 16
@@ -152,21 +152,20 @@ dpmi_pm_block *lookup_pm_block_by_shmname(dpmi_pm_block_root *root,
     return NULL;
 }
 
-static int commit(void *ptr, size_t size)
+static int commit(dosaddr_t targ, size_t size)
 {
-  dosaddr_t targ = DOSADDR_REL(ptr);
   size = HOST_PAGE_ALIGN(size);
   if (mprotect_mapping(MAPPING_DPMI, targ, size,
 	PROT_READ | PROT_WRITE | DPMI_PROT_EXEC) == -1)
     return 0;
-  mcommit(ptr, size);
+  mcommit(MEM_BASE32(targ), size);
   return 1;
 }
 
-static int uncommit(void *ptr, size_t size)
+static int uncommit(dosaddr_t targ, size_t size)
 {
   size = HOST_PAGE_ALIGN(size);
-  if (mprotect_mapping(MAPPING_DPMI, DOSADDR_REL(ptr), size, PROT_NONE) == -1)
+  if (mprotect_mapping(MAPPING_DPMI, targ, size, PROT_NONE) == -1)
     return 0;
   return 1;
 }
@@ -215,16 +214,16 @@ int dpmi_lin_mem_free(void)
     if (!dpmi_lin_rsv_base)
 	return 0;
     return smget_free_space_upto(&main_pool,
-	    &dpmi_lin_rsv_base[dpmi_lin_mem_rsv()]);
+	    dpmi_lin_rsv_base + dpmi_lin_mem_rsv());
 }
 
 int dpmi_alloc_pool(void)
 {
     uint32_t memsize = dpmi_mem_size();
 
-    dpmi_lin_rsv_base = MEM_BASE32(LOWMEM_SIZE + HMASIZE);
-    dpmi_base = MEM_BASE32(config.dpmi_base);
-    c_printf("DPMI: mem init, mpool is %d bytes at %p\n", memsize, dpmi_base);
+    dpmi_lin_rsv_base = LOWMEM_SIZE + HMASIZE;
+    dpmi_base = config.dpmi_base;
+    c_printf("DPMI: mem init, mpool is %d bytes at %#x\n", memsize, dpmi_base);
     /* Create DPMI pool */
     sminit_com(&mem_pool, dpmi_base, memsize, commit, uncommit, 0);
     dpmi_total_memory = config.dpmi * 1024;
@@ -407,7 +406,7 @@ static void restore_page_protection(dpmi_pm_block *block)
 dpmi_pm_block * DPMI_malloc(dpmi_pm_block_root *root, unsigned int size)
 {
     dpmi_pm_block *block;
-    unsigned char *realbase;
+    dosaddr_t realbase;
     int i;
 
    /* aligned size to PAGE size */
@@ -420,7 +419,7 @@ dpmi_pm_block * DPMI_malloc(dpmi_pm_block_root *root, unsigned int size)
 	free_pm_block(root, block);
 	return NULL;
     }
-    block->base = DOSADDR_REL(realbase);
+    block->base = realbase;
     block->linear = 0;
     for (i = 0; i < size / HOST_PAGE_SIZE; i++)
 	block->attrs[i] = 9;
@@ -435,7 +434,7 @@ dpmi_pm_block * DPMI_mallocLinear(dpmi_pm_block_root *root,
   dosaddr_t base, unsigned int size, int committed)
 {
     dpmi_pm_block *block;
-    unsigned char *realbase;
+    dosaddr_t realbase;
     int i;
 
    /* aligned size to PAGE size */
@@ -446,12 +445,12 @@ dpmi_pm_block * DPMI_mallocLinear(dpmi_pm_block_root *root,
 	base = -1;
     else {
 	/* fixed allocation */
-	if (base < DOSADDR_REL(dpmi_lin_rsv_base)) {
+	if (base < dpmi_lin_rsv_base) {
 	    D_printf("DPMI: failing lin alloc to lowmem %x, size %x\n",
 		    base, size);
 	    return NULL;
 	}
-	if ((uint64_t)base + size > DOSADDR_REL(dpmi_lin_rsv_base) +
+	if ((uint64_t)base + size > dpmi_lin_rsv_base +
 		dpmi_lin_mem_rsv()) {
 	    D_printf("DPMI: failing lin alloc to %x, size %x\n", base, size);
 	    return NULL;
@@ -463,15 +462,15 @@ dpmi_pm_block * DPMI_mallocLinear(dpmi_pm_block_root *root,
 
     if (base == -1)
 	realbase = smalloc_aligned_topdown(&main_pool,
-		&dpmi_lin_rsv_base[dpmi_lin_mem_rsv()],
+		dpmi_lin_rsv_base + dpmi_lin_mem_rsv(),
 		HOST_PAGE_SIZE, size);
     else
-	realbase = smalloc_fixed(&main_pool, MEM_BASE32(base), size);
-    if (realbase == NULL) {
+	realbase = smalloc_fixed(&main_pool, base, size);
+    if (realbase == (dosaddr_t)-1) {
 	free_pm_block(root, block);
 	return NULL;
     }
-    block->base = DOSADDR_REL(realbase);
+    block->base = realbase;
     mprotect_mapping(MAPPING_DPMI, block->base, size, committed ?
 		DPMI_PROT_RWX : PROT_NONE);
     block->linear = 1;
@@ -518,7 +517,7 @@ static void do_unmap_shm(dpmi_pm_block *block)
     if (err)
         error("restore_mapping() failed\n");
     e_invalidate_full(block->base, block->size);
-    smfree(&mem_pool, MEM_BASE32(block->base));
+    smfree(&mem_pool, block->base);
     unregister_hardware_ram_virtual(block->base);
     block->mapped = 0;
     if (block->stalled_shm_addr)
@@ -572,9 +571,9 @@ int DPMI_free(dpmi_pm_block_root *root, unsigned int handle)
 	}
 	mprotect_mapping(MAPPING_DPMI, block->base, block->size,
 		    PROT_READ | PROT_WRITE);
-	smfree(&main_pool, MEM_BASE32(block->base));
+	smfree(&main_pool, block->base);
     } else {
-	smfree(&mem_pool, MEM_BASE32(block->base));
+	smfree(&mem_pool, block->base);
     }
     for (i = 0; i < block->size / HOST_PAGE_SIZE; i++) {
 	if ((block->attrs[i] & 7) == 1) {   // if committed priv page, account it
@@ -697,8 +696,8 @@ dpmi_pm_block *DPMI_mallocShared(dpmi_pm_block_root *root,
 {
     int i, rc;
     dpmi_pm_block *ptr;
-    void *addr, *addr2 = NULL;
-    dosaddr_t targ;
+    void *addr2 = NULL;
+    dosaddr_t addr, targ;
     char *shmname;
     struct shm_fhm *fhm;
     int prot = PROT_READ | PROT_WRITE;
@@ -726,13 +725,13 @@ dpmi_pm_block *DPMI_mallocShared(dpmi_pm_block_root *root,
     }
     if (!(flags & SHM_NOEXEC))
         prot |= DPMI_PROT_EXEC;
-    targ = DOSADDR_REL(addr);
+    targ = addr;
     size = HOST_PAGE_ALIGN(size);
     if (!addr2) {
         addr2 = mmap_shm_mapping(size, prot, fhm->fd);
         if (addr2 == MAP_FAILED) {
             perror("mmap()");
-            error("shared memory map failed %p %p\n", addr2, addr);
+            error("shared memory map failed %p %#x\n", addr2, addr);
             goto err3;
         }
         fhm->addr = addr2;
@@ -774,8 +773,8 @@ static dpmi_pm_block *DPMI_mallocSharedNS_common(dpmi_pm_block_root *root,
 {
     int i, err;
     dpmi_pm_block *ptr;
-    void *addr, *addr2 = NULL;
-    dosaddr_t targ;
+    void *addr2 = NULL;
+    dosaddr_t addr, targ;
     void *shlock = NULL, *dlock = NULL;
     char *ddname = strrchr(dname, '/') + 1;
     char shlock_dir[256];
@@ -820,15 +819,16 @@ static dpmi_pm_block *DPMI_mallocSharedNS_common(dpmi_pm_block_root *root,
         fhm->dlock = dlock;
         fh_add(&shmap, &fhm->fhnode);
     }
+
     if (!(flags & SHM_NOEXEC))
         prot |= DPMI_PROT_EXEC;
-    targ = DOSADDR_REL(addr);
+    targ = addr;
     size = HOST_PAGE_ALIGN(size);
     if (!addr2) {
         addr2 = mmap_shm_mapping(size, prot, fd);
         if (addr2 == MAP_FAILED) {
             perror("mmap()");
-            error("shared memory map failed %p %p\n", addr2, addr);
+            error("shared memory map failed %p %#x\n", addr2, addr);
             goto err3;
         }
         fhm->addr = addr2;
@@ -1045,7 +1045,7 @@ dpmi_pm_block * DPMI_realloc(dpmi_pm_block_root *root,
   unsigned int handle, unsigned int newsize)
 {
     dpmi_pm_block *block;
-    unsigned char *ptr;
+    dosaddr_t ptr;
 
     if (!newsize)	/* DPMI spec. says resize to 0 is an error */
 	return NULL;
@@ -1070,11 +1070,11 @@ dpmi_pm_block * DPMI_realloc(dpmi_pm_block_root *root,
     e_invalidate_full(block->base, block->size);
     mprotect_mapping(MAPPING_DPMI, block->base, block->size,
         DPMI_PROT_RWX);
-    if (!(ptr = smrealloc(&mem_pool, MEM_BASE32(block->base), newsize)))
+    if (!(ptr = smrealloc(&mem_pool, block->base, newsize)))
 	return NULL;
 
     finish_realloc(block, newsize, 1);
-    block->base = DOSADDR_REL(ptr);
+    block->base = ptr;
     block->size = newsize;
     restore_page_protection(block);
     return block;
@@ -1084,7 +1084,7 @@ dpmi_pm_block * DPMI_reallocLinear(dpmi_pm_block_root *root,
   unsigned handle, unsigned newsize, int committed)
 {
     dpmi_pm_block *block;
-    unsigned char *ptr;
+    dosaddr_t ptr;
 
     if (!newsize)	/* DPMI spec. says resize to 0 is an error */
 	return NULL;
@@ -1113,14 +1113,14 @@ dpmi_pm_block * DPMI_reallocLinear(dpmi_pm_block_root *root,
     e_invalidate_full(block->base, block->size);
     mprotect_mapping(MAPPING_DPMI, block->base, block->size,
       DPMI_PROT_RWX);
-    ptr = smrealloc(&main_pool, MEM_BASE32(block->base), newsize);
-    if (ptr == NULL) {
+    ptr = smrealloc(&main_pool, block->base, newsize);
+    if (ptr == (dosaddr_t)-1) {
 	restore_page_protection(block);
 	return NULL;
     }
 
     finish_realloc(block, newsize, committed);
-    block->base = DOSADDR_REL(ptr);
+    block->base = ptr;
     block->size = newsize;
     /* restore_page_protection() will set proper prots */
     mprotect_mapping(MAPPING_DPMI, block->base, block->size,

--- a/src/dosext/misc/xms.c
+++ b/src/dosext/misc/xms.c
@@ -143,7 +143,7 @@ umb_setup(int umb_ems)
     }
 #endif
     assert(umbs_used < UMBS);
-    sminit(&umbs[umbs_used], MEM_BASE32(addr_start), size);
+    sminit(&umbs[umbs_used], addr_start, size);
     smregister_error_notifier(&umbs[umbs_used], xx_printf);
     umbs_used++;
     Debug0(("umb_setup: addr %x size 0x%04x\n",
@@ -165,7 +165,7 @@ umb_find(int segbase)
   dosaddr_t addr = SEGOFF2LINEAR(segbase, 0);
 
   for (i = 0; i < umbs_used; i++) {
-    dosaddr_t base = DOSADDR_REL(smget_base_addr(&umbs[i]));
+    dosaddr_t base = smget_base_addr(&umbs[i]);
     if (addr >= base && addr < base + umbs[i].size)
       return (i);
   }
@@ -179,9 +179,9 @@ umb_allocate(int size)
 
   for (i = 0; i < umbs_used; i++) {
     if (smget_largest_free_area(&umbs[i]) >= size) {
-      void *addr = smalloc(&umbs[i], size);
-      assert(addr);
-      return DOSADDR_REL(addr);
+      dosaddr_t addr = smalloc(&umbs[i], size);
+      assert(addr != (dosaddr_t)-1);
+      return addr;
     }
   }
   return 0;
@@ -192,7 +192,7 @@ static void umb_free_all(void)
   int i;
 
   for (i = 0; i < umbs_used; i++) {
-    e_invalidate_full(DOSADDR_REL(smget_base_addr(&umbs[i])), umbs[i].size);
+    e_invalidate_full(smget_base_addr(&umbs[i]), umbs[i].size);
     smfree_all(&umbs[i]);
   }
   umbs_used = 0;
@@ -203,7 +203,7 @@ static int umb_free(int segbase)
   int umb = umb_find(segbase);
 
   if (umb != UMB_NULL)
-    return smfree(&umbs[umb], SEG2UNIX(segbase));
+    return smfree(&umbs[umb], SEGOFF2LINEAR(segbase, 0));
   return -1;
 }
 

--- a/src/include/memory.h
+++ b/src/include/memory.h
@@ -187,7 +187,6 @@ dosaddr_t physaddr_to_dosaddr(unsigned addr, int len);
 #ifndef MAP_FAILED
 #define MAP_FAILED (void*)-1
 #endif
-//void *lowmemp(const unsigned char *ptr);
 
 /* This is the global mem_base pointer: *all* memory is with respect
    to this base. It is normally set to 0 but with mmap_min_addr


### PR DESCRIPTION
smalloc functions exclusively return pointer in DOS space which were then converted to dosaddr_t using DOSADDR_REL. As DOSADDR_REL is problematic with softmmu, let it work with dosaddr_t directly.

This is somewhat intrusive but also fairly mechanical (I used search-replace multiple times)

There are however 3 issues I'm not 100% sure about:
1. `xms.c`
```@@ -203,7 +203,7 @@ static int umb_free(int segbase)
   int umb = umb_find(segbase);
 
   if (umb != UMB_NULL)
-    return smfree(&umbs[umb], SEG2UNIX(segbase));
+    return smfree(&umbs[umb], SEGOFF2LINEAR(segbase, 0));
   return -1;
 }
 
```
This looks like it was a bug since SEG2UNIX gives a lowmem_base-based address but smfree expect mem_base based. I guess umb_free just isn't called very often?

2. `dpmi/memory.c`
```
@@ -868,7 +867,7 @@ static dpmi_pm_block *DPMI_mallocSharedNS_common(dpmi_pm_block_root *root,
     return ptr;
 
 err4:
-    restore_mapping(MAPPING_DPMI, DOSADDR_REL(addr2), size);
+    restore_mapping(MAPPING_DPMI, targ, size);
 err3:
     smfree(&mem_pool, addr);
 err2:
```
here it also looks like DOSADDR_REL(addr2) was invalid, since addr2 is not a DOS space pointer, it's from mmap of the fd. Also I *think* it may also need this
```
    addr2 = close_shm(fhm->fd, &rc, NULL);
    if (addr2)
        munmap_shm_mapping(addr2);
```
in the error unwinding but maybe I'm missing something.

3. With this patch all DOSADDR_REL is gone except for these:
```
src/plugin/dj64/djdev64.c:        return DOSADDR_REL(ptr);
src/plugin/dnative/dnative.c:  get_cr2(d) = _scp_cr2 ? DOSADDR_REL(LINP(_scp_cr2)) : 0;
src/plugin/dremote/uffd.c:    page_fault = DOSADDR_REL((void *)(uintptr_t)msg.arg.pagefault.address) >>
src/plugin/dremote/uffd.c:        int start_page = (DOSADDR_REL((void *)(uintptr_t)rgns[i].start) - base) >> PAGE_SHIFT;
src/plugin/dremote/uffd.c:    unsigned page_fault = DOSADDR_REL(addr) >> PAGE_SHIFT;
src/plugin/dremote/uffd.c:    unsigned page_fault = DOSADDR_REL(addr) >> PAGE_SHIFT;
```
dnative and uffd aren't problematic since with native DPMI the fault address needs to be translated to DOS space anyway. But for djdev64:dj64_ptr2addr() I'm not sure what to do here, could it use LINEAR2UNIX instead of MEM_BASE32 and then:
```
    if (ptr >= LINEAR2UNIX(config.dpmi_base) &&
            ptr < LINEAR2UNIX(config.dpmi_base + dpmi_mem_size()))
        return (ptr - LINEAR2UNIX(config.dpmi_base)) + config.dpmi_base;
```
as this is all linearly mapped?