### PR TITLE
CI: cancel superseded runs on PR-triggered workflows

### DIFF
--- a/.github/workflows/create-packages-docker.yml
+++ b/.github/workflows/create-packages-docker.yml
@@ -1,3 +1,7 @@
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/create-packages-emscripten.yml
+++ b/.github/workflows/create-packages-emscripten.yml
@@ -1,3 +1,7 @@
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/create-packages-termux.yml
+++ b/.github/workflows/create-packages-termux.yml
@@ -1,5 +1,9 @@
 name: Create Packages (Termux)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/test-suite-triggered.yml
+++ b/.github/workflows/test-suite-triggered.yml
@@ -1,5 +1,9 @@
 name: Test Suite (Triggered)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 on:
   push:
 


### PR DESCRIPTION
> Body drafted by Claude (Opus 5) at andy5995's direction.

Pushing again to a PR branch left the previous run going, so a busy branch could hold several full test-suite runs at once.

test-suite-worker.yml is deliberately left alone: it is reusable (workflow_call only), where github.workflow resolves to the caller, so a group there could cancel sibling calls. Cancelling the caller already stops it.