### PR TITLE
CI: Add CPU wraparound test

### DIFF
--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -411,6 +411,31 @@ class BaseTestCase(object):
         ofile = basename.with_suffix('.com')
         check_call(["nasm", "-f", "bin", "-o", str(ofile), str(sfile)])
 
+    def mkexe_with_nasm(self, fname, content, dname=None, extraargs=None):
+        if dname is None:
+            p = self.workdir
+        else:
+            p = Path(dname).resolve()
+        basename = p / fname
+        relname = basename.relative_to(self.topdir)
+
+        sfile = basename.with_suffix('.asm')
+        sfile.write_text(content)
+        check_call(["nasm", "-f", "obj", "-o", f"{relname}.obj", f"{relname}.asm"])
+
+        # Link using wlink
+        watcom = environ.get("WATCOM", '0')
+        if watcom == '0':
+            raise ValueError('WATCOM variable not set')
+        environ['INCLUDE'] = f'{watcom}/h'
+
+        args = ["wlink", "name", f"{relname}.exe", "format", "dos", "file", f"{relname}.obj",
+                "option", f"map={relname}.map",
+                "option", "quiet"]
+        if extraargs:
+            args += extraargs
+        check_call(args)
+
     def mkexe_with_watcom(self, fname, content, dname=None, extraargs=None):
         if dname is None:
             p = self.workdir

--- a/test/func_cpu_wraparound.py
+++ b/test/func_cpu_wraparound.py
@@ -1,0 +1,54 @@
+
+def cpu_wraparound_ip(self):
+
+    self.mkfile("testit.bat", """\
+c:\\cpuwrpip
+rem end
+""", newline="\r\n")
+
+    # build sources
+    self.mkexe_with_nasm("cpuwrpip", r"""
+
+bits 16
+cpu 8086
+
+segment CODE1 align=16 class=CODE
+..start:
+    mov ax, DATA1
+    mov ds, ax
+
+    ; Jump into the second code segment to start the test
+    jmp CODE2:pretop
+
+segment CODE2 align=16 class=CODE
+    ; 1. This code sits at the START of the segment (offset 0000h)
+    ; 2. When the CPU wraps from FFFFh, it lands right here.
+
+    mov dx, msg_wrap
+    mov ah, 09h
+    int 21h
+
+    mov ax, 4C00h
+    int 21h
+
+    ; --- PADDING ---
+    ; Pad until exactly 2 bytes are left in the 64KB segment
+    times 65534 - ($ - $$) db 90h
+
+global pretop
+pretop:
+    nop ; at offset FFFEh
+    nop ; at offset FFFFh
+    ; After executing the byte at FFFFh, IP increments to 0000h.
+    ; Execution continues there
+
+segment DATA1 align=16 class=DATA
+    msg_wrap db 'PASS: Segment wrapped! Back at offset 0000h', 0Dh, 0Ah, '$'
+
+segment STACK stack align=16 class=STACK
+    resb 512
+""")
+
+    results = self.runDosemu("testit.bat")
+
+    self.assertIn("PASS: Segment wrapped! Back at offset 0000h", results)

--- a/test/test_processor.py
+++ b/test/test_processor.py
@@ -11,6 +11,7 @@ from func_build_freedos import build_freedos
 from func_build_pcmos import build_pcmos
 from func_cpu_trap_flag import cpu_trap_flag
 from func_cpu_methods import cpu_create_items
+from func_cpu_wraparound import cpu_wraparound_ip
 from func_fpu_bart_exceptions import fpu_bart_exceptions_fpex, fpu_bart_exceptions_fpexes
 from fpu.qemu import fpu_create_items
 
@@ -31,6 +32,11 @@ class OurTestCase(BaseTestCase):
     def test_build_pcmos(self):
         """Build PC-MOS"""
         build_pcmos(self)
+
+    @mark('cputest')
+    def test_cpu_wraparound_ip(self):
+        """CPU Wraparound IP"""
+        cpu_wraparound_ip(self)
 
     @mark('fputest')
     def test_fpu_bart_exceptions_fpex(self):


### PR DESCRIPTION
I was slightly intrigued by the IP wraparound discussion, AI debate aside. I wrote a little nasm test and I found that its success varies.

- [x] real hardware under FreeDOS 1.4 (no drivers loaded) - Prints success message.
- [ ] real hardware under FreeDOS 1.4 (with jemm loaded)  - JEMM aborts it.
- [ ] qemu under FreeDOS 1.4 floppy setup disk - stops with error, not familiar with qemu errors so not sure how to describe.
- [ ] dosemu emulation - GPF at seg:fffe.
- [ ] dosemu kvm - GPF at seg:10000.
