### PR TITLE
Fix text scrolling in graphics modes

### DIFF
--- a/src/base/bios/vgabios.c
+++ b/src/base/bios/vgabios.c
@@ -158,6 +158,35 @@ Bit8u xstart,Bit8u ystart,Bit8u cols,Bit8u nbcols,Bit8u cheight,Bit8u attr)
 }
 
 // --------------------------------------------------------------------------------------------
+static void vgamem_copy_lin(
+Bit8u xstart,Bit8u ysrc,Bit8u ydest,Bit8u cols,Bit8u nbcols,Bit8u cheight)
+{
+ Bit16u src,dest;
+ Bit8u i;
+
+ src=(ysrc*cheight*nbcols+xstart)*8;
+ dest=(ydest*cheight*nbcols+xstart)*8;
+ for(i=0;i<cheight;i++)
+  {
+    memcpyb(0xa000,dest+i*nbcols*8,0xa000,src+i*nbcols*8,cols*8);
+  }
+}
+
+// --------------------------------------------------------------------------------------------
+static void vgamem_fill_lin(
+Bit8u xstart,Bit8u ystart,Bit8u cols,Bit8u nbcols,Bit8u cheight,Bit8u attr)
+{
+ Bit16u dest;
+ Bit8u i;
+
+ dest=(ystart*cheight*nbcols+xstart)*8;
+ for(i=0;i<cheight;i++)
+  {
+   memsetb(0xa000,dest+i*nbcols*8,attr,cols*8);
+  }
+}
+
+// --------------------------------------------------------------------------------------------
 static void biosfn_scroll(
 Bit8u nblines,Bit8u attr,Bit8u rul,Bit8u cul,Bit8u rlr,Bit8u clr,Bit8u page,
 Bit8u dir)
@@ -290,6 +319,35 @@ Bit8u dir)
               vgamem_fill_cga(address,cul,i,cols,nbcols,cheight,attr);
              else
               vgamem_copy_cga(address,cul,i,i-nblines,cols,nbcols,cheight);
+             if (i>rlr) break;
+            }
+          }
+        }
+       break;
+     case LINEAR8:
+       if(nblines==0&&rul==0&&cul==0&&rlr==nbrows-1&&clr==nbcols-1)
+        {
+         memsetb(vmi->buffer_start,0,attr,nbrows*nbcols*cheight*8);
+        }
+       else
+        {
+         // if Scroll up
+         if(dir==SCROLL_UP)
+          {for(i=rul;i<=rlr;i++)
+            {
+             if((i+nblines>rlr)||(nblines==0))
+              vgamem_fill_lin(cul,i,cols,nbcols,cheight,attr);
+             else
+              vgamem_copy_lin(cul,i+nblines,i,cols,nbcols,cheight);
+            }
+          }
+         else
+          {for(i=rlr;i>=rul;i--)
+            {
+             if((i<rul+nblines)||(nblines==0))
+              vgamem_fill_lin(cul,i,cols,nbcols,cheight,attr);
+             else
+              vgamem_copy_lin(cul,i,i-nblines,cols,nbcols,cheight);
              if (i>rlr) break;
             }
           }

--- a/src/base/misc/dos2linux.c
+++ b/src/base/misc/dos2linux.c
@@ -944,7 +944,7 @@ void memcpy_2unix(void *dest, dosaddr_t src, size_t n)
 
 void memcpy_2dos(dosaddr_t dest, const void *src, size_t n)
 {
-  if (vga.inst_emu && dest >= 0xa0000 && dest < 0xc0000)
+  if (dest >= 0xa0000 && dest < 0xc0000)
     memcpy_to_vga(dest, src, n);
   else {
     e_invalidate(dest, n);
@@ -961,7 +961,7 @@ void memcpy_2dos(dosaddr_t dest, const void *src, size_t n)
 
 void memset_dos(dosaddr_t dest, unsigned char ch, size_t n)
 {
-  if (vga.inst_emu && dest >= 0xa0000 && dest < 0xc0000)
+  if (dest >= 0xa0000 && dest < 0xc0000)
     vga_memset(dest, ch, n);
   else {
     e_invalidate(dest, n);
@@ -977,7 +977,7 @@ void memset_dos(dosaddr_t dest, unsigned char ch, size_t n)
 
 void memsetw_dos(dosaddr_t dest, unsigned short ch, size_t n)
 {
-  if (vga.inst_emu && dest >= 0xa0000 && dest < 0xc0000)
+  if (dest >= 0xa0000 && dest < 0xc0000)
     vga_memsetw(dest, ch, n);
   else {
     e_invalidate(dest, n * 2);
@@ -990,7 +990,7 @@ void memsetw_dos(dosaddr_t dest, unsigned short ch, size_t n)
 
 void memsetl_dos(dosaddr_t dest, unsigned int ch, size_t n)
 {
-  if (vga.inst_emu && dest >= 0xa0000 && dest < 0xc0000)
+  if (dest >= 0xa0000 && dest < 0xc0000)
     vga_memsetl(dest, ch, n);
   else {
     e_invalidate(dest, n * 4);
@@ -1006,9 +1006,13 @@ void memmove_dos2dos(dosaddr_t dest, dosaddr_t src, size_t n)
   /* XXX GW (Game Wizard Pro) does this.
      TODO: worry about overlaps; could be a little cleaner
      using the memcheck.c mechanism */
-  if (vga.inst_emu && src >= 0xa0000 && src < 0xc0000)
-    memcpy_dos_from_vga(dest, src, n);
-  else if (vga.inst_emu && dest >= 0xa0000 && dest < 0xc0000)
+  if (vga.inst_emu && src >= 0xa0000 && src < 0xc0000) {
+    if (dest >= 0xa0000 && dest < 0xc0000)
+      vga_memcpy(dest, src, n);
+    else
+      memcpy_dos_from_vga(dest, src, n);
+  }
+  else if (dest >= 0xa0000 && dest < 0xc0000)
     memcpy_dos_to_vga(dest, src, n);
   else {
     e_invalidate(dest, n);
@@ -1028,9 +1032,13 @@ void memmove_dos2dos(dosaddr_t dest, dosaddr_t src, size_t n)
 void memcpy_dos2dos(unsigned dest, unsigned src, size_t n)
 {
   /* Jazz Jackrabbit does DOS read to VGA via protmode selector */
-  if (vga.inst_emu && src >= 0xa0000 && src < 0xc0000)
-    memcpy_dos_from_vga(dest, src, n);
-  else if (vga.inst_emu && dest >= 0xa0000 && dest < 0xc0000)
+  if (vga.inst_emu && src >= 0xa0000 && src < 0xc0000) {
+    if (dest >= 0xa0000 && dest < 0xc0000)
+      vga_memcpy(dest, src, n);
+    else
+      memcpy_dos_from_vga(dest, src, n);
+  }
+  else if (dest >= 0xa0000 && dest < 0xc0000)
     memcpy_dos_to_vga(dest, src, n);
   else {
     e_invalidate(dest, n);
@@ -1056,7 +1064,7 @@ int dos_read(int fd, unsigned data, int cnt)
 {
   int ret;
   /* GW also reads or writes directly from a file to protected video memory. */
-  if (vga.inst_emu && data >= 0xa0000 && data < 0xc0000) {
+  if (data >= 0xa0000 && data < 0xc0000) {
     char buf[cnt];
     ret = unix_read(fd, buf, cnt);
     if (ret >= 0)


### PR DESCRIPTION
commit 19af7988a broke text scrolling in graphics modes (e.g. `xmode -mode 6` or `xmode -mode 0x12`); now `dos2linux.c` deals with all those cases (writes to VGA memory are special even outside instremu since it's made dirty)

I also added scrolling for `xmode -mode 0x13` (ported from newer LGPL'ed VGABIOS)

See discussion in #2881