### PR TITLE
speaker: implement PC speaker wave generation

### DIFF
--- a/etc/dosemu.conf
+++ b/etc/dosemu.conf
@@ -627,9 +627,9 @@
 ##############################################################################
 ## Speaker and sound settings
 
-# speaker: default: "emulated", or "native" (console only) or "" (off)
+# speaker: default: "sound", "emulated", or "native" (priv/-s only) or "" (off)
 
-# $_speaker = "off"
+# $_speaker = "sound"
 
 # sound support
 

--- a/src/base/dev/misc/timers.c
+++ b/src/base/dev/misc/timers.c
@@ -595,6 +595,7 @@ static void spkr_io_write(ioport_t port, Bit8u value, void *arg) {
           break;
 
        case SPKR_EMULATED:
+       case SPKR_SOUND:
 	  if ((value & 3) == (port61 & 3))
 	    break;
 	  port61 = value & 0x0f;

--- a/src/base/init/config.c
+++ b/src/base/init/config.c
@@ -260,6 +260,7 @@ void dump_config_status(void (*printfunc)(const char *, ...))
       case SPKR_OFF: s = "off"; break;
       case SPKR_NATIVE: s = "native"; break;
       case SPKR_EMULATED: s = "emulated"; break;
+      case SPKR_SOUND: s = "sound"; break;
       default: s = "wrong"; break;
     }
     (*print)("dualmon %d\nforce_vt_switch %d\nspeaker \"%s\"\n",

--- a/src/base/init/lexer.l
+++ b/src/base/init/lexer.l
@@ -374,6 +374,7 @@ ems_conv_pages		RETURN(EMS_CONV_PAGES);
 
 	/* speaker values */
 
+sound			RETURN(SOUND);
 emulated		RETURN(EMULATED);
 native			RETURN(NATIVE);
 

--- a/src/base/init/parser.y
+++ b/src/base/init/parser.y
@@ -678,7 +678,7 @@ line:		CHARSET '{' charset_flags '}' {}
                         c_printf("CONF: allowing speaker port access!\n");
 		      } else {
                         c_printf("CONF: native speaker not allowed: emulate\n");
-			$2 = SPKR_EMULATED;
+			$2 = SPKR_SOUND;
 		      }
 		    }
 		    else
@@ -1870,9 +1870,10 @@ irq_bool:	expression {
 speaker		: L_OFF		{ $$ = SPKR_OFF; }
 		| NATIVE	{ $$ = SPKR_NATIVE; }
 		| EMULATED	{ $$ = SPKR_EMULATED; }
-		| STRING        { yyerror("got '%s', expected 'emulated' or 'native'", $1);
+		| SOUND		{ $$ = SPKR_SOUND; }
+		| STRING        { yyerror("got '%s', expected 'sound', 'emulated' or 'native'", $1);
 				  free($1); }
-		| error         { yyerror("expected 'emulated' or 'native'"); }
+		| error         { yyerror("expected 'sound', 'emulated' or 'native'"); }
 		;
 
 cpu_vm		: L_AUTO	{ $$ = -1; }

--- a/src/base/speaker/Makefile
+++ b/src/base/speaker/Makefile
@@ -3,7 +3,7 @@ include $(top_builddir)/Makefile.conf
 
 # Makefile for speaker code.
 
-CFILES=speaker.c $(X_CFILES) console_speaker.c evdev_speaker.c
+CFILES=speaker.c $(X_CFILES) console_speaker.c evdev_speaker.c sound_speaker.c
 
 SFILES=
 ALL=$(CFILES) $(SFILES)

--- a/src/base/speaker/sound_speaker.c
+++ b/src/base/speaker/sound_speaker.c
@@ -1,0 +1,184 @@
+/*
+ * speaker Emulation via sound card
+ * inspired by wave generation function from QEMU: hw/audio/pcspk.c
+ * =============================================================================
+ */
+
+#include "emu.h"
+#include "speaker.h"
+#include "timers.h"
+#include "utilities.h"
+#include "sound/sound.h"
+
+#include <pthread.h>
+#include <semaphore.h>
+
+#define DIV_ROUND_UP(n,d) (((n) + (d) - 1) / (d))
+#define PCSPK_BUF_LEN 2470
+#define PCSPK_SAMPLE_RATE 44100
+#define PCSPK_MAX_FREQ (PCSPK_SAMPLE_RATE >> 1)
+#define PCSPK_MIN_COUNT DIV_ROUND_UP(SPEAKER_PERIOD_BASE, PCSPK_MAX_FREQ) // 55
+
+typedef struct {
+	sndbuf_t sample_buf[PCSPK_BUF_LEN][SNDBUF_CHANS];
+	unsigned int pit_count;
+	unsigned int samples;
+	unsigned int play_pos;
+	int pcm_stream;
+	sem_t sem;
+	pthread_t thr;
+	int running, stopping;
+	unsigned short period;
+	pthread_mutex_t run_mtx;
+} PCSpkState;
+
+static PCSpkState beep = {
+	.pit_count = (unsigned int)-1,
+	.run_mtx = PTHREAD_MUTEX_INITIALIZER
+};
+
+/*
+ * wave generation function from QEMU: hw/audio/pcspk.c
+ */
+static inline void generate_samples(PCSpkState *s)
+{
+	unsigned int i;
+
+	if (s->pit_count == 65535) {
+		s->samples = PCSPK_BUF_LEN;
+		for (i = 0; i < PCSPK_BUF_LEN; ++i)
+			s->sample_buf[i][0] = -32;
+	}
+	else if (s->pit_count) {
+		const uint32_t m = PCSPK_SAMPLE_RATE * s->pit_count;
+		const uint32_t n = ((uint64_t)SPEAKER_PERIOD_BASE << 32) / m;
+
+		/* multiple of wavelength for gapless looping */
+		s->samples = ((PCSPK_BUF_LEN * SPEAKER_PERIOD_BASE / m * m) / (SPEAKER_PERIOD_BASE >> 1) + 1) >> 1;
+		for (i = 0; i < s->samples; ++i)
+			s->sample_buf[i][0] = (64 & (n * i >> 25)) - 32;
+	} else {
+		s->samples = PCSPK_BUF_LEN;
+		for (i = 0; i < PCSPK_BUF_LEN; ++i)
+			s->sample_buf[i][0] = 128; /* silence */
+	}
+}
+
+static void speaker_process_samples(PCSpkState *s, unsigned int nsamples)
+{
+	unsigned int n;
+
+	n = s->period;
+	/* avoid frequencies that are not reproducible with sample rate */
+	if (n < PCSPK_MIN_COUNT)
+		n = 0;
+
+	if (s->pit_count != n) {
+		s->pit_count = n;
+		s->play_pos = 0;
+		generate_samples(s);
+	}
+
+	if (s->pit_count && s->pit_count != 65535) {
+		const uint32_t m = PCSPK_SAMPLE_RATE * s->pit_count;
+		/* round up to multiple of wavelength */
+		nsamples = (((nsamples * SPEAKER_PERIOD_BASE + m - 1) / m
+			     * m) / (SPEAKER_PERIOD_BASE >> 1) + 1) >> 1;
+	}
+
+	while (nsamples > 0) {
+		n = _min(s->samples - s->play_pos, nsamples);
+		pcm_write_interleaved(&s->sample_buf[s->play_pos], n, PCSPK_SAMPLE_RATE,
+				      PCM_FORMAT_U8, 1, s->pcm_stream);
+		s->play_pos = (s->play_pos + n) % s->samples;
+		nsamples -= n;
+	}
+}
+
+static void speaker_run(PCSpkState *s)
+{
+	unsigned int nsamples;
+	double period, speaker_time_cur;
+	hitimer_t curtime;
+
+	curtime = GETusTIME(0);
+	speaker_time_cur = pcm_get_stream_time(s->pcm_stream);
+	if (curtime < speaker_time_cur)
+		return;
+	if (s->stopping) {
+		pcm_flush(s->pcm_stream);
+		s->running = 0;
+		return;
+	}
+	period = pcm_frame_period_us(PCSPK_SAMPLE_RATE);
+	nsamples = (curtime - speaker_time_cur) / period;
+	speaker_process_samples(s, nsamples);
+	if (debug_level('S') >= 7)
+		S_printf("speaker: processed %i samples\n", nsamples);
+}
+
+static void *speaker_thread(void *arg)
+{
+	PCSpkState *s = arg;
+
+	while (1) {
+		sem_wait(&s->sem);
+		pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL);
+		pthread_mutex_lock(&s->run_mtx);
+		if (s->running)
+			speaker_run(s);
+		pthread_mutex_unlock(&s->run_mtx);
+		pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+	}
+	return NULL;
+}
+
+static void speaker_timer(void)
+{
+	sem_post(&beep.sem);
+}
+
+static void sound_speaker_on(void *gp, unsigned short period)
+{
+	PCSpkState *s = gp;
+
+	pthread_mutex_lock(&s->run_mtx);
+	s->period = period;
+	if (!s->running)
+		pcm_prepare_stream(s->pcm_stream);
+	s->running = 1;
+	s->stopping = 0;
+	pthread_mutex_unlock(&s->run_mtx);
+	sem_post(&s->sem);
+}
+
+static void sound_speaker_off(void *gp)
+{
+	PCSpkState *s = gp;
+
+	pthread_mutex_lock(&s->run_mtx);
+	s->stopping = 1;
+	s->period = 0;
+	pthread_mutex_unlock(&s->run_mtx);
+}
+
+void sound_speaker_init(void)
+{
+	if (config.speaker != SPKR_SOUND) return;
+	register_speaker(&beep, sound_speaker_on, sound_speaker_off);
+	sigalrm_register_handler(speaker_timer);
+	beep.pcm_stream = pcm_allocate_stream(1, "PC-SPEAKER", (void *)MC_PCSP);
+	sem_init(&beep.sem, 0, 0);
+	pthread_create(&beep.thr, NULL, speaker_thread, &beep);
+#if defined(HAVE_PTHREAD_SETNAME_NP) && defined(__GLIBC__)
+	pthread_setname_np(beep.thr, "dosemu: speaker");
+#endif
+}
+
+void sound_speaker_done(void)
+{
+	if (config.speaker != SPKR_SOUND) return;
+	pthread_cancel(beep.thr);
+	pthread_join(beep.thr, NULL);
+	sem_destroy(&beep.sem);
+}

--- a/src/base/speaker/speaker.c
+++ b/src/base/speaker/speaker.c
@@ -163,6 +163,7 @@ void speaker_pause (void)
 		std_port_outb (0x61, saved_port_val & 0xFC);	/* clear timer & speaker bits */
 		break;
 	case SPKR_EMULATED:
+	case SPKR_SOUND:
 		speaker_off ();
 		break;
 	case SPKR_OFF:
@@ -178,6 +179,7 @@ void speaker_resume (void)
 		std_port_outb (0x61, saved_port_val);	/* restore timer & speaker bits */
 		break;
 	case SPKR_EMULATED:
+	case SPKR_SOUND:
 //		do_sound(pit[2].write_latch & 0xffff);
 		break;
 	case SPKR_OFF:
@@ -187,13 +189,14 @@ void speaker_resume (void)
 
 void speaker_init (void)
 {
+	sound_speaker_init();
 	evdev_speaker_init();
 	console_speaker_init();
 }
 
 void speaker_done (void)
 {
-	if (config.speaker == SPKR_EMULATED) {
+	if (config.speaker == SPKR_EMULATED || config.speaker == SPKR_SOUND) {
 		g_printf("SPEAKER: sound off\n");
 		speaker_off();		/* turn off any sound */
 	}
@@ -207,6 +210,7 @@ void speaker_done (void)
 		 */
 		port_outb(0x61, port_inb(0x61)&0xFC); /* turn off any sound */
 	}
+	sound_speaker_done();
 	/* reset the speaker to its default */
 	register_speaker(NULL, NULL, NULL);
 }

--- a/src/include/emu.h
+++ b/src/include/emu.h
@@ -387,7 +387,7 @@ typedef struct config_info {
 } config_t;
 
 
-enum { SPKR_OFF, SPKR_NATIVE, SPKR_EMULATED };
+enum { SPKR_OFF, SPKR_NATIVE, SPKR_EMULATED, SPKR_SOUND };
 enum { CPUVM_VM86, CPUVM_KVM, CPUVM_EMU, CPUVM_NATIVE };
 
 extern void parent_nextscan(void);

--- a/src/include/speaker.h
+++ b/src/include/speaker.h
@@ -51,6 +51,8 @@ void register_speaker(void *gp,
 /* for now declare these here */
 void console_speaker_init(void);
 void evdev_speaker_init(void);
+void sound_speaker_init(void);
+void sound_speaker_done(void);
 
 void speaker_init(void);
 void speaker_done(void);

--- a/src/plugin/X/X.c
+++ b/src/plugin/X/X.c
@@ -826,7 +826,8 @@ int X_init(void)
   }
 
 #if CONFIG_X_SPEAKER
-  X_register_speaker(display);
+  if (config.speaker == SPKR_EMULATED)
+    X_register_speaker(display);
 #endif
 
   pthread_create(&event_thr, NULL, X_handle_events, NULL);


### PR DESCRIPTION
using $_speaker = "generated" (new default), this emulates the PC speaker via the soundcard using the same algorithm as QEMU (no effort to go beyond basic beeps, so no advanced techniques such as RealSound).

This just implements a square wave, but as the duration isn't known in advance (the passed 30s is fake and gives rise to a buffer that is too large for sndpcm.c), it needs to keep feeding chunks of it to sndpcm.c, and the current method using a sigalrm handler is a bit awkward.

Some hints were taken from an older patch by @andrewbird https://sourceforge.net/p/dosemu/patches/125/
and its discussion.

Tested with an old pacman https://archive.org/details/PCMan

Fixes #402