### PR TITLE
kvm: assert that VM flag was not lost [#2624]

### DIFF
--- a/src/base/emu-i386/kvm.c
+++ b/src/base/emu-i386/kvm.c
@@ -1583,6 +1583,12 @@ int true_kvm_vm86(struct vm86_struct *info)
       vm86_ret = kvm_handle_vm86_fault(regs, info->cpu_type);
   } while (vm86_ret == -1);
 
+  /* On Xeon, in VME mode sometimes the IDT handler is invoked instead
+   * of GPF. Assert that we are still in V86, not in such IDT handler.
+   * See https://github.com/dosemu2/dosemu2/issues/2624
+   * for details.
+   */
+  assert(regs->eflags & X86_EFLAGS_VM);
   info->regs = *regs;
   info->regs.eflags |= X86_EFLAGS_IOPL;
 #if 0


### PR DESCRIPTION
Xeon sometimes invokes IDT handler in VME mode, instead of GPF. It is currently unknown if it ever does so with RPL=3 handlers, or only with RPL=0 ones.
With RPL=0 this problem was already observed, and this assert is needed to make sure it never happens with RPL=3.

Note: because of 38471663b this assert should never trigger in practice. Its only for debugging.