### PR TITLE
Ci 266

### DIFF
--- a/.github/workflows/test-suite-worker.yml
+++ b/.github/workflows/test-suite-worker.yml
@@ -58,6 +58,10 @@ jobs:
         sysctl -a
         echo "::endgroup::"
 
+        echo "::group::KVM permissions"
+        getfacl -p /dev/kvm
+        echo "::endgroup::"
+
     - name: Package install
       run: ./ci_prereq.sh
 

--- a/ci_test.sh
+++ b/ci_test.sh
@@ -40,7 +40,7 @@ set +e
 
 cat >&2 << EOF
 =====================================================
-=         Tests run on KVM and emulated CPU         =
+=      Tests run on emulated CPU, KVM and VM86      =
 =====================================================
 EOF
 env NO_FAILFAST=1 python3 test/test_processor.py

--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -979,6 +979,14 @@ class MyTestResult(unittest.TextTestResult):
             self.stop()
 
     def addSkip(self, test, reason):
+        # Class setup skips wrap the suite state in a '_ErrorHolder' object
+        if type(test).__name__ == '_ErrorHolder':
+            # This triggers unittest's internal _write_status generator
+            # to cleanly output 'None ... ' exactly once.
+            self._newline = True
+            #if hasattr(self.stream, 'startTestRun'):       # doesn't seem to be necessary, leave here in case it is.
+            #    self.stream.startTestRun = False
+
         if reason.startswith("ACCEPTEDFAIL\n"):
             if self.showAll:
                 if self.with_color_terminal:

--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -273,10 +273,9 @@ class BaseTestCase(object):
                         reason = "Blacklisted kernel [6.11 - 6.13]"
 
             except FileNotFoundError:
-                pass
+                reason = "Device file /dev/kvm does not exist"
             except PermissionError:
-                op = check_output(["getfacl", "/dev/kvm"])
-                reason = "Permissions wrong on /dev/kvm\n%s" % op.decode('ASCII')
+                reason = "Permissions wrong on /dev/kvm"
 
             if cls.use_cpu == 'kvm':
                 if not cls.have_kvm:

--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -253,6 +253,13 @@ class BaseTestCase(object):
                 print(" \nUsing Emulation", file=stderr, flush=True)
                 return
 
+            if cls.use_cpu == 'vm86':
+                if not cls.have_vm86:
+                    print(" \nUsing VM86", file=stderr, flush=True)
+                    raise unittest.SkipTest("VM86 not available: 32bit x86 only")
+                print(" \nUsing VM86 32bit x86", file=stderr, flush=True)
+                return
+
             reason = ""
             try:
                 with open("/dev/kvm", "r+b"):
@@ -273,7 +280,7 @@ class BaseTestCase(object):
 
             if cls.use_cpu == 'kvm':
                 if not cls.have_kvm:
-                    print(" \nUsing KVM ", end='', file=stderr, flush=True)
+                    print(" \nUsing KVM", file=stderr, flush=True)
                     raise unittest.SkipTest("KVM not available: %s" % reason)
                 print(" \nUsing KVM", file=stderr, flush=True)
                 return

--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -828,11 +828,14 @@ class BaseTestCase(object):
 class MyTestResult(unittest.TextTestResult):
 
     with_color_terminal = False
+    no_unlink_logs = False
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if (self.stream.isatty() or environ.get("CI")) and not environ.get("NO_COLOR"):
             self.with_color_terminal = True
+        if environ.get("NO_RMLOGS", "0") == "1":
+            self.no_unlink_logs = True
 
     def getDescription(self, test):
         if 'SubTest' in strclass(test.__class__):
@@ -945,8 +948,9 @@ class MyTestResult(unittest.TextTestResult):
 
     def addExpectedFailure(self, test, err):
         super().addExpectedFailure(test, err)
-        for _, l in test.logfiles.items():
-            l[0].unlink(missing_ok=True)
+        if not self.no_unlink_logs:
+            for _, l in test.logfiles.items():
+                l[0].unlink(missing_ok=True)
 
     def addFailure(self, test, err):
         if self.showAll:
@@ -979,8 +983,9 @@ class MyTestResult(unittest.TextTestResult):
                 self.stream.flush()
 
             # Remove the logfiles which will trip the overall failure logic
-            for _, l in test.logfiles.items():
-                l[0].unlink(missing_ok=True)
+            if not self.no_unlink_logs:
+                for _, l in test.logfiles.items():
+                    l[0].unlink(missing_ok=True)
             test.logfiles = {}
         else:
             super().addSkip(test, reason)
@@ -998,8 +1003,9 @@ class MyTestResult(unittest.TextTestResult):
             self.stream.write('.')
             self.stream.flush()
 
-        for _, l in test.logfiles.items():
-            l[0].unlink(missing_ok=True)
+        if not self.no_unlink_logs:
+            for _, l in test.logfiles.items():
+                l[0].unlink(missing_ok=True)
 
     def addSubTest(self, test, subtest, err):
         super(MyTestResult, self).addSubTest(test, subtest, err)
@@ -1042,6 +1048,7 @@ def main_setup(cases):
                   "  NO_KVM=1             Disables KVM, equivalent to autodetection not finding /dev/kvm\n" +
                   "  NO_ACCEPTFAILURES=1  Disables the acceptFailure mechanism so promoting test failures to FAIL\n" +
                   "  NO_TESTRUN=1         Exit the test runner after setting up the test environment and print the command line to be used\n" +
+                  "  NO_RMLOGS=1          Don't delete the logfiles on successful runs, only really useful for local testing\n" +
                   "  SKIP_EXPENSIVE=1     Tests that have been marked as expensive are not run\n" +
                   "  SKIP_NATIVE_DPMI=1   Tests that use native DPMI are not run\n")
             exit(0)

--- a/test/fpu/qemu.py
+++ b/test/fpu/qemu.py
@@ -21,8 +21,6 @@ CTESTS = [
 ]
 
 EMU_TESTS = (
-    ('native', 'native'), #  CPU native vm86(i386 only) + native DPMI
-
     ('jit',    'native'), #  CPU JIT vm86 + native DPMI
     ('sim',    'native'), #  CPU simulated vm86 + native DPMI
 
@@ -38,6 +36,10 @@ KVM_TESTS = (
 
     ('jit',    'kvm'),    #  CPU JIT vm86 + KVM DPMI
     ('sim',    'kvm'),    #  CPU simulated vm86 + KVM DPMI
+)
+
+VM86_TESTS = (
+    ('native', 'native'), #  CPU native vm86(i386 only) + native DPMI
 )
 
 
@@ -136,7 +138,11 @@ def create_test(test):
 
 
 def fpu_create_items(testcase):
-    tests = KVM_TESTS if testcase.use_cpu == 'kvm' else EMU_TESTS
+    tests = {
+        'emu': EMU_TESTS,
+        'kvm': KVM_TESTS,
+        'vm86': VM86_TESTS,
+    }[testcase.use_cpu]
 
     # Insert each test into the testcase
     for ctest in CTESTS:

--- a/test/func_cpu_methods.py
+++ b/test/func_cpu_methods.py
@@ -60,8 +60,6 @@ $_ignore_djgpp_null_derefs = (off)
     self.assertFilesEqual(reffile, dosfile)
 
 EMU_TESTS = (
-    ('native', 'native'), #  CPU native vm86(i386 only) + native DPMI
-
     ('jit',    'native'), #  CPU JIT vm86 + native DPMI
     ('sim',    'native'), #  CPU simulated vm86 + native DPMI
 
@@ -77,6 +75,10 @@ KVM_TESTS = (
 
     ('jit',    'kvm'),    #  CPU JIT vm86 + KVM DPMI
     ('sim',    'kvm'),    #  CPU simulated vm86 + KVM DPMI
+)
+
+VM86_TESTS = (
+    ('native', 'native'), #  CPU native vm86(i386 only) + native DPMI
 )
 
 
@@ -103,8 +105,12 @@ def create_test(test):
 
 
 def cpu_create_items(testcase):
+    tests = {
+        'emu': EMU_TESTS,
+        'kvm': KVM_TESTS,
+        'vm86': VM86_TESTS,
+    }[testcase.use_cpu]
 
-    tests = KVM_TESTS if testcase.use_cpu == 'kvm' else EMU_TESTS
 
     # Insert each test into the testcase
     for test in tests:

--- a/test/func_cpu_trap_flag.py
+++ b/test/func_cpu_trap_flag.py
@@ -4,12 +4,16 @@ from cpuinfo import get_cpu_info
 
 
 def cpu_trap_flag(self):
-    if self.use_cpu == "kvm":
+    if self.use_cpu == "emu":
+        cpu_vm = 'emulated'
+    elif self.use_cpu == "kvm":
         if not self.have_kvm:
             self.skipTest("requires KVM")
         cpu_vm = 'kvm'
-    elif self.use_cpu == "emu":
-        cpu_vm = 'emulated'
+    elif self.use_cpu == "vm86":
+        if not self.have_vm86:
+            self.skipTest("requires vm86() only on 32bit x86")
+        cpu_vm = 'vm86'
     else:
         raise ValueError('invalid self.use_cpu')
 

--- a/test/test_processor.py
+++ b/test/test_processor.py
@@ -41,6 +41,23 @@ class OurTestCase(BaseTestCase):
         fpu_bart_exceptions_fpexes(self)
 
 
+class EMUTestCase(ppdosgit(OurTestCase, {
+        "test_fpu_f2xm1_sim_sim": KNOWNFAIL,
+        "test_fpu_fisttp_jit_jit": UNSUPPORTED,  # Requires Pentium 4 (SSE3)
+        "test_fpu_fisttp_sim_sim": UNSUPPORTED,  # Requires Pentium 4 (SSE3)
+        "test_fpu_fp_exceptions_sim_sim": KNOWNFAIL,
+        "test_fpu_fprem_sim_sim": KNOWNFAIL,
+        "test_fpu_fyl2x_sim_sim": KNOWNFAIL,
+        "test_fpu_fyl2xp1_sim_sim": KNOWNFAIL,
+    })):
+    use_cpu = 'emu'
+
+    @mark('cputest')
+    def test_cpu_trap_flag(self):
+        """CPU Trap Flag"""
+        cpu_trap_flag(self)
+
+
 class KVMTestCase(ppdosgit(OurTestCase, {
         "test_fpu_f2xm1_kvm_sim": KNOWNFAIL,
         "test_fpu_fisttp_kvm_jit": UNSUPPORTED,  # Requires Pentium 4 (SSE3)
@@ -59,16 +76,12 @@ class KVMTestCase(ppdosgit(OurTestCase, {
         cpu_trap_flag(self)
 
 
-class EMUTestCase(ppdosgit(OurTestCase, {
-        "test_fpu_f2xm1_sim_sim": KNOWNFAIL,
+class VM86TestCase(ppdosgit(OurTestCase, {
+        # Unknown
         "test_fpu_fisttp_jit_jit": UNSUPPORTED,  # Requires Pentium 4 (SSE3)
         "test_fpu_fisttp_sim_sim": UNSUPPORTED,  # Requires Pentium 4 (SSE3)
-        "test_fpu_fp_exceptions_sim_sim": KNOWNFAIL,
-        "test_fpu_fprem_sim_sim": KNOWNFAIL,
-        "test_fpu_fyl2x_sim_sim": KNOWNFAIL,
-        "test_fpu_fyl2xp1_sim_sim": KNOWNFAIL,
     })):
-    use_cpu = 'emu'
+    use_cpu = 'vm86'
 
     @mark('cputest')
     def test_cpu_trap_flag(self):
@@ -81,6 +94,7 @@ if __name__ == '__main__':
     cases = [
         EMUTestCase,
         KVMTestCase,
+        VM86TestCase,
     ]
 
     # Dynamically create tests


### PR DESCRIPTION
A few CI tweaks. Highlights are:

  - New environment variable (NO_RMLOGS) to allow retention of all logs, even on success. Only really useful for local testing as it defeats the failure detection logic in the CI.
  - Split the vm86 native tests in `test_processor.py` out to a separate class so they only get to run on a 32 bit kernel. Avoids all the individual test skips, and replaces them with one class skip. 