### PR TITLE
CI: Win95 FE mangles video in -dumb mode

### DIFF
--- a/test/common_os.py
+++ b/test/common_os.py
@@ -277,6 +277,7 @@ def msdos700(baseclass, actions):
                 ("command.com", "67696207c3963a0dc9afab8cf37dbdb966c1f663"),
                 ("share.exe", "67d6524f7d700147013365e1656e93c842b9af07"),
                 ("dos/himem.sys", "837993a3ec3edec102de9ab78a39ae049007d991"),
+                ("fx-video.com", "fb75a6605c40787e805022b36328a050712ddd1d"),  # Fix the Video mode byte for `dosemu -td`
             ]
             cls.systype = SYSTYPE_MSDOS_NEW
             cls.autoexec = "autoemu.bat"
@@ -286,7 +287,7 @@ def msdos700(baseclass, actions):
                 ("boot-900-15-17.blk", "8c1243481112f320f2a5f557f30db11174fe7e3d"),
             ]
             cls.images = [
-                ("boot-floppy.img", "634912c5c778a3f576e32cdc264b26a9736a8195"),
+                ("boot-floppy.img", "efb3e6d2eeb0530f87d59daf269fee128b326871"),
             ]
             cls.actions = actions
 
@@ -296,6 +297,7 @@ def msdos700(baseclass, actions):
             # Use the (almost) standard shipped config
             contents = (self.cmddir / self.autoexec).read_text()
             contents = re.sub(r"[Dd]:\\", r"c:\\", contents)
+            contents = re.sub(r"@echo off", r"@echo off"+"\n"+r"c:\\fx-video", contents)
             self.mkfile(self.autoexec, contents, newline="\r\n")
 
         def setUpDosConfig(self):

--- a/test/func_floppy.py
+++ b/test/func_floppy.py
@@ -19,6 +19,10 @@ $_bootdrive = "a"
 
 
 def floppy_vfs(self):
+    autofixes = ''
+    if "Windows 95" in self.version:  # AKA MS-DOS 7.0
+        autofixes = "fx-video"
+
     self.mkfile(self.confsys, """\
 DOS=UMB,HIGH
 lastdrive=Z
@@ -33,12 +37,13 @@ install=a:\\dosemu\\emufs.com
 shell=command.com /e:1024 /k %s
 """ % self.autoexec, newline="\r\n")
 
-    self.mkfile(self.autoexec, """\
+    self.mkfile(self.autoexec, f"""\
+{autofixes}
 prompt $P$G
 path a:\\bin;a:\\gnu;a:\\dosemu
 system -s DOSEMU_VERSION
-@echo %s
-""" % IPROMPT, newline="\r\n")
+@echo {IPROMPT}
+""", newline="\r\n")
 
     results = self.runDosemu("version.bat", config="""\
 $_hdimage = ""


### PR DESCRIPTION
As discussed to great length here
https://github.com/dosemu2/dosemu2/issues/2817

1/ Updated test-binaries to include a new MS-DOS-7.00.tar with `fx-video.com`, a renamed `vid.com` provided by Stas in the linked issue above.
2/ Updated the setUpDosAutoexec() for MSDOS700TestCase to call the fix on boot.
3/ Included the `fx-video.com` and the tweak to autoexec on the `boot-floppy.img`.