### PR TITLE
dj64: convert logic using MEM_BASE32/DOSADDR_REL to LINEAR2UNIX (#2772)

### DIFF
--- a/src/plugin/dj64/djdev64.c
+++ b/src/plugin/dj64/djdev64.c
@@ -106,29 +106,28 @@ static int ustore_get(int handle)
 
 static uint8_t *dj64_addr2ptr(uint32_t addr)
 {
-    return MEM_BASE32(addr);
+    return LINEAR2UNIX(addr);
 }
 
 static uint8_t *dj64_addr2ptr2(uint32_t addr, uint32_t len)
 {
     e_invalidate(addr, len);
-    return MEM_BASE32(addr);
+    return LINEAR2UNIX(addr);
 }
 
 static uint32_t dj64_ptr2addr(const uint8_t *ptr)
 {
-    if (ptr >= MEM_BASE32(config.dpmi_base) &&
-            ptr < MEM_BASE32(config.dpmi_base + dpmi_mem_size()))
-        return DOSADDR_REL(ptr);
+    uint8_t *dpmi_base_ptr = LINEAR2UNIX(config.dpmi_base);
+    if (ptr >= dpmi_base_ptr && ptr < dpmi_base_ptr + dpmi_mem_size())
+        return config.dpmi_base + (ptr - dpmi_base_ptr);
     dosemu_error("bad ptr2addr %p\n", ptr);
     return -1;
 }
 
 static int dj64_dos_ptr(const uint8_t *ptr)
 {
-    if ((ptr >= MEM_BASE32(config.dpmi_base) &&
-            ptr < MEM_BASE32(config.dpmi_base + dpmi_mem_size())) ||
-            (ptr >= MEM_BASE32(0) && ptr < MEM_BASE32(LOWMEM_SIZE + HMASIZE)))
+    uint8_t *dpmi_base_ptr = LINEAR2UNIX(config.dpmi_base);
+    if (ptr >= dpmi_base_ptr && ptr < dpmi_base_ptr + dpmi_mem_size())
         return 1;
     return 0;
 }


### PR DESCRIPTION
This also causes dj64_dos_ptr() (is_dos_ptr() function pointer) to no longer accept pointers to low DOS memory, but dj64_ptr2addr() rejected those already so it made no sense to accept them in any case (in functionality used by dj64 to avoid redundant dosobjs in dj64_obj_init).

See https://github.com/dosemu2/dosemu2/pull/2801#issuecomment-4077369731 and below for discussion.