### PR TITLE
console: fix vga_initialized variable

### DIFF
--- a/src/plugin/console/vga.c
+++ b/src/plugin/console/vga.c
@@ -39,6 +39,7 @@
 static int vga_init(void);
 static int vga_post_init(void);
 static struct video_system *Video_console;
+int vga_initialized;
 
 /* Here are the REGS values for valid dos int10 call */
 


### PR DESCRIPTION
Silly regression from 9743f1374, would compile but not load the console plugin any more.