### PR TITLE
Detach for console graphics (#634)

### DIFF
--- a/src/base/kbd_unicode/keyb_raw.c
+++ b/src/base/kbd_unicode/keyb_raw.c
@@ -13,13 +13,12 @@
 #include "Sys/kd.h"
 #endif
 #include <sys/ioctl.h>
-#include "vc.h"
+
 #include "ioselect.h"
 #include "keyboard.h"
 #include "keyb_clients.h"
 #include "translate/keysym_attributes.h"
 #include "keystate.h"
-#include "keyb_raw.h"
 
 #define KBBUF_SIZE (KEYB_QUEUE_LENGTH / 2)
 
@@ -156,26 +155,15 @@ static void print_termios(struct termios term)
 }
 #endif
 
-void kbdraw_priv_init(void)
+static int set_raw_mode(void)
 {
-  if (on_console()) {
-    kbd_fd = console_fd;
-  } else {
-    kbd_fd = STDIN_FILENO;
-    if (config.console_keyb == KEYB_RAW) {
-      k_printf("KBD(raw): not on console, using TTY mode\n");
-      config.console_keyb = KEYB_TTY;
-    }
-  }
-
+  struct termios buf = save_termios;
 #ifdef __linux__
-  if (config.console_keyb == KEYB_RAW) {
-    int err;
+  int err;
 
+  if (config.console_keyb == KEYB_RAW) {
     k_printf("KBD(raw): Setting keyboard to RAW mode\n");
-    enter_priv_on();
     err = ioctl(kbd_fd, KDSKBMODE, K_RAW);
-    leave_priv_setting();
     if (err) {
       error("kbd raw mode failed: %s\n", strerror(errno));
       config.console_keyb = KEYB_TTY;
@@ -185,11 +173,6 @@ void kbdraw_priv_init(void)
   if (config.console_keyb == KEYB_RAW)
     config.console_keyb = KEYB_TTY;
 #endif
-}
-
-static int set_raw_mode(void)
-{
-  struct termios buf = save_termios;
   cfmakeraw(&buf);
   k_printf("KBD(raw): Setting TERMIOS Structure.\n");
   if (tcsetattr(kbd_fd, TCSAFLUSH, &buf) < 0) {
@@ -220,6 +203,7 @@ static int raw_keyboard_init(void)
 
   k_printf("KBD(raw): raw_keyboard_init()\n");
 
+  kbd_fd = STDIN_FILENO;
 #ifdef __linux__
   if (config.console_keyb == KEYB_RAW) {
     int rc = ioctl(kbd_fd, KDGKBMODE, &save_mode);

--- a/src/base/kbd_unicode/keyb_raw.h
+++ b/src/base/kbd_unicode/keyb_raw.h
@@ -1,6 +1,0 @@
-#ifndef KEYB_RAW_H
-#define KEYB_RAW_H
-
-void kbdraw_priv_init(void);
-
-#endif

--- a/src/base/kbd_unicode/keyboard.c
+++ b/src/base/kbd_unicode/keyboard.c
@@ -21,7 +21,6 @@
 #include "keyboard.h"
 #include "keyb_clients.h"
 #include "keyb_server.h"
-#include "keyb_raw.h"
 
 static int initialized;
 
@@ -30,7 +29,6 @@ void keyb_priv_init(void)
 	/* this must be initialized before starting port-server */
 	keyb_8042_init();
 	open_console();
-	kbdraw_priv_init();
 }
 
 void keyb_init(void)

--- a/src/base/video/video.c
+++ b/src/base/video/video.c
@@ -532,7 +532,7 @@ int on_console(void)
 {
 #ifdef __linux__
     struct stat chkbuf;
-    int major, minor;
+    int major, minor, detach = 0;
 
     if (console_fd == -1) {
 	const char *tname = getenv("SUDO_TTY");
@@ -543,6 +543,9 @@ int on_console(void)
 		console_fd = dup(STDIN_FILENO);
 	} else {
 	    console_fd = open(tname, O_RDWR | O_CLOEXEC);
+	    /* we will need to detach to get a
+	       controlling terminal later */
+	    detach = 1;
 	}
     }
     if (console_fd == -1)
@@ -557,8 +560,10 @@ int on_console(void)
     c_printf("major = %d minor = %d\n",
 	    major, minor);
     /* console major num is 4, minor 64 is the first serial line */
-    if (S_ISCHR(chkbuf.st_mode) && (major == 4) && (minor < 64))
+    if (S_ISCHR(chkbuf.st_mode) && (major == 4) && (minor < 64)) {
+       if (detach) config.detach = 1;
        return 1;
+    }
 
 err:
     close(console_fd);

--- a/src/plugin/console/console.c
+++ b/src/plugin/console/console.c
@@ -153,10 +153,12 @@ int console_size(void)
 
 static int console_init(void)
 {
-  int co, li;
-  gettermcap(&co, &li);
-  consolesize = TEXT_SIZE(co,li);
-  register_hardware_ram('v', VGA_PHYS_TEXT_BASE, TEXT_SIZE(co,li));
+  if (!config.vga) {
+    int co, li;
+    gettermcap(&co, &li);
+    consolesize = TEXT_SIZE(co,li);
+    register_hardware_ram('v', VGA_PHYS_TEXT_BASE, TEXT_SIZE(co,li));
+  }
 
   if (config.detach)
     consolenum = detach();

--- a/src/plugin/console/detach.c
+++ b/src/plugin/console/detach.c
@@ -43,9 +43,13 @@ static const char vt_base[] = "/dev/tty";
 
 static int open_vt (int vt)  {
   char path[MAXPATHLEN];
+  int fd;
 
   sprintf(path, "%s%d", vt_base, vt);
-  return open (path, O_RDWR);
+  enter_priv_on();
+  fd = open (path, O_RDWR);
+  leave_priv_setting();
+  return fd;
 }
 
 /* open the main console */
@@ -54,7 +58,10 @@ static int open_console (void)  {
   int pos;
   for (pos = 0; CONSOLE[pos]; pos++)  {
     errno = 0;
-    if ((console = open (CONSOLE[pos], O_WRONLY)) >= 0)  {
+    enter_priv_on();
+    console = open (CONSOLE[pos], O_WRONLY);
+    leave_priv_setting();
+    if (console >= 0)  {
       return console;
     }
   }
@@ -66,7 +73,7 @@ unsigned short detach (void) {
 #ifdef __linux__
   struct vt_stat vts;
 #endif
-  int pid;
+  pid_t ppid, ppgid;
   int fd;
     struct stat statout, staterr;
 
@@ -95,6 +102,25 @@ unsigned short detach (void) {
     return(0);
   }
 
+  /* change PGID to the parent's PID to be able to do setsid()
+     without fork(), technique borrowed from X server */
+  ppid = getppid();
+  ppgid = getpgid(ppid);
+  setpgid(0, ppgid);
+  if (setsid() < 0) {
+    perror("setsid");
+    close(fd);
+    return(0);
+  }
+
+  // after setsid this will automatically be the
+  // controlling terminal
+  fd = open_vt(dosemu_vt);
+  if (fd < 0) {
+    perror("open_vt");
+    return(0);
+  }
+
   if (ioctl(fd, VT_ACTIVATE, dosemu_vt) < 0) {
     perror("VT_ACTIVATE");
     close(fd);
@@ -107,17 +133,8 @@ unsigned short detach (void) {
     return(0);
   }
 
-  if ((pid = fork()) < 0) {
-    perror("fork");
-    close(fd);
-    return(0);
-  }
-
-  if (pid) {
-    _exit(0);
-  }
-
-  close(fd);
+  close(console_fd);
+  console_fd = fd;
 
   /* only reassign stderr to the new VT if it isn't already redirected */
   fstat(2, &statout);
@@ -143,7 +160,6 @@ unsigned short detach (void) {
   /* set the permissions to stop other people accessing the vt */
   fchmod (0, S_IRUSR | S_IWUSR);
 
-  setsid();
 #ifdef __linux__
   return(vts.v_active); /* return old VT. */
 #endif

--- a/src/plugin/console/vga.c
+++ b/src/plugin/console/vga.c
@@ -575,6 +575,7 @@ static int vga_initialize(void)
     error("console video plugin unavailable\n");
     return -1;
   }
+  Video_console->priv_init();
   set_console_video();
 
   linux_regs.mem = NULL;


### PR DESCRIPTION
As discussed in #634, this PR always detaches for `dosemu -s` in console graphics mode, which works around sudo's pseudo-tty: as it can get full permission on a new virtual console even after dropping root privs, thereby not needing to use priv to set the raw keyboard, and allowing some other console ioctl's to work that were silently failing (or just left a non-fatal log entry). This PR is fairly minimal.

General state of console graphics:
* in QEMU, works in all situations I tested, including nested KVM
* on a 2019 laptop with CSM, booting in BIOS mode via a USB stick and `nomodeset`, which gives an actual old school VGA text mode console
  * with cpuemu it's tricky: the VBIOS uses PIT timer 2 (port 0x42), and hangs unless I add a little usleep here:
```
--- a/src/base/dev/misc/timers.c
+++ b/src/base/dev/misc/timers.c
@@ -327,6 +327,7 @@ Bit8u pit_inp(ioport_t port, void *arg)
   int ret = 0;
   port -= 0x40;
 
+  if (port == 2) usleep(1);
   if ((port == 2) && (config.speaker == SPKR_NATIVE))
        return std_port_inb(0x42);
   else if (port == 1)
```
I don't understand the PIT well enough why this helps, but it does! I did not use the native speaker to avoid messing that up.
  * exactly like described in #634 with KVM it hangs the laptop (panic, flashing caps-lock, but no log), as soon as it accesses VRAM (memory at 0xa0000) (I determined this from doing excessive logging and fsync'ing boot.log). Seems the mapping from /dev/mem and then into guest memory doesn't work properly.
* on the same laptop with nomodeset in UEFI mode (efifb), it works similar to BIOS mode (so the VGA hardware still works in UEFI mode), except that it can't restore the efifb console via VESA save/restore, so once you've exited dosemu you're blind.

I'm not sure if I can fix #634 and given present VGA hardware disappearance and the fact that KVM on console is problematic in any case since all port i/o causes a VMEXIT which slows it down. Moreover the more modern way to do VGA passthrough is VFIO, but that needs some extra things (ideally a second GPU and display), and some non-trivial coding and setup.

It would be nice to know though why the PIT sleep was needed.