### PR TITLE
xms: in xms_move_EMB check destination handle is valid

### DIFF
--- a/src/dosext/misc/xms.c
+++ b/src/dosext/misc/xms.c
@@ -885,7 +885,7 @@ xms_move_EMB(void)
     d = NULL;
   }
   else {
-    if (!handles[e.DestHandle].addr) {
+    if (e.DestHandle >= NUM_HANDLES || !handles[e.DestHandle].addr) {
       x_printf("XMS: invalid dest handle\n");
       return 0xa5;
     }


### PR DESCRIPTION
XMS move with an invalid handle could crash dosemu2. Assemble test case using `nasm test.asm -o test.com`, or load from https://pushbx.org/ecm/test/20260814/ Full source:

```
; Public Domain

	struc XMSMOVE
xmLength:	resd 1
xmSourceHandle:	resw 1
xmSourceAddress:resd 1
xmDestHandle:	resw 1
xmDestAddress:	resd 1
	endstruc

	cpu 8086
	org 256
start:
	cmp sp, stack.top
	jb fail

	mov ax, cs
	mov word [load_from_xms_block + xmDestAddress + 2], ax
	mov word [save_to_xms_block + xmSourceAddress + 2], ax

	mov ax, 4300h
	int 2Fh
	cmp al, 80h
	jne fail

	mov ax, 4310h
	int 2Fh
	push es
	push bx
	mov bp, sp

	mov ah, 0Bh
	mov si, load_from_xms_block
	call far [bp]
	dec ax
	jz fail

	mov ah, 0Bh
	mov si, save_to_xms_block
	call far [bp]
	dec ax
	jz fail

success:
	mov ah, 09h
	mov dx, msg.success
	int 21h
	mov ax, 4C00h
	int 21h

fail:
	mov ah, 09h
	mov dx, msg.fail
	int 21h
	mov ax, 4C01h
	int 21h

msg:
.success:	db "SUCCESS",13,10,36
.fail:		db "FAIL",13,10,36

	align 2, db 0
load_from_xms_block:	istruc XMSMOVE
at xmLength,		dd 512
at xmSourceHandle,	dw -1		; invalid handle
at xmSourceAddress,	dd 0
at xmDestHandle,	dw 0		; 86 Mode memory
at xmDestAddress,	dw buffer, 0	; -> buffer (segment written here)
			iend

save_to_xms_block:	istruc XMSMOVE
at xmLength,		dd 512
at xmSourceHandle,	dw 0		; 86 Mode memory
at xmSourceAddress,	dw buffer, 0	; -> buffer (segment written here)
at xmDestHandle,	dw -1		; invalid handle
at xmDestAddress,	dd 0
			iend

	absolute $
	alignb 16
buffer:
	resb 512
stack:
	resb 512
	alignb 2
.top:
```