### PR TITLE
Bake $(libdir) into dosemu2.bin RUNPATH

### DIFF
--- a/src/arch/linux/Makefile.main
+++ b/src/arch/linux/Makefile.main
@@ -104,7 +104,8 @@ $(BINPATH)/bin/$(DOSLIBLINKNAME): $(BINPATH)/bin/$(DOSLIB)
 	$(LN_S) -f $(DOSLIB) $@
 
 $(BINPATH)/bin/$(DOSBIN): base/core/main.o $(BINPATH)/bin/$(DOSLIBLINKNAME)
-	$(LD) $(DOSBIN_LDFLAGS) $(LDFLAGS) -o $@ $< -L $(BINPATH)/bin -ldosemu2
+	$(LD) $(DOSBIN_LDFLAGS) $(LDFLAGS) -o $@ $< -L $(BINPATH)/bin -ldosemu2 \
+	   -Wl,-rpath,$(libdir)
 else
 $(BINPATH)/bin/$(DOSBIN): base/core/main.o $(LIBS_)
 	$(LD) $(DOSBIN_LDFLAGS) $(LDFLAGS) -o $@ $< \


### PR DESCRIPTION
On Arch, I tried using `./configure` but after I installed and ran `ldconfig`, and tried running dosemu, I got the error: 

```
/usr/local/libexec/dosemu2/dosemu2.bin: error while loading shared libraries: libdosemu2.so.0.1: cannot open shared object file: No such file or directory
```

Also I tried `prefix=$HOME/.local` and got the same behavior.

Everything did work as expected when I used `--prefix=/usr`. But this patch solved the library error above.
