### PR TITLE
fdpp: Allow unprefixed logging to be indicated

### DIFF
--- a/src/plugin/fdpp/fdpp.c
+++ b/src/plugin/fdpp/fdpp.c
@@ -116,13 +116,16 @@ static void fdpp_panic(const char *msg)
 
 static void fdpp_print(int prio, const char *format, va_list ap)
 {
-    switch(prio) {
+    switch(prio & 0xffff) {
     case FDPP_PRINT_TERMINAL:
         vfprintf(stderr, format, ap);
         break;
     case FDPP_PRINT_LOG:
         if (debug_level('f')) {
-            log_printf("fdpp: ");
+#ifdef FDPP_PRINT_LOG_NOPREFIX
+            if (!(prio & FDPP_PRINT_LOG_NOPREFIX))
+#endif
+                log_printf("fdpp: ");
             vlog_printf(format, ap);
         }
         break;

--- a/test/func_mfs_read_write.py
+++ b/test/func_mfs_read_write.py
@@ -1,9 +1,9 @@
 def mfs_file_read(self, nametype):
     if nametype == "LFN":
-        testname = "verylongname.txt"
+        testfile = "verylongname.txt"
         disablelfn = ""
     elif nametype == "SFN":
-        testname = "shrtname.txt"
+        testfile = "shrtname.txt"
         disablelfn = "set LFN=n"
     else:
         raise ValueError("Incorrect argument")
@@ -11,14 +11,14 @@ def mfs_file_read(self, nametype):
     testdata = self.mkstring(128)
     testdir = self.mkworkdir('d')
 
-    self.mkfile("testit.bat", """\
-%s
+    self.mkfile("testit.bat", f"""\
+{disablelfn}
 d:
-c:\\mfsread %s %s
+c:\\mfsread {testfile}
 rem end
-""" % (disablelfn, testname, testdata), newline="\r\n")
+""", newline="\r\n")
 
-    self.mkfile(testname, testdata, dname=testdir)
+    self.mkfile(testfile, testdata, dname=testdir)
 
     # compile sources
     self.mkexe_with_djgpp("mfsread", r"""
@@ -66,11 +66,11 @@ $_floppy_a = ""
 def mfs_file_write(self, nametype, operation):
     if nametype == "LFN":
         ename = "mfslfn"
-        testname = "verylongname.txt"
+        testfile = "verylongname.txt"
         disablelfn = ""
     elif nametype == "SFN":
         ename = "mfssfn"
-        testname = "shrtname.txt"
+        testfile = "shrtname.txt"
         disablelfn = "set LFN=n"
     else:
         raise ValueError("Incorrect argument")
@@ -101,15 +101,15 @@ def mfs_file_write(self, nametype, operation):
     testdata = self.mkstring(64)   # need to be fairly short to pass as arg
     testdir = self.mkworkdir('d')
 
-    self.mkfile("testit.bat", """\
-%s
+    self.mkfile("testit.bat", f"""\
+{disablelfn}
 d:
-c:\\%s %s %s
+c:\\{ename} {testfile} {testdata}
 rem end
-""" % (disablelfn, ename, testname, testdata), newline="\r\n")
+""", newline="\r\n")
 
     if operation != "create" and operation != "createreadonly":
-        self.mkfile(testname, testprfx, dname=testdir)
+        self.mkfile(testfile, testprfx, dname=testdir)
 
     # compile sources
     self.mkexe_with_djgpp(ename, r"""
@@ -158,7 +158,7 @@ $_floppy_a = ""
     self.assertNotIn("open failed", results)
 
     try:
-        filedata = (testdir / testname).read_text()
+        filedata = (testdir / testfile).read_text()
     except Exception as e:   # Ensure we 'FAIL' not 'ERROR'
         raise self.failureException(e) from None
 


### PR DESCRIPTION
FDPP kernel can assemble logging lines iteratively, so we end up with the locally applied "fdpp: " prefix multiple times in the output. Allow the caller to add "@" to the front of the string to indicate that it shouldn't be prefixed and to print the remainder.