### PR TITLE
serial: share the rx-push helper between drivers

### DIFF
--- a/src/base/serial/nullmm.c
+++ b/src/base/serial/nullmm.c
@@ -19,35 +19,11 @@
  *
  * Author: stsp
  */
-#include <string.h>
 #include "emu.h"
 #include "init.h"
 #include "utilities.h"
 #include "ser_defs.h"
 #include "nullmm.h"
-
-static int add_buf(com_t *c, const char *buf, int len)
-{
-  if (RX_BUF_BYTES(c->num) + len > RX_BUFFER_SIZE) {
-    if(s3_printf) s_printf("SER%d: Too many bytes (%i) in buffer\n", c->num,
-        RX_BUF_BYTES(c->num));
-    return 0;
-  }
-
-  /* Slide the buffer contents to the bottom */
-  rx_buffer_slide(c->num);
-
-  memcpy(&c->rx_buf[c->rx_buf_end], buf, len);
-  if (debug_level('s') >= 9) {
-    int i;
-    for (i = 0; i < len; i++)
-      s_printf("SER%d: Got mouse data byte: %#x\n", c->num,
-          c->rx_buf[c->rx_buf_end + i]);
-  }
-  c->rx_buf_end += len;
-  receive_engine(c->num);
-  return len;
-}
 
 static int nullmm_get_tx_queued(com_t *c)
 {
@@ -68,7 +44,7 @@ static ssize_t nullmm_write(com_t *c, char *buf, size_t len)
   int idx = get_com_idx(c->cfg->nullmm);
   if (idx == -1)
     return -1;
-  return add_buf(&com[idx], buf, len);
+  return serial_rx_push(&com[idx], buf, len);
 }
 
 static int nullmm_dtr(com_t *c, int flag)

--- a/src/base/serial/ser_defs.h
+++ b/src/base/serial/ser_defs.h
@@ -427,6 +427,8 @@ int ser_close(int num);
 int uart_fill(int num);
 int serial_get_msr(int num);
 
+int serial_rx_push(com_t *c, const char *buf, int len);
+
 void fossil_init(void);
 
 struct serial_drv {

--- a/src/base/serial/ser_irq.c
+++ b/src/base/serial/ser_irq.c
@@ -19,6 +19,7 @@
 
 #include <unistd.h>
 #include <stdio.h>
+#include <string.h>
 #include <errno.h>
 
 #include "emu.h"
@@ -86,6 +87,33 @@ void serial_timer_update(void)
   }
 }
 #endif
+
+/* Hand bytes to the UART receive queue on behalf of a driver that is
+ * pushed to rather than read from (sermouse, nullmm).  Returns the
+ * number accepted, which is 0 if the queue has no room for all of it.
+ */
+int serial_rx_push(com_t *c, const char *buf, int len)
+{
+  if (RX_BUF_BYTES(c->num) + len > RX_BUFFER_SIZE) {
+    if(s3_printf) s_printf("SER%d: Too many bytes (%i) in buffer\n", c->num,
+        RX_BUF_BYTES(c->num));
+    return 0;
+  }
+
+  /* Slide the buffer contents to the bottom */
+  rx_buffer_slide(c->num);
+
+  memcpy(&c->rx_buf[c->rx_buf_end], buf, len);
+  if (debug_level('s') >= 9) {
+    int i;
+    for (i = 0; i < len; i++)
+      s_printf("SER%d: Got data byte: %#x\n", c->num,
+          c->rx_buf[c->rx_buf_end + i]);
+  }
+  c->rx_buf_end += len;
+  receive_engine(c->num);
+  return len;
+}
 
 /* This function does housekeeping for serial receive operations.  Duties
  * of this function include keeping the UART FIFO/RBR register filled,

--- a/src/base/serial/sermouse.c
+++ b/src/base/serial/sermouse.c
@@ -68,25 +68,7 @@ static int add_buf(com_t *c, const char *buf, int len)
 {
   if (!serm.enabled || !serm.opened || serm.div != DIV_1200)
     return 0;
-  if (RX_BUF_BYTES(c->num) + len > RX_BUFFER_SIZE) {
-    if(s3_printf) s_printf("SER%d: Too many bytes (%i) in buffer\n", c->num,
-        RX_BUF_BYTES(c->num));
-    return 0;
-  }
-
-  /* Slide the buffer contents to the bottom */
-  rx_buffer_slide(c->num);
-
-  memcpy(&c->rx_buf[c->rx_buf_end], buf, len);
-  if (debug_level('s') >= 9) {
-    int i;
-    for (i = 0; i < len; i++)
-      s_printf("SER%d: Got mouse data byte: %#x\n", c->num,
-          c->rx_buf[c->rx_buf_end + i]);
-  }
-  c->rx_buf_end += len;
-  receive_engine(c->num);
-  return len;
+  return serial_rx_push(c, buf, len);
 }
 
 static void ser_mouse_move_button(int num, int press, void *udata)


### PR DESCRIPTION
> Body drafted by Claude (Opus 5) at andy5995's direction.

sermouse and nullmm carried the same slide/memcpy/receive_engine sequence; nullmm's copy still had sermouse's "Got mouse data byte" wording in its debug line. Move it to ser_irq.c as serial_rx_push() and have both call it. sermouse keeps its own guard on the mouse state, which is the only part that differed.

The debug line now says "Got data byte" for both, so a level-9 serial log from the mouse loses the word "mouse". No test covers sermouse, so that path is by inspection.