### PR TITLE
simx86: forgotten MSSTP on POPF/IRET [fixes #2877]

### DIFF
--- a/src/base/emu-i386/simx86/codegen-sim.c
+++ b/src/base/emu-i386/simx86/codegen-sim.c
@@ -2634,11 +2634,7 @@ static unsigned int Gen_sim(IGen *IG, unsigned int *pmem_ref)
 #endif
 		{
 			TNode *G = FindTree(ePC);
-			if (
-#if 1
-					G &&
-#endif
-					GoodNode(G)) {
+			if (G && GoodNode(G) && !((IG->mode & CKSIGN) && exit_pending())) {
 				IG = (IGen *)G->addr;
 				continue;
 			}

--- a/src/base/emu-i386/simx86/codegen-x86.c
+++ b/src/base/emu-i386/simx86/codegen-x86.c
@@ -1885,11 +1885,15 @@ shrot0:
 #ifdef __x86_64__
 		// movl %%eax,%%edi
 		G2M(0x89,0xc7,Cp);
-		// lea 3+2(%%rip), %%rsi // tailcode
-		G3M(0x48,0x8d,0x35,Cp); G4(3+2,Cp);
+		// movl mode,%%esi
+		G1(0xbe,Cp); G4(mode,Cp);
+		// lea 3+2(%%rip), %%rdx // tailcode
+		G3M(0x48,0x8d,0x15,Cp); G4(3+2,Cp);
 #else
 		// push address of tailcode
 		G1(PUSHwi,Cp); G4((uintptr_t)GetExecCodeBuf(Cp+4+1+3+2+2),Cp);
+		// push mode
+		G1(PUSHwi,Cp); G4(mode,Cp);
 		// push ePC
 		G1(PUSHax,Cp);
 #endif
@@ -1897,7 +1901,7 @@ shrot0:
 		G3M(0xff,0x53,Ofs_JmpIndirect(),Cp);
 #ifndef __x86_64__
 		// need to pop arguments for i386
-		G2M(POPdx,POPdx,Cp);
+		G3M(POPdx,POPdx,POPdx,Cp);
 #endif
 		// jump to next block if a compatible one exists
 		// otherwise to the tail code

--- a/src/base/emu-i386/simx86/cpatch.c
+++ b/src/base/emu-i386/simx86/cpatch.c
@@ -865,7 +865,7 @@ unsigned int Sim_helper_jit(unsigned int mem_ref, unsigned int data,
     return ret;
 }
 
-unsigned char *Jmp_indirect_helper(unsigned int ePC,
+unsigned char *Jmp_indirect_helper(unsigned int ePC, unsigned int mode,
 				   unsigned char *tailcode)
 {
     unsigned char *ret;
@@ -882,7 +882,10 @@ unsigned char *Jmp_indirect_helper(unsigned int ePC,
     /* excessive e_querynode() seems to not help */
     {
         TNode *G = FindTree(ePC);
-        ret = (G && GoodNode(G)) ? GetExecCodeBuf(G->addr) : tailcode;
+        if (G && GoodNode(G) && !((mode & CKSIGN) && exit_pending()))
+            ret = GetExecCodeBuf(G->addr);
+        else
+            ret = tailcode;
     }
 #endif
     InCompiledCode++;

--- a/src/base/emu-i386/simx86/cpatch.h
+++ b/src/base/emu-i386/simx86/cpatch.h
@@ -26,7 +26,9 @@ ASMLINKAGE(unsigned int,Sim_helper_jit,(unsigned int mem_ref, \
 					unsigned int data, \
 					struct sim_stack *s));
 ASMLINKAGE(unsigned char *,Jmp_indirect_helper,(unsigned int ePC, \
-						unsigned char *tailcode));
+						unsigned int mode,\
+						unsigned char *tailcode\
+						));
 
 int Cpatch(sigcontext_t *scp);
 int UnCpatch(unsigned char *eip);

--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -1728,7 +1728,7 @@ intop3b:		{ int op = ArOpsFR[D_MO(opc)];
 			    PC++; goto not_permitted;	/* GPF */
 			}
 			Gen(O_SIM, _mode, opc, 0, P0);
-			PC = JumpGen(PC, Interp_LONG_CS, _mode, opc, 1);
+			PC = JumpGen(PC, Interp_LONG_CS, _mode|CKSIGN, opc, 1);
 			break;
 /*9d*/	case POPF:
 			PC++;


### PR DESCRIPTION
exit_TFSET was used instead of MSSTP. It didn't work when returning via indirect helper, as that one jumps directly to compiled code. MSSTP should work properly in all cases.
exit_TFSET must be completely removed as we are not supposed to exit on the particular instruction that sets TF: we must exit on a next one.

Also stop shadowing "eip" var in Sim_helper.