### PR TITLE
serial: drop DTR/RTS through the driver on reset

### DIFF
--- a/src/base/serial/ser_init.c
+++ b/src/base/serial/ser_init.c
@@ -140,6 +140,12 @@ static void ser_reset_dev(int num)
   com[num].IER = 0;			/* Interrupt Enable Register */
   com[num].LCR = UART_LCR_WLEN8;	/* Line Control Register: 5N1 */
   com[num].FCReg = 0; 			/* FIFO Control Register */
+  if (com[num].opened > 0) {
+    if (com[num].MCR & UART_MCR_DTR)
+      serial_dtr(num, 0);
+    if ((com[num].MCR & UART_MCR_RTS) && !com_cfg[num].system_rtscts)
+      serial_rts(num, 0);
+  }
   com[num].MCR = 0;			/* Modem Control Register */
 }
 


### PR DESCRIPTION
> Body drafted by Claude (Opus 5) at andy5995's direction.

put_mcr() is the only path that reaches serial_dtr(), and it runs only when DOS writes MCR. ser_reset_dev() cleared the register directly, so the falling edge never reached the driver and a DOS reboot left a real modem still off-hook.

This is code inspection plus a build, not a demonstrated fix. It compiles and the existing serial tests still pass, but neither exercises the change: no driver in the tree reports DTR in a way a test can observe, and I have no real serial hardware to try it on. Found while working on the vmodem driver, which is what gave DTR meaning enough to notice the gap.