### PR TITLE
CI: Check for timeout before assertFilesEqual()

### DIFF
--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -701,10 +701,6 @@ class BaseTestCase(object):
                 if eofisok:
                     trms += [pexpect.EOF,]
                 myexpect(child, trms, timeout=timeout)
-                if outfile is None:
-                    ret += child.before.decode('cp437', 'replace')
-                else:
-                    ret = outfile.read_text()
             except pexpect.TIMEOUT as e:
                 ret = f"Timeout: {e.my['timeout']} seconds waiting for {e.my['pattern']}\n"
                 tlog = self.logfiles['log'][0].read_text()
@@ -713,6 +709,11 @@ class BaseTestCase(object):
                     self.shouldStop = True
             except pexpect.EOF as e:
                 ret = f"EndOfFile: waiting for {e.my['pattern']}\n"
+            finally:
+                if outfile is None:
+                    ret += child.before.decode('cp437', 'replace')
+                else:
+                    ret += outfile.read_text()
 
         try:
             child.close(force=True)

--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -1,5 +1,6 @@
 import inspect
 import pexpect
+import termios
 import string
 import random
 import re
@@ -660,6 +661,14 @@ class BaseTestCase(object):
             _exit(0)  # Don't let unittest handle it, just exit
 
         child = pexpect.spawn(dbin, args)
+
+        # Tweak the pty to eliminate double CRs
+        fd = child.fileno()
+        attrs = termios.tcgetattr(fd)
+        attrs[1] &= ~termios.ONLCR
+        # attrs[1] |= termios.OCRNL     # turns any CRs left into NL - horrible
+        termios.tcsetattr(fd, termios.TCSANOW, attrs)
+
         ret = ''
         with open(self.logfiles['xpt'][0], "wb") as fout:
             child.logfile = fout

--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -751,13 +751,13 @@ class BaseTestCase(object):
             ret = check_output(args, cwd=cwd, timeout=timeout, stderr=STDOUT).decode(
                 'ASCII', errors='backslashreplace')
         except CalledProcessError as e:
+            ret = 'NonZeroReturn:%d\n' % e.returncode
             if e.output is not None:
-                ret = e.output.decode('ASCII', errors='backslashreplace')
-            ret += '\nNonZeroReturn:%d\n' % e.returncode
+                ret += e.output.decode('ASCII', errors='backslashreplace')
         except TimeoutExpired as e:
+            ret = 'Timeout:%d seconds\n' % timeout
             if e.output is not None:
-                ret = e.output.decode('ASCII', errors='backslashreplace')
-            ret += '\nTimeout:%d seconds\n' % timeout
+                ret += e.output.decode('ASCII', errors='backslashreplace')
             # Now wait for any further logging from dosemu as hopefully it's
             # dying.
             sleep(5)

--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -719,6 +719,7 @@ class BaseTestCase(object):
         except PtyProcessError:
             pass
 
+        self.assertNotIn('Timeout:', ret)
         return ret
 
     def runDosemuCmdline(self, xargs, cwd=None, config=DOSEMU_CONF_DEFAULT, timeout=None):
@@ -762,6 +763,7 @@ class BaseTestCase(object):
         finally:
             self.logfiles['xpt'][0].write_text(ret)
 
+        self.assertNotIn('Timeout:', ret)
         return ret
 
     def assertFilesEqual(self, reffile, dosfile):
@@ -835,7 +837,6 @@ class BaseTestCase(object):
 
         results = self.runDosemu("version.bat")
 
-        self.assertNotIn('Timeout', results)
         self.assertNotIn('NonZeroReturn', results)
         self.assertIn(self.version, results)
 

--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -636,8 +636,11 @@ class BaseTestCase(object):
 
     def runDosemu(self, cmd, opts=None, outfile=None, config=DOSEMU_CONF_DEFAULT, timeout=None,
                     eofisok=False, interactions=[]):
+        default_timeout = int(environ.get("DEFAULT_TIMEOUT", '15'))
         if timeout is None:
-            timeout = int(environ.get("DEFAULT_TIMEOUT", '15'))
+            timeout = default_timeout
+        else:
+            timeout += default_timeout
 
         # Note: if debugging is turned on then times increase 10x
         dbin = str(self.dosemu)
@@ -689,7 +692,7 @@ class BaseTestCase(object):
 
             try:
                 prompt = r'(system -e|unix -e|' + IPROMPT + ')'
-                myexpect(child, [prompt + '[\r\n]*'], timeout=40)
+                myexpect(child, [prompt + '[\r\n]*'], timeout=(default_timeout + 25))
                 myexpect(child, ['>[\r\n]*', pexpect.TIMEOUT], timeout=1)
                 child.send(cmd + '\n')
                 for resp in interactions:
@@ -724,8 +727,11 @@ class BaseTestCase(object):
         return ret
 
     def runDosemuCmdline(self, xargs, cwd=None, config=DOSEMU_CONF_DEFAULT, timeout=None):
+        default_timeout = int(environ.get("DEFAULT_TIMEOUT", '15'))
         if timeout is None:
-            timeout = int(environ.get("DEFAULT_TIMEOUT", '15')) + 15  # A little extra to match the old value
+            timeout = default_timeout
+        else:
+            timeout += default_timeout
 
         args = [str(self.dosemu),
                 "--Fimagedir", str(self.imagedir),

--- a/test/func_build_freecom.py
+++ b/test/func_build_freecom.py
@@ -54,7 +54,6 @@ set PATH=C:\\devel\\watcomc\\binw;C:\\devel\\nasm;C:\\bin;%OLDPATH%
     args = ["-q", "-K", ".", "-E", "build.bat"]
     results = self.runDosemuCmdline(args, cwd=root, timeout=450)
 
-    self.assertNotIn('Timeout', results)
     self.assertNotIn('NonZeroReturn', results)
 
     # Test for resultant command.com file

--- a/test/func_build_freedos.py
+++ b/test/func_build_freedos.py
@@ -58,7 +58,6 @@ set DOS4G=QUIET
     args = ["-q", "-K", ".", "-E", "build.bat"]
     results = self.runDosemuCmdline(args, cwd=root, timeout=120)
 
-    self.assertNotIn('Timeout', results)
     self.assertNotIn('NonZeroReturn', results)
 
     # Test for resultant kernel file

--- a/test/func_build_pcmos.py
+++ b/test/func_build_pcmos.py
@@ -33,7 +33,6 @@ def build_pcmos(self):
     args = ["-q", "-K", r".:SOURCES\src", "-E", "MAKEMOS.BAT", r"path=%D\bin;%O"]
     results = self.runDosemuCmdline(args, cwd=mosroot, timeout=300)
 
-    self.assertNotIn('Timeout', results)
     self.assertNotIn('NonZeroReturn', results)
 
     missing = [str(x.relative_to(mosroot)) for x in outfiles if not x.exists()]

--- a/test/func_misc.py
+++ b/test/func_misc.py
@@ -138,7 +138,6 @@ int main(int argc, char *argv[])
 
     results = self.runDosemuCmdline(["-E", "justerro.com"])
 
-    self.assertNotIn('Timeout', results)
     self.assertIn('NonZeroReturn:53', results)
 
 
@@ -154,7 +153,6 @@ rem end
     args = ["TESTVAR1=" + tstring1, "-E", "testit.bat"]
     results = self.runDosemuCmdline(args)
 
-    self.assertNotIn('Timeout', results)
     self.assertNotIn('NonZeroReturn', results)
     self.assertIn("rem end", results, msg="Test incomplete:\n")
     self.assertIn(tstring1, results)


### PR DESCRIPTION
If we are diffing a DOS program's output file against a reference, we should capture the normal output and check that it didn't timeout before completing the output file.