### PR TITLE
Shift the display page start address only in text modes

### DIFF
--- a/src/base/bios/vgabios.c
+++ b/src/base/bios/vgabios.c
@@ -235,8 +235,11 @@ Bit8u page)
  address=pgsize*page;
  write_bda_word(BIOSMEM_CURRENT_START,address);
 
- // Now the CRTC start address
- address>>=1;
+ // Now the CRTC start address, which the CRTC counts in words for text
+ // and in bytes for the planar graphics modes.  The LGPL vgabios shifts
+ // only in its TEXT arm; the port at e89164764 kept the shift and lost
+ // the arm, halving the offset in graphics modes and rolling the display.
+ address>>=vgabios_using_text_mode()?1:0;
 
  // CRTC regs 0x0c and 0x0d
  crtc_addr=read_bda_word(BIOSMEM_CRTC_ADDRESS);


### PR DESCRIPTION
> Written by Claude (Opus 5), an LLM made by Anthropic, at andy5995's
> direction.

The CRTC counts words in text modes but bytes in the planar graphics modes, so
shifting unconditionally put mode 0Dh page 1 at 0x1000 instead of 0x2000 and
rolled the display by 4096 bytes.

The LGPL vgabios shifts only in its TEXT arm
([vgabios.c#L1336-L1350](https://github.com/bochs-emu/VGABIOS/blob/12d978bd86fe88ee6b8620b0f1e91c7fb81bc2e6/vgabios/vgabios.c#L1336-L1350)):

```c
 if(vga_modes[line].class==TEXT)
  {
   pgsize=read_bda_word(BIOSMEM_PAGE_SIZE);
   address=pgsize*page;
   write_bda_word(BIOSMEM_CURRENT_START,address);
   address>>=1;
  }
 else
  {
   address = page * (*(Bit16u *)&video_param_table[vga_modes[line].vpti].slength_l);
  }
```

The port at `e89164764` kept the shift and lost the arm. Before it the code
read `crt_outw(0xc, address/(using_text_mode() ? 2 : 1))`, so this restores the
earlier behaviour, in the form bartoldeman suggested below. `using_text_mode()`
is the same predicate as upstream's class test: `int10.c` sets
`BIOS_VDU_CONTROL` straight from `vmi->mode_class == TEXT`.

Modes 04h, 05h and 13h count words and doublewords rather than bytes, so a
text/graphics test does not give the CRTC's unit for them — but they hold a
single page each, so INT 10h AH=05 never moves their start address.

**Testing.** Major Stryker's title screen flips pages through AH=05 in mode
0Dh. Built twice in a container and run under Xvfb with `-D+v`, making the same
INT 10h calls each time:

```
address>>=1                     Start Address = 0x1000    (page 1, wrong)
address>>=using_text_mode()?1:0 Start Address = 0x2000    (page 1, = page size)
```

Doom (mode 13h) and the text modes are unaffected either way. Frame captures
are not offered as evidence: the screen reachable there is animated, so
consecutive frames differ regardless.

Whether it also explains the frame-level corruption in #1377 or #2303 is
untested.
