### PR TITLE
Use LGPL VGABIOS code for text mode cursor, scroll, page management

### DIFF
--- a/src/base/bios/int10.c
+++ b/src/base/bios/int10.c
@@ -143,29 +143,12 @@ static void set_cursor_shape(uint16_t shape)
    cshape cursor_shape;
    cursor_shape.w = shape;
 
-   WRITE_WORD(BIOS_CURSOR_SHAPE, cursor_shape.w);
-
-   cs=CURSOR_START(cursor_shape) & 0x1F;
-   ce=CURSOR_END(cursor_shape) & 0x1F;
-
-   if (cursor_shape.w & 0x6000 || cs>ce) {
+   cs = CURSOR_START(cursor_shape);
+   ce = CURSOR_END(cursor_shape);
+   if (cursor_shape.w & 0x2000 || cs>ce)
       i10_deb("no cursor\n");
-      crt_outw(0xa, NO_CURSOR);
-      return;
-   }
 
-   cs&=0x0F;
-   ce&=0x0F;
-   if (ce>3 && ce<12 && (config.cardtype != CARD_MDA)) {
-      int vga_font_height = READ_WORD(BIOS_FONT_HEIGHT);
-      if (cs>ce-3) cs+=vga_font_height-ce-1;
-      else if (cs>3) cs=vga_font_height/2;
-      ce=vga_font_height-1;
-   }
-   i10_msg("mapped cursor: start %d, end %d\n", cs, ce);
-   CURSOR_START(cursor_shape)=cs;
-   CURSOR_END(cursor_shape)=ce;
-   crt_outw(0xa, cursor_shape.w);
+   vgaemu_set_cursor_shape(cs, ce);
 }
 
 /* This is a better scroll routine, mostly for aesthetic reasons. It was

--- a/src/base/bios/int10.c
+++ b/src/base/bios/int10.c
@@ -144,85 +144,6 @@ static void set_cursor_shape(uint16_t shape)
    vgaemu_set_cursor_shape(cs, ce);
 }
 
-/* This is a better scroll routine, mostly for aesthetic reasons. It was
- * just too horrible to contemplate a scroll that worked 1 character at a
- * time :-)
- *
- * It may give some performance improvement on some systems (it does
- * on mine) (Andrew Tridgell)
- */
-static void
-bios_scroll(int x0, int y0, int x1, int y1, int l, int att)
-{
-  int dx = x1 - x0 + 1;
-  int dy = y1 - y0 + 1;
-  int x, y, co, li;
-  uint16_t blank = ' ' | (att << 8);
-  uint16_t tbuf[MAX_COLUMNS];
-  unsigned sadr;
-
-  if (config.dumb_video)
-     return;
-
-  li= READ_BYTE(BIOS_ROWS_ON_SCREEN_MINUS_1) + 1;
-  co= READ_WORD(BIOS_SCREEN_COLUMNS);
-  sadr = screen_adr(0) + READ_WORD(BIOS_VIDEO_MEMORY_ADDRESS);
-
-  if (sadr < VGA_PHYS_TEXT_BASE && ((att & 7) != 0) && ((att & 7) != 7))
-    {
-      blank = ' ' | ((att | 7) << 8);
-    }
-
-
-  if (x1 >= co || y1 >= li)
-    {
-      v_printf("VID: Scroll parameters out of bounds, in Scroll!\n");
-      v_printf("VID: Attempting to fix with clipping!\n");
-    /* kludge for ansi.sys' clear screen - we'd better do real clipping */
-    /* Also a cludge to fix list, but in the other dimension */
-      if (x1 >= co) x1 = co -1;
-      if (y1 >= li) y1 = li -1;
-      dx = x1 - x0 +1;
-      dy = y1 - x0 +1;
-    }
-  if (dx <= 0 || dy <= 0 || x0 < 0 || x1 >= co || y0 < 0 || y1 >= li)
-    {
-      v_printf("VID: Scroll parameters impossibly out of bounds, giving up!\n");
-    return;
-    }
-
-  /* make a blank line */
-  for (x = 0; x < dx; x++)
-    tbuf[x] = blank;
-
-  if (l >= dy || l <= -dy)
-    l = 0;
-
-  if (l == 0) {			/* Wipe mode */
-    for (y = y0; y <= y1; y++)
-      memcpy_to_vga(sadr + 2 * (y * co + x0), tbuf, dx * 2);
-    return;
-  }
-
-  if (l > 0) {
-    if (dx == co)
-      vga_memcpy(sadr + 2 * y0 * co, sadr + 2 * (y0 + l) * co, (dy - l) * dx * 2);
-    else
-      for (y = y0; y <= (y1 - l); y++)
-	vga_memcpy(sadr + 2 * (y * co + x0), sadr + 2 * ((y + l) * co + x0), dx * 2);
-
-    for (y = y1 - l + 1; y <= y1; y++)
-      memcpy_to_vga(sadr + 2 * (y * co + x0), tbuf, dx * 2);
-  }
-  else {
-    for (y = y1; y >= (y0 - l); y--)
-      vga_memcpy(sadr + 2 * (y * co + x0), sadr + 2 * ((y + l) * co + x0), dx * 2);
-
-    for (y = y0 - l - 1; y >= y0; y--)
-      memcpy_to_vga(sadr + 2 * (y * co + x0), tbuf, dx * 2);
-  }
-}
-
 static int using_text_mode(void)
 {
   unsigned char mode = READ_BYTE(BIOS_VDU_CONTROL);
@@ -320,13 +241,11 @@ void tty_char_out(unsigned char ch, int s, int attr)
   }
   if (ypos == li) {
     ypos--;
-    if(gfx_mode)
-      vgaemu_scroll(0, 0, co - 1, li - 1, 1, 0);
-    else {
-      /* Scroll with color newline */
-      bios_scroll(0,0,co-1,li-1,1,
-		  vga_read(screen_adr(s) + 2*(ypos*co + xpos) + 1));
-    }
+    /* Scroll with color newline in text mode */
+    unsigned char attr = (gfx_mode ? 0:
+			  vga_read(screen_adr(s) + 2*(ypos*co + xpos) + 1));
+    if (!config.dumb_video)
+      vgaemu_scroll(0, 0, co-1, li-1, 1, attr);
   }
   do_set_cursor_pos(s, xpos, ypos);
 }
@@ -852,10 +771,7 @@ int int10(void) /* with dualmon */
         "scroll up: %u lines, area %u.%u-%u.%u, attr 0x%02x\n",
         LO(ax), LO(cx), HI(cx), LO(dx), HI(dx), HI(bx)
       );
-      if(using_text_mode()) {
-        bios_scroll(LO(cx), HI(cx), LO(dx), HI(dx), LO(ax), HI(bx));
-      }
-      else {
+      if(!config.dumb_video) {
         vgaemu_scroll(LO(cx), HI(cx), LO(dx), HI(dx), LO(ax), HI(bx));
       }
       break;
@@ -867,10 +783,7 @@ int int10(void) /* with dualmon */
         "scroll dn: %u lines, area %u.%u-%u.%u, attr 0x%02x\n",
         LO(ax), LO(cx), HI(cx), LO(dx), HI(dx), HI(bx)
       );
-      if(using_text_mode()) {
-        bios_scroll(LO(cx), HI(cx), LO(dx), HI(dx), -LO(ax), HI(bx));
-      }
-      else {
+      if(!config.dumb_video) {
         vgaemu_scroll(LO(cx), HI(cx), LO(dx), HI(dx), -LO(ax), HI(bx));
       }
       break;

--- a/src/base/bios/int10.c
+++ b/src/base/bios/int10.c
@@ -107,13 +107,6 @@ unsigned screen_adr(int page)
 static void tty_char_out(unsigned char ch, int s, int attr);
 static void vga_ROM_to_RAM(unsigned height, int bank);
 
-static void crt_outw(unsigned index, unsigned value)
-{
-  unsigned port = READ_WORD(BIOS_VIDEO_PORT);
-  port_outw(port, index | (value & 0xff00));
-  port_outw(port, (index + 1) | ((value & 0xff) << 8));
-}
-
 static unsigned do_set_cursor_pos(unsigned page, int x, int y)
 {
   unsigned old_y;
@@ -747,7 +740,7 @@ int int10(void) /* with dualmon */
 {
   /* some code here is copied from Alan Cox ***************/
   int x, y, co, li;
-  unsigned page, page_size, address;
+  unsigned page;
   unsigned sm;
   Bit16u shape, pos;
 
@@ -849,15 +842,7 @@ int int10(void) /* with dualmon */
 	i10_msg("set display page: bad page %d\n", page);
 	break;
       }
-      page_size = READ_WORD(BIOS_VIDEO_MEMORY_USED);
-      address = page_size * page;
-      crt_outw(0xc, address/(using_text_mode() ? 2 : 1));
-
-      WRITE_BYTE(BIOS_CURRENT_SCREEN_PAGE, page);
-      WRITE_WORD(BIOS_VIDEO_MEMORY_ADDRESS, address);
-      x = get_bios_cursor_x_position(page);
-      y = get_bios_cursor_y_position(page);
-      set_cursor_pos(page, x, y);
+      vgaemu_set_active_page(page);
       break;
 
 

--- a/src/base/bios/int10.c
+++ b/src/base/bios/int10.c
@@ -769,6 +769,7 @@ int int10(void) /* with dualmon */
   int x, y, co, li;
   unsigned page, page_size, address;
   unsigned sm;
+  Bit16u shape, pos;
 
 #if 0 && USE_DUALMON
   static int last_equip=-1;
@@ -836,17 +837,13 @@ int int10(void) /* with dualmon */
 
 
     case 0x03:		/* get cursor pos/shape */
-      /* output start & end scanline even if the requested page is invalid */
-      LWORD(ecx) = READ_WORD(BIOS_CURSOR_SHAPE);
-
       page = HI(bx);
-      if (page > 7) {
-        LWORD(edx) = 0;
+      vgaemu_get_cursor_pos(page, &shape, &pos);
+      LWORD(ecx) = shape;
+      LWORD(edx) = pos;
+
+      if (page > 7)
         i10_msg("get cursor pos: page > 7: %d\n", page);
-      } else {
-        LO(dx) = get_bios_cursor_x_position(page);
-        HI(dx) = get_bios_cursor_y_position(page);
-      }
 
       i10_deb(
         "get cursor pos: page %u, x.y %u.%u, shape %u-%u\n",

--- a/src/base/bios/int10.c
+++ b/src/base/bios/int10.c
@@ -59,6 +59,7 @@
 #include "utilities.h"
 #include "dos2linux.h"
 #include "timers.h"
+#include "vgabios.h"
 #include "vgaemu.h"
 #include "vgatext.h"
 

--- a/src/base/bios/int10.c
+++ b/src/base/bios/int10.c
@@ -116,13 +116,10 @@ static void crt_outw(unsigned index, unsigned value)
 
 static unsigned do_set_cursor_pos(unsigned page, int x, int y)
 {
-  unsigned co, old_y;
+  unsigned old_y;
 
   old_y = get_bios_cursor_y_position(page);
-  set_bios_cursor_x_position(page, x);
-  set_bios_cursor_y_position(page, y);
-  co = READ_WORD(BIOS_SCREEN_COLUMNS);
-  crt_outw(0xe, READ_WORD(BIOS_VIDEO_MEMORY_ADDRESS)/2 + y * co + x);
+  vgaemu_set_cursor_pos(page, x, y);
   return old_y;
 }
 

--- a/src/base/bios/vgabios.c
+++ b/src/base/bios/vgabios.c
@@ -95,6 +95,18 @@ static int vgabios_using_text_mode(void)
     return (!(mode & 2));
 }
 
+static unsigned vgabios_screen_adr(void)
+{
+    /* This is the text screen base, the DOS program actually has to use.
+     * Programs that support simultaneous dual monitor support rely on
+     * the fact, that the BIOS takes B0000 for EQUIP-flags 4..5 = 3
+     * else B8000 as regenbuffer address. Each compatible PC-BIOS behaves so.
+     * This is ugly, but there is no screen buffer address in the BIOS-DATA
+     * at 0x400. (Hans)
+     */
+    return (READ_WORD(BIOS_CONFIGURATION) & 0x30) == 0x30 ? 0xb000 : 0xb800;
+}
+
 static void biosfn_set_cursor_pos(Bit8u page,Bit16u cursor)
 {
  Bit8u xcurs,ycurs,current;
@@ -380,18 +392,19 @@ Bit8u dir)
 
  if(vgabios_using_text_mode())
   {
+   Bit16u buffer_start = vgabios_screen_adr();
    // Get the page size
    pgsize=read_bda_word(BIOSMEM_PAGE_SIZE);
    // Compute the address
    address=pgsize*page;
    chattr = ((Bit16u)attr << 8) + ' ';
 #ifdef DEBUG
-   printf("Scroll, address %04x (%04x %04x %02x)\n",address,nbrows,nbcols,page);
+   v_printf("Scroll, address %04x (%04x %04x %02x)\n",address,nbrows,nbcols,page);
 #endif
 
    if(nblines==0&&rul==0&&cul==0&&rlr==nbrows-1&&clr==nbcols-1)
     {
-     memsetw(vmi->buffer_start,address,chattr,nbrows*nbcols);
+     memsetw(buffer_start,address,chattr,nbrows*nbcols);
     }
    else
     {// if Scroll up
@@ -399,18 +412,18 @@ Bit8u dir)
       {for(i=rul;i<=rlr;i++)
         {
          if((i+nblines>rlr)||(nblines==0))
-          memsetw(vmi->buffer_start,address+(i*nbcols+cul)*2,chattr,cols);
+          memsetw(buffer_start,address+(i*nbcols+cul)*2,chattr,cols);
          else
-          memcpyw(vmi->buffer_start,address+(i*nbcols+cul)*2,vmi->buffer_start,((i+nblines)*nbcols+cul)*2,cols);
+          memcpyw(buffer_start,address+(i*nbcols+cul)*2,buffer_start,((i+nblines)*nbcols+cul)*2,cols);
         }
       }
      else
       {for(i=rlr;i>=rul;i--)
         {
          if((i<rul+nblines)||(nblines==0))
-          memsetw(vmi->buffer_start,address+(i*nbcols+cul)*2,chattr,cols);
+          memsetw(buffer_start,address+(i*nbcols+cul)*2,chattr,cols);
          else
-          memcpyw(vmi->buffer_start,address+(i*nbcols+cul)*2,vmi->buffer_start,((i-nblines)*nbcols+cul)*2,cols);
+          memcpyw(buffer_start,address+(i*nbcols+cul)*2,buffer_start,((i-nblines)*nbcols+cul)*2,cols);
          if (i>rlr) break;
         }
       }

--- a/src/base/bios/vgabios.c
+++ b/src/base/bios/vgabios.c
@@ -88,6 +88,12 @@ static vga_mode_info *get_vmi(void)
     return vga_emu_find_mode(READ_BYTE(BIOS_VIDEO_MODE), NULL);
 }
 
+static int vgabios_using_text_mode(void)
+{
+    unsigned char mode = READ_BYTE(BIOS_VDU_CONTROL);
+    return (!(mode & 2));
+}
+
 static void biosfn_set_cursor_pos(Bit8u page,Bit16u cursor)
 {
  Bit8u xcurs,ycurs,current;
@@ -277,7 +283,7 @@ Bit8u dir)
  if(nblines>nbrows)nblines=0;
  cols=clr-cul+1;
 
- if(vmi->mode_class==TEXT)
+ if(vgabios_using_text_mode())
   {
    // Get the page size
    pgsize=read_bda_word(BIOSMEM_PAGE_SIZE);
@@ -638,7 +644,7 @@ static void biosfn_write_char_attr (Bit8u car,Bit8u page,Bit8u attr,
  // Get the dimensions
  nbcols=read_bda_word(BIOSMEM_NB_COLS);
 
- if(vmi->mode_class==TEXT)
+ if(vgabios_using_text_mode())
   {
    // Get the page size
    pgsize=read_bda_word(BIOSMEM_PAGE_SIZE);
@@ -698,7 +704,7 @@ static void biosfn_write_char_only (Bit8u car,Bit8u page,Bit8u attr,
  // Get the dimensions
  nbcols=read_bda_word(BIOSMEM_NB_COLS);
 
- if(vmi->mode_class==TEXT)
+ if(vgabios_using_text_mode())
   {
    // Get the page size
    pgsize=read_bda_word(BIOSMEM_PAGE_SIZE);
@@ -976,7 +982,7 @@ static void biosfn_write_teletype(Bit8u car,Bit8u page,Bit8u attr,Bit8u flag)
 
    default:
 
-    if(vmi->mode_class==TEXT)
+    if(vgabios_using_text_mode())
      {
       // Get the page size
       pgsize=read_bda_word(BIOSMEM_PAGE_SIZE);
@@ -1025,7 +1031,7 @@ static void biosfn_write_teletype(Bit8u car,Bit8u page,Bit8u attr,Bit8u flag)
  // Do we need to scroll ?
  if(ycurs==nbrows)
   {
-   if(vmi->mode_class==TEXT)
+   if(vgabios_using_text_mode())
     {
      pgsize=read_bda_word(BIOSMEM_PAGE_SIZE);
      address=pgsize*page+(xcurs+(ycurs-1)*nbcols)*2;

--- a/src/base/bios/vgabios.c
+++ b/src/base/bios/vgabios.c
@@ -132,26 +132,29 @@ static void set_cursor_pos(Bit8u page,Bit16u cursor)
  biosfn_set_cursor_pos(page,cursor);
 }
 
-#if 0
 // --------------------------------------------------------------------------------------------
 static void biosfn_get_cursor_pos (Bit8u page,Bit16u *shape,Bit16u *pos)
 {
+ /* output start & end scanline even if the requested page is invalid */
+ *shape = read_bda_word(BIOSMEM_CURSOR_TYPE);
  // Default
- *shape = 0;
  *pos = 0;
 
  if(page>7)return;
  // FIXME should handle VGA 14/16 lines
- *shape = read_bda_word(BIOSMEM_CURSOR_TYPE);
  *pos = read_bda_word(BIOSMEM_CURSOR_POS+page*2);
 }
-#endif
 
 // --------------------------------------------------------------------------------------------
 static Bit16u get_cursor_pos (Bit8u page)
 {
  if(page>7)return 0;
  return read_bda_word(BIOSMEM_CURSOR_POS+page*2);
+}
+
+void vgaemu_get_cursor_pos(Bit8u page, Bit16u *shape, Bit16u *pos)
+{
+  biosfn_get_cursor_pos(page, shape, pos);
 }
 
 // --------------------------------------------------------------------------------------------

--- a/src/base/bios/vgabios.c
+++ b/src/base/bios/vgabios.c
@@ -1,10 +1,6 @@
 // ============================================================================================
-/*
- * vgabios.c
- */
-// ============================================================================================
 //
-//  Copyright (C) 2001-2008 the LGPL VGABios developers Team
+//  Copyright (C) 2001-2025 The LGPL VGABios developers Team
 //
 //  This library is free software; you can redistribute it and/or
 //  modify it under the terms of the GNU Lesser General Public
@@ -18,11 +14,11 @@
 //
 //  You should have received a copy of the GNU Lesser General Public
 //  License along with this library; if not, write to the Free Software
-//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+//  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
 //
 // ============================================================================================
 //
-//  This VGA Bios is specific to the plex86/bochs Emulated VGA card.
+//  This VGA Bios is specific to the Bochs Emulated VGA card.
 //  You can NOT drive any physical vga card with it.
 //
 // ============================================================================================
@@ -65,9 +61,12 @@
 
 #define vga_msg(x...) v_printf("VGAEmu: " x)
 #define read_byte_far(seg, off) (read_byte(SEGOFF2LINEAR(seg, off)))
+#define read_bda_byte(off) (read_byte_far(BIOSMEM_SEG, off))
 #define write_byte_far(seg, off, val) (write_byte(SEGOFF2LINEAR(seg, off), val))
 #define read_word_far(seg, off) (read_word(SEGOFF2LINEAR(seg, off)))
+#define read_bda_word(off) (read_word_far(BIOSMEM_SEG, off))
 #define write_word_far(seg, off, val) (write_word(SEGOFF2LINEAR(seg, off), val))
+#define write_bda_word(off, val) (write_word_far(BIOSMEM_SEG, off, val))
 #define outw port_outw
 #define memsetb(seg, off, val, len) memset_dos(SEGOFF2LINEAR(seg, off), val, len)
 #define memsetw(seg, off, val, len) memsetw_dos(SEGOFF2LINEAR(seg, off), val, len)
@@ -89,33 +88,31 @@ static vga_mode_info *get_vmi(void)
     return vga_emu_find_mode(READ_BYTE(BIOS_VIDEO_MODE), NULL);
 }
 
-// --------------------------------------------------------------------------------------------
 static void biosfn_set_cursor_pos(Bit8u page,Bit16u cursor)
 {
  Bit8u xcurs,ycurs,current;
- Bit16u nbcols,nbrows,address,crtc_addr;
+ Bit16u nbcols,address,crtc_addr;
 
  // Should not happen...
  if(page>7)return;
 
  // Bios cursor pos
- write_word_far(BIOSMEM_SEG, BIOSMEM_CURSOR_POS+2*page, cursor);
+ write_bda_word(BIOSMEM_CURSOR_POS+2*page, cursor);
 
  // Set the hardware cursor
- current=read_byte_far(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
+ current=read_bda_byte(BIOSMEM_CURRENT_PAGE);
  if(page==current)
   {
    // Get the dimensions
-   nbcols=read_word_far(BIOSMEM_SEG,BIOSMEM_NB_COLS);
-   nbrows=read_byte_far(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1;
+   nbcols=read_bda_word(BIOSMEM_NB_COLS);
 
    xcurs=cursor&0x00ff;ycurs=(cursor&0xff00)>>8;
 
-   // Calculate the address knowing nbcols nbrows and page num
-   address=SCREEN_IO_START(nbcols,nbrows,page)+xcurs+ycurs*nbcols;
+   // Calculate the address
+   address=read_bda_word(BIOSMEM_CURRENT_START)/2+xcurs+ycurs*nbcols;
 
    // CRTC regs 0x0e and 0x0f
-   crtc_addr=read_word_far(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
+   crtc_addr=read_bda_word(BIOSMEM_CRTC_ADDRESS);
    port_outb(crtc_addr,0x0e);
    port_outb(crtc_addr+1,(address&0xff00)>>8);
    port_outb(crtc_addr,0x0f);
@@ -123,6 +120,13 @@ static void biosfn_set_cursor_pos(Bit8u page,Bit16u cursor)
   }
 }
 
+// --------------------------------------------------------------------------------------------
+static void set_cursor_pos(Bit8u page,Bit16u cursor)
+{
+ biosfn_set_cursor_pos(page,cursor);
+}
+
+#if 0
 // --------------------------------------------------------------------------------------------
 static void biosfn_get_cursor_pos (Bit8u page,Bit16u *shape,Bit16u *pos)
 {
@@ -132,8 +136,16 @@ static void biosfn_get_cursor_pos (Bit8u page,Bit16u *shape,Bit16u *pos)
 
  if(page>7)return;
  // FIXME should handle VGA 14/16 lines
- *shape = read_word_far(BIOSMEM_SEG,BIOSMEM_CURSOR_TYPE);
- *pos = read_word_far(BIOSMEM_SEG,BIOSMEM_CURSOR_POS+page*2);
+ *shape = read_bda_word(BIOSMEM_CURSOR_TYPE);
+ *pos = read_bda_word(BIOSMEM_CURSOR_POS+page*2);
+}
+#endif
+
+// --------------------------------------------------------------------------------------------
+static Bit16u get_cursor_pos (Bit8u page)
+{
+ if(page>7)return 0;
+ return read_bda_word(BIOSMEM_CURSOR_POS+page*2);
 }
 
 // --------------------------------------------------------------------------------------------
@@ -221,13 +233,13 @@ Bit8u xstart,Bit8u ysrc,Bit8u ydest,Bit8u cols,Bit8u nbcols,Bit8u cheight)
 
 // --------------------------------------------------------------------------------------------
 static void vgamem_fill_lin(
-Bit8u xstart,Bit8u ystart,Bit8u cols,Bit8u nbcols,Bit8u cheight,Bit8u attr)
+Bit8u xstart,Bit8u ystart,Bit8u cols,Bit8u rows,Bit8u nbcols,Bit8u cheight,Bit8u attr)
 {
  Bit16u dest;
  Bit8u i;
 
  dest=(ystart*cheight*nbcols+xstart)*8;
- for(i=0;i<cheight;i++)
+ for(i=0;i<cheight*rows;i++)
   {
    memsetb(0xa000,dest+i*nbcols*8,attr,cols*8);
   }
@@ -238,25 +250,27 @@ static void biosfn_scroll(
 Bit8u nblines,Bit8u attr,Bit8u rul,Bit8u cul,Bit8u rlr,Bit8u clr,Bit8u page,
 Bit8u dir)
 {
+ // page == 0xFF if current
+
  Bit8u cheight,bpp,cols;
  Bit16u nbcols,nbrows,i;
- Bit16u address;
- vga_mode_info *vmi = get_vmi();
- if (!vmi)
-   return;
-
- // page == 0xFF if current
+ Bit16u address,pgsize,chattr;
 
  if(rul>rlr)return;
  if(cul>clr)return;
 
+ // Get the mode
+ vga_mode_info *vmi = get_vmi();
+ if (!vmi)
+   return;
+
  // Get the dimensions
- nbrows=read_byte_far(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1;
- nbcols=read_word_far(BIOSMEM_SEG,BIOSMEM_NB_COLS);
+ nbrows=read_bda_byte(BIOSMEM_NB_ROWS)+1;
+ nbcols=read_bda_word(BIOSMEM_NB_COLS);
 
  // Get the current page
  if(page==0xFF)
-  page=read_byte_far(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
+  page=read_bda_byte(BIOSMEM_CURRENT_PAGE);
 
  if(rlr>=nbrows)rlr=nbrows-1;
  if(clr>=nbcols)clr=nbcols-1;
@@ -265,15 +279,18 @@ Bit8u dir)
 
  if(vmi->mode_class==TEXT)
   {
+   // Get the page size
+   pgsize=read_bda_word(BIOSMEM_PAGE_SIZE);
    // Compute the address
-   address=SCREEN_MEM_START(nbcols,nbrows,page);
+   address=pgsize*page;
+   chattr = ((Bit16u)attr << 8) + ' ';
 #ifdef DEBUG
    printf("Scroll, address %04x (%04x %04x %02x)\n",address,nbrows,nbcols,page);
 #endif
 
    if(nblines==0&&rul==0&&cul==0&&rlr==nbrows-1&&clr==nbcols-1)
     {
-     memsetw(vmi->buffer_start,address,(Bit16u)attr*0x100+' ',nbrows*nbcols);
+     memsetw(vmi->buffer_start,address,chattr,nbrows*nbcols);
     }
    else
     {// if Scroll up
@@ -281,7 +298,7 @@ Bit8u dir)
       {for(i=rul;i<=rlr;i++)
         {
          if((i+nblines>rlr)||(nblines==0))
-          memsetw(vmi->buffer_start,address+(i*nbcols+cul)*2,(Bit16u)attr*0x100+' ',cols);
+          memsetw(vmi->buffer_start,address+(i*nbcols+cul)*2,chattr,cols);
          else
           memcpyw(vmi->buffer_start,address+(i*nbcols+cul)*2,vmi->buffer_start,((i+nblines)*nbcols+cul)*2,cols);
         }
@@ -290,7 +307,7 @@ Bit8u dir)
       {for(i=rlr;i>=rul;i--)
         {
          if((i<rul+nblines)||(nblines==0))
-          memsetw(vmi->buffer_start,address+(i*nbcols+cul)*2,(Bit16u)attr*0x100+' ',cols);
+          memsetw(vmi->buffer_start,address+(i*nbcols+cul)*2,chattr,cols);
          else
           memcpyw(vmi->buffer_start,address+(i*nbcols+cul)*2,vmi->buffer_start,((i-nblines)*nbcols+cul)*2,cols);
          if (i>rlr) break;
@@ -300,20 +317,31 @@ Bit8u dir)
   }
  else
   {
+   // FIXME gfx modes > 8 bpp not supported
    address=READ_WORD(BIOS_VIDEO_MEMORY_USED)*page;
-   cheight=read_byte_far(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT);
-   switch(vmi->type)
+   cheight=read_bda_byte(BIOSMEM_CHAR_HEIGHT);
+   if(nblines==0&&rul==0&&cul==0&&rlr==nbrows-1&&clr==nbcols-1&&vmi->type!=LINEAR8)
     {
-     case PLANAR4:
-     case PLANAR1:
-       if(nblines==0&&rul==0&&cul==0&&rlr==nbrows-1&&clr==nbcols-1)
-        {
+     switch(vmi->type)
+      {
+       case PLANAR4:
+       case PLANAR1:
          port_outw(VGAREG_GRDC_ADDRESS, 0x0205);
          memsetb(vmi->buffer_start,address,attr,nbrows*nbcols*cheight);
          port_outw(VGAREG_GRDC_ADDRESS, 0x0005);
-        }
-       else
-        {// if Scroll up
+         break;
+       case CGA:
+         bpp=vmi->color_bits;
+         memsetb(vmi->buffer_start,address,attr,nbrows*nbcols*cheight*bpp);
+         break;
+      }
+    }
+   else
+    {
+     switch(vmi->type)
+      {
+       case PLANAR4:
+       case PLANAR1:
          if(dir==SCROLL_UP)
           {for(i=rul;i<=rlr;i++)
             {
@@ -329,20 +357,12 @@ Bit8u dir)
              if((i<rul+nblines)||(nblines==0))
               vgamem_fill_pl4(address,cul,i,cols,nbcols,cheight,attr);
              else
-              vgamem_copy_pl4(address,cul,i,i-nblines,cols,nbcols,cheight);
-             if (i>rlr) break;
+              vgamem_copy_pl4(address,cul,i-nblines,i,cols,nbcols,cheight);
             }
           }
-        }
-       break;
-     case CGA:
-       bpp=vmi->color_bits;
-       if(nblines==0&&rul==0&&cul==0&&rlr==nbrows-1&&clr==nbcols-1)
-        {
-         memsetb(vmi->buffer_start,address,attr,nbrows*nbcols*cheight*bpp);
-        }
-       else
-        {
+         break;
+       case CGA:
+         bpp=vmi->color_bits;
          if(bpp==2)
           {
            cul<<=1;
@@ -365,25 +385,18 @@ Bit8u dir)
              if((i<rul+nblines)||(nblines==0))
               vgamem_fill_cga(address,cul,i,cols,nbcols,cheight,attr);
              else
-              vgamem_copy_cga(address,cul,i,i-nblines,cols,nbcols,cheight);
-             if (i>rlr) break;
+              vgamem_copy_cga(address,cul,i-nblines,i,cols,nbcols,cheight);
             }
           }
-        }
-       break;
-     case LINEAR8:
-       if(nblines==0&&rul==0&&cul==0&&rlr==nbrows-1&&clr==nbcols-1)
-        {
-         memsetb(vmi->buffer_start,0,attr,nbrows*nbcols*cheight*8);
-        }
-       else
-        {
-         // if Scroll up
-         if(dir==SCROLL_UP)
+         break;
+       case LINEAR8:
+         if(nblines==0)
+          vgamem_fill_lin(cul,rul,cols,rlr-rul+1,nbcols,cheight,attr);
+         else if(dir==SCROLL_UP)
           {for(i=rul;i<=rlr;i++)
             {
-             if((i+nblines>rlr)||(nblines==0))
-              vgamem_fill_lin(cul,i,cols,nbcols,cheight,attr);
+             if(i+nblines>rlr)
+              vgamem_fill_lin(cul,i,cols,1,nbcols,cheight,attr);
              else
               vgamem_copy_lin(cul,i+nblines,i,cols,nbcols,cheight);
             }
@@ -391,20 +404,19 @@ Bit8u dir)
          else
           {for(i=rlr;i>=rul;i--)
             {
-             if((i<rul+nblines)||(nblines==0))
-              vgamem_fill_lin(cul,i,cols,nbcols,cheight,attr);
+             if(i<rul+nblines)
+              vgamem_fill_lin(cul,i,cols,1,nbcols,cheight,attr);
              else
-              vgamem_copy_lin(cul,i,i-nblines,cols,nbcols,cheight);
-             if (i>rlr) break;
+              vgamem_copy_lin(cul,i-nblines,i,cols,nbcols,cheight);
             }
           }
-        }
-       break;
+         break;
 #ifdef DEBUG
-     default:
-       printf("Scroll in graphics mode ");
-       unimplemented();
+       default:
+         printf("Scroll in graphics mode ");
+         unimplemented();
 #endif
+      }
     }
   }
 }
@@ -611,32 +623,36 @@ static void biosfn_write_char_attr (Bit8u car,Bit8u page,Bit8u attr,
     Bit16u count)
 {
  Bit8u cheight,xcurs,ycurs,bpp;
- Bit16u nbcols,nbrows,address;
- Bit16u cursor,dummy;
+ Bit16u nbcols,pgsize,address;
+ Bit16u cursor,carattr;
+
+ // Get the mode
  vga_mode_info *vmi = get_vmi();
  if (!vmi)
    return;
 
  // Get the cursor pos for the page
- biosfn_get_cursor_pos(page,&dummy,&cursor);
+ cursor=get_cursor_pos(page);
  xcurs=cursor&0x00ff;ycurs=(cursor&0xff00)>>8;
 
  // Get the dimensions
- nbrows=read_byte_far(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1;
- nbcols=read_word_far(BIOSMEM_SEG,BIOSMEM_NB_COLS);
+ nbcols=read_bda_word(BIOSMEM_NB_COLS);
 
  if(vmi->mode_class==TEXT)
   {
+   // Get the page size
+   pgsize=read_bda_word(BIOSMEM_PAGE_SIZE);
    // Compute the address
-   address=SCREEN_MEM_START(nbcols,nbrows,page)+(xcurs+ycurs*nbcols)*2;
+   address=pgsize*page+(xcurs+ycurs*nbcols)*2;
 
-   dummy=((Bit16u)attr<<8)+car;
-   memsetw(vmi->buffer_start,address,dummy,count);
+   carattr=((Bit16u)attr<<8)+car;
+   memsetw(vmi->buffer_start,address,carattr,count);
   }
  else
   {
+   // FIXME gfx modes > 8 bpp not supported
    address=READ_WORD(BIOS_VIDEO_MEMORY_USED)*page;
-   cheight=read_byte_far(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT);
+   cheight=read_bda_byte(BIOSMEM_CHAR_HEIGHT);
    bpp=vmi->color_bits;
    while((count-->0) && (xcurs<nbcols))
     {
@@ -667,24 +683,27 @@ static void biosfn_write_char_only (Bit8u car,Bit8u page,Bit8u attr,
     Bit16u count)
 {
  Bit8u cheight,xcurs,ycurs,bpp;
- Bit16u nbcols,nbrows,address;
- Bit16u cursor,dummy;
+ Bit16u nbcols,pgsize,address;
+ Bit16u cursor;
+
+ // Get the mode
  vga_mode_info *vmi = get_vmi();
  if (!vmi)
    return;
 
  // Get the cursor pos for the page
- biosfn_get_cursor_pos(page,&dummy,&cursor);
+ cursor=get_cursor_pos(page);
  xcurs=cursor&0x00ff;ycurs=(cursor&0xff00)>>8;
 
  // Get the dimensions
- nbrows=read_byte_far(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1;
- nbcols=read_word_far(BIOSMEM_SEG,BIOSMEM_NB_COLS);
+ nbcols=read_bda_word(BIOSMEM_NB_COLS);
 
  if(vmi->mode_class==TEXT)
   {
+   // Get the page size
+   pgsize=read_bda_word(BIOSMEM_PAGE_SIZE);
    // Compute the address
-   address=SCREEN_MEM_START(nbcols,nbrows,page)+(xcurs+ycurs*nbcols)*2;
+   address=pgsize*page+(xcurs+ycurs*nbcols)*2;
 
    while(count-->0)
     {write_byte_far(vmi->buffer_start,address,car);
@@ -693,8 +712,9 @@ static void biosfn_write_char_only (Bit8u car,Bit8u page,Bit8u attr,
   }
  else
   {
+   // FIXME gfx modes > 8 bpp not supported
    address=READ_WORD(BIOS_VIDEO_MEMORY_USED)*page;
-   cheight=read_byte_far(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT);
+   cheight=read_bda_byte(BIOSMEM_CHAR_HEIGHT);
    bpp=vmi->color_bits;
    while((count-->0) && (xcurs<nbcols))
     {
@@ -747,6 +767,8 @@ static void biosfn_write_pixel(Bit8u BH,Bit8u AL,Bit16u CX,Bit16u DX)
 {
  Bit8u mask,attr,data;
  Bit16u addr;
+
+ // Get the mode
  vga_mode_info *vmi = get_vmi();
  if (!vmi)
    return;
@@ -755,7 +777,7 @@ static void biosfn_write_pixel(Bit8u BH,Bit8u AL,Bit16u CX,Bit16u DX)
   {
    case PLANAR4:
    case PLANAR1:
-     addr = CX/8+DX*read_word_far(BIOSMEM_SEG,BIOSMEM_NB_COLS)+
+     addr = CX/8+DX*read_bda_word(BIOSMEM_NB_COLS)+
        READ_WORD(BIOS_VIDEO_MEMORY_USED)*BH;
      mask = 0x80 >> (CX & 0x07);
      port_outw(VGAREG_GRDC_ADDRESS, (mask << 8) | 0x08);
@@ -815,7 +837,7 @@ ASM_END
      write_byte_far(0xb800,addr,data);
      break;
    case LINEAR8:
-     addr=CX+DX*(read_word_far(BIOSMEM_SEG,BIOSMEM_NB_COLS)*8)+
+     addr=CX+DX*(read_bda_word(BIOSMEM_NB_COLS)*8)+
        READ_WORD(BIOS_VIDEO_MEMORY_USED)*BH;
      write_byte_far(0xa000,addr,AL);
      break;
@@ -840,6 +862,8 @@ static unsigned char biosfn_read_pixel(Bit8u BH,Bit16u CX,Bit16u DX)
 {
  Bit8u mask,attr,data,i;
  Bit16u addr;
+
+ // Get the mode
  vga_mode_info *vmi = get_vmi();
  if (!vmi)
    return 0xff;
@@ -848,7 +872,7 @@ static unsigned char biosfn_read_pixel(Bit8u BH,Bit16u CX,Bit16u DX)
   {
    case PLANAR4:
    case PLANAR1:
-     addr = CX/8+DX*read_word_far(BIOSMEM_SEG,BIOSMEM_NB_COLS)+
+     addr = CX/8+DX*read_bda_word(BIOSMEM_NB_COLS)+
        READ_WORD(BIOS_VIDEO_MEMORY_USED)*BH;
      mask = 0x80 >> (CX & 0x07);
      attr = 0x00;
@@ -873,7 +897,7 @@ static unsigned char biosfn_read_pixel(Bit8u BH,Bit16u CX,Bit16u DX)
       }
      break;
    case LINEAR8:
-     addr=CX+DX*(read_word_far(BIOSMEM_SEG,BIOSMEM_NB_COLS)*8)+
+     addr=CX+DX*(read_bda_word(BIOSMEM_NB_COLS)*8)+
        READ_WORD(BIOS_VIDEO_MEMORY_USED)*BH;
      attr=read_byte_far(0xa000,addr);
      break;
@@ -904,23 +928,25 @@ static void biosfn_write_teletype(Bit8u car,Bit8u page,Bit8u attr,Bit8u flag)
 {// flag = WITH_ATTR / NO_ATTR
 
  Bit8u cheight,xcurs,ycurs,bpp;
- Bit16u nbcols,nbrows,address;
- Bit16u cursor,dummy;
+ Bit16u nbcols,nbrows,pgsize,address;
+ Bit16u cursor;
+
+ // special case if page is 0xff, use current page
+ if(page==0xff)
+  page=read_bda_byte(BIOSMEM_CURRENT_PAGE);
+
+ // Get the mode
  vga_mode_info *vmi = get_vmi();
  if (!vmi)
    return;
 
- // special case if page is 0xff, use current page
- if(page==0xff)
-  page=read_byte_far(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
-
  // Get the cursor pos for the page
- biosfn_get_cursor_pos(page,&dummy,&cursor);
- xcurs=cursor&0x00ff;ycurs=(cursor&0xff00)>>8;
+ cursor=get_cursor_pos(page);
+ xcurs = cursor & 0x00ff; ycurs = (Bit8u)(cursor >> 8);
 
  // Get the dimensions
- nbrows=read_byte_far(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1;
- nbcols=read_word_far(BIOSMEM_SEG,BIOSMEM_NB_COLS);
+ nbrows=read_bda_byte(BIOSMEM_NB_ROWS)+1;
+ nbcols=read_bda_word(BIOSMEM_NB_COLS);
 
  switch(car)
   {
@@ -941,20 +967,21 @@ static void biosfn_write_teletype(Bit8u car,Bit8u page,Bit8u attr,Bit8u flag)
     break;
 
    case '\t':
-    do
-     {
+    do {
       biosfn_write_teletype(' ',page,attr,flag);
-      biosfn_get_cursor_pos(page,&dummy,&cursor);
-      xcurs=cursor&0x00ff;ycurs=(cursor&0xff00)>>8;
-     }while(xcurs%8==0);
+      cursor = get_cursor_pos(page);
+      xcurs = cursor & 0x00ff; ycurs = (Bit8u)(cursor >> 8);
+     } while ((xcurs % 8) == 0);
     break;
 
    default:
 
     if(vmi->mode_class==TEXT)
      {
+      // Get the page size
+      pgsize=read_bda_word(BIOSMEM_PAGE_SIZE);
       // Compute the address
-      address=SCREEN_MEM_START(nbcols,nbrows,page)+(xcurs+ycurs*nbcols)*2;
+      address=pgsize*page+(xcurs+ycurs*nbcols)*2;
 
       // Write the char
       write_byte_far(vmi->buffer_start,address,car);
@@ -965,7 +992,8 @@ static void biosfn_write_teletype(Bit8u car,Bit8u page,Bit8u attr,Bit8u flag)
     else
      {
       address=READ_WORD(BIOS_VIDEO_MEMORY_USED)*page;
-      cheight=read_byte_far(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT);
+      // FIXME gfx modes > 8 bpp not supported
+      cheight=read_bda_byte(BIOSMEM_CHAR_HEIGHT);
       bpp=vmi->color_bits;
       switch(vmi->type)
        {
@@ -999,7 +1027,8 @@ static void biosfn_write_teletype(Bit8u car,Bit8u page,Bit8u attr,Bit8u flag)
   {
    if(vmi->mode_class==TEXT)
     {
-     address=SCREEN_MEM_START(nbcols,nbrows,page)+(xcurs+(ycurs-1)*nbcols)*2;
+     pgsize=read_bda_word(BIOSMEM_PAGE_SIZE);
+     address=pgsize*page+(xcurs+(ycurs-1)*nbcols)*2;
      attr=read_byte_far(vmi->buffer_start,address+1);
      biosfn_scroll(0x01,attr,0,0,nbrows-1,nbcols-1,page,SCROLL_UP);
     }
@@ -1011,8 +1040,8 @@ static void biosfn_write_teletype(Bit8u car,Bit8u page,Bit8u attr,Bit8u flag)
   }
 
  // Set the cursor for the page
- cursor=ycurs; cursor<<=8; cursor+=xcurs;
- biosfn_set_cursor_pos(page,cursor);
+ cursor = ((Bit16u)ycurs << 8) | xcurs;
+ set_cursor_pos(page,cursor);
 }
 
 void vgaemu_put_char(unsigned char c, unsigned char page, unsigned char attr)
@@ -1030,11 +1059,11 @@ void vgaemu_put_char(unsigned char c, unsigned char page, unsigned char attr)
 static void biosfn_write_string(Bit8u flag,Bit8u page,Bit8u attr,Bit16u count,
     Bit8u row,Bit8u col,Bit16u seg,Bit16u offset)
 {
- Bit16u newcurs,oldcurs,dummy;
+ Bit16u newcurs,oldcurs;
  Bit8u car;
 
  // Read curs info for the page
- biosfn_get_cursor_pos(page,&dummy,&oldcurs);
+ oldcurs=get_cursor_pos(page);
 
  // if row=0xff special case : use current cursor position
  if(row==0xff)
@@ -1043,7 +1072,7 @@ static void biosfn_write_string(Bit8u flag,Bit8u page,Bit8u attr,Bit16u count,
   }
 
  newcurs=row; newcurs<<=8; newcurs+=col;
- biosfn_set_cursor_pos(page,newcurs);
+ set_cursor_pos(page,newcurs);
 
  while(count--!=0)
   {
@@ -1056,6 +1085,6 @@ static void biosfn_write_string(Bit8u flag,Bit8u page,Bit8u attr,Bit16u count,
 
  // Set back curs pos
  if((flag&0x01)==0)
-  biosfn_set_cursor_pos(page,oldcurs);
+  set_cursor_pos(page,oldcurs);
 }
 #endif

--- a/src/base/bios/vgabios.c
+++ b/src/base/bios/vgabios.c
@@ -90,6 +90,53 @@ static vga_mode_info *get_vmi(void)
 }
 
 // --------------------------------------------------------------------------------------------
+static void biosfn_set_cursor_pos(Bit8u page,Bit16u cursor)
+{
+ Bit8u xcurs,ycurs,current;
+ Bit16u nbcols,nbrows,address,crtc_addr;
+
+ // Should not happen...
+ if(page>7)return;
+
+ // Bios cursor pos
+ write_word_far(BIOSMEM_SEG, BIOSMEM_CURSOR_POS+2*page, cursor);
+
+ // Set the hardware cursor
+ current=read_byte_far(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
+ if(page==current)
+  {
+   // Get the dimensions
+   nbcols=read_word_far(BIOSMEM_SEG,BIOSMEM_NB_COLS);
+   nbrows=read_byte_far(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1;
+
+   xcurs=cursor&0x00ff;ycurs=(cursor&0xff00)>>8;
+
+   // Calculate the address knowing nbcols nbrows and page num
+   address=SCREEN_IO_START(nbcols,nbrows,page)+xcurs+ycurs*nbcols;
+
+   // CRTC regs 0x0e and 0x0f
+   crtc_addr=read_word_far(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
+   port_outb(crtc_addr,0x0e);
+   port_outb(crtc_addr+1,(address&0xff00)>>8);
+   port_outb(crtc_addr,0x0f);
+   port_outb(crtc_addr+1,address&0x00ff);
+  }
+}
+
+// --------------------------------------------------------------------------------------------
+static void biosfn_get_cursor_pos (Bit8u page,Bit16u *shape,Bit16u *pos)
+{
+ // Default
+ *shape = 0;
+ *pos = 0;
+
+ if(page>7)return;
+ // FIXME should handle VGA 14/16 lines
+ *shape = read_word_far(BIOSMEM_SEG,BIOSMEM_CURSOR_TYPE);
+ *pos = read_word_far(BIOSMEM_SEG,BIOSMEM_CURSOR_POS+page*2);
+}
+
+// --------------------------------------------------------------------------------------------
 static void vgamem_copy_pl4(Bit16u vstart,
 Bit8u xstart,Bit8u ysrc,Bit8u ydest,Bit8u cols,Bit8u nbcols,Bit8u cheight)
 {
@@ -382,19 +429,6 @@ void vgaemu_scroll(int x0, int y0, int x1, int y1, int n, unsigned char attr)
 }
 
 // --------------------------------------------------------------------------------------------
-static void biosfn_get_cursor_pos (Bit8u page,Bit16u *shape,Bit16u *pos)
-{
- // Default
- *shape = 0;
- *pos = 0;
-
- if(page>7)return;
- // FIXME should handle VGA 14/16 lines
- *shape = read_word_far(BIOSMEM_SEG,BIOSMEM_CURSOR_TYPE);
- *pos = read_word_far(BIOSMEM_SEG,BIOSMEM_CURSOR_POS+page*2);
-}
-
-// --------------------------------------------------------------------------------------------
 static void write_gfx_char_pl4(Bit16u vstart,Bit8u car,Bit8u attr,
 	Bit8u xcurs,Bit8u ycurs,Bit8u nbcols,Bit8u cheight)
 {
@@ -571,201 +605,6 @@ static void write_gfx_char_lin(Bit16u vstart,Bit8u car,Bit8u attr,
     }
   }
 }
-
-// --------------------------------------------------------------------------------------------
-static void biosfn_set_cursor_pos(Bit8u page,Bit16u cursor)
-{
- Bit8u xcurs,ycurs,current;
- Bit16u nbcols,nbrows,address,crtc_addr;
-
- // Should not happen...
- if(page>7)return;
-
- // Bios cursor pos
- write_word_far(BIOSMEM_SEG, BIOSMEM_CURSOR_POS+2*page, cursor);
-
- // Set the hardware cursor
- current=read_byte_far(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
- if(page==current)
-  {
-   // Get the dimensions
-   nbcols=read_word_far(BIOSMEM_SEG,BIOSMEM_NB_COLS);
-   nbrows=read_byte_far(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1;
-
-   xcurs=cursor&0x00ff;ycurs=(cursor&0xff00)>>8;
-
-   // Calculate the address knowing nbcols nbrows and page num
-   address=SCREEN_IO_START(nbcols,nbrows,page)+xcurs+ycurs*nbcols;
-
-   // CRTC regs 0x0e and 0x0f
-   crtc_addr=read_word_far(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
-   port_outb(crtc_addr,0x0e);
-   port_outb(crtc_addr+1,(address&0xff00)>>8);
-   port_outb(crtc_addr,0x0f);
-   port_outb(crtc_addr+1,address&0x00ff);
-  }
-}
-
-// --------------------------------------------------------------------------------------------
-static void biosfn_write_teletype(Bit8u car,Bit8u page,Bit8u attr,Bit8u flag)
-{// flag = WITH_ATTR / NO_ATTR
-
- Bit8u cheight,xcurs,ycurs,bpp;
- Bit16u nbcols,nbrows,address;
- Bit16u cursor,dummy;
- vga_mode_info *vmi = get_vmi();
- if (!vmi)
-   return;
-
- // special case if page is 0xff, use current page
- if(page==0xff)
-  page=read_byte_far(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
-
- // Get the cursor pos for the page
- biosfn_get_cursor_pos(page,&dummy,&cursor);
- xcurs=cursor&0x00ff;ycurs=(cursor&0xff00)>>8;
-
- // Get the dimensions
- nbrows=read_byte_far(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1;
- nbcols=read_word_far(BIOSMEM_SEG,BIOSMEM_NB_COLS);
-
- switch(car)
-  {
-   case 7:
-    //FIXME should beep
-    break;
-
-   case 8:
-    if(xcurs>0)xcurs--;
-    break;
-
-   case '\r':
-    xcurs=0;
-    break;
-
-   case '\n':
-    ycurs++;
-    break;
-
-   case '\t':
-    do
-     {
-      biosfn_write_teletype(' ',page,attr,flag);
-      biosfn_get_cursor_pos(page,&dummy,&cursor);
-      xcurs=cursor&0x00ff;ycurs=(cursor&0xff00)>>8;
-     }while(xcurs%8==0);
-    break;
-
-   default:
-
-    if(vmi->mode_class==TEXT)
-     {
-      // Compute the address
-      address=SCREEN_MEM_START(nbcols,nbrows,page)+(xcurs+ycurs*nbcols)*2;
-
-      // Write the char
-      write_byte_far(vmi->buffer_start,address,car);
-
-      if(flag==WITH_ATTR)
-       write_byte_far(vmi->buffer_start,address+1,attr);
-     }
-    else
-     {
-      address=READ_WORD(BIOS_VIDEO_MEMORY_USED)*page;
-      cheight=read_byte_far(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT);
-      bpp=vmi->color_bits;
-      switch(vmi->type)
-       {
-        case PLANAR4:
-        case PLANAR1:
-          write_gfx_char_pl4(address,car,attr,xcurs,ycurs,nbcols,cheight);
-          break;
-        case CGA:
-          write_gfx_char_cga(address,car,attr,xcurs,ycurs,nbcols,bpp);
-          break;
-        case LINEAR8:
-          write_gfx_char_lin(address,car,attr,xcurs,ycurs,nbcols,cheight);
-          break;
-#ifdef DEBUG
-        default:
-          unimplemented();
-#endif
-       }
-     }
-    xcurs++;
-  }
-
- // Do we need to wrap ?
- if(xcurs==nbcols)
-  {xcurs=0;
-   ycurs++;
-  }
-
- // Do we need to scroll ?
- if(ycurs==nbrows)
-  {
-   if(vmi->mode_class==TEXT)
-    {
-     address=SCREEN_MEM_START(nbcols,nbrows,page)+(xcurs+(ycurs-1)*nbcols)*2;
-     attr=read_byte_far(vmi->buffer_start,address+1);
-     biosfn_scroll(0x01,attr,0,0,nbrows-1,nbcols-1,page,SCROLL_UP);
-    }
-   else
-    {
-     biosfn_scroll(0x01,0x00,0,0,nbrows-1,nbcols-1,page,SCROLL_UP);
-    }
-   ycurs-=1;
-  }
-
- // Set the cursor for the page
- cursor=ycurs; cursor<<=8; cursor+=xcurs;
- biosfn_set_cursor_pos(page,cursor);
-}
-
-void vgaemu_put_char(unsigned char c, unsigned char page, unsigned char attr)
-{
- vga_msg(
-    "vgaemu_put_char: page %d, char 0x%02x, attr 0x%02x\n",
-    page, c, attr
- );
-
- biosfn_write_teletype(c, page, attr, NO_ATTR);
-}
-
-#if 0
-// --------------------------------------------------------------------------------------------
-static void biosfn_write_string(Bit8u flag,Bit8u page,Bit8u attr,Bit16u count,
-    Bit8u row,Bit8u col,Bit16u seg,Bit16u offset)
-{
- Bit16u newcurs,oldcurs,dummy;
- Bit8u car;
-
- // Read curs info for the page
- biosfn_get_cursor_pos(page,&dummy,&oldcurs);
-
- // if row=0xff special case : use current cursor position
- if(row==0xff)
-  {col=oldcurs&0x00ff;
-   row=(oldcurs&0xff00)>>8;
-  }
-
- newcurs=row; newcurs<<=8; newcurs+=col;
- biosfn_set_cursor_pos(page,newcurs);
-
- while(count--!=0)
-  {
-   car=read_byte_far(seg,offset++);
-   if((flag&0x02)!=0)
-    attr=read_byte_far(seg,offset++);
-
-   biosfn_write_teletype(car,page,attr,WITH_ATTR);
-  }
-
- // Set back curs pos
- if((flag&0x01)==0)
-  biosfn_set_cursor_pos(page,oldcurs);
-}
-#endif
 
 // --------------------------------------------------------------------------------------------
 static void biosfn_write_char_attr (Bit8u car,Bit8u page,Bit8u attr,
@@ -1059,3 +898,164 @@ unsigned char vgaemu_get_pixel(int x, int y, unsigned char page)
  );
  return biosfn_read_pixel(page, x, y);
 }
+
+// --------------------------------------------------------------------------------------------
+static void biosfn_write_teletype(Bit8u car,Bit8u page,Bit8u attr,Bit8u flag)
+{// flag = WITH_ATTR / NO_ATTR
+
+ Bit8u cheight,xcurs,ycurs,bpp;
+ Bit16u nbcols,nbrows,address;
+ Bit16u cursor,dummy;
+ vga_mode_info *vmi = get_vmi();
+ if (!vmi)
+   return;
+
+ // special case if page is 0xff, use current page
+ if(page==0xff)
+  page=read_byte_far(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
+
+ // Get the cursor pos for the page
+ biosfn_get_cursor_pos(page,&dummy,&cursor);
+ xcurs=cursor&0x00ff;ycurs=(cursor&0xff00)>>8;
+
+ // Get the dimensions
+ nbrows=read_byte_far(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1;
+ nbcols=read_word_far(BIOSMEM_SEG,BIOSMEM_NB_COLS);
+
+ switch(car)
+  {
+   case 7:
+    //FIXME should beep
+    break;
+
+   case 8:
+    if(xcurs>0)xcurs--;
+    break;
+
+   case '\r':
+    xcurs=0;
+    break;
+
+   case '\n':
+    ycurs++;
+    break;
+
+   case '\t':
+    do
+     {
+      biosfn_write_teletype(' ',page,attr,flag);
+      biosfn_get_cursor_pos(page,&dummy,&cursor);
+      xcurs=cursor&0x00ff;ycurs=(cursor&0xff00)>>8;
+     }while(xcurs%8==0);
+    break;
+
+   default:
+
+    if(vmi->mode_class==TEXT)
+     {
+      // Compute the address
+      address=SCREEN_MEM_START(nbcols,nbrows,page)+(xcurs+ycurs*nbcols)*2;
+
+      // Write the char
+      write_byte_far(vmi->buffer_start,address,car);
+
+      if(flag==WITH_ATTR)
+       write_byte_far(vmi->buffer_start,address+1,attr);
+     }
+    else
+     {
+      address=READ_WORD(BIOS_VIDEO_MEMORY_USED)*page;
+      cheight=read_byte_far(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT);
+      bpp=vmi->color_bits;
+      switch(vmi->type)
+       {
+        case PLANAR4:
+        case PLANAR1:
+          write_gfx_char_pl4(address,car,attr,xcurs,ycurs,nbcols,cheight);
+          break;
+        case CGA:
+          write_gfx_char_cga(address,car,attr,xcurs,ycurs,nbcols,bpp);
+          break;
+        case LINEAR8:
+          write_gfx_char_lin(address,car,attr,xcurs,ycurs,nbcols,cheight);
+          break;
+#ifdef DEBUG
+        default:
+          unimplemented();
+#endif
+       }
+     }
+    xcurs++;
+  }
+
+ // Do we need to wrap ?
+ if(xcurs==nbcols)
+  {xcurs=0;
+   ycurs++;
+  }
+
+ // Do we need to scroll ?
+ if(ycurs==nbrows)
+  {
+   if(vmi->mode_class==TEXT)
+    {
+     address=SCREEN_MEM_START(nbcols,nbrows,page)+(xcurs+(ycurs-1)*nbcols)*2;
+     attr=read_byte_far(vmi->buffer_start,address+1);
+     biosfn_scroll(0x01,attr,0,0,nbrows-1,nbcols-1,page,SCROLL_UP);
+    }
+   else
+    {
+     biosfn_scroll(0x01,0x00,0,0,nbrows-1,nbcols-1,page,SCROLL_UP);
+    }
+   ycurs-=1;
+  }
+
+ // Set the cursor for the page
+ cursor=ycurs; cursor<<=8; cursor+=xcurs;
+ biosfn_set_cursor_pos(page,cursor);
+}
+
+void vgaemu_put_char(unsigned char c, unsigned char page, unsigned char attr)
+{
+ vga_msg(
+    "vgaemu_put_char: page %d, char 0x%02x, attr 0x%02x\n",
+    page, c, attr
+ );
+
+ biosfn_write_teletype(c, page, attr, NO_ATTR);
+}
+
+#if 0
+// --------------------------------------------------------------------------------------------
+static void biosfn_write_string(Bit8u flag,Bit8u page,Bit8u attr,Bit16u count,
+    Bit8u row,Bit8u col,Bit16u seg,Bit16u offset)
+{
+ Bit16u newcurs,oldcurs,dummy;
+ Bit8u car;
+
+ // Read curs info for the page
+ biosfn_get_cursor_pos(page,&dummy,&oldcurs);
+
+ // if row=0xff special case : use current cursor position
+ if(row==0xff)
+  {col=oldcurs&0x00ff;
+   row=(oldcurs&0xff00)>>8;
+  }
+
+ newcurs=row; newcurs<<=8; newcurs+=col;
+ biosfn_set_cursor_pos(page,newcurs);
+
+ while(count--!=0)
+  {
+   car=read_byte_far(seg,offset++);
+   if((flag&0x02)!=0)
+    attr=read_byte_far(seg,offset++);
+
+   biosfn_write_teletype(car,page,attr,WITH_ATTR);
+  }
+
+ // Set back curs pos
+ if((flag&0x01)==0)
+  biosfn_set_cursor_pos(page,oldcurs);
+}
+#endif

--- a/src/base/bios/vgabios.c
+++ b/src/base/bios/vgabios.c
@@ -63,6 +63,7 @@
 #define read_byte_far(seg, off) (read_byte(SEGOFF2LINEAR(seg, off)))
 #define read_bda_byte(off) (read_byte_far(BIOSMEM_SEG, off))
 #define write_byte_far(seg, off, val) (write_byte(SEGOFF2LINEAR(seg, off), val))
+#define write_bda_byte(off, val) (write_byte_far(BIOSMEM_SEG, off, val))
 #define read_word_far(seg, off) (read_word(SEGOFF2LINEAR(seg, off)))
 #define read_bda_word(off) (read_word_far(BIOSMEM_SEG, off))
 #define write_word_far(seg, off, val) (write_word(SEGOFF2LINEAR(seg, off), val))
@@ -201,6 +202,51 @@ void vgaemu_set_cursor_shape(int cs, int ce)
 {
   biosfn_set_cursor_shape(cs, ce);
   vga_msg("mapped cursor: start %d, end %d\n", cs, ce);
+}
+
+// --------------------------------------------------------------------------------------------
+static void biosfn_set_active_page (
+Bit8u page)
+{
+ Bit16u cursor,crtc_addr;
+ Bit16u pgsize,address;
+
+ if(page>7)return;
+
+ // Get pos curs pos for the right page
+ cursor=get_cursor_pos(page);
+
+ // Get the page size
+ pgsize=read_bda_word(BIOSMEM_PAGE_SIZE);
+
+ // Calculate the mem address
+ address=pgsize*page;
+ write_bda_word(BIOSMEM_CURRENT_START,address);
+
+ // Now the CRTC start address
+ address>>=1;
+
+ // CRTC regs 0x0c and 0x0d
+ crtc_addr=read_bda_word(BIOSMEM_CRTC_ADDRESS);
+ port_outb(crtc_addr,0x0c);
+ port_outb(crtc_addr+1,(address&0xff00)>>8);
+ port_outb(crtc_addr,0x0d);
+ port_outb(crtc_addr+1,address&0x00ff);
+
+ // And change the BIOS page
+ write_bda_byte(BIOSMEM_CURRENT_PAGE,page);
+
+#ifdef DEBUG
+ v_printf("Set active page %02x address %04x\n",page,address);
+#endif
+
+ // Display the cursor, now the page is active
+ set_cursor_pos(page,cursor);
+}
+
+void vgaemu_set_active_page(unsigned page)
+{
+  biosfn_set_active_page(page);
 }
 
 // --------------------------------------------------------------------------------------------

--- a/src/base/bios/vgabios.c
+++ b/src/base/bios/vgabios.c
@@ -163,6 +163,47 @@ void vgaemu_get_cursor_pos(Bit8u page, Bit16u *shape, Bit16u *pos)
 }
 
 // --------------------------------------------------------------------------------------------
+static void biosfn_set_cursor_shape(
+Bit8u CH,Bit8u CL)
+{Bit16u cheight,curs,crtc_addr;
+ Bit8u modeset_ctl;
+
+ CH&=0x3f;
+ CL&=0x1f;
+
+ curs=(CH<<8)+CL;
+ write_bda_word(BIOSMEM_CURSOR_TYPE,curs);
+
+ modeset_ctl=read_bda_byte(BIOSMEM_MODESET_CTL);
+ cheight = read_bda_word(BIOSMEM_CHAR_HEIGHT);
+ if((modeset_ctl&0x01) && (cheight>8) && (CL<8) && (CH<0x20))
+  {
+   if(CL!=(CH+1))
+    {
+     CH = ((CH+1) * cheight / 8) -1;
+    }
+   else
+    {
+     CH = ((CL+1) * cheight / 8) - 2;
+    }
+   CL = ((CL+1) * cheight / 8) - 1;
+  }
+
+ // CTRC regs 0x0a and 0x0b
+ crtc_addr=read_word_far(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
+ port_outb(crtc_addr,0x0a);
+ port_outb(crtc_addr+1,CH);
+ port_outb(crtc_addr,0x0b);
+ port_outb(crtc_addr+1,CL);
+}
+
+void vgaemu_set_cursor_shape(int cs, int ce)
+{
+  biosfn_set_cursor_shape(cs, ce);
+  vga_msg("mapped cursor: start %d, end %d\n", cs, ce);
+}
+
+// --------------------------------------------------------------------------------------------
 static void vgamem_copy_pl4(Bit16u vstart,
 Bit8u xstart,Bit8u ysrc,Bit8u ydest,Bit8u cols,Bit8u nbcols,Bit8u cheight)
 {

--- a/src/base/bios/vgabios.c
+++ b/src/base/bios/vgabios.c
@@ -126,6 +126,11 @@ static void biosfn_set_cursor_pos(Bit8u page,Bit16u cursor)
   }
 }
 
+void vgaemu_set_cursor_pos(unsigned page, int x, int y)
+{
+  biosfn_set_cursor_pos(page, (y << 8) | x);
+}
+
 // --------------------------------------------------------------------------------------------
 static void set_cursor_pos(Bit8u page,Bit16u cursor)
 {

--- a/src/base/bios/vgabios.h
+++ b/src/base/bios/vgabios.h
@@ -51,8 +51,4 @@ typedef unsigned short Boolean;
 #define NO_ATTR     2
 #define WITH_ATTR   3
 
-#define SCREEN_SIZE(x,y) (((x*y*2)|0x00ff)+1)
-#define SCREEN_MEM_START(x,y,p) ((((x*y*2)|0x00ff)+1)*p)
-#define SCREEN_IO_START(x,y,p) ((((x*y)|0x00ff)+1)*p)
-
 #endif

--- a/src/base/bios/vgabios.h
+++ b/src/base/bios/vgabios.h
@@ -1,6 +1,15 @@
 #ifndef vgabios_h_included
 #define vgabios_h_included
 
+void vgaemu_scroll(int x0, int y0, int x1, int y1, int n, unsigned char attr);
+void vgaemu_put_char(unsigned char c, unsigned char page, unsigned char attr);
+void vgaemu_repeat_char(unsigned char c, unsigned char page,
+    unsigned char attr, int count);
+void vgaemu_repeat_char_attr(unsigned char c, unsigned char page,
+    unsigned char attr, int count);
+void vgaemu_put_pixel(int x, int y, unsigned char page, unsigned char attr);
+unsigned char vgaemu_get_pixel(int x, int y, unsigned char page);
+
 /* Types */
 #if 0
 typedef unsigned char  Bit8u;

--- a/src/base/bios/vgabios.h
+++ b/src/base/bios/vgabios.h
@@ -4,6 +4,7 @@
 void vgaemu_set_cursor_shape(int cs, int ce);
 void vgaemu_set_cursor_pos(unsigned page, int x, int y);
 void vgaemu_get_cursor_pos(Bit8u page,Bit16u *shape,Bit16u *pos);
+void vgaemu_set_active_page(unsigned page);
 void vgaemu_scroll(int x0, int y0, int x1, int y1, int n, unsigned char attr);
 void vgaemu_put_char(unsigned char c, unsigned char page, unsigned char attr);
 void vgaemu_repeat_char(unsigned char c, unsigned char page,

--- a/src/base/bios/vgabios.h
+++ b/src/base/bios/vgabios.h
@@ -1,6 +1,7 @@
 #ifndef vgabios_h_included
 #define vgabios_h_included
 
+void vgaemu_set_cursor_pos(unsigned page, int x, int y);
 void vgaemu_get_cursor_pos(Bit8u page,Bit16u *shape,Bit16u *pos);
 void vgaemu_scroll(int x0, int y0, int x1, int y1, int n, unsigned char attr);
 void vgaemu_put_char(unsigned char c, unsigned char page, unsigned char attr);

--- a/src/base/bios/vgabios.h
+++ b/src/base/bios/vgabios.h
@@ -1,6 +1,7 @@
 #ifndef vgabios_h_included
 #define vgabios_h_included
 
+void vgaemu_set_cursor_shape(int cs, int ce);
 void vgaemu_set_cursor_pos(unsigned page, int x, int y);
 void vgaemu_get_cursor_pos(Bit8u page,Bit16u *shape,Bit16u *pos);
 void vgaemu_scroll(int x0, int y0, int x1, int y1, int n, unsigned char attr);

--- a/src/base/bios/vgabios.h
+++ b/src/base/bios/vgabios.h
@@ -1,6 +1,7 @@
 #ifndef vgabios_h_included
 #define vgabios_h_included
 
+void vgaemu_get_cursor_pos(Bit8u page,Bit16u *shape,Bit16u *pos);
 void vgaemu_scroll(int x0, int y0, int x1, int y1, int n, unsigned char attr);
 void vgaemu_put_char(unsigned char c, unsigned char page, unsigned char attr);
 void vgaemu_repeat_char(unsigned char c, unsigned char page,

--- a/src/base/video/text.c
+++ b/src/base/video/text.c
@@ -278,10 +278,10 @@ static void draw_cursor(void)
  */
 static void redraw_cursor(void)
 {
-  if (prev_cursor_shape != NO_CURSOR)
+  if (!(prev_cursor_shape & NO_CURSOR))
     restore_cell(prev_cursor_location);
 
-  if (vga.crtc.cursor_shape.w != NO_CURSOR)
+  if (!(vga.crtc.cursor_shape.w & NO_CURSOR))
     draw_cursor();
 
   prev_cursor_location = memoffs_to_location(vga.crtc.cursor_location);
@@ -521,7 +521,7 @@ static void update_cursor(void)
     return;
   }
   pthread_rwlock_unlock(&rdrw_mtx);
-  if (vga.crtc.cursor_shape.w == NO_CURSOR)
+  if (vga.crtc.cursor_shape.w & NO_CURSOR)
     return;
   if (memoffs_to_location(vga.crtc.cursor_location) !=
 	prev_cursor_location) {

--- a/src/include/bios.h
+++ b/src/include/bios.h
@@ -47,14 +47,9 @@ extern "C" {
 #define BIOS_VIDEO_MEMORY_USED          0x44c
 #define BIOS_VIDEO_MEMORY_ADDRESS       0x44e
 
-#define set_bios_cursor_x_position(screen, val) \
-                        LOWMEM_WRITE_BYTE(0x450 + 2*(screen), (val))
 #define get_bios_cursor_x_position(screen) \
                         LOWMEM_READ_BYTE(0x450 + 2*(screen))
 
-
-#define set_bios_cursor_y_position(screen, val) \
-                        LOWMEM_WRITE_BYTE(0x451 + 2*(screen), (val))
 #define get_bios_cursor_y_position(screen) \
                         LOWMEM_READ_BYTE(0x451 + 2*(screen))
 

--- a/src/include/vgaemu.h
+++ b/src/include/vgaemu.h
@@ -511,14 +511,6 @@ void vga_mark_dirty(dosaddr_t addr, int len);
 void dirty_all_vga_colors(void);
 int changed_vga_colors(void (*upd_func)(DAC_entry *, int, void *), void *arg);
 void vgaemu_adj_cfg(unsigned, unsigned);
-void vgaemu_scroll(int x0, int y0, int x1, int y1, int n, unsigned char attr);
-void vgaemu_put_char(unsigned char c, unsigned char page, unsigned char attr);
-void vgaemu_repeat_char(unsigned char c, unsigned char page,
-    unsigned char attr, int count);
-void vgaemu_repeat_char_attr(unsigned char c, unsigned char page,
-    unsigned char attr, int count);
-void vgaemu_put_pixel(int x, int y, unsigned char page, unsigned char attr);
-unsigned char vgaemu_get_pixel(int x, int y, unsigned char page);
 unsigned char vga_read(unsigned addr);
 void vga_write(unsigned addr, unsigned char val);
 unsigned short vga_read_word(unsigned addr);


### PR DESCRIPTION
This PR is a step towards separating bios from internal hardware state for VGA.

I synced vgabios.c as much as possible with upstream (they've moved a lot to asm so this means the C code).
Moving cursor/scroll routines there were a few differences in behavior, checking with real BIOS, sometimes it was a bug in vgabios (ignoring equipment byte, unconditional cursor shape get), sometimes in dosemu2 (mono attr workaround, handling of invisible cursor bit in shape).