### PR TITLE
CI: Add 26.04 runner and make it default on some workflows

### DIFF
--- a/.github/workflows/test-suite-manual.yml
+++ b/.github/workflows/test-suite-manual.yml
@@ -23,11 +23,12 @@ on:
       os:
         description: "OS version"
         required: true
-        default: "ubuntu-24.04"
+        default: "ubuntu-26.04"
         type: choice
         options:
           - ubuntu-22.04
           - ubuntu-24.04
+          - ubuntu-26.04
 
 jobs:
   manual:

--- a/.github/workflows/test-suite-scheduled.yml
+++ b/.github/workflows/test-suite-scheduled.yml
@@ -8,22 +8,22 @@ on:
 
 jobs:
   asan:
-    name: Test Suite (asan-simple-ubuntu-24.04)
+    name: Test Suite (asan-simple-ubuntu-26.04)
     if: (github.repository_owner == 'dosemu2')
     uses: ./.github/workflows/test-suite-worker.yml
     with:
       bldtype: 'asan'
       runtype: 'simple'
-      os: 'ubuntu-24.04'
+      os: 'ubuntu-26.04'
 
   full:
-    name: Test Suite (standard-full-ubuntu-24.04)
+    name: Test Suite (standard-full-ubuntu-26.04)
     if: (github.repository_owner == 'dosemu2')
     uses: ./.github/workflows/test-suite-worker.yml
     with:
       bldtype: 'standard'
       runtype: 'full'
-      os: 'ubuntu-24.04'
+      os: 'ubuntu-26.04'
 
   packaged:
     name: Test Suite (packaged-full-*)
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-26.04]
     uses: ./.github/workflows/test-suite-worker.yml
     with:
       bldtype: 'packaged'

--- a/.github/workflows/test-suite-triggered.yml
+++ b/.github/workflows/test-suite-triggered.yml
@@ -13,9 +13,9 @@ on:
 
 jobs:
   triggered:
-    name: "Test Suite (standard-${{ (github.event_name == 'push' && github.repository_owner == 'dosemu' && github.ref_name == 'devel') && 'simple' || 'normal' }}-ubuntu-24.04)"
+    name: "Test Suite (standard-${{ (github.event_name == 'push' && github.repository_owner == 'dosemu' && github.ref_name == 'devel') && 'simple' || 'normal' }}-ubuntu-26.04)"
     uses: ./.github/workflows/test-suite-worker.yml
     with:
       bldtype: 'standard'
       runtype: ${{ (github.event_name == 'push' && github.repository_owner == 'dosemu' && github.ref_name == 'devel') && 'simple' || 'normal' }}
-      os: 'ubuntu-24.04'
+      os: 'ubuntu-26.04'

--- a/ci_build_or_install.sh
+++ b/ci_build_or_install.sh
@@ -5,11 +5,11 @@ set -e
 if [ "${BLDTYPE}" = "packaged" ] ; then
   echo "Adding dosemu2 PPA..."
   sudo add-apt-repository -y -c main -c main/debug ppa:dosemu2/ppa
-  sudo apt install -y \
-    dosemu2 \
-    dosemu2-dbgsym \
-    fdpp \
-    fdpp-dbgsym
+  sudo apt install -y -f \
+    dosemu2 dosemu2-dbgsym \
+    libfdldr35 libfdldr35-dbgsym \
+    libfdpp35 libfdpp35-dbgsym \
+
   exit 0
 fi
 
@@ -36,20 +36,26 @@ git clone --depth 1 --no-single-branch https://github.com/dosemu2/fdpp.git ${LOC
   fi
 
   echo "Configuring PPAs..."
-  # Install the build dependancies based FDPP's debian/control file
-  sudo add-apt-repository ppa:stsp-0/nasm-segelf
-  sudo add-apt-repository ppa:stsp-0/thunk-gen
+  sudo add-apt-repository -y --no-update ppa:stsp-0/thunk-gen
   sudo apt update -q
-  mk-build-deps --install --root-cmd sudo
+  sudo apt install -f
+
+  # Install the build dependancies based FDPP's debian/control file
+  mk-build-deps --install --root-cmd sudo || sudo apt install ./fdpp-build-deps*.deb --simulate
 
   make
   sudo make install
 )
 
+sudo add-apt-repository -y --no-update -c main -c main/debug ppa:dosemu2/ppa
+sudo apt update -q
+sudo apt install -f
+
+# Remove fdpp-dev from debian build dependencies (use bash as padding)
+sed -i -e 's/fdpp-dev,/bash,/' debian/control
+
 # Install the build dependancies based Dosemu's debian/control file
-sudo add-apt-repository -y -c main -c main/debug ppa:dosemu2/ppa
-mk-build-deps --install --root-cmd sudo
-sudo apt remove -y fdpp
+mk-build-deps --install --root-cmd sudo || sudo apt install ./dosemu2-build-deps*.deb --simulate
 
 if [ "${BLDTYPE}" = "asan" ] ; then
   sed -i 's/asan off/asan on/g' compiletime-settings.devel

--- a/ci_test_prereq.sh
+++ b/ci_test_prereq.sh
@@ -2,9 +2,15 @@
 
 set -e
 
-echo "Configuring PPAs..."
-sudo add-apt-repository -y ppa:jwt27/djgpp-toolchain
-sudo add-apt-repository -y ppa:stsp-0/gcc-ia16
+# Install djgpp and ia16 compilers / libs.
+sudo add-apt-repository -y --no-update ppa:jwt27/djgpp-toolchain
+sudo add-apt-repository -y --no-update ppa:stsp-0/gcc-ia16
+is_amd64v3=$(apt-config dump | grep -q 'Variants.*amd64v3' && echo true || echo false) # APT::Architecture-Variants "amd64v3"
+if [ "$is_amd64v3" = "true" ] ; then
+  # Since there are no host libs to link against we can use amd64 arch on arm64v3
+  sudo sed -i '/^URIs:/i Architectures: amd64' /etc/apt/sources.list.d/jwt27-ubuntu-djgpp-toolchain-resolute.sources
+  sudo sed -i '/^URIs:/i Architectures: amd64' /etc/apt/sources.list.d/stsp-0-ubuntu-gcc-ia16-resolute.sources
+fi
 sudo apt update -q
 
 sudo apt install -y \
@@ -29,9 +35,9 @@ sudo apt install -y \
   libvirt-daemon \
   libvirt-daemon-system
 
-sudo apt install -y \
+sudo apt install -y -f \
   dj64-dbgsym \
-  djdev64-dbgsym
+  libdjdev64-0-dbgsym
 
 # Install the FAT mount helper
 sudo cp test/dosemu_fat_mount.sh /bin/.

--- a/ci_test_prereq.sh
+++ b/ci_test_prereq.sh
@@ -33,7 +33,21 @@ sudo apt install -y \
   dos2unix \
   bridge-utils \
   libvirt-daemon \
-  libvirt-daemon-system
+  libvirt-daemon-system \
+  dnsmasq-base \
+  iptables
+
+if [ -f /etc/os-release ] ; then
+    . /etc/os-release
+    OS_VERSION=${VERSION_ID}
+else
+    OS_VERSION="unknown"
+fi
+if [ "$OS_VERSION" = "26.04" ] ; then
+    sudo virsh net-define /etc/libvirt/qemu/networks/default.xml || true
+    sudo virsh net-start default || true
+    sudo virsh net-autostart default || true
+fi
 
 sudo apt install -y -f \
   dj64-dbgsym \


### PR DESCRIPTION
1/ Switch to the 26.04 Github runner (subarch amd64v3)

2/ Some repositories (maybe external) don't have packages for the new
   Ubuntu subarchitecture "amd64v3". Whilst apparently it is bad practice
   and potentially unreliable to mix plain amd64 packages with amd64v3
   where linking will take place, it's okay if the app is self contained.
   Fortunately this is the case for us, where both problem packages are
   compilers producing non-host binaries. Add detection that the host
   desires amd64v3 packages, and tweak the problem repository definitions
   to access plain amd64 packages.

3/ Avoid doing apt-add-repository's automatic apt update. Run one update
   after adding multiple repositories.

4/ FDPP no longer requires nasm-segelf