### PR TITLE
BIOS: tidy up offsets 0xfffd and 0xffff

### DIFF
--- a/src/base/bios/x86/bios.S
+++ b/src/base/bios/x86/bios.S
@@ -1125,9 +1125,11 @@ INT71_OFF:
 /* COMPAS FFFF5		ROM BIOS date */
 	.ascii	"02/25/93"  /* our bios date */
 /* COMPAS FFFFD		unused */
-	hlt
+	.byte   0x0    /* useful for ensuring termination of the bios date string */
 /* COMPAS FFFFE		system model ID */
 	.byte	0xfc   /* model byte = IBM AT */
+/* COMPAS FFFFF		known to be a submodel byte, a checksum byte or simply padding */
+	.byte   0x0    /* padding */
 
 	.globl  bios_f000_end
 bios_f000_end:


### PR DESCRIPTION
Fixes #2926

0xfffd was a hlt instruction(0xf4)
0xffff was missing (our bios was short)

Incidentally https://flint.cs.yale.edu/feng/cos/resources/BIOS/mem.htm has 0xffff as a submodel byte with these values

Model |	Model byte | Submodel byte |
------|------------|-------------- |
PC | FF | - |
Portable PC | FE | 00 |
XT model 256 | FC | 02 |
PS/2 model 30 | FA | 00 |
PS/2 model 60 | FC | 04 |
PS/2 model 80 | F8 | 01 |

Qemu's `./pc-bios/bios.bin`
~~~
01ffe0 80 fa 80 80 d9 00 66 0f b6 d1 e9 bf c2 cd 1b cb  >......f.........<
01fff0 ea 5b e0 00 f0 30 36 2f 32 33 2f 39 39 00 fc 00  >.[...06/23/99...<
020000
~~~

Dosemu's existing `./src/base/bios/x86/bios.o.bin`
~~~
001fe0 24 44 4f 53 45 4d 55 24 00 00 00 02 00 00 00 00  >$DOSEMU$........<
001ff0 ea 5b e0 00 f0 30 32 2f 32 35 2f 39 33 f4 fc     >.[...02/25/93..<
001fff
~~~

Dosemu's with this commit
~~~
001fe0 24 44 4f 53 45 4d 55 24 00 00 00 02 00 00 00 00  >$DOSEMU$........<
001ff0 ea 5b e0 00 f0 30 32 2f 32 35 2f 39 33 00 fc 00  >.[...02/25/93...<
002000
~~~