### PR TITLE
CI: Add test_dosdebug

### DIFF
--- a/ci_test.sh
+++ b/ci_test.sh
@@ -18,6 +18,7 @@ fi
 
 export PYTHONUNBUFFERED=1
 export TEST_DOSEMU=/usr/local/bin/dosemu
+export TEST_DOSDEBUG=/usr/local/bin/dosdebug
 export TEST_CMDDIR=/usr/local/share/dosemu/commands
 
 if [ "${BLDTYPE}" = "packaged" ] ; then
@@ -25,6 +26,7 @@ if [ "${BLDTYPE}" = "packaged" ] ; then
     export SKIP_NATIVE_DPMI=1
   fi
   export TEST_DOSEMU=/usr/bin/dosemu
+  export TEST_DOSDEBUG=/usr/bin/dosdebug
   export TEST_CMDDIR=/usr/share/dosemu/dosemu2-cmds-0.3
 elif [ "${BLDTYPE}" = "asan" ] ; then
   export DEFAULT_TIMEOUT=45
@@ -66,6 +68,8 @@ case "${RUNTYPE}" in
     python3 test/test_dosemu.py PPDOSGITTestCase
     ;;
 esac
+
+python3 test/test_dosdebug.py
 
 for i in test_*.*.*.log ; do
   test -f $i || exit 0

--- a/src/plugin/debugger/dosdebug.c
+++ b/src/plugin/debugger/dosdebug.c
@@ -531,10 +531,11 @@ int main (int argc, char **argv)
 #endif
 
         if (!running) {
+          int err;
           /* collect all remaining input */
           do
             usleep(100000);
-          while (handle_dbg_input(&ret) && ret == 0);
+          while (handle_dbg_input(&err) && err == 0);
           fputs("\n", fpconout);
           fflush(fpconout);
           break;

--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -1,4 +1,5 @@
 import inspect
+import multiprocessing as mp
 import pexpect
 import string
 import random
@@ -7,6 +8,7 @@ import traceback
 import unittest
 
 from datetime import datetime, timezone
+from enum import StrEnum, auto
 from functools import wraps
 from hashlib import sha1
 from os import environ, rename, _exit
@@ -15,11 +17,12 @@ from pathlib import Path
 from platform import system, machine, release
 from ptyprocess import PtyProcessError
 from shutil import copy, rmtree
-from subprocess import (Popen, call, check_call, check_output,
+from subprocess import (Popen, call, check_call, check_output, run,
                         DEVNULL, STDOUT, TimeoutExpired, CalledProcessError)
-from sys import argv, exc_info, exit, stdout, stderr, version_info
+from sys import argv, exit, stdout, stderr, version_info
 from tarfile import open as topen
-from time import sleep
+from tempfile import TemporaryDirectory
+from time import sleep, time
 from unittest.util import strclass
 
 __common_framework = True
@@ -179,8 +182,20 @@ def acceptFailure(func):
         except self.failureException:
             if environ.get("NO_ACCEPTFAILURES", '0') == '1':
                 raise
-            self.skipTest(f"ACCEPTEDFAIL\n")
+            self.skipTest("ACCEPTEDFAIL\n")
     return wrapper
+
+
+class CmdState(StrEnum):
+    WaitAfterStartForTimeout = auto()
+    WaitAfterStartForSentinal = auto()
+    WaitAtPromptForTimeout = auto()
+    WaitAtPromptForSentinal = auto()
+
+
+class EarlyExit(Exception):
+    """Break out of a try block without an error."""
+    pass
 
 
 class BaseTestCase(object):
@@ -215,6 +230,7 @@ class BaseTestCase(object):
 
         cls.cmddir = Path(environ.get("TEST_CMDDIR", cls.topdir / "src" / "bindist"))
         cls.dosemu = Path(environ.get("TEST_DOSEMU", cls.topdir / "bin" / "dosemu"))
+        cls.dosdebug = Path(environ.get("TEST_DOSDEBUG", cls.topdir / "bin" / "dosdebug"))
 
         cls.version = "BaseTestCase default"
         cls.prettyname = "NoPrettyNameSet"
@@ -354,6 +370,10 @@ class BaseTestCase(object):
 
         # Tag the end of autoexec.bat for runDosemu()
         self.mkfile(self.autoexec, "\r\n@echo " + IPROMPT + "\r\n", mode="a")
+
+        # Name the sentinel files
+        self.sentinel_dos_ready = self.imagedir / 'dos-ready.sentinel'
+        self.sentinel_dbg_finished = self.imagedir / 'dbg-finished.sentinel'
 
     def setUpDosAutoexec(self):
         # Use the standard shipped autoexec
@@ -622,6 +642,14 @@ class BaseTestCase(object):
         else:
             return r"c:\share"
 
+    def waitforsentinel(self, sentinel, timeout):
+        start_time = time()
+        while not sentinel.exists():
+            sleep(0.1)  # Always wait at least this
+            if time() - start_time > timeout:
+                return None
+        return time() - start_time
+
     def runDosemu(self, cmd, opts=None, outfile=None, config=DOSEMU_CONF_DEFAULT, timeout=None,
                     eofisok=False, interactions=[]):
         if timeout is None:
@@ -668,9 +696,41 @@ class BaseTestCase(object):
                     raise
 
             try:
+                if cmd == CmdState.WaitAfterStartForTimeout:
+                    sleep(8)  # No better way to confirm we are ready to accept commands if we want to avoid checking the prompt was written by int10
+                    self.sentinel_dos_ready.touch()
+                    sleep(timeout)
+                    ret += f"{cmd}: spent {timeout} seconds after start\n"
+                    raise EarlyExit(f"cmd is {cmd}")
+
+                if cmd == CmdState.WaitAfterStartForSentinal:
+                    sleep(8)
+                    self.sentinel_dos_ready.touch()
+                    if waitedfor := self.waitforsentinel(self.sentinel_dbg_finished, timeout):
+                        ret += f"{cmd}: received sentinel file after {waitedfor} seconds after start\n"
+                    else:
+                        ret += f"{cmd}: spent {timeout} seconds waiting for sentinel file after start\n"
+                    raise EarlyExit(f"cmd is {cmd}")
+
                 prompt = r'(system -e|unix -e|' + IPROMPT + ')'
                 myexpect(child, [prompt + '[\r\n]*'], timeout=40)
                 myexpect(child, ['>[\r\n]*', pexpect.TIMEOUT], timeout=1)
+
+                if cmd == CmdState.WaitAtPromptForTimeout:
+                    self.sentinel_dos_ready.touch()
+                    sleep(timeout)
+                    ret += f"{cmd}: spent {timeout} seconds at the DOS prompt\n"
+                    raise EarlyExit(f"cmd is {cmd}")
+
+                if cmd == CmdState.WaitAtPromptForSentinal:
+                    self.sentinel_dos_ready.touch()
+                    if waitedfor := self.waitforsentinel(self.sentinel_dbg_finished, timeout):
+                        ret += f"{cmd}: received sentinel file after {waitedfor} seconds waiting at the DOS prompt\n"
+                    else:
+                        ret += f"{cmd}: spent {timeout} seconds waiting for sentinel file at the DOS prompt\n"
+                    raise EarlyExit(f"cmd is {cmd}")
+
+                # We just have a plain batchfile name in 'cmd'
                 child.send(cmd + '\n')
                 for resp in interactions:
                     myexpect(child, resp[0])
@@ -693,6 +753,8 @@ class BaseTestCase(object):
                     self.shouldStop = True
             except pexpect.EOF as e:
                 ret = f"EndOfFile: waiting for {e.my['pattern']}\n"
+            except EarlyExit:
+                pass
 
         try:
             child.close(force=True)
@@ -743,6 +805,64 @@ class BaseTestCase(object):
             self.logfiles['xpt'][0].write_text(ret)
 
         return ret
+
+    def runDosemuWithDosdebug(self, doscmd, dbgscr,
+                              dosconfig=DOSEMU_CONF_DEFAULT, dostimeout=None,
+                              dbgtimeout=None):
+
+        def worker_dosdebug():
+            if not (waitedfor := self.waitforsentinel(self.sentinel_dos_ready, 30)):
+                self.sentinel_dbg_finished.touch()  # Tell runDosemu we are done anyway
+                self.fail(f"worker_dosdebug: spent 30 seconds waiting for dos_ready sentinel file\n")
+
+            with TemporaryDirectory() as tmpdir:
+                sfile = Path(tmpdir) / "dosdebug.sh"
+                sfile.write_text(dbgscr)
+                sfile.chmod(0o755)
+
+                output = ''
+                try:
+                    result = run([sfile,], capture_output=True, text=True, timeout=dbgtimeout)
+                    if result.returncode != 0:
+                        output += f"\n--- STDOUT ---\n{result.stdout}"
+                        output += f"\n--- STDERR ---\n{result.stderr}"
+                        output += f"\n--- DBGSCR ---\n{dbgscr}"
+                        self.fail(f"Script failed!\n{output}")
+                    output = result.stdout
+                except TimeoutExpired as e:
+                    # e.stdout and e.stderr contain whatever was captured up to the timeout
+                    output += f"\n--- STDOUT ---\n{e.stdout}"
+                    output += f"\n--- STDERR ---\n{e.stderr}"
+                    output += f"\n--- DBGSCR ---\n{dbgscr}"
+                    self.fail(f"Script timed out!\n{output}")
+                finally:
+                    self.sentinel_dbg_finished.touch()
+
+            self.logfiles['dbl'] = [self.topdir / f'{self.id()}.dbl', "dosdebug.log"]
+            self.logfiles['dbl'][0].write_text(output)
+            return output
+
+        def worker_dosemu(q, *args, **kwargs):
+            dosoutput = self.runDosemu(*args, **kwargs)
+            q.put(dosoutput)
+
+        # Now start the dosemu session in another process
+        q = mp.Queue()
+        p = mp.Process(
+                target=worker_dosemu,
+                args=(q, doscmd),
+                kwargs={"config": dosconfig, "timeout": dostimeout}
+        )
+        p.start()
+
+        # Now start the debugger session in this process
+        dbgoutput = worker_dosdebug()
+
+        # Collect the output from the dosemu session
+        dosoutput = q.get(timeout=120)  # returns as soon as we get one put()'s data
+        p.join()
+
+        return (dosoutput, dbgoutput)
 
     def assertFilesEqual(self, reffile, dosfile):
         """Compare DOS output to reference file"""

--- a/test/test_dosdebug.py
+++ b/test/test_dosdebug.py
@@ -1,0 +1,62 @@
+#!/usr/bin/python3
+
+from common_framework import BaseTestCase, CmdState, main, main_setup
+from common_os import frdos130, msdos700, ppdosgit
+
+
+class OurTestCase(BaseTestCase):
+
+    def test_cga_text(self):
+        """CGA text in video ram at startup"""
+
+        dbg_script = f"""\
+#!/bin/bash
+set -e
+echo 'd b800:0540 256' | {self.dosdebug}
+echo 'd b800:0640 256' | {self.dosdebug}
+echo 'd b800:0740 256' | {self.dosdebug}
+echo 'd b800:0840 256' | {self.dosdebug}
+echo 'd b800:0940 256' | {self.dosdebug}
+echo 'd b800:0a40 256' | {self.dosdebug}
+echo 'd b800:0b40 256' | {self.dosdebug}
+echo 'd b800:0c40 256' | {self.dosdebug}
+echo 'd b800:0d40 256' | {self.dosdebug}
+echo 'd b800:0e40 256' | {self.dosdebug}
+echo 'd b800:0f40 256' | {self.dosdebug}
+"""
+
+        dos_results, dbg_results = self.runDosemuWithDosdebug(
+                CmdState.WaitAfterStartForSentinal,
+                dbg_script,
+                dostimeout=30, dbgtimeout=60)
+
+        # Nothing we care about in dos output
+#        self.assertIn("dosemu", dos_results)
+
+        # Process the dbg output
+        tlist = []
+        for l in dbg_results.splitlines():
+            # 'b800:0b40 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................'
+            w = l.split()
+            if w and w[0].startswith('b800:'):
+                tlist += w[1:17]
+        tstr = ' '.join(tlist)
+        self.assertIn("43 07 3A 07 5C 07 3E 07", tstr)  # C.:.\.>.
+
+
+# The DOS variants we want get included here
+FRDOS130TestCase = frdos130(OurTestCase, {})
+PPDOSGITTestCase = ppdosgit(OurTestCase, {})
+MSDOS700TestCase = msdos700(OurTestCase, {})
+
+if __name__ == '__main__':
+
+    # Dynamically created tests are added here
+
+    cases = [
+        PPDOSGITTestCase,
+        FRDOS130TestCase,
+        MSDOS700TestCase,
+    ]
+    xargv = main_setup(cases)
+    main(xargv)

--- a/test/test_dosdebug.py
+++ b/test/test_dosdebug.py
@@ -12,16 +12,27 @@ class OurTestCase(BaseTestCase):
         dbg_script = f"""\
 #!/bin/bash
 set -e
+sleep 1
 echo 'd b800:0540 256' | {self.dosdebug}
+sleep 1
 echo 'd b800:0640 256' | {self.dosdebug}
+sleep 1
 echo 'd b800:0740 256' | {self.dosdebug}
+sleep 1
 echo 'd b800:0840 256' | {self.dosdebug}
+sleep 1
 echo 'd b800:0940 256' | {self.dosdebug}
+sleep 1
 echo 'd b800:0a40 256' | {self.dosdebug}
+sleep 1
 echo 'd b800:0b40 256' | {self.dosdebug}
+sleep 1
 echo 'd b800:0c40 256' | {self.dosdebug}
+sleep 1
 echo 'd b800:0d40 256' | {self.dosdebug}
+sleep 1
 echo 'd b800:0e40 256' | {self.dosdebug}
+sleep 1
 echo 'd b800:0f40 256' | {self.dosdebug}
 """
 

--- a/test/test_dosdebug.py
+++ b/test/test_dosdebug.py
@@ -43,6 +43,25 @@ echo 'd b800:0f40 256' | {self.dosdebug}
         tstr = ' '.join(tlist)
         self.assertIn("43 07 3A 07 5C 07 3E 07", tstr)  # C.:.\.>.
 
+    def test_ivec_at_startup(self):
+        """Use the IVEC command to show the interrupt vectors at startup"""
+
+        dbg_script = f"""\
+#!/bin/bash
+set -e
+echo 'ivec' | {self.dosdebug}
+"""
+
+        dos_results, dbg_results = self.runDosemuWithDosdebug(
+                CmdState.WaitAtPromptForSentinal,
+                dbg_script,
+                dostimeout=30, dbgtimeout=60)
+
+        self.assertRegex(dbg_results, r"  33  [0-9A-Z]{4}:[0-9A-Z]{4}\(MOUSE_INT33_OFF\)")
+        self.assertRegex(dbg_results, r"  41  [0-9A-Z]{4}:[0-9A-Z]{4}\(HD_parameter_table0\)")
+        self.assertRegex(dbg_results, r"  46  [0-9A-Z]{4}:[0-9A-Z]{4}\(HD_parameter_table1\)")
+        self.assertRegex(dbg_results, r"  61  [0-9A-Z]{4}:[0-9A-Z]{4}\(TCPDRV_OFF\)")
+
 
 # The DOS variants we want get included here
 FRDOS130TestCase = frdos130(OurTestCase, {})


### PR DESCRIPTION
I started adding a dosdebug test facility using the simple bash script driver, but there are problems.

1. ~dosdebug on exiting due to EOF returns non zero so I had to apply `|| true` to each line~ Have patch.
2. ~dosdebug's `d` command really needs a bytes per line option, otherwise if the target string is split over two lines, the search won't find it. Being able to specify 20 bytes per line would mean I could assume that the start of any DOS screen line would be aligned with start of a debug line.~ I'll process the dosdebug output back into one long string in the test.
3. ~I need to figure out some sort of synchronisation method as currently after starting the dosemu, I wait 8 secs before assuming DOS has booted and starting the dosdebug script.~ Used a file based method
4. ~And the big one for this test: if the video output is broken the dosemu runner can't know when to sit at the C:\> prompt~ Just have to wait for an arbitrary time (used 8 secs)



