### PR TITLE
Speaker fixes and cleanups

### DIFF
--- a/src/base/bios/int10.c
+++ b/src/base/bios/int10.c
@@ -320,7 +320,9 @@ void tty_char_out(unsigned char ch, int s, int attr)
     break;
 
   case 7:           /* Bell */
-    speaker_on(125, 0x637);
+    speaker_on(0x637);
+    kill_time(125000);
+    speaker_off();
     return;
 
   default:          /* Printable character */

--- a/src/base/core/emu.c
+++ b/src/base/core/emu.c
@@ -517,20 +517,6 @@ static void __leavedos_main(int code, int sig)
 #endif
     if (config.cpu_vm == CPUVM_KVM || config.cpu_vm_dpmi == CPUVM_KVM)
       kvm_done();
-    if (config.speaker == SPKR_EMULATED) {
-      g_printf("SPEAKER: sound off\n");
-      speaker_off();		/* turn off any sound */
-    }
-    else if (config.speaker==SPKR_NATIVE) {
-       g_printf("SPEAKER: sound off\n");
-       /* Since the speaker is native hardware use port manipulation,
-	* we don't know what is actually implementing the kernel's
-	* ioctls.
-	* My port logic is actually stolen from kd_nosound in the kernel.
-	* 		--EB 21 September 1997
-	*/
-        port_outb(0x61, port_inb(0x61)&0xFC); /* turn off any sound */
-    }
 
     free(vm86_hlt_state);
 

--- a/src/base/core/int.c
+++ b/src/base/core/int.c
@@ -154,7 +154,7 @@ static void change_window_title(char *title)
 	Video->change_config(CHG_TITLE_APPNAME, title);
 }
 
-static void kill_time(long usecs)
+void kill_time(long usecs)
 {
     hitimer_t t_start;
 

--- a/src/base/dev/misc/8042.c
+++ b/src/base/dev/misc/8042.c
@@ -30,7 +30,6 @@
 #include "keyboard/keyboard.h"
 #include "keyboard/keyb_server.h"
 #include "keyboard/keyb_clients.h"
-#include "speaker.h"
 #include "hma.h"
 
 /* bios-assisted keyboard read hack */
@@ -346,7 +345,6 @@ static Bit8u read_port60(void)
 Bit8u keyb_io_read(ioport_t port, void *arg)
 {
   Bit8u r = 0;
-  static Bit8u port61_ff;
 
   switch (port) {
   case 0x60:
@@ -354,13 +352,6 @@ Bit8u keyb_io_read(ioport_t port, void *arg)
     if (!port60_ready)
       pic_untrigger(1);
     k_printf("8042: read port 0x60 read=0x%02x\n",r);
-    break;
-
-  case 0x61:
-    /* Handle only PC-Speaker right now */
-    r = spkr_io_read(port);
-    port61_ff ^= 0x10;
-    r |= port61_ff;
     break;
 
   case 0x64:
@@ -379,14 +370,6 @@ void keyb_io_write(ioport_t port, Bit8u value, void *arg)
 #if KEYB_CMD
      write_port60(value);
 #endif
-    break;
-
-  case 0x61:
-    if (value & 0x80) {
-      k_printf("8042: IRQ ACK, %i\n", port60_ready);
-      int_check_queue();   /* reschedule irq1 if appropriate */
-    }
-    spkr_io_write(port, value);
     break;
 
   case 0x64:
@@ -415,11 +398,6 @@ void keyb_8042_init(void)
   io_device.handler_name = "8042 Keyboard command";
   io_device.start_addr   = 0x0064;
   io_device.end_addr     = 0x0064;
-  port_register_handler(io_device, 0);
-
-  io_device.handler_name = "Keyboard controller port B";
-  io_device.start_addr   = 0x0061;
-  io_device.end_addr     = 0x0061;
   port_register_handler(io_device, 0);
 }
 

--- a/src/base/dev/misc/timers.c
+++ b/src/base/dev/misc/timers.c
@@ -598,7 +598,7 @@ void spkr_io_write(ioport_t port, Bit8u value) {
    }
 }
 
-void pit_init(void)
+void pit_priv_init(void)
 {
   emu_iodev_t  io_device = {};
 
@@ -631,13 +631,17 @@ void pit_init(void)
   io_device.end_addr     = 0x0043;
   port_register_handler(io_device, 0);
 
-  /* register_handler for port 0x61 is in keyboard code */
-  port61 = 0x0c;
 #if 0
   io_device.start_addr   = 0x0047;
   io_device.end_addr     = 0x0047;
   port_register_handler(io_device, 0);
 #endif
+}
+
+void pit_init(void)
+{
+  /* register_handler for port 0x61 is in keyboard code */
+  port61 = 0x0c;
 
   vtmr_register(VTMR_PIT, timer_irq_ack);
   vtmr_register_latch(VTMR_PIT, pit_latch_hndl);

--- a/src/base/dev/misc/timers.c
+++ b/src/base/dev/misc/timers.c
@@ -39,6 +39,7 @@
 #include "vtmr.h"
 #include "timer/evtimer.h"
 #include "timers.h"
+#include "keyboard/keyb_server.h"
 
 #undef  DEBUG_PIT
 #undef  ONE_MINUTE_TEST
@@ -562,23 +563,33 @@ static int timer_irq_ack(int masked)
  *  1	speaker data status
  *  0	timer 2 clock gate to speaker status
  */
-Bit8u spkr_io_read(ioport_t port) {
+static Bit8u spkr_io_read(ioport_t port, void *arg) {
+   Bit8u r = 0;
+   static Bit8u port61_ff;
+
    if (port==0x61)  {
       if (config.speaker == SPKR_NATIVE)
-         return std_port_inb(0x61);
+         r = std_port_inb(0x61);
       else {
 	 /* keep the connection between port 0x61 and PIT timer#2 */
 	 pit_latch(2);
-         return ((*((Bit8u *)&pic_sys_time)&0x10) | /* or anything that toggles quick enough */
+         r = ((*((Bit8u *)&pic_sys_time)&0x10) | /* or anything that toggles quick enough */
 		(pit[2].outpin? 0x20:0) |	/* outpin: 00 or 80 */
 		(port61&0xcf));
       }
+      port61_ff ^= 0x10;
+      r |= port61_ff;
+      return r;
    }
    return 0xff;
 }
 
-void spkr_io_write(ioport_t port, Bit8u value) {
+static void spkr_io_write(ioport_t port, Bit8u value, void *arg) {
    if (port==0x61) {
+      if (value & 0x80) {
+          k_printf("8042: IRQ ACK, %i\n", port60_ready);
+          int_check_queue();   /* reschedule irq1 if appropriate */
+      }
       switch (config.speaker) {
        case SPKR_NATIVE:
           std_port_outb(0x61, value & 0x03);
@@ -636,11 +647,17 @@ void pit_priv_init(void)
   io_device.end_addr     = 0x0047;
   port_register_handler(io_device, 0);
 #endif
+
+  io_device.read_portb   = spkr_io_read;
+  io_device.write_portb  = spkr_io_write;
+  io_device.handler_name = "Keyboard controller port B";
+  io_device.start_addr   = 0x0061;
+  io_device.end_addr     = 0x0061;
+  port_register_handler(io_device, 0);
 }
 
 void pit_init(void)
 {
-  /* register_handler for port 0x61 is in keyboard code */
   port61 = 0x0c;
 
   vtmr_register(VTMR_PIT, timer_irq_ack);

--- a/src/base/dev/misc/timers.c
+++ b/src/base/dev/misc/timers.c
@@ -667,10 +667,14 @@ void pit_init(void)
   pit[0].evtmr = evtimer_create(timer_activate, (void *)(uintptr_t)0);
   pit[1].evtmr = evtimer_create(timer_activate, (void *)(uintptr_t)1);
   pit[2].evtmr = evtimer_create(timer_activate, (void *)(uintptr_t)2);
+
+  speaker_init();
 }
 
 void pit_done(void)
 {
+  speaker_done();
+
   evtimer_delete(pit[0].evtmr);
   evtimer_delete(pit[1].evtmr);
   evtimer_delete(pit[2].evtmr);

--- a/src/base/dev/misc/timers.c
+++ b/src/base/dev/misc/timers.c
@@ -150,18 +150,17 @@ void do_sound(Bit16u period)
 	 *
 	 * But if you set it too low, then sounds can be cut off - clarence
 	 */
-	static const unsigned sound_duration = 30000;  /* in milliseconds */
 	switch (port61 & 3) {
 	case 3:		/* speaker on & speaker control through timer channel 2 */
 		if ((pit[2].mode == 2) || (pit[2].mode == 3)) {		/* is this test needed? */
-			speaker_on(sound_duration,period);
+			speaker_on(period);
 		}
 		else {
 			speaker_off();	/* is this correct? */
 		}
 		break;
 	case 2:		/* speaker on & direct speaker through bit 1 */
-		speaker_on(sound_duration, 0xffff); /* on as long as possible */
+		speaker_on(0xffff); /* on as long as possible */
 		break;
 	case 1:		/* speaker off & speaker control through timer channel 2 */
 	case 0:		/* speaker off & direct speaker through bit 1 */

--- a/src/base/dev/misc/timers.c
+++ b/src/base/dev/misc/timers.c
@@ -161,7 +161,7 @@ void do_sound(Bit16u period)
 		}
 		break;
 	case 2:		/* speaker on & direct speaker through bit 1 */
-		speaker_on(sound_duration, 0xfff); /* on as long as possible */
+		speaker_on(sound_duration, 0xffff); /* on as long as possible */
 		break;
 	case 1:		/* speaker off & speaker control through timer channel 2 */
 	case 0:		/* speaker off & direct speaker through bit 1 */

--- a/src/base/init/config.c
+++ b/src/base/init/config.c
@@ -1112,10 +1112,6 @@ static void config_post_process(void)
 	}
 	if (config.console_keyb == -1 && config.console_video)
 	    config.console_keyb = KEYB_RAW;
-	if (config.speaker == SPKR_EMULATED) {
-	    register_speaker((void *)(uintptr_t)console_fd,
-			     console_speaker_on, console_speaker_off);
-	}
     } else
 #endif
     {

--- a/src/base/init/config.c
+++ b/src/base/init/config.c
@@ -1131,11 +1131,6 @@ static void config_post_process(void)
 #endif
 	}
 	config.console_video = 0;
-#if 0
-	if (config.speaker == SPKR_NATIVE) {
-	    config.speaker = SPKR_EMULATED;
-	}
-#endif
     }
     if (!config.console_video)
 	config.vga = config.mapped_bios = 0;
@@ -1177,14 +1172,6 @@ static void config_post_process(void)
         getuid(), geteuid(), getgid(), getegid());
     c_printf("CONF: priv operations %s\n",
             can_do_root_stuff ? "available" : "unavailable");
-
-    /* Speaker scrub */
-#ifdef X86_EMULATOR
-    if (IS_EMU() && config.speaker==SPKR_NATIVE) {
-	c_printf("SPEAKER: can`t use native mode with cpu-emu\n");
-	config.speaker=SPKR_EMULATED;
-    }
-#endif
 
     if (config.pci && !can_do_root_stuff) {
         c_printf("CONF: Warning: PCI requires root, disabled\n");

--- a/src/base/init/init.c
+++ b/src/base/init/init.c
@@ -284,6 +284,7 @@ void device_init(void)
   video_config_init();	/* privileged part of video init */
   keyb_priv_init();
   mouse_priv_init();
+  pit_priv_init();
 }
 
 /*

--- a/src/base/kbd_unicode/keyboard.c
+++ b/src/base/kbd_unicode/keyboard.c
@@ -26,13 +26,12 @@ static int initialized;
 
 void keyb_priv_init(void)
 {
-	/* this must be initialized before starting port-server */
-	keyb_8042_init();
 	open_console();
 }
 
 void keyb_init(void)
 {
+	keyb_8042_init();
 	if (!keyb_server_init()) {
 		error("can't init keyboard server\n");
 		leavedos(19);

--- a/src/base/speaker/Makefile
+++ b/src/base/speaker/Makefile
@@ -3,7 +3,7 @@ include $(top_builddir)/Makefile.conf
 
 # Makefile for speaker code.
 
-CFILES=speaker.c $(X_CFILES) console_speaker.c
+CFILES=speaker.c $(X_CFILES) console_speaker.c evdev_speaker.c
 
 SFILES=
 ALL=$(CFILES) $(SFILES)

--- a/src/base/speaker/console_speaker.c
+++ b/src/base/speaker/console_speaker.c
@@ -11,18 +11,17 @@
 
 #include "emu.h"
 
-static void console_speaker_on(void *gp, unsigned ms, unsigned short period)
+static void console_speaker_on(void *gp, unsigned short period)
 {
 #ifdef __linux__
-	ioctl((int)(uintptr_t)gp, KDMKTONE,
-		(unsigned) ((ms & 0xffff) << 16) | (period & 0xffff));
+	ioctl((int)(uintptr_t)gp, KIOCSOUND, period);
 #endif
 }
 
 static void console_speaker_off(void *gp)
 {
 #ifdef __linux__
-	ioctl((int)(uintptr_t)gp, KDMKTONE, 0);
+	ioctl((int)(uintptr_t)gp, KIOCSOUND, 0);
 #endif
 }
 

--- a/src/base/speaker/console_speaker.c
+++ b/src/base/speaker/console_speaker.c
@@ -9,8 +9,9 @@
 #include "Sys/kd.h"
 #endif
 
+#include "emu.h"
 
-void console_speaker_on(void *gp, unsigned ms, unsigned short period)
+static void console_speaker_on(void *gp, unsigned ms, unsigned short period)
 {
 #ifdef __linux__
 	ioctl((int)(uintptr_t)gp, KDMKTONE,
@@ -18,9 +19,16 @@ void console_speaker_on(void *gp, unsigned ms, unsigned short period)
 #endif
 }
 
-void console_speaker_off(void *gp)
+static void console_speaker_off(void *gp)
 {
 #ifdef __linux__
 	ioctl((int)(uintptr_t)gp, KDMKTONE, 0);
 #endif
+}
+
+void console_speaker_init(void)
+{
+	if (config.speaker == SPKR_EMULATED && console_fd != -1)
+		register_speaker((void *)(uintptr_t)console_fd,
+				 console_speaker_on, console_speaker_off);
 }

--- a/src/base/speaker/evdev_speaker.c
+++ b/src/base/speaker/evdev_speaker.c
@@ -1,0 +1,42 @@
+#ifdef __linux__
+#include "speaker.h"
+/*
+ * evdev speaker Emulation
+ * =============================================================================
+ */
+
+#include "linux/input.h"
+#include "emu.h"
+
+static void evdev_speaker_on(void *gp, unsigned short period)
+{
+	struct input_event e = {.type = EV_SND, .code = SND_TONE,
+				.value = speaker_period_to_Hz(period)};
+	write((int)(uintptr_t)gp, &e, sizeof e);
+}
+
+static void evdev_speaker_off(void *gp)
+{
+	struct input_event e = {.type = EV_SND, .code = SND_TONE,
+				.value = 0};
+	write((int)(uintptr_t)gp, &e, sizeof e);
+}
+
+void evdev_speaker_init(void)
+{
+	if (config.speaker == SPKR_EMULATED && console_fd == -1) {
+		int fd = open("/dev/input/by-path/platform-pcspkr-event-spkr",
+			      O_WRONLY);
+		if (fd != -1)
+			register_speaker((void *)(uintptr_t)fd,
+					 evdev_speaker_on, evdev_speaker_off);
+	}
+}
+
+#else
+
+void evdev_speaker_init(void)
+{
+}
+
+#endif

--- a/src/base/speaker/speaker.c
+++ b/src/base/speaker/speaker.c
@@ -187,6 +187,7 @@ void speaker_resume (void)
 
 void speaker_init (void)
 {
+	evdev_speaker_init();
 	console_speaker_init();
 }
 

--- a/src/base/speaker/speaker.c
+++ b/src/base/speaker/speaker.c
@@ -184,3 +184,28 @@ void speaker_resume (void)
 		break;
 	}
 }
+
+void speaker_init (void)
+{
+	console_speaker_init();
+}
+
+void speaker_done (void)
+{
+	if (config.speaker == SPKR_EMULATED) {
+		g_printf("SPEAKER: sound off\n");
+		speaker_off();		/* turn off any sound */
+	}
+	else if (config.speaker==SPKR_NATIVE) {
+		g_printf("SPEAKER: sound off\n");
+		/* Since the speaker is native hardware use port manipulation,
+		 * we don't know what is actually implementing the kernel's
+		 * ioctls.
+		 * My port logic is actually stolen from kd_nosound in the kernel.
+		 * 		--EB 21 September 1997
+		 */
+		port_outb(0x61, port_inb(0x61)&0xFC); /* turn off any sound */
+	}
+	/* reset the speaker to its default */
+	register_speaker(NULL, NULL, NULL);
+}

--- a/src/base/speaker/speaker.c
+++ b/src/base/speaker/speaker.c
@@ -19,8 +19,8 @@
  *
  * For parts of dosemu that want to beep the pc-speaker (say the video bios)
  * #include "speaker.h"
- * Use 'speaker_on(ms, period)'
- * to turn the pc-speaker on for 'ms' milliseconds with period 'period'.
+ * Use 'speaker_on(period)'
+ * to turn the pc-speaker on with period 'period'.
  * The function returns immediately.
  *
  * Use 'speaker_off()'
@@ -91,7 +91,7 @@ static int speaker_is_on;
 #include <stdio.h> /* for putchar */
 #include <unistd.h>
 
-static void dumb_speaker_on(void * gp, unsigned ms, unsigned short period)
+static void dumb_speaker_on(void * gp, unsigned short period)
 {
 	FILE *out = (config.tty_stderr ? real_stderr : stdout);
 	putc('\007', out);
@@ -129,7 +129,7 @@ void register_speaker(void *gp,
 }
 
 /* this does the EMULATED mode speaker emulation */
-void speaker_on(unsigned ms, unsigned short period)
+void speaker_on(unsigned short period)
 {
 	if (config.speaker == SPKR_OFF)
 		return;
@@ -138,7 +138,7 @@ void speaker_on(unsigned ms, unsigned short period)
 	if (!speaker.on) {
 		speaker = dumb_speaker;
 	}
-	speaker.on(speaker.gp, ms, period);
+	speaker.on(speaker.gp, period);
 }
 
 void speaker_off(void)

--- a/src/include/int.h
+++ b/src/include/int.h
@@ -31,6 +31,7 @@ void setup_interrupts(void);
 void version_init(void);
 void dos_post_boot_reset(void);
 void int_try_disable_revect(void);
+void kill_time(long usecs);
 
 enum { I_NOT_HANDLED, I_HANDLED, I_SECOND_REVECT };
 

--- a/src/include/iodev.h
+++ b/src/include/iodev.h
@@ -20,6 +20,7 @@ extern void iodev_register(const char *name, void (*init_func)(void),
 void iodev_unregister(const char *name);
 void iodev_add_device(const char *dev_name);
 
+extern void  pit_priv_init(void);
 extern void  pit_init(void);
 extern void  pit_done(void);
 extern void  pit_reset(void);

--- a/src/include/speaker.h
+++ b/src/include/speaker.h
@@ -54,11 +54,4 @@ void X_speaker_off(void *gp);
 void console_speaker_on(void *gp, unsigned ms, unsigned short period);
 void console_speaker_off(void *gp);
 
-/*
- * These are used by kbd code but reside in timers.c
- * =============================================================================
- */
-Bit8u spkr_io_read(ioport_t port);
-void spkr_io_write(ioport_t port, Bit8u value);
-
 #endif /* SPEAKER_H */

--- a/src/include/speaker.h
+++ b/src/include/speaker.h
@@ -49,9 +49,9 @@ void register_speaker(void *gp,
  * =============================================================================
  */
 /* for now declare these here */
-void X_speaker_on(void *gp, unsigned ms, unsigned short period);
-void X_speaker_off(void *gp);
-void console_speaker_on(void *gp, unsigned ms, unsigned short period);
-void console_speaker_off(void *gp);
+void console_speaker_init(void);
+
+void speaker_init(void);
+void speaker_done(void);
 
 #endif /* SPEAKER_H */

--- a/src/include/speaker.h
+++ b/src/include/speaker.h
@@ -7,7 +7,7 @@
  * Caller speaker functions
  * ============================================================================
  */
-void speaker_on(unsigned ms, unsigned short period);
+void speaker_on(unsigned short period);
 void speaker_off(void);
 void speaker_pause(void);
 void speaker_resume(void);
@@ -35,7 +35,7 @@ static inline unsigned short speaker_Hz_to_period(unsigned Hz)
  *  Speaker registration
  * ============================================================================
  */
-typedef void (*speaker_on_t)(void *gp, unsigned ms, unsigned short period);
+typedef void (*speaker_on_t)(void *gp, unsigned short period);
 typedef void (*speaker_off_t)(void *gp);
 
 /* an invalid value of speaker_on || speaker_off resets the default speaker */

--- a/src/include/speaker.h
+++ b/src/include/speaker.h
@@ -50,6 +50,7 @@ void register_speaker(void *gp,
  */
 /* for now declare these here */
 void console_speaker_init(void);
+void evdev_speaker_init(void);
 
 void speaker_init(void);
 void speaker_done(void);

--- a/src/plugin/X/X.c
+++ b/src/plugin/X/X.c
@@ -277,11 +277,6 @@
 #include "screen.h"
 #endif
 
-#if CONFIG_X_SPEAKER
-#include "speaker.h"
-#endif
-
-
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 typedef struct { unsigned char r, g, b; } c_cube;
 
@@ -561,13 +556,6 @@ void X_pre_init(void)
   XInitThreads();
 }
 
-void X_register_speaker(Display *display)
-{
-#if CONFIG_X_SPEAKER
-  register_speaker(display, X_speaker_on, X_speaker_off);
-#endif
-}
-
 static void SetWindowMotifOptions(Display *display, Window window)
 {
   Atom wm_hints = XInternAtom(display, "_MOTIF_WM_HINTS", True);
@@ -837,7 +825,9 @@ int X_init(void)
     X_printf("X: X_init: mouse grabbing disabled\n");
   }
 
+#if CONFIG_X_SPEAKER
   X_register_speaker(display);
+#endif
 
   pthread_create(&event_thr, NULL, X_handle_events, NULL);
 #if defined(HAVE_PTHREAD_SETNAME_NP) && defined(__GLIBC__)
@@ -867,13 +857,6 @@ void X_close(void)
 
   /* terminate remapper early so that render thread is cancelled */
   remapper_done();
-
-#if CONFIG_X_SPEAKER
-  /* turn off the sound, and */
-  speaker_off();
-  /* reset the speaker to it's default */
-  register_speaker(NULL, NULL, NULL);
-#endif
 
 #ifdef HAVE_XVIDMODE
   X_xf86vm_done();

--- a/src/plugin/X/X_speaker.c
+++ b/src/plugin/X/X_speaker.c
@@ -6,13 +6,14 @@
 
 #include <X11/X.h>
 #include <X11/Xlib.h>
+#include "X.h"
 #include "speaker.h"
 
 /*
  * X speaker emulation
  * =============================================================================
  */
-void X_speaker_on(void *gp, unsigned ms, unsigned short period)
+static void X_speaker_on(void *gp, unsigned ms, unsigned short period)
 {
 	XKeyboardControl new_state;
 	Display *display = gp;
@@ -41,9 +42,13 @@ void X_speaker_on(void *gp, unsigned ms, unsigned short period)
 	XChangeKeyboardControl(display, KBBellDuration | KBBellPitch, &new_state);
 }
 
-void X_speaker_off(void*gp)
+static void X_speaker_off(void*gp)
 {
 	/* Just make a zero length sound */
 	X_speaker_on(gp, 0,0);
 }
 
+void X_register_speaker(Display *display)
+{
+	register_speaker(display, X_speaker_on, X_speaker_off);
+}

--- a/src/plugin/X/X_speaker.c
+++ b/src/plugin/X/X_speaker.c
@@ -13,7 +13,7 @@
  * X speaker emulation
  * =============================================================================
  */
-static void X_speaker_on(void *gp, unsigned ms, unsigned short period)
+static void X_speaker_on(void *gp, unsigned short period)
 {
 	XKeyboardControl new_state;
 	Display *display = gp;
@@ -32,7 +32,8 @@ static void X_speaker_on(void *gp, unsigned ms, unsigned short period)
 	 * 32767 kHz. Since the X server interprets the pitch as a short int
 	 */
 	if (new_state.bell_pitch >= 0x8000) new_state.bell_pitch = 0x7fff;
-	new_state.bell_duration = ms;
+	/* long default, it'll be switched off */
+	new_state.bell_duration = period == 0 ? 0 : 30000;
 	XChangeKeyboardControl(display, KBBellDuration | KBBellPitch, &new_state);
 
 	/* Reset the sound defaults */
@@ -45,7 +46,7 @@ static void X_speaker_on(void *gp, unsigned ms, unsigned short period)
 static void X_speaker_off(void*gp)
 {
 	/* Just make a zero length sound */
-	X_speaker_on(gp, 0,0);
+	X_speaker_on(gp, 0);
 }
 
 void X_register_speaker(Display *display)


### PR DESCRIPTION
This is partially a prep PR for #2848; I also wanted to compare the native speaker to compare what td2 sounds like there.

So, a bunch of fixes and cleanups:
* ports 0x42 & 0x43 were initialized after forking off the port server and privs dropped, so native speaker was broken. It's now fixed and also works in SDL mode, as long as you use "dosemu -s", so I can compare native speaker sounds even without console graphics.
* I moved port 0x61 handling completely to timers.c, it's more natural there
* direct speaker bit banging period fix from #2848 
* moving init/deinit code to more local places
* don't pass duration any more, this was only used by int10.c, where a delay works better; some backend APIs don't allow a duration or it's more complicated (like in #2848)
* added an evdev backend. This allows basic emulating beeping from SDL via the real PC speaker, if you have the `beep` utility installed (because that sets up some udev rules for `/dev/input/by-path/platform-pcspkr-event-spkr`.