### PR TITLE
simx86: forgotten exit_pending() for IRET

### DIFF
--- a/src/base/emu-i386/simx86/cpatch.c
+++ b/src/base/emu-i386/simx86/cpatch.c
@@ -874,7 +874,7 @@ unsigned char *Jmp_indirect_helper(unsigned int ePC,
 #if 0
     if (e_querynode(ePC)) {
         TNode *G = FindTree(ePC);
-        ret = GoodNode(G) ? GetExecCodeBuf(G->addr) : tailcode;
+        ret = (GoodNode(G) && !exit_pending()) ? GetExecCodeBuf(G->addr) : tailcode;
     } else {
         ret = tailcode;
     }
@@ -882,7 +882,7 @@ unsigned char *Jmp_indirect_helper(unsigned int ePC,
     /* excessive e_querynode() seems to not help */
     {
         TNode *G = FindTree(ePC);
-        ret = (G && GoodNode(G)) ? GetExecCodeBuf(G->addr) : tailcode;
+        ret = (G && GoodNode(G) && !exit_pending()) ? GetExecCodeBuf(G->addr) : tailcode;
     }
 #endif
     InCompiledCode++;


### PR DESCRIPTION
The indirect jump checked neither exit_STI nor exit_TFSET, which are both potentially set by IRET, and should cause an exit.

Fixes #2877

Alternative to #2878, this patch comes from https://github.com/dosemu2/dosemu2/issues/2877#issuecomment-4505477501 by @stsp.