### PR TITLE
Serial vmodem fixes

### DIFF
--- a/src/base/serial/ser_init.c
+++ b/src/base/serial/ser_init.c
@@ -256,10 +256,22 @@ static void do_ser_init(int num)
   if (com_cfg[num].end_port == 0)
     com_cfg[num].end_port = com_cfg[num].base_port + 7;
 
+  if (com_cfg[num].vmodem) {
 #ifdef USE_MODEMU
-  if (com_cfg[num].vmodem)
     com_cfg[num].dev = modemu_init(num);
+    if (!com_cfg[num].dev || !com_cfg[num].dev[0]) {
+      /* Don't fall through to the default /dev/ttySx below: a vmodem
+       * port must never silently degrade into opening real hardware. */
+      error("SER%d: vmodem initialization failed\n", num);
+      config.exitearly = 1;
+      return;
+    }
+#else
+    error("SER%d: vmodem support is not compiled in\n", num);
+    config.exitearly = 1;
+    return;
 #endif
+  }
   /* Is the device file undef? */
   if ((!com_cfg[num].dev || !com_cfg[num].dev[0]) && !com_cfg[num].mouse &&
       !com_cfg[num].is_file) {

--- a/src/base/serial/ser_init.c
+++ b/src/base/serial/ser_init.c
@@ -408,11 +408,13 @@ void serial_close(void)
   for (i = 0; i < config.num_ser; i++) {
     if (com[i].opened <= 0)
       continue;
+    /* close the DOS-side fd first: ser_close() operates on the pty
+     * slave, and modemu_done() closes its master */
+    ser_close(i);
 #ifdef USE_MODEMU
     if (com_cfg[i].vmodem)
       modemu_done(i);
 #endif
-    ser_close(i);
   }
 }
 


### PR DESCRIPTION
> PR description drafted by Claude (Fable 5), an LLM by Anthropic, at andy5995's direction.

Two vmodem fixes extracted from PR 2925 (these changes will get removed from that PR):

- When `modemu_init()` fails (a second vmodem port, for example), or when the modemu plugin is not compiled in, `do_ser_init()` fell through to the default-device path and silently opened the real `/dev/ttySx`. It now errors out early.
- `serial_close()` ran `modemu_done()` — which closes the pty master — before `ser_close()`, which still operates on the slave of that pty. Reordered. Harmless with the current plugin, but the order matters once the plugin owns more of the pty's state.