### PR TITLE
Eliminate MEM_BASE32/mem_base where possible (#2772)

### DIFF
--- a/src/base/bios/vgabios.c
+++ b/src/base/bios/vgabios.c
@@ -343,7 +343,7 @@ static void write_gfx_char_pl4(Bit16u vstart,Bit8u car,Bit8u attr,
  Bit8u *fdata;
  Bit16u addr,dest,src;
 
- fdata = MEM_BASE32(IVEC(0x43));
+ fdata = dosaddr_to_unixaddr(IVEC(0x43));
  addr=xcurs+ycurs*cheight*nbcols+vstart;
  src = car * cheight;
  port_outw(VGAREG_SEQU_ADDRESS, 0x0f02);
@@ -405,7 +405,7 @@ static void write_gfx_char_cga(Bit16u vstart,Bit8u car,Bit8u attr,
   }
  else
   {
-   fdata = MEM_BASE32(IVEC(0x1f));
+   fdata = dosaddr_to_unixaddr(IVEC(0x1f));
    fdata -= 0x80 * 8;
   }
  addr=(xcurs*bpp)+ycurs*320+vstart;
@@ -485,7 +485,7 @@ static void write_gfx_char_lin(Bit16u vstart,Bit8u car,Bit8u attr,
  Bit16u src;
  Bit32u addr,dest;
 
- fdata = MEM_BASE32(IVEC(0x43));
+ fdata = dosaddr_to_unixaddr(IVEC(0x43));
  addr=xcurs*8+ycurs*nbcols*8*cheight+vstart;
  plane = addr >> 16;
  port_outw(VGAREG_SEQU_ADDRESS, ((1 << (plane + 8))) | 2);  // switch plane

--- a/src/base/dev/vga/vgaemu.c
+++ b/src/base/dev/vga/vgaemu.c
@@ -1088,7 +1088,7 @@ int vga_emu_fault(dosaddr_t lin_addr, unsigned err, cpuctx_t *scp)
     if (debug_level('v') && DPMIValidSelector(_cs) &&
 	  (((daddr = GetSegmentBase(_cs) + _eip) < 0x110000) ||
 	   dpmi_is_valid_range(daddr, 15))) {
-     cs_ip = MEM_BASE32(daddr);
+     cs_ip = LINEAR2UNIX(daddr);
      vga_deb_map(
       "vga_emu_fault: cs:eip = %04x:%04x, instr: %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x\n",
       (unsigned) _cs, (unsigned) _eip,

--- a/src/base/misc/dos2linux.c
+++ b/src/base/misc/dos2linux.c
@@ -672,10 +672,10 @@ void default_sim_pagefault_handler(dosaddr_t addr, int err, uint32_t op, int len
   }
   if (err & 2)
     dosemu_error("Invalid write to addr %#x, ptr %p, len %d\n",
-		 addr, MEM_BASE32(addr), len);
+		 addr, LINEAR2UNIX(addr), len);
   else
     dosemu_error("Invalid read from addr %#x, ptr %p\n",
-		 addr, MEM_BASE32(addr));
+		 addr, LINEAR2UNIX(addr));
   leavedos_main(1);
 }
 

--- a/src/base/video/instremu.c
+++ b/src/base/video/instremu.c
@@ -117,7 +117,7 @@ typedef struct x86_regs {
   unsigned prefixes, rep;
   unsigned (*instr_read)(struct rm rm);
   void (*instr_write)(struct rm rm, unsigned u);
-  struct rm (*modrm)(unsigned char *cp, struct x86_regs *x86, int *inst_len);
+  struct rm (*modrm)(dosaddr_t cp, struct x86_regs *x86, int *inst_len);
 } x86_regs;
 
 #if DEBUG_INSTR >= 1
@@ -161,9 +161,9 @@ static unsigned instr_read_word(struct rm rm);
 static unsigned instr_read_dword(struct rm rm);
 static void instr_write_word(struct rm rm, unsigned u);
 static void instr_write_dword(struct rm rm, unsigned u);
-static dosaddr_t sib(unsigned char *cp, x86_regs *x86, int *inst_len);
-static struct rm modrm32(unsigned char *cp, x86_regs *x86, int *inst_len);
-static struct rm modrm16(unsigned char *cp, x86_regs *x86, int *inst_len);
+static dosaddr_t sib(dosaddr_t cp, x86_regs *x86, int *inst_len);
+static struct rm modrm32(dosaddr_t cp, x86_regs *x86, int *inst_len);
+static struct rm modrm16(dosaddr_t cp, x86_regs *x86, int *inst_len);
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -468,68 +468,70 @@ static inline void pop(unsigned *val, x86_regs *x86)
 #define sreg(reg, x86) ((&((x86)->es))+((reg)&0x7))
 #define sreg_idx(reg) (es_INDEX+((reg)&0x7))
 
-dosaddr_t sib(unsigned char *cp, x86_regs *x86, int *inst_len)
+dosaddr_t sib(dosaddr_t cp, x86_regs *x86, int *inst_len)
 {
-  unsigned addr = 0;
+  unsigned addr = 0, sibbyte;
 
-  switch(cp[1] & 0xc0) { /* decode modifier */
+  switch(READ_BYTE(cp + 1) & 0xc0) { /* decode modifier */
   case 0x40:
-    addr = (int)(signed char)cp[3];
+    addr = (int)(signed char)READ_BYTE(cp + 3);
     break;
   case 0x80:
-    addr = R_DWORD(cp[3]);
+    addr = READ_DWORD(cp + 3);
     break;
   }
 
-  if ((cp[2] & 0x38) != 0x20) /* index cannot be esp */
-    addr += *reg(cp[2]>>3, x86) << (cp[2] >> 6);
+  sibbyte = READ_BYTE(cp + 2);
+  if ((sibbyte & 0x38) != 0x20) /* index cannot be esp */
+    addr += *reg(sibbyte>>3, x86) << (sibbyte >> 6);
 
-  switch(cp[2] & 0x07) { /* decode address */
+  switch(sibbyte & 0x07) { /* decode address */
   case 0x00:
   case 0x01:
   case 0x02:
   case 0x03:
   case 0x06:
   case 0x07:
-    return (addr + *reg(cp[2], x86) + x86->seg_base);
+    return (addr + *reg(sibbyte, x86) + x86->seg_base);
   case 0x04: /* esp */
     return (addr + x86->esp + x86->seg_ss_base);
   case 0x05:
-    if (cp[1] >= 0x40)
+    if (READ_BYTE(cp + 1) >= 0x40)
       return (addr + x86->ebp + x86->seg_ss_base);
     else {
       *inst_len += 4;
-      return (addr + R_DWORD(cp[3]) + x86->seg_base);
+      return (addr + READ_DWORD(cp + 3) + x86->seg_base);
     }
   }
   return 0; /* keep gcc happy */
 }
 
-struct rm modrm16(unsigned char *cp, x86_regs *x86, int *inst_len)
+struct rm modrm16(dosaddr_t cp, x86_regs *x86, int *inst_len)
 {
-  unsigned addr = 0;
+  unsigned addr = 0, modrm;
   struct rm rm = {};
   *inst_len = 0;
 
-  switch(cp[1] & 0xc0) { /* decode modifier */
+  modrm = READ_BYTE(cp + 1);
+  switch(modrm & 0xc0) { /* decode modifier */
   case 0x40:
-    addr = (short)(signed char)cp[2];
+    addr = (short)(signed char)READ_BYTE(cp + 2);
     *inst_len = 1;
     break;
   case 0x80:
-    addr = R_WORD(cp[2]);
+    addr = READ_WORD(cp + 2);
     *inst_len = 2;
     break;
   case 0xc0:
-    if (cp[0]&1) /*(d)word*/
-      rm.r = (unsigned char *)reg(cp[1], x86);
+    if (READ_BYTE(cp)&1) /*(d)word*/
+      rm.r = (unsigned char *)reg(modrm, x86);
     else
-      rm.r = reg8(cp[1], x86);
+      rm.r = reg8(modrm, x86);
     return rm;
   }
 
 
-  switch(cp[1] & 0x07) { /* decode address */
+  switch(modrm & 0x07) { /* decode address */
   case 0x00:
     rm.m = (((addr + x86->ebx + x86->esi) & 0xffff) + x86->seg_base);
     break;
@@ -549,11 +551,11 @@ struct rm modrm16(unsigned char *cp, x86_regs *x86, int *inst_len)
     rm.m = (((addr + x86->edi) & 0xffff) + x86->seg_base);
     break;
   case 0x06:
-    if (cp[1] >= 0x40)
+    if (modrm >= 0x40)
       rm.m = (((addr + x86->ebp) & 0xffff) + x86->seg_ss_base);
     else {
       *inst_len += 2;
-      rm.m = (R_WORD(cp[2]) + x86->seg_base);
+      rm.m = (READ_WORD(cp + 2) + x86->seg_base);
     }
     break;
   case 0x07:
@@ -563,48 +565,49 @@ struct rm modrm16(unsigned char *cp, x86_regs *x86, int *inst_len)
   return rm;
 }
 
-struct rm modrm32(unsigned char *cp, x86_regs *x86, int *inst_len)
+struct rm modrm32(dosaddr_t cp, x86_regs *x86, int *inst_len)
 {
-  unsigned addr = 0;
+  unsigned addr = 0, modrm;
   struct rm rm = {};
   *inst_len = 0;
 
-  switch(cp[1] & 0xc0) { /* decode modifier */
+  modrm = READ_BYTE(cp + 1);
+  switch(modrm & 0xc0) { /* decode modifier */
   case 0x40:
-    addr = (int)(signed char)cp[2];
+    addr = (int)(signed char)READ_BYTE(cp + 2);
     *inst_len = 1;
     break;
   case 0x80:
-    addr = R_DWORD(cp[2]);
+    addr = READ_DWORD(cp + 2);
     *inst_len = 4;
     break;
   case 0xc0:
-    if (cp[0]&1) /*(d)word*/
-      rm.r = ((unsigned char *)reg(cp[1], x86));
+    if (READ_BYTE(cp)&1) /*(d)word*/
+      rm.r = ((unsigned char *)reg(modrm, x86));
     else
-      rm.r = reg8(cp[1], x86);
+      rm.r = reg8(modrm, x86);
     return rm;
   }
 
-  switch(cp[1] & 0x07) { /* decode address */
+  switch(modrm & 0x07) { /* decode address */
   case 0x00:
   case 0x01:
   case 0x02:
   case 0x03:
   case 0x06:
   case 0x07:
-    rm.m = (addr + *reg(cp[1], x86) + x86->seg_base);
+    rm.m = (addr + *reg(modrm, x86) + x86->seg_base);
     break;
   case 0x04: /* sib byte follows */
     *inst_len += 1;
     rm.m = sib(cp, x86, inst_len);
     break;
   case 0x05:
-    if (cp[1] >= 0x40)
+    if (modrm >= 0x40)
       rm.m = (addr + x86->ebp + x86->seg_ss_base);
     else {
       *inst_len += 4;
-      rm.m = (R_DWORD(cp[2]) + x86->seg_base);
+      rm.m = (READ_DWORD(cp + 2) + x86->seg_base);
     }
     break;
   }
@@ -617,7 +620,7 @@ static int handle_prefixes(x86_regs *x86)
   int prefix = 0;
 
   for (;; eip++) {
-    switch(*(unsigned char *)MEM_BASE32(x86->cs_base + eip)) {
+    switch(READ_BYTE(x86->cs_base + eip)) {
     /* handle (some) prefixes */
       case 0x26:
         prefix++;
@@ -797,12 +800,12 @@ int decode_modify_segreg_insn(cpuctx_t *scp, int pmode,
   x86.prefixes = handle_prefixes(&x86);
   x86.eip += x86.prefixes;
 
-  switch(*(unsigned char *)MEM_BASE32(cs + x86.eip)) {
+  switch(READ_BYTE(cs + x86.eip)) {
     case 0x8e:		/* mov segreg,r/m16 */
-      ret = sreg_idx(*(unsigned char *)MEM_BASE32(cs + x86.eip + 1) >> 3);
-      mem = x86.modrm(MEM_BASE32(cs + x86.eip), &x86, &inst_len);
-      if ((*(unsigned char *)MEM_BASE32(cs + x86.eip + 1) & 0xc0) == 0xc0)  /* compensate for mov r,segreg */
-        memcpy(new_val, reg(*(unsigned char *)MEM_BASE32(cs + x86.eip + 1), &x86), 2);
+      ret = sreg_idx(READ_BYTE(cs + x86.eip + 1) >> 3);
+      mem = x86.modrm(cs + x86.eip, &x86, &inst_len);
+      if ((READ_BYTE(cs + x86.eip + 1) & 0xc0) == 0xc0)  /* compensate for mov r,segreg */
+        memcpy(new_val, reg(READ_BYTE(cs + x86.eip + 1), &x86), 2);
       else
         *new_val = instr_read_word(mem);
       x86.eip += inst_len + 2;
@@ -816,9 +819,9 @@ int decode_modify_segreg_insn(cpuctx_t *scp, int pmode,
       pop(&tmp_eip, &x86);
       pop(new_val, &x86);
       ret = cs_INDEX;
-      switch (*(unsigned char *)MEM_BASE32(cs + x86.eip)) {
+      switch (READ_BYTE(cs + x86.eip)) {
         case 0xca: /*retf imm 16*/
-	  x86.esp += ((unsigned short *) (MEM_BASE32(cs + x86.eip + 1)))[0];
+	  x86.esp += READ_WORD(cs + x86.eip + 1);
 	  break;
         case 0xcf: /*iret*/
 	{
@@ -843,23 +846,23 @@ int decode_modify_segreg_insn(cpuctx_t *scp, int pmode,
     break;
 
     case 0xc4:		/* les */
-      mem = x86.modrm(MEM_BASE32(cs + x86.eip), &x86, &inst_len);
+      mem = x86.modrm(cs + x86.eip, &x86, &inst_len);
       *new_val = instr_read_word(M(mem.m+x86.operand_size));
       if (x86.operand_size == 2)
-	R_WORD(*reg(*(unsigned char *)MEM_BASE32(cs + x86.eip + 1) >> 3, &x86)) = instr_read_word(mem);
+	R_WORD(*reg(READ_BYTE(cs + x86.eip + 1) >> 3, &x86)) = instr_read_word(mem);
       else
-	*reg(*(unsigned char *)MEM_BASE32(cs + x86.eip + 1) >> 3, &x86) = instr_read_dword(mem);
+	*reg(READ_BYTE(cs + x86.eip + 1) >> 3, &x86) = instr_read_dword(mem);
       ret = es_INDEX;
       x86.eip += inst_len + 2;
       break;
 
     case 0xc5:		/* lds */
-      mem = x86.modrm(MEM_BASE32(cs + x86.eip), &x86, &inst_len);
+      mem = x86.modrm(cs + x86.eip, &x86, &inst_len);
       *new_val = instr_read_word(M(mem.m+x86.operand_size));
       if (x86.operand_size == 2)
-	R_WORD(*reg(*(unsigned char *)MEM_BASE32(cs + x86.eip + 1) >> 3, &x86)) = instr_read_word(mem);
+	R_WORD(*reg(READ_BYTE(cs + x86.eip + 1) >> 3, &x86)) = instr_read_word(mem);
       else
-	*reg(*(unsigned char *)MEM_BASE32(cs + x86.eip + 1) >> 3, &x86) = instr_read_dword(mem);
+	*reg(READ_BYTE(cs + x86.eip + 1) >> 3, &x86) = instr_read_dword(mem);
       ret = ds_INDEX;
       x86.eip += inst_len + 2;
       break;
@@ -867,50 +870,50 @@ int decode_modify_segreg_insn(cpuctx_t *scp, int pmode,
     case 0x07:	/* pop es */
     case 0x17:	/* pop ss */
     case 0x1f:	/* pop ds */
-      ret = sreg_idx(*(unsigned char *)MEM_BASE32(cs + x86.eip) >> 3);
+      ret = sreg_idx(READ_BYTE(cs + x86.eip) >> 3);
       pop(new_val, &x86);
       x86.eip++;
       break;
 
     case 0x0f:
       x86.eip++;
-      switch (*(unsigned char *)MEM_BASE32(cs + x86.eip)) {
+      switch (READ_BYTE(cs + x86.eip)) {
         case 0xa1:	/* pop fs */
         case 0xa9:	/* pop gs */
 	  pop(new_val, &x86);
-	  ret = sreg_idx(*(unsigned char *)MEM_BASE32(cs + x86.eip) >> 3);
+	  ret = sreg_idx(READ_BYTE(cs + x86.eip) >> 3);
 	  x86.eip++;
 	  break;
 
 	case 0xb2:	/* lss */
-	  mem = x86.modrm(MEM_BASE32(cs + x86.eip), &x86, &inst_len);
+	  mem = x86.modrm(cs + x86.eip, &x86, &inst_len);
 	  *new_val = instr_read_word(M(mem.m+x86.operand_size));
 	  if (x86.operand_size == 2)
-	    R_WORD(*reg(*(unsigned char *)MEM_BASE32(cs + x86.eip + 1) >> 3, &x86)) = instr_read_word(mem);
+	    R_WORD(*reg(READ_BYTE(cs + x86.eip + 1) >> 3, &x86)) = instr_read_word(mem);
 	  else
-	    *reg(*(unsigned char *)MEM_BASE32(cs + x86.eip + 1) >> 3, &x86) = instr_read_dword(mem);
+	    *reg(READ_BYTE(cs + x86.eip + 1) >> 3, &x86) = instr_read_dword(mem);
 	  ret = ss_INDEX;
 	  x86.eip += inst_len + 2;
 	  break;
 
 	case 0xb4:	/* lfs */
-	  mem = x86.modrm(MEM_BASE32(cs + x86.eip), &x86, &inst_len);
+	  mem = x86.modrm(cs + x86.eip, &x86, &inst_len);
 	  *new_val = instr_read_word(M(mem.m+x86.operand_size));
 	  if (x86.operand_size == 2)
-	    R_WORD(*reg(*(unsigned char *)MEM_BASE32(cs + x86.eip + 1) >> 3, &x86)) = instr_read_word(mem);
+	    R_WORD(*reg(READ_BYTE(cs + x86.eip + 1) >> 3, &x86)) = instr_read_word(mem);
 	  else
-	    *reg(*(unsigned char *)MEM_BASE32(cs + x86.eip + 1) >> 3, &x86) = instr_read_dword(mem);
+	    *reg(READ_BYTE(cs + x86.eip + 1) >> 3, &x86) = instr_read_dword(mem);
 	  ret = fs_INDEX;
 	  x86.eip += inst_len + 2;
 	  break;
 
 	case 0xb5:	/* lgs */
-	  mem = x86.modrm(MEM_BASE32(cs + x86.eip), &x86, &inst_len);
+	  mem = x86.modrm(cs + x86.eip, &x86, &inst_len);
 	  *new_val = instr_read_word(M(mem.m+x86.operand_size));
 	  if (x86.operand_size == 2)
-	    R_WORD(*reg(*(unsigned char *)MEM_BASE32(cs + x86.eip + 1) >> 3, &x86)) = instr_read_word(mem);
+	    R_WORD(*reg(READ_BYTE(cs + x86.eip + 1) >> 3, &x86)) = instr_read_word(mem);
 	  else
-	    *reg(*(unsigned char *)MEM_BASE32(cs + x86.eip + 1) >> 3, &x86) = instr_read_dword(mem);
+	    *reg(READ_BYTE(cs + x86.eip + 1) >> 3, &x86) = instr_read_dword(mem);
 	  ret = gs_INDEX;
 	  x86.eip += inst_len + 2;
 	  break;

--- a/src/dosext/dpmi/dpmi.c
+++ b/src/dosext/dpmi/dpmi.c
@@ -6567,7 +6567,7 @@ char *DPMI_show_state(cpuctx_t *scp)
       int i;
       #define CSPP (csp2 - 10)
       pos += sprintf(buf + pos, "OPS  : ");
-      if ((CSPP >= &mem_base[0] && CSPP + 10 < &mem_base[0x110000]) ||
+      if ((daddr >= 10 && daddr < 0x110000) ||
 	  ((mapping_find_hole((uintptr_t)CSPP, (uintptr_t)CSPP + 10, 1) == MAP_FAILED) &&
 	   dpmi_is_valid_range(daddr - 10, 10))) {
 	for (i = 0; i < 10; i++)
@@ -6575,7 +6575,7 @@ char *DPMI_show_state(cpuctx_t *scp)
       } else {
 	pos += sprintf(buf + pos, "<invalid memory> ");
       }
-      if ((csp2 >= &mem_base[0] && csp2 + 10 < &mem_base[0x110000]) ||
+      if ((daddr < 0x110000 - 10) ||
 	  ((mapping_find_hole((uintptr_t)csp2, (uintptr_t)csp2 + 10, 1) == MAP_FAILED) &&
 	   dpmi_is_valid_range(daddr, 10))) {
 	pos += sprintf(buf + pos, "-> ");
@@ -6601,7 +6601,7 @@ char *DPMI_show_state(cpuctx_t *scp)
       }
       #define SSPP (ssp2 - 10)
       pos += sprintf(buf + pos, "STACK: ");
-      if ((SSPP >= &mem_base[0] && SSPP + 10 < &mem_base[0x110000]) ||
+      if ((saddr >= 10 && saddr < 0x110000) ||
 	  ((mapping_find_hole((uintptr_t)SSPP, (uintptr_t)SSPP + 10, 1) == MAP_FAILED) &&
 	   dpmi_is_valid_range(saddr - 10, 10))) {
 	for (i = 0; i < 10; i++)
@@ -6609,7 +6609,7 @@ char *DPMI_show_state(cpuctx_t *scp)
       } else {
 	pos += sprintf(buf + pos, "<invalid memory> ");
       }
-      if ((ssp2 >= &mem_base[0] && ssp2 + 10 < &mem_base[0x110000]) ||
+      if ((saddr < 0x110000 - 10) ||
 	  ((mapping_find_hole((uintptr_t)ssp2, (uintptr_t)ssp2 + 10, 1) == MAP_FAILED) &&
 	   dpmi_is_valid_range(saddr, 10))) {
 	pos += sprintf(buf + pos, "-> ");

--- a/src/include/aspi.h
+++ b/src/include/aspi.h
@@ -22,7 +22,7 @@
 typedef Bit32u 		FARPTR16;
 typedef Bit32u		FARPROC16;
 #define FARPTR16_TO_LIN(a) \
-	&mem_base[((a&0xffff) + ((a >> 12)& 0x000ffff0))]
+	MK_FP32((a) >> 16, (a) & 0xffff)
 
 #define SS_PENDING	0x00
 #define SS_COMP		0x01

--- a/src/plugin/debugger/mhpdbgc.c
+++ b/src/plugin/debugger/mhpdbgc.c
@@ -2607,7 +2607,7 @@ static void mhp_print_ldt(int argc, char *argv[])
                    (type & 0x08) ? "Code" : "Data", (type2 & 0x04) ? 32 : 16, (type >> 5) & 0x03,
                    (type >> 7) ? 'P' : ' ', (type & 4) ? ((type & 8) ? 'C' : 'E') : ' ',
                    (type & 2) ? ((type & 8) ? 'R' : 'W') : ' ', (type & 1) ? 'A' : ' ', (lp_[1] & Abit) ? 'a' : ' ',
-                   MEM_BASE32(base_addr), cache_mismatch ? " (cache mismatch)" : "");
+                   LINEAR2UNIX(base_addr), cache_mismatch ? " (cache mismatch)" : "");
       else
         mhp_printf("%04x: %08x %08x System(%02x)%s\n", i, base_addr, limit, type,
                    cache_mismatch ? " (cache mismatch)" : "");

--- a/src/plugin/dnative/dnative.c
+++ b/src/plugin/dnative/dnative.c
@@ -540,7 +540,7 @@ static char *_show_state(sigcontext_t *scp)
       int i;
       #define CSPP (csp2 - 10)
       pos += sprintf(buf + pos, "OPS  : ");
-      if ((CSPP >= &mem_base[0] && CSPP + 10 < &mem_base[0x110000]) ||
+      if ((daddr >= 10 && daddr < 0x110000) ||
 	  ((mapping_find_hole((uintptr_t)CSPP, (uintptr_t)CSPP + 10, 1) == MAP_FAILED) &&
 	   dpmi_is_valid_range(daddr - 10, 10))) {
 	for (i = 0; i < 10; i++)
@@ -548,7 +548,7 @@ static char *_show_state(sigcontext_t *scp)
       } else {
 	pos += sprintf(buf + pos, "<invalid memory> ");
       }
-      if ((csp2 >= &mem_base[0] && csp2 + 10 < &mem_base[0x110000]) ||
+      if ((daddr < 0x110000 - 10) ||
 	  ((mapping_find_hole((uintptr_t)csp2, (uintptr_t)csp2 + 10, 1) == MAP_FAILED) &&
 	   dpmi_is_valid_range(daddr, 10))) {
 	pos += sprintf(buf + pos, "-> ");
@@ -574,7 +574,7 @@ static char *_show_state(sigcontext_t *scp)
       }
       #define SSPP (ssp2 - 10)
       pos += sprintf(buf + pos, "STACK: ");
-      if ((SSPP >= &mem_base[0] && SSPP + 10 < &mem_base[0x110000]) ||
+      if ((saddr >= 10 && saddr < 0x110000) ||
 	  ((mapping_find_hole((uintptr_t)SSPP, (uintptr_t)SSPP + 10, 1) == MAP_FAILED) &&
 	   dpmi_is_valid_range(saddr - 10, 10))) {
 	for (i = 0; i < 10; i++)
@@ -582,7 +582,7 @@ static char *_show_state(sigcontext_t *scp)
       } else {
 	pos += sprintf(buf + pos, "<invalid memory> ");
       }
-      if ((ssp2 >= &mem_base[0] && ssp2 + 10 < &mem_base[0x110000]) ||
+      if ((saddr < 0x110000 - 10) ||
 	  ((mapping_find_hole((uintptr_t)ssp2, (uintptr_t)ssp2 + 10, 1) == MAP_FAILED) &&
 	   dpmi_is_valid_range(saddr, 10))) {
 	pos += sprintf(buf + pos, "-> ");

--- a/src/plugin/msdos/instr_dec.c
+++ b/src/plugin/msdos/instr_dec.c
@@ -70,11 +70,11 @@ static unsigned char it[0x100] = {
   0, 1, 0, 0, 1, 1, 7, 7,    1, 1, 1, 1, 1, 1, 7, 7
 };
 
-static unsigned arg_len(unsigned char *p, int asp)
+static unsigned arg_len(dosaddr_t p, int asp)
 {
   unsigned u = 0, m, s = 0;
 
-  m = *p & 0xc7;
+  m = READ_BYTE(p) & 0xc7;
   if(asp) {
     if(m == 5) {
       u = 5;
@@ -109,14 +109,14 @@ static unsigned arg_len(unsigned char *p, int asp)
   return u;
 }
 
-static int _instr_len(unsigned char *p, int is_32)
+static int _instr_len(dosaddr_t p, int is_32)
 {
   unsigned u, osp, asp;
-  unsigned char *p0 = p;
+  dosaddr_t p0 = p;
 
   osp = asp = is_32;
 
-  for(u = 1; u && p - p0 < 17;) switch(*p++) {		/* get prefixes */
+  for(u = 1; u && p - p0 < 17;) switch(READ_BYTE(p++)) {		/* get prefixes */
     case 0x26:	/* es: */
 //      seg = 1;
       break;
@@ -155,9 +155,9 @@ static int _instr_len(unsigned char *p, int is_32)
 
   if(p - p0 >= 16) return 0;
 
-  if(*p == 0x0f) {
+  if(READ_BYTE(p) == 0x0f) {
     p++;
-    switch (*p) {
+    switch (READ_BYTE(p)) {
     case 0xba:
       p += 4;
       return p - p0;
@@ -170,12 +170,12 @@ static int _instr_len(unsigned char *p, int is_32)
       return p - p0;
     default:
       /* not yet */
-      error("unsupported instr_len %x %x\n", p[0], p[1]);
+      error("unsupported instr_len %x %x\n", READ_BYTE(p), READ_BYTE(p + 1));
       return 0;
     }
   }
 
-  switch(it[*p]) {
+  switch(it[READ_BYTE(p)]) {
     case 1:	/* op-code */
       p += 1; break;
 
@@ -366,12 +366,12 @@ static unsigned instr_binary_dword(unsigned op, unsigned op1, unsigned op2, unsi
 static uint32_t x86_pop(cpuctx_t *scp, x86_ins *x86)
 {
   unsigned ss_base = GetSegmentBase(_ss);
-  unsigned char *mem = MEM_BASE32(ss_base + (_esp & wordmask[(x86->_32bit+1)*2]));
+  dosaddr_t mem = ss_base + (_esp & wordmask[(x86->_32bit+1)*2]);
   if (x86->_32bit)
     _esp += x86->operand_size;
   else
     _LWORD(esp) += x86->operand_size;
-  return (x86->operand_size == 4 ? READ_DWORDP(mem) : READ_WORDP(mem));
+  return (x86->operand_size == 4 ? READ_DWORD(mem) : READ_WORD(mem));
 }
 
 static int x86_handle_prefixes(cpuctx_t *scp, unsigned cs_base,
@@ -389,7 +389,7 @@ static int x86_handle_prefixes(cpuctx_t *scp, unsigned cs_base,
   x86->ss = 0;
   x86->address_size = x86->operand_size = (x86->_32bit + 1) * 2;
   for (;; eip++) {
-    switch(*(unsigned char *)MEM_BASE32(cs_base + eip)) {
+    switch(READ_BYTE(cs_base + eip)) {
     /* handle (some) prefixes */
       case 0x26:
         prefix++;
@@ -438,18 +438,16 @@ static int x86_handle_prefixes(cpuctx_t *scp, unsigned cs_base,
   return prefix;
 }
 
-static void make_retf_frame(cpuctx_t *scp, void *sp,
+static void make_retf_frame(cpuctx_t *scp, dosaddr_t sp,
 	uint32_t cs, uint32_t eip, int is_32)
 {
   if (is_32) {
-    unsigned int *ssp = sp;
-    *--ssp = cs;
-    *--ssp = eip;
+    WRITE_DWORD(sp - 4, cs);
+    WRITE_DWORD(sp - 8, eip);
     _esp -= 8;
   } else {
-    unsigned short *ssp = sp;
-    *--ssp = cs;
-    *--ssp = eip;
+    WRITE_WORD(sp - 2, cs);
+    WRITE_WORD(sp - 4, eip);
     _LWORD(esp) -= 4;
   }
 }
@@ -457,9 +455,9 @@ static void make_retf_frame(cpuctx_t *scp, void *sp,
 #define PATCH_SIZE 8
 #define STACK_SIZE (PATCH_SIZE + 8)
 
-static void lxx_patch(cpuctx_t *scp, unsigned char *csp, int len, int is_32)
+static void lxx_patch(cpuctx_t *scp, dosaddr_t csp, int len, int is_32)
 {
-  unsigned char *sp;
+  dosaddr_t sp;
   unsigned int lp[LDT_ENTRY_SIZE / 4], esp, base;
   unsigned char retf[] = { 0xca, PATCH_SIZE, 0 };
 
@@ -469,13 +467,13 @@ static void lxx_patch(cpuctx_t *scp, unsigned char *csp, int len, int is_32)
   }
   assert(len + sizeof(retf) <= PATCH_SIZE);
   _esp -= PATCH_SIZE;
-  sp = SEL_ADR(_ss, _esp);
   esp = (dpmi_segment_is32(_ss) ? _esp : _LWORD(esp));
+  sp = GetSegmentBase(_ss) + esp;
   make_retf_frame(scp, sp, _cs, _eip, is_32);
   /* prepare the patch */
-  memcpy(sp, csp, len);
-  sp[0] = 0x8b;  // replace lXX with mov
-  memcpy(sp + len, retf, sizeof(retf));
+  MEMCPY_DOS2DOS(sp, csp, len);
+  WRITE_BYTE(sp, 0x8b);  // replace lXX with mov
+  MEMCPY_2DOS(sp + len, retf, sizeof(retf));
   GetDescriptor(_cs, lp);
   SetDescriptor(patch_cs, lp);
   base = GetSegmentBase(_ss);
@@ -488,19 +486,19 @@ static void lxx_patch(cpuctx_t *scp, unsigned char *csp, int len, int is_32)
 int decode_segreg(cpuctx_t *scp)
 {
   unsigned cs, eip;
-  unsigned char *csp, *orig_csp;
+  dosaddr_t csp, orig_csp;
   int ret = -1;
   x86_ins x86;
 
   x86._32bit = dpmi_segment_is32(_cs);
   cs = GetSegmentBase(_cs);
   eip = _eip + x86_handle_prefixes(scp, cs, &x86);
-  csp = (unsigned char *)MEM_BASE32(cs + eip);
-  orig_csp = (unsigned char *)MEM_BASE32(cs + _eip);
+  csp = cs + eip;
+  orig_csp = cs + _eip;
 
-  switch(*csp) {
+  switch(READ_BYTE(csp)) {
     case 0x8e:		/* mov segreg,r/m16 */
-      ret = sreg_idx(*(unsigned char *)MEM_BASE32(cs + eip + 1) >> 3);
+      ret = sreg_idx(READ_BYTE(cs + eip + 1) >> 3);
       _eip += _instr_len(orig_csp, x86._32bit);
       break;
 
@@ -511,9 +509,9 @@ int decode_segreg(cpuctx_t *scp)
       unsigned tmp_eip = x86_pop(scp, &x86);
       x86_pop(scp, &x86);
       ret = cs_INDEX;
-      switch (*(unsigned char *)MEM_BASE32(cs + eip)) {
+      switch (READ_BYTE(cs + eip)) {
         case 0xca: /*retf imm 16*/
-	  _esp += ((unsigned short *) (MEM_BASE32(cs + eip + 1)))[0];
+	  _esp += READ_WORD(cs + eip + 1);
 	  break;
         case 0xcf: /*iret*/
 	  _eflags = dpmi_flags_from_stack_iret(scp, x86_pop(scp, &x86));
@@ -526,8 +524,8 @@ int decode_segreg(cpuctx_t *scp)
     case 0xea:			/* jmp seg:off16/off32 */
     {
       unsigned tmp_eip;
-      tmp_eip = x86.operand_size == 4 ? READ_DWORDP(MEM_BASE32(cs + eip + 1)) :
-		READ_WORDP(MEM_BASE32(cs + eip + 1));
+      tmp_eip = x86.operand_size == 4 ? READ_DWORD(cs + eip + 1) :
+		READ_WORD(cs + eip + 1);
       ret = cs_INDEX;
       _eip = tmp_eip;
     }
@@ -537,7 +535,7 @@ int decode_segreg(cpuctx_t *scp)
       int len = _instr_len(orig_csp, x86._32bit);
       _eip += len;
       assert(len > 0);
-      lxx_patch(scp, MEM_BASE32(cs + eip), len, x86._32bit);
+      lxx_patch(scp, cs + eip, len, x86._32bit);
       ret = es_INDEX;
       break;
     }
@@ -546,7 +544,7 @@ int decode_segreg(cpuctx_t *scp)
       int len = _instr_len(orig_csp, x86._32bit);
       _eip += len;
       assert(len > 0);
-      lxx_patch(scp, MEM_BASE32(cs + eip), len, x86._32bit);
+      lxx_patch(scp, cs + eip, len, x86._32bit);
       ret = ds_INDEX;
       break;
     }
@@ -554,18 +552,18 @@ int decode_segreg(cpuctx_t *scp)
     case 0x07:	/* pop es */
     case 0x17:	/* pop ss */
     case 0x1f:	/* pop ds */
-      ret = sreg_idx(*(unsigned char *)MEM_BASE32(cs + eip) >> 3);
+      ret = sreg_idx(READ_BYTE(cs + eip) >> 3);
       x86_pop(scp, &x86);
       _eip = eip + 1;
       break;
 
     case 0x0f:
       eip++;
-      switch (*(unsigned char *)MEM_BASE32(cs + eip)) {
+      switch (READ_BYTE(cs + eip)) {
         case 0xa1:	/* pop fs */
         case 0xa9:	/* pop gs */
 	  x86_pop(scp, &x86);
-	  ret = sreg_idx(*(unsigned char *)MEM_BASE32(cs + eip) >> 3);
+	  ret = sreg_idx(READ_BYTE(cs + eip) >> 3);
 	  _eip = eip + 1;
 	  break;
 
@@ -578,7 +576,7 @@ int decode_segreg(cpuctx_t *scp)
 	  int len = _instr_len(orig_csp, x86._32bit);
 	  _eip += len;
 	  assert(len > 1);
-	  lxx_patch(scp, MEM_BASE32(cs + eip), len - 1, x86._32bit);
+	  lxx_patch(scp, cs + eip, len - 1, x86._32bit);
 	  ret = fs_INDEX;
 	  break;
 	}
@@ -587,7 +585,7 @@ int decode_segreg(cpuctx_t *scp)
 	  int len = _instr_len(orig_csp, x86._32bit);
 	  _eip += len;
 	  assert(len > 1);
-	  lxx_patch(scp, MEM_BASE32(cs + eip), len - 1, x86._32bit);
+	  lxx_patch(scp, cs + eip, len - 1, x86._32bit);
 	  ret = gs_INDEX;
 	  break;
 	}
@@ -662,16 +660,16 @@ static uint32_t reg(cpuctx_t *scp, int reg)
 
 int decode_memop(cpuctx_t *scp, uint32_t *op, dosaddr_t cr2)
 {
-    unsigned cs, eip, seg_base;
-    unsigned char *csp, *orig_csp;
+    unsigned cs, eip, seg_base, csp0;
+    dosaddr_t csp, orig_csp;
     x86_ins x86;
     int inst_len, loop_inc, ret = 0;
 
     x86._32bit = dpmi_segment_is32(_cs);
     cs = GetSegmentBase(_cs);
     eip = _eip + x86_handle_prefixes(scp, cs, &x86);
-    csp = (unsigned char *)MEM_BASE32(cs + eip);
-    orig_csp = (unsigned char *)MEM_BASE32(cs + _eip);
+    csp = cs + eip;
+    orig_csp = cs + _eip;
     inst_len = _instr_len(orig_csp, x86._32bit);
     loop_inc = (_eflags & DF) ? -1 : 1;
     if (x86.rep) {
@@ -713,30 +711,31 @@ int decode_memop(cpuctx_t *scp, uint32_t *op, dosaddr_t cr2)
     else
 	seg_base = GetSegmentBase(_ds);
 
-    switch(*csp) {
+    csp0 = READ_BYTE(csp);
+    switch(csp0) {
     case 0x88:		/* mov r/m8,reg8 */
-	*op = reg8(scp, csp[1] >> 3);
+	*op = reg8(scp, READ_BYTE(csp + 1) >> 3);
 	ret = 1;
 	break;
 
     case 0x89:		/* mov r/m16,reg */
-	*op = reg(scp, csp[1] >> 3);
+	*op = reg(scp, READ_BYTE(csp + 1) >> 3);
 	ret = x86.operand_size;
 	break;
 
     case 0xc6:		/* mov r/m8,imm8 */
-	*op = orig_csp[inst_len - 1];
+	*op = READ_BYTE(orig_csp + inst_len - 1);
 	ret = 1;
 	break;
 
     case 0xc7:		/* mov r/m,imm */
 	switch (x86.operand_size) {
 	case 2:
-	    *op = *(uint16_t *)(orig_csp + inst_len - 2);
+	    *op = READ_WORD(orig_csp + inst_len - 2);
 	    ret = 2;
 	    break;
 	case 4:
-	    *op = *(uint32_t *)(orig_csp + inst_len - 4);
+	    *op = READ_DWORD(orig_csp + inst_len - 4);
 	    ret = 4;
 	    break;
 	}
@@ -744,21 +743,21 @@ int decode_memop(cpuctx_t *scp, uint32_t *op, dosaddr_t cr2)
 
      case 0x80:		/* logical r/m8,imm8 */
      case 0x82:
-	*op = instr_binary_byte(csp[1] >> 3, read_byte(cr2),
-		orig_csp[inst_len - 1], (unsigned*)&_eflags);
+	*op = instr_binary_byte(READ_BYTE(csp + 1) >> 3, read_byte(cr2),
+		READ_BYTE(orig_csp + inst_len - 1), (unsigned*)&_eflags);
 	ret = 1;
 	break;
 
     case 0x81:		/* logical r/m,imm */
 	switch (x86.operand_size) {
 	case 2:
-	    *op = instr_binary_word(csp[1] >> 3, read_word(cr2),
-		    *(uint16_t *)(orig_csp + inst_len - 2), (unsigned*)&_eflags);
+	    *op = instr_binary_word(READ_BYTE(csp + 1) >> 3, read_word(cr2),
+		    READ_WORD(orig_csp + inst_len - 2), (unsigned*)&_eflags);
 	    ret = 2;
 	    break;
 	case 4:
-	    *op = instr_binary_dword(csp[1] >> 3, read_dword(cr2),
-		    *(uint32_t *)(orig_csp + inst_len - 4), (unsigned*)&_eflags);
+	    *op = instr_binary_dword(READ_BYTE(csp + 1) >> 3, read_dword(cr2),
+		    READ_DWORD(orig_csp + inst_len - 4), (unsigned*)&_eflags);
 	    ret = 4;
 	    break;
 	}
@@ -767,13 +766,13 @@ int decode_memop(cpuctx_t *scp, uint32_t *op, dosaddr_t cr2)
     case 0x83:		/* logical r/m,imm8 */
 	switch (x86.operand_size) {
 	case 2:
-	    *op = instr_binary_word(csp[1] >> 3, read_word(cr2),
-		    (short)*(signed char *)(orig_csp + inst_len - 1), (unsigned*)&_eflags);
+	    *op = instr_binary_word(READ_BYTE(csp + 1) >> 3, read_word(cr2),
+		    (short)(signed char)READ_BYTE(orig_csp + inst_len - 1), (unsigned*)&_eflags);
 	    ret = 2;
 	    break;
 	case 4:
-	    *op = instr_binary_dword(csp[1] >> 3, read_dword(cr2),
-		    (int)*(signed char *)(orig_csp + inst_len - 1), (unsigned*)&_eflags);
+	    *op = instr_binary_dword(READ_BYTE(csp + 1) >> 3, read_dword(cr2),
+		    (int)(signed char)READ_BYTE(orig_csp + inst_len - 1), (unsigned*)&_eflags);
 	    ret = 4;
 	    break;
 	}
@@ -805,12 +804,12 @@ int decode_memop(cpuctx_t *scp, uint32_t *op, dosaddr_t cr2)
     case 0xa4:		/* movsb */
 	switch (x86.address_size) {
 	case 2:
-	    *op = *(unsigned char *)MEM_BASE32(seg_base + _LWORD(esi));
+	    *op = READ_BYTE(seg_base + _LWORD(esi));
 	    _LWORD(edi) += loop_inc;
 	    _LWORD(esi) += loop_inc;
 	    break;
 	case 4:
-	    *op = *(unsigned char *)MEM_BASE32(seg_base + _esi);
+	    *op = READ_BYTE(seg_base + _esi);
 	    _edi += loop_inc;
 	    _esi += loop_inc;
 	    break;
@@ -823,12 +822,12 @@ int decode_memop(cpuctx_t *scp, uint32_t *op, dosaddr_t cr2)
 	case 2:
 	    switch (x86.address_size) {
 	    case 2:
-		*op = *(uint16_t *)MEM_BASE32(seg_base + _LWORD(esi));
+		*op = READ_WORD(seg_base + _LWORD(esi));
 		_LWORD(edi) += loop_inc * 2;
 		_LWORD(esi) += loop_inc * 2;
 		break;
 	    case 4:
-		*op = *(uint16_t *)MEM_BASE32(seg_base + _esi);
+		*op = READ_WORD(seg_base + _esi);
 		_edi += loop_inc * 2;
 		_esi += loop_inc * 2;
 		break;
@@ -838,12 +837,12 @@ int decode_memop(cpuctx_t *scp, uint32_t *op, dosaddr_t cr2)
 	case 4:
 	    switch (x86.address_size) {
 	    case 2:
-		*op = *(uint32_t *)MEM_BASE32(seg_base + _LWORD(esi));
+		*op = READ_DWORD(seg_base + _LWORD(esi));
 		_LWORD(edi) += loop_inc * 4;
 		_LWORD(esi) += loop_inc * 4;
 		break;
 	    case 4:
-		*op = *(uint32_t *)MEM_BASE32(seg_base + _esi);
+		*op = READ_DWORD(seg_base + _esi);
 		_edi += loop_inc * 4;
 		_esi += loop_inc * 4;
 		break;
@@ -903,8 +902,8 @@ int decode_memop(cpuctx_t *scp, uint32_t *op, dosaddr_t cr2)
     case 0x28:		/* sub r/m8,reg8 */
     case 0x30:		/* xor r/m8,reg8 */
 //    case 0x38:		/* cmp r/m8,reg8 */
-	*op = instr_binary_byte(csp[0] >> 3, read_byte(cr2),
-		reg8(scp, csp[1] >> 3), (unsigned*)&_eflags);
+	*op = instr_binary_byte(csp0 >> 3, read_byte(cr2),
+		reg8(scp, READ_BYTE(csp + 1) >> 3), (unsigned*)&_eflags);
 	ret = 1;
 	break;
 
@@ -918,13 +917,13 @@ int decode_memop(cpuctx_t *scp, uint32_t *op, dosaddr_t cr2)
 //  case 0x39:		/* cmp r/m16,reg16 */
 	switch (x86.operand_size) {
 	case 2:
-	    *op = instr_binary_word(csp[0] >> 3, read_word(cr2),
-		    reg(scp, csp[1] >> 3), (unsigned*)&_eflags);
+	    *op = instr_binary_word(csp0 >> 3, read_word(cr2),
+		    reg(scp, READ_BYTE(csp + 1) >> 3), (unsigned*)&_eflags);
 	    ret = 2;
 	    break;
 	case 4:
-	    *op = instr_binary_dword(csp[0] >> 3, read_dword(cr2),
-		    reg(scp, csp[1] >> 3), (unsigned*)&_eflags);
+	    *op = instr_binary_dword(csp0 >> 3, read_dword(cr2),
+		    reg(scp, READ_BYTE(csp + 1) >> 3), (unsigned*)&_eflags);
 	    ret = 4;
 	    break;
 	}
@@ -932,7 +931,7 @@ int decode_memop(cpuctx_t *scp, uint32_t *op, dosaddr_t cr2)
 
     case 0xfe: /* inc/dec mem */
 	*op = read_byte(cr2);
-	switch (csp[1] & 0x38) {
+	switch (READ_BYTE(csp + 1) & 0x38) {
 	case 0:	/* inc */
 	    (*op)++;
 	    break;
@@ -944,11 +943,11 @@ int decode_memop(cpuctx_t *scp, uint32_t *op, dosaddr_t cr2)
 	break;
 
     case 0x0f:
-	switch (csp[1]) {
+	switch (READ_BYTE(csp + 1)) {
 	case 0xba: { /* GRP8 - Code Extension 22 */
-	    switch (csp[2] & 0x38) {
+	    switch (READ_BYTE(csp + 2) & 0x38) {
 	    case 0x30: { /* BTR r/m16, imm8 */
-		uint32_t mask = 1 << (csp[4] & 0x1f);
+		uint32_t mask = 1 << (READ_BYTE(csp + 4) & 0x1f);
 		switch (x86.operand_size) {
 		case 2:
 		    *op = read_word(cr2);
@@ -967,19 +966,19 @@ int decode_memop(cpuctx_t *scp, uint32_t *op, dosaddr_t cr2)
 		break;
 	    }
 	    default:
-		error("Unimplemented memop decode GRP8 %#x\n", csp[2]);
+		error("Unimplemented memop decode GRP8 %#x\n", READ_BYTE(csp + 2));
 		break;
 	    }
 	    break;
 	}
 	default:
-	    error("Unimplemented memop decode 0x0f %#x\n", csp[1]);
+	    error("Unimplemented memop decode 0x0f %#x\n", READ_BYTE(csp + 1));
 	    return -1;
 	}
 	break;
 
     default:
-	error("Unimplemented memop decode %#x\n", *csp);
+	error("Unimplemented memop decode %#x\n", csp0);
 	return -1;
   }
 

--- a/src/plugin/msdos/msdos.c
+++ b/src/plugin/msdos/msdos.c
@@ -1857,8 +1857,7 @@ int msdos_pre_extender(cpuctx_t *scp,
     return (alt_ent ? MSDOS_RM : MSDOS_RMINT);
 }
 
-#define RMSEG_ADR(type, seg, reg)  type(&mem_base[(RMREG(seg) << 4) + \
-    RMLWORD(reg)])
+#define RMSEG_ADR(type, seg, reg)  type(MK_FP32(RMREG(seg), RMLWORD(reg)))
 
 far_t get_xms_call(void) { return MSDOS_CLIENT.XMS_call; }
 unsigned short scratch_seg(cpuctx_t *scp, int off, void *arg)

--- a/src/plugin/msdos/msdos_ldt.c
+++ b/src/plugin/msdos/msdos_ldt.c
@@ -81,7 +81,7 @@ unsigned short msdos_ldt_init(int page_size)
     name_sel = AllocateDescriptors(1);
     name = msdos_malloc(name_len);
     tempname(tmpnm, 6);
-    strcpy((char *)MEM_BASE32(name), tmpnm);
+    MEMCPY_2DOS(name, tmpnm, strlen(tmpnm) + 1);
     SetSegmentBaseAddress(name_sel, name);
     SetSegmentLimit(name_sel, name_len - 1);
     shm.name_selector = name_sel;
@@ -92,7 +92,7 @@ unsigned short msdos_ldt_init(int page_size)
     assert(!err);
     ldt_h = shm.handle;
     ldt_bb = shm.addr;
-    ldt_backbuf = MEM_BASE32(ldt_bb);
+    ldt_backbuf = LINEAR2UNIX(ldt_bb);
 
     shm.flags = SHM_NOEXEC;
     err = DPMIAllocateShared(&shm);

--- a/src/plugin/msdos/xms.c
+++ b/src/plugin/msdos/xms.c
@@ -168,7 +168,7 @@ static void xmshlp_thr(void *arg)
                 src = xms_map(scp, e->SourceHandle,
                               e->SourceOffset + e->Length);
                 if (src != (dosaddr_t)-1)
-                    s = MEM_BASE32(src + e->SourceOffset);
+                    s = LINEAR2UNIX(src + e->SourceOffset);
             } else {
                 s = SEL_ADR_CLNT(_ds_, e->SourceOffset, is_32);
             }
@@ -180,7 +180,7 @@ static void xmshlp_thr(void *arg)
             if (e->DestHandle != 0) {
                 dst = xms_map(scp, e->DestHandle, e->DestOffset + e->Length);
                 if (dst != (dosaddr_t)-1)
-                    d = MEM_BASE32(dst + e->DestOffset);
+                    d = LINEAR2UNIX(dst + e->DestOffset);
             } else {
                 d = SEL_ADR_CLNT(_ds_, e->DestOffset, is_32);
             }


### PR DESCRIPTION
This PR eliminates MEM_BASE32 and mem_base where possible. Using LINEAR2UNIX/dosaddr_to_unixaddr (same thing but I just went with the one already used in the respective file), MK_FP32, and READ_* macros.

This way I'll be able to completely disable use of mem_base in full sim mode in #2775.