### PR TITLE
mapping: fix munmap_mapping_pa() [#2817]

### DIFF
--- a/src/base/core/int.c
+++ b/src/base/core/int.c
@@ -569,9 +569,6 @@ static int dos_helper(int stk_offs, int revect)
 		    restore_mapping_pa(GRAPH_BASE, GRAPH_SIZE);
 		} else {
 		    munmap_mapping_pa(MAPPING_VGAEMU, GRAPH_BASE, GRAPH_SIZE);
-		    alias_mapping(MAPPING_LOWMEM, GRAPH_BASE, GRAPH_SIZE,
-			    PROT_READ | PROT_WRITE | PROT_EXEC,
-			    LOWMEM(GRAPH_BASE));
 		}
 		break;
 	    case DOS_SUBHELPER_VIDEO_MAP_b:
@@ -580,10 +577,6 @@ static int dos_helper(int stk_offs, int revect)
 		} else {
 		    munmap_mapping_pa(MAPPING_VGAEMU, MDA_PHYS_TEXT_BASE,
 				      MDA_TEXT_SIZE);
-		    alias_mapping(MAPPING_LOWMEM, MDA_PHYS_TEXT_BASE,
-			    MDA_TEXT_SIZE,
-			    PROT_READ | PROT_WRITE | PROT_EXEC,
-			    LOWMEM(MDA_PHYS_TEXT_BASE));
 		}
 		break;
 	    default:

--- a/src/base/lib/mapping/mapping.c
+++ b/src/base/lib/mapping/mapping.c
@@ -398,18 +398,13 @@ int munmap_mapping(int cap, dosaddr_t targ, size_t mapsize)
 int munmap_mapping_pa(int cap, unsigned int addr, size_t mapsize)
 {
   struct hardware_ram *hw;
-  int err;
   dosaddr_t va = do_get_hardware_ram(addr, mapsize, &hw);
   if (va == (dosaddr_t)-1)
     return -1;
   assert(addr >= GRAPH_BASE);
   if (!hwram_is_mapped(hw, addr, mapsize))
     return -1;
-  if (!(cap & MAPPING_INIT_LOWRAM)) {
-    err = munmap_mapping(MAPPING_LOWMEM, va, mapsize);
-    if (err)
-      return err;
-  }
+  restore_mapping(cap, va, mapsize);
   hwram_map_aliasmap(hw, addr, mapsize, 0);
   return 0;
 }
@@ -418,7 +413,7 @@ int munmap_mapping_pa(int cap, unsigned int addr, size_t mapsize)
 int restore_mapping(int cap, dosaddr_t targ, size_t mapsize)
 {
   int ret;
-  assert((cap & MAPPING_DPMI) && (targ != (dosaddr_t)-1));
+  assert((cap & (MAPPING_DPMI | MAPPING_VGAEMU | MAPPING_INIT_LOWRAM)) && (targ != (dosaddr_t)-1));
   ret = alias_mapping(cap, targ, mapsize, PROT_READ | PROT_WRITE,
       LOWMEM(targ));
   if (is_kvm_map(cap))

--- a/src/base/lib/mapping/mapping.c
+++ b/src/base/lib/mapping/mapping.c
@@ -1002,9 +1002,15 @@ static unsigned do_find_hardware_ram(dosaddr_t va, uint32_t size,
     if (hw->vbase == -1)
       continue;
     if (hw->vbase <= va && va + size <= hw->vbase + hw->size) {
-	if (r_hw)
-	  *r_hw = hw;
-      return hw->base + va - hw->vbase;
+      unsigned addr = hw->base + va - hw->vbase;
+      if (!hwram_is_mapped(hw, addr & _PAGE_MASK, PAGE_ALIGN(size))) {
+        /* make sure its not kmem somehow unmapped */
+        assert(hw->type != 'v' && hw->type != 'h');
+        return -1;
+      }
+      if (r_hw)
+        *r_hw = hw;
+      return addr;
     }
   }
   return -1;

--- a/src/base/lib/mapping/mapping.c
+++ b/src/base/lib/mapping/mapping.c
@@ -228,7 +228,6 @@ int alias_mapping_high(int cap, dosaddr_t targ, size_t mapsize, int protect,
 }
 
 #ifdef __linux__
-// check if mapped for kmem, only used for assert
 static int kmem_mapped(dosaddr_t addr, int mapsize)
 {
   struct hardware_ram *hw;
@@ -404,6 +403,12 @@ int munmap_mapping_pa(int cap, unsigned int addr, size_t mapsize)
   assert(addr >= GRAPH_BASE);
   if (!hwram_is_mapped(hw, addr, mapsize))
     return -1;
+#ifdef __linux__
+  if (kmem_mapped(addr, mapsize)) {
+    error("not unmapping kmem from %x (size %zx)\n", addr, mapsize);
+    return -1;
+  }
+#endif
   restore_mapping(cap, va, mapsize);
   hwram_map_aliasmap(hw, addr, mapsize, 0);
   return 0;


### PR DESCRIPTION
It should call restore_mapping().
int.c was instead calling alias_mapping() by hands after munmap_mapping_pa(), but vgaemu.c didn't, so it remained mapped to video memory.