### PR TITLE
PIT: fix counters 1 and 2 to use ticks instead of ns.

### DIFF
--- a/src/base/dev/misc/timers.c
+++ b/src/base/dev/misc/timers.c
@@ -254,7 +254,7 @@ static int _pit_latch(int latch, uint64_t cur)
 	    ticks = 0;  // should not be here
 	}
       } else {
-	ticks = p->cntr - (cur % p->cntr);
+	ticks = p->cntr - (NS_TO_TICKS(cur) % p->cntr);
       }
 
       if ((p->mode & 3)==3) {


### PR DESCRIPTION
Intel i915 vbios (and other BIOSes) use timer #2 (usually used for the speaker) as a GP counter, but it was returning incorrect latch values, somehow causing no screen output for console graphics with cpuemu.

Looks like a regression from 11acfe350f : in there a conversion for timer #0 from ns to ticks happens but not for #1 and #2.

See also #2813 : the PIT sleep was a workaround but not a proper fix.