### PR TITLE
Ci 259

### DIFF
--- a/.github/workflows/test-suite-worker.yml
+++ b/.github/workflows/test-suite-worker.yml
@@ -68,17 +68,23 @@ jobs:
         OS: ${{ inputs.os }}
       run: ./ci_build_or_install.sh
 
-    - name: Cache binaries
+    - name: Cache
+      id: cache
       uses: actions/cache@v5
-      env:
-        cache-name: test-binaries
       with:
         path: ~/cache
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+        key: cache-v00001
         restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
+          cache-
 
-    - name: Add an ACL for ourselves
+    - name: Populate cache
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        echo "Cache missed! Populating with fresh binaries"
+        [ -h "test-binaries" ] || ln -s "${HOME}"/cache "test-binaries"
+        python3 test/test_dosemu.py --get-test-binaries
+
+    - name: Add an ACL to KVM for ourselves
       run: |
           echo 'SUBSYSTEM=="misc", KERNEL=="kvm", RUN+="/usr/bin/setfacl -m u:'${USER}':rw- /dev/kvm"' | sudo tee /etc/udev/rules.d/99-kvm4dosemu2.rules
           sudo udevadm control --reload-rules

--- a/ci_test.sh
+++ b/ci_test.sh
@@ -16,8 +16,8 @@ if [ "${CI}" = "true" ] ; then
   [ -h "${TBINS}" ] || ln -s "${HOME}"/cache "${TBINS}"
 else
   [ -d "${TBINS}"] || mkdir "${TBINS}"
+  python3 test/test_dosemu.py --get-test-binaries
 fi
-python3 test/test_dosemu.py --get-test-binaries
 
 export PYTHONUNBUFFERED=1
 export TEST_DOSEMU=/usr/local/bin/dosemu

--- a/ci_test.sh
+++ b/ci_test.sh
@@ -39,6 +39,8 @@ elif [ "${RUNTYPE}" = "full" ] ; then
   export NO_FAILFAST=1
 fi
 
+set +e
+
 cat >&2 << EOF
 =====================================================
 =         Tests run on KVM and emulated CPU         =

--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -58,6 +58,15 @@ TEST_BINARIES = (
     'TEST_R200.tar',
 )
 
+# Freedos 1.4 packages
+TEST_FREEDOS_HOST = "https://www.ibiblio.org/pub/micro/pc-stuff/freedos/files/repositories/1.4"
+TEST_FREEDOS_PKGS = (
+    'devel/dj_make.zip',
+    'devel/nasm.zip',
+    'devel/watcomc.zip',
+    'devel/upx.zip',
+)
+
 DOSEMU_CONF_DEFAULT = """\
 $_hdimage = "dXXXXs/c:hdtype1 +1"
 $_floppy_a = ""
@@ -121,12 +130,19 @@ def get_test_binaries():
         tbindir.mkdir()
 
     for tfile in TEST_BINARIES:
-        if not Path(tbindir / tfile).exists():
-            check_call([
-                "wget",
-                "--no-verbose",
-                TEST_BINARY_HOST + '/' + tfile,
-            ], stderr=STDOUT, cwd=tbindir)
+        check_call([
+            "wget",
+            "--no-verbose",
+            f"{TEST_BINARY_HOST}/{tfile}",
+        ], stderr=STDOUT, cwd=tbindir)
+
+    for zfile in TEST_FREEDOS_PKGS:
+        check_call([
+            "wget",
+            "--no-verbose",
+            "--inet4-only",
+            f"{TEST_FREEDOS_HOST}/{zfile}",
+        ], stderr=STDOUT, cwd=tbindir)
 
 
 def mark(attr_names):

--- a/test/func_build_freecom.py
+++ b/test/func_build_freecom.py
@@ -1,6 +1,8 @@
 from os import environ
 from subprocess import check_call, CalledProcessError, run, STDOUT
 
+from common_framework import BINSDIR
+
 
 def build_freecom(self):
     if environ.get("SKIP_EXPENSIVE"):
@@ -14,23 +16,17 @@ def build_freecom(self):
     except CalledProcessError:
         self.skipTest("repository unavailable")
 
-    # Now need to download Watcom 1.9 packages and unpack
+    # Now need to unpack packages already downloaded from freedos
     # Path to watcom binaries will be 'c:/devel/watcomc/binw'
-    pkgurl = 'https://www.ibiblio.org/pub/micro/pc-stuff/freedos/files/repositories/1.3/devel'
     try:
         for pkg in ['watcomc', 'nasm']:
-            check_call([
-                "wget",
-                "-q",
-                pkgurl + '/%s.zip' % pkg,
-            ], stderr=STDOUT, cwd=self.imagedir)
             check_call([
                 "unzip",
                 "-LL",
                 "-q",
-                str(self.imagedir) + '/%s.zip' % pkg,
+                f"{self.topdir}/{BINSDIR}/{pkg}.zip",
             ], stderr=STDOUT, cwd=self.workdir)
-    except:
+    except CalledProcessError:
         self.skipTest("DOS pkgs unavailable")
 
     # Generate the config

--- a/test/func_build_freedos.py
+++ b/test/func_build_freedos.py
@@ -1,6 +1,8 @@
 from os import environ
 from subprocess import check_call, check_output, CalledProcessError, STDOUT
 
+from common_framework import BINSDIR
+
 
 def build_freedos(self):
     if environ.get("SKIP_EXPENSIVE"):
@@ -15,21 +17,15 @@ def build_freedos(self):
     except CalledProcessError:
         self.skipTest("GIT repository problem")
 
-    # Now need to download Watcom 1.9 packages and unpack
+    # Now need to unpack packages already downloaded from freedos
     # Path to watcom binaries will be 'c:/devel/watcomc/binw'
-    pkgurl = 'https://www.ibiblio.org/pub/micro/pc-stuff/freedos/files/repositories/1.4/devel'
     try:
         for pkg in ['watcomc', 'nasm', 'dj_make', 'upx']:
-            check_call([
-                "wget",
-                "-q",
-                pkgurl + '/%s.zip' % pkg,
-            ], stderr=STDOUT, cwd=self.imagedir)
             check_call([
                 "unzip",
                 "-LL",
                 "-q",
-                str(self.imagedir) + '/%s.zip' % pkg,
+                f"{self.topdir}/{BINSDIR}/{pkg}.zip",
             ], stderr=STDOUT, cwd=self.workdir)
 
         dosbin = self.workdir / 'bin'


### PR DESCRIPTION
A couple of tweaks here:
1/ Don't exit the test script early on failure, which will finally ensure we collect the system logs.
2/ Use the Github Actions cache for FreeDOS packages, which will exclude the download time from the test times and make it more reliable. Quite often in the recent past the tests have been skipped due to the FreeDOS download server
being unavailable.