### PR TITLE
vgaemu: fix graphics for Comanche Maximum Overkill [#1703]

### DIFF
--- a/src/base/dev/vga/vgaemu.c
+++ b/src/base/dev/vga/vgaemu.c
@@ -2921,10 +2921,7 @@ void vgaemu_adj_cfg(unsigned what, unsigned msg)
 	      ((vga.crtc.data[0x9] & 0x20) << (9 - 5));
       vertical_blanking_end =
 	      vga.crtc.data[0x16] & 0x7F;
-      if (vga.mode_class == TEXT)
-        char_height = (vga.crtc.data[0x9] & 0x1f) + 1;
-      else
-        char_height = vga.char_height;
+      char_height = (vga.crtc.data[0x9] & 0x1f) + 1;
       vertical_multiplier = char_height << ((vga.crtc.data[0x9] & 0x80) >> 7);
       /* see VGADOC: CGA is special for reg 9 */
       if(vga.mode_type == CGA) vertical_multiplier = char_height;
@@ -2945,7 +2942,7 @@ void vgaemu_adj_cfg(unsigned what, unsigned msg)
       if (vga.mode_class == TEXT)
         height *= char_height;
       else
-        height = vga.height;
+        char_height = vga.char_height;
       /* By Eric (eric@coli.uni-sb.de):                        */
       /* Required for 80x100 CGA "text graphics" with 8x2 font */
       if (vga.height != height || vga.char_height != char_height) {
@@ -3064,7 +3061,7 @@ void vgaemu_adj_cfg(unsigned what, unsigned msg)
       }
       old_color_bits = vga.color_bits;
       vga.color_bits = vga.pixel_size;
-      vgaemu_adjust_instremu((vga.mode_type==PL4 || vga.mode_type==PL2)
+      vgaemu_adjust_instremu((vga.mode_type==PL4 || vga.mode_type==PL2 || vga.mem.planes > 1)
 			     ? EMU_ALL_INST : 0);
       if (oldclass != vga.mode_class) {
 	vgaemu_adj_cfg(CFG_SEQ_ADDR_MODE, 0);


### PR DESCRIPTION
This game uses Mode-X but not via the usual mode 13h but using mode 12h instead, This confused the code since it now used a 320x480 resolution (instead of 320x240) without instremu and without correct vga.line_compare.

We can reliably determine vga.height and vga.line_compare (via the multiplier) from CRTC values, as they are set to reasonable values even in VESA modes with height <= 1024. The instremu check needs to take the number of planes into account, as it does elsewhere already.

This fixes the graphics in Comanche but the game itself still hangs randomly, I think through overlong sequences in simx86 that still need to be fixed.