### PR TITLE
simx86: fix UD exception from REP op

### DIFF
--- a/src/base/emu-i386/simx86/interp.c
+++ b/src/base/emu-i386/simx86/interp.c
@@ -1912,6 +1912,9 @@ repag0:
 					if (debug_level('e')>4)
 					    e_printf("ADDRoverride: new _mode %04x\n",repmod);
 					PC++; goto repag0;
+				default:
+					e_printf("illegal op: rep %x\n", repop);
+					goto illegal_op;
 			}
 			if ((_mode & MSSTP) && !(repmod & (MREP|MREPNE))) {
 				/* with TF set, we use LOOP instead of REP so we can stop at


### PR DESCRIPTION
It was skipping REP prefix before raising.
The cause was a missing "default" case in REP switch. This fix is needed for compatibility with dj32, which requires the precise exceptions from REP-prefixed UD.