### PR TITLE
serial: report queued bytes from the null-modem driver

### DIFF
--- a/src/base/serial/nullmm.c
+++ b/src/base/serial/nullmm.c
@@ -59,10 +59,7 @@ static void nullmm_tx_buffer_dump(com_t *c)
 
 static int nullmm_get_tx_queued(com_t *c)
 {
-  int idx = get_com_idx(c->cfg->nullmm);
-  if (idx == -1)
-    return -1;
-  return RX_BUF_BYTES(com[idx].num);
+  return 0;
 }
 
 static void nullmm_termios(com_t *c)

--- a/src/base/serial/nullmm.c
+++ b/src/base/serial/nullmm.c
@@ -59,7 +59,10 @@ static void nullmm_tx_buffer_dump(com_t *c)
 
 static int nullmm_get_tx_queued(com_t *c)
 {
-  return 0;
+  int idx = get_com_idx(c->cfg->nullmm);
+  if (idx == -1)
+    return -1;
+  return RX_BUF_BYTES(com[idx].num);
 }
 
 static void nullmm_termios(com_t *c)

--- a/test/func_serial.py
+++ b/test/func_serial.py
@@ -51,3 +51,28 @@ rem end
         self.assertIn('hello', text)
     except FileNotFoundError:
         self.fail(f"file {ofile} was not created")
+
+
+def serial_nullmm_loopback(self):
+    """Two COM ports wired to each other: what DOS writes on one it
+    reads back on the other. Stays well under RX_BUFFER_SIZE, because a
+    single DOS process cannot drain the far end while it is still
+    writing."""
+    payload = "DATA_VIA_NULLMM"
+
+    config = DOSEMU_CONF_DEFAULT
+    config += """\
+$_com1 = "nullmodem 2"
+$_com2 = "nullmodem 1"
+"""
+    # ^Z terminates the `type`, as DOS has no other end-of-input here.
+    self.mkfile("payload.txt", payload + "\r\n\x1a", newline="")
+    self.mkfile("testit.bat", """\
+copy /b payload.txt com1 > nul
+type com2
+rem end
+""", newline="\r\n")
+
+    results = self.runDosemu("testit.bat", config=config)
+
+    self.assertIn(payload, results)

--- a/test/func_serial.py
+++ b/test/func_serial.py
@@ -54,11 +54,17 @@ rem end
 
 
 def serial_nullmm_loopback(self):
-    """Two COM ports wired to each other: what DOS writes on one it
-    reads back on the other. Stays well under RX_BUFFER_SIZE, because a
-    single DOS process cannot drain the far end while it is still
-    writing."""
-    payload = "DATA_VIA_NULLMM"
+    # Two COM ports wired to each other: what DOS writes on one it
+    # reads back on the other. The payload (with CR LF ^Z, 31 bytes)
+    # is under RX_BUFFER_SIZE (128) so add_buf never drops, and over
+    # TX_QUEUE_THRESHOLD (14) so the copy crosses the flow-control
+    # regime: DOS is single-tasking, so nothing drains the peer until
+    # the copy has completed. Both markers asserted separately, so a
+    # truncated transfer fails on the tail marker instead of as an
+    # opaque expect timeout.
+    head = "NULLMM_BEGIN"
+    tail = "NULLMM_END"
+    payload = head + "_data_" + tail
 
     config = DOSEMU_CONF_DEFAULT
     config += """\
@@ -68,11 +74,12 @@ $_com2 = "nullmodem 1"
     # ^Z terminates the `type`, as DOS has no other end-of-input here.
     self.mkfile("payload.txt", payload + "\r\n\x1a", newline="")
     self.mkfile("testit.bat", """\
-copy /b payload.txt com1 > nul
+copy /b payload.txt com1
 type com2
 rem end
 """, newline="\r\n")
 
     results = self.runDosemu("testit.bat", config=config)
 
-    self.assertIn(payload, results)
+    self.assertIn(head, results)
+    self.assertIn(tail, results)

--- a/test/test_dosemu.py
+++ b/test/test_dosemu.py
@@ -66,7 +66,7 @@ from func_findfile import (mfs_findfile_ufs_lfn, mfs_findfile_ufs_sfn,
                            mfs_findfile_vfat_linux_mounted_lfn, mfs_findfile_vfat_linux_mounted_sfn,
                            sfn_findfirst)
 from func_serial import (serial_simple_read_echo, serial_simple_write_file,
-                         lpt_simple_write_pipe)
+                         serial_nullmm_loopback, lpt_simple_write_pipe)
 from func_truename import (mfs_truename_ufs_lfn, mfs_truename_ufs_sfn, mfs_truename_vfat_linux_mounted_lfn,
                            mfs_truename_vfat_linux_mounted_sfn, sfn_truename)
 
@@ -863,6 +863,11 @@ class OurTestCase(BaseTestCase):
     def test_serial_simple_write_file(self):
         """Serial Simple Write File"""
         serial_simple_write_file(self)
+
+    @mark('serialtest')
+    def test_serial_nullmm_loopback(self):
+        """Serial null-modem loopback"""
+        serial_nullmm_loopback(self)
 
     # Obviously not a serial device, but may as well group together
     @mark('serialtest')


### PR DESCRIPTION
> Comment drafted by Claude (Fable 5), an LLM by Anthropic, at andy5995's direction.

Being precise about what the test proves, since it is less than it looks: it wires `$_com1 = "nullmodem 2"` to `$_com2 = "nullmodem 1"`, writes a short line on one port and reads it back on the other. It passes identically with and without the patch. I know that because of a mistake — an early container run picked up the unpatched tree, which turned into a useful control.

The reason it cannot catch this one is the sizing. Flow control only engages once the peer holds more than `TX_QUEUE_THRESHOLD` (14) bytes, and a single DOS process cannot fill the far end while it is also the only thing that drains it. Writing past `RX_BUFFER_SIZE` and reading afterwards deadlocks by construction. If you have a way you would rather see this exercised, I will write it.

One consequence worth naming, reasoned from the code rather than observed. Before the patch a DOS program writing past the peer's 128-byte buffer with nothing draining lost the excess silently, because `add_buf()` refuses and `nullmm_write()` returns 0. With the patch THRE stays clear instead, so a program that honours it waits rather than losing data. Correct for real hardware, and better than silent loss, but it does turn a case that used to complete into one that blocks.

Unrelated, from writing the test: the config keyword is `nullmodem`, while the field and the driver are `nullmm`. The only occurrence outside `src/base/serial/` is the lexer rule, so there is nothing to find by grepping for `nullmm` in a config.
