### PR TITLE
vgaemu: always adjust KVM MMIO on graph_base (0xa0) for instremu

### DIFF
--- a/src/base/dev/vga/vgaemu.c
+++ b/src/base/dev/vga/vgaemu.c
@@ -2775,7 +2775,6 @@ static void vgaemu_adjust_instremu(int value)
 {
   int i;
   int changed = (vga.inst_emu != value);
-  vga_mapping_type *vmt = &vga.mem.map[VGAEMU_MAP_BANK_MODE];
 
   if (!changed)
     return;
@@ -2812,9 +2811,9 @@ static void vgaemu_adjust_instremu(int value)
 	vga_emu_protect_page((vga.mem.graph_base >> PAGE_SHIFT) + i, RW, 1);
     }
   }
+  /* As above we need to protect 0xa0 (graph_base) in any case */
   if (config.cpu_vm == CPUVM_KVM || config.cpu_vm_dpmi == CPUVM_KVM)
-    kvm_set_mmio(vmt->base_page * HOST_PAGE_SIZE, vmt->pages * HOST_PAGE_SIZE,
-		 value != 0);
+    kvm_set_mmio(vga.mem.graph_base, vga.mem.graph_size, value != 0);
 }
 
 /*


### PR DESCRIPTION
This mirrors 590cd7f2: if KVM MMIO was tried to be disabled on 0xb8000 in text mode it was a no-op, and programs trying to write to 0xa0000 would cause an MMIO exit when they should not.

Example: running TD2 for a second time, see
https://github.com/dosemu2/dosemu2/pull/2848#issuecomment-4488069103