### PR TITLE
Claude finishing off Jules vfs implementation.

### DIFF
--- a/src/arch/linux/Makefile.main
+++ b/src/arch/linux/Makefile.main
@@ -44,7 +44,7 @@ DPMI = dosext/dpmi dosext/dpmi/doslib dosext/dpmi/dnative
 _LIBSUBDIRS=base/video base/dev/vga base/core base/kbd_unicode \
 	arch/linux/async base/lib/mapping $(LIBMC) \
 	base/misc base/lib/misc base/lib/libpcl base/lib/timer \
-	base/lib/fslib $(LIBBSD) \
+	base/lib/vfs base/lib/fslib $(LIBBSD) \
 	base/dev/misc \
 	base/emu-i386 $(XCPUEMU) base/speaker \
 	base/dev/pic base/dev/ne2k \

--- a/src/base/core/emu.c
+++ b/src/base/core/emu.c
@@ -232,7 +232,7 @@ void boot(void)
 
     if (dp->type == PARTITION) {/* we boot partition boot record, not MBR! */
 	d_printf("Booting partition boot record from part=%s....\n", dp->dev_name);
-	if (dos_read(dp->fdesc, buffer, SECTOR_SIZE) != SECTOR_SIZE) {
+	if (dos_read_posix(dp->fdesc, buffer, SECTOR_SIZE) != SECTOR_SIZE) {
 	    error("reading partition boot sector using partition %s.\n", dp->dev_name);
 	    leavedos(16);
 	}

--- a/src/base/lib/vfs/Makefile
+++ b/src/base/lib/vfs/Makefile
@@ -1,0 +1,14 @@
+#
+# (C) Copyright dosemu2 project.
+#
+
+top_builddir=../../../..
+include $(top_builddir)/Makefile.conf
+
+CFILES = vfs.c
+SFILES =
+ALL_CPPFLAGS += -I$(REALTOPDIR)/src/base/lib/fslib
+
+include $(REALTOPDIR)/src/Makefile.common
+
+all: lib

--- a/src/base/lib/vfs/vfs.c
+++ b/src/base/lib/vfs/vfs.c
@@ -1,0 +1,470 @@
+/*
+ *  Copyright (C) 2026  @stsp, generated with Jules AI
+ *  https://jules.google.com
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ * VFS (Virtual File System) implementation
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <errno.h>
+#include "fslib/fslib.h"
+#include "vfs.h"
+
+/*
+ * Default POSIX backend implementation
+ */
+
+static int posix_file_close(vfs_file_t *file)
+{
+  int rc = 0;
+  if (file) {
+    if (file->fd != -1)
+      rc = close(file->fd);
+    free(file);
+  }
+  return rc;
+}
+
+static ssize_t posix_file_read(vfs_file_t *file, void *buf, size_t count)
+{
+  if (!file)
+    return -1;
+  return read(file->fd, buf, count);
+}
+
+static ssize_t posix_file_write(vfs_file_t *file, const void *buf, size_t count)
+{
+  if (!file)
+    return -1;
+  return write(file->fd, buf, count);
+}
+
+static off_t posix_file_lseek(vfs_file_t *file, off_t offset, int whence)
+{
+  if (!file)
+    return -1;
+  return lseek(file->fd, offset, whence);
+}
+
+static int posix_file_fstat(vfs_file_t *file, struct stat *sb)
+{
+  if (!file)
+    return -1;
+  return fstat(file->fd, sb);
+}
+
+static int posix_file_ftruncate(vfs_file_t *file, off_t length)
+{
+  if (!file)
+    return -1;
+  return ftruncate(file->fd, length);
+}
+
+static int posix_file_fsync(vfs_file_t *file)
+{
+  if (!file)
+    return -1;
+  return fsync(file->fd);
+}
+
+static int posix_file_get_async_fd(vfs_file_t *file, void *handle)
+{
+  if (file)
+    return file->fd;
+  return mfs_async_getfd(handle);
+}
+
+static const struct vfs_file_ops posix_file_ops = {
+  .close = posix_file_close,
+  .read = posix_file_read,
+  .write = posix_file_write,
+  .lseek = posix_file_lseek,
+  .fstat = posix_file_fstat,
+  .ftruncate = posix_file_ftruncate,
+  .fsync = posix_file_fsync,
+  .get_async_fd = posix_file_get_async_fd,
+};
+
+vfs_file_t *vfs_file_wrap_posix(int fd)
+{
+  vfs_file_t *file;
+  if (fd == -1)
+    return NULL;
+  file = malloc(sizeof(*file));
+  if (!file) {
+    close(fd);
+    return NULL;
+  }
+  file->ops = &posix_file_ops;
+  file->fd = fd;
+  return file;
+}
+
+static int posix_dir_closedir(vfs_dir_t *dir)
+{
+  int rc = 0;
+  if (dir) {
+    if (dir->d)
+      rc = closedir(dir->d);
+    else if (dir->fd != -1)
+      rc = close(dir->fd);
+    free(dir);
+  }
+  return rc;
+}
+
+static struct dirent *posix_dir_readdir(vfs_dir_t *dir)
+{
+  if (!dir || !dir->d)
+    return NULL;
+  return readdir(dir->d);
+}
+
+static int posix_dir_fstatat(vfs_dir_t *dir, const char *pathname, struct stat *statbuf, int flags)
+{
+  if (!dir || dir->fd == -1)
+    return -1;
+  return fstatat(dir->fd, pathname, statbuf, flags);
+}
+
+static int posix_dir_dirfd(vfs_dir_t *dir)
+{
+  if (!dir)
+    return -1;
+  if (dir->d)
+    return dirfd(dir->d);
+  return dir->fd;
+}
+
+static const struct vfs_dir_ops posix_dir_ops = {
+  .closedir = posix_dir_closedir,
+  .readdir = posix_dir_readdir,
+  .fstatat = posix_dir_fstatat,
+  .dirfd = posix_dir_dirfd,
+};
+
+vfs_dir_t *vfs_dir_wrap_posix(DIR *d, int fd)
+{
+  vfs_dir_t *dir;
+  if (!d && fd == -1)
+    return NULL;
+  dir = malloc(sizeof(*dir));
+  if (!dir) {
+    if (d)
+      closedir(d);
+    else if (fd != -1)
+      close(fd);
+    return NULL;
+  }
+  dir->ops = &posix_dir_ops;
+  dir->d = d;
+  dir->fd = fd;
+  return dir;
+}
+
+static vfs_file_t *posix_fs_open(vfs_fs_t *fs, const char *path, int flags)
+{
+  int fd = mfs_open_file(fs->mfs_idx, path, flags);
+  return vfs_file_wrap_posix(fd);
+}
+
+static vfs_file_t *posix_fs_creat(vfs_fs_t *fs, const char *path, int flags, mode_t mode)
+{
+  int fd = mfs_create_file(fs->mfs_idx, path, flags, mode);
+  return vfs_file_wrap_posix(fd);
+}
+
+static int posix_fs_unlink(vfs_fs_t *fs, const char *path)
+{
+  return mfs_unlink_file(fs->mfs_idx, path);
+}
+
+static int posix_fs_getxattr(vfs_fs_t *fs, const char *path)
+{
+  return mfs_getxattr_file(fs->mfs_idx, path);
+}
+
+static int posix_fs_setxattr(vfs_fs_t *fs, const char *path, int attr)
+{
+  return mfs_setxattr_file(fs->mfs_idx, path, attr);
+}
+
+static int posix_fs_statvfs(vfs_fs_t *fs, const char *path, struct statvfs *sb)
+{
+  return do_mfs_statvfs(fs->mfs_idx, path, sb);
+}
+
+static int posix_fs_mkdir(vfs_fs_t *fs, const char *path, mode_t mode)
+{
+  return mfs_mkdir(fs->mfs_idx, path, mode);
+}
+
+static int posix_fs_rmdir(vfs_fs_t *fs, const char *path)
+{
+  return mfs_rmdir(fs->mfs_idx, path);
+}
+
+static int posix_fs_stat(vfs_fs_t *fs, const char *path, struct stat *sb)
+{
+  return mfs_stat_file(fs->mfs_idx, path, sb);
+}
+
+static int posix_fs_rename(vfs_fs_t *fs, const char *oldpath, const char *newpath)
+{
+  return mfs_rename_file(fs->mfs_idx, oldpath, newpath);
+}
+
+static int posix_fs_access(vfs_fs_t *fs, const char *path, int mode)
+{
+  return mfs_access(fs->mfs_idx, path, mode);
+}
+
+static int posix_fs_utime(vfs_fs_t *fs, const char *fpath, time_t atime, time_t mtime)
+{
+  return mfs_utime(fs->mfs_idx, fpath, atime, mtime);
+}
+
+static void *posix_fs_open_async(vfs_fs_t *fs, const char *path, int flags)
+{
+  return mfs_open_async(fs->mfs_idx, path, flags);
+}
+
+static vfs_dir_t *posix_fs_opendir(vfs_fs_t *fs, const char *path)
+{
+  int dfd = mfs_open_file(fs->mfs_idx, path, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+  DIR *d;
+  if (dfd == -1) {
+    return NULL;
+  }
+  d = fdopendir(dfd);
+  if (!d) {
+    close(dfd);
+    return NULL;
+  }
+  return vfs_dir_wrap_posix(d, dfd);
+}
+
+static const struct vfs_fs_ops posix_fs_ops = {
+  .open = posix_fs_open,
+  .creat = posix_fs_creat,
+  .unlink = posix_fs_unlink,
+  .getxattr = posix_fs_getxattr,
+  .setxattr = posix_fs_setxattr,
+  .statvfs = posix_fs_statvfs,
+  .mkdir = posix_fs_mkdir,
+  .rmdir = posix_fs_rmdir,
+  .stat = posix_fs_stat,
+  .rename = posix_fs_rename,
+  .access = posix_fs_access,
+  .utime = posix_fs_utime,
+  .open_async = posix_fs_open_async,
+  .opendir = posix_fs_opendir,
+};
+
+static vfs_fs_t fs_instances[128];
+
+vfs_fs_t *vfs_get_fs(int mfs_idx)
+{
+  if (mfs_idx <= 0 || mfs_idx >= 128)
+    return NULL;
+  fs_instances[mfs_idx].ops = &posix_fs_ops;
+  fs_instances[mfs_idx].mfs_idx = mfs_idx;
+  return &fs_instances[mfs_idx];
+}
+
+vfs_file_t *vfs_open(vfs_fs_t *fs, const char *path, int flags)
+{
+  if (!fs || !fs->ops || !fs->ops->open)
+    return NULL;
+  return fs->ops->open(fs, path, flags);
+}
+
+vfs_file_t *vfs_creat(vfs_fs_t *fs, const char *path, int flags, mode_t mode)
+{
+  if (!fs || !fs->ops || !fs->ops->creat)
+    return NULL;
+  return fs->ops->creat(fs, path, flags, mode);
+}
+
+int vfs_unlink(vfs_fs_t *fs, const char *path)
+{
+  if (!fs || !fs->ops || !fs->ops->unlink)
+    return -1;
+  return fs->ops->unlink(fs, path);
+}
+
+int vfs_getxattr(vfs_fs_t *fs, const char *path)
+{
+  if (!fs || !fs->ops || !fs->ops->getxattr)
+    return -1;
+  return fs->ops->getxattr(fs, path);
+}
+
+int vfs_setxattr(vfs_fs_t *fs, const char *path, int attr)
+{
+  if (!fs || !fs->ops || !fs->ops->setxattr)
+    return -1;
+  return fs->ops->setxattr(fs, path, attr);
+}
+
+int vfs_statvfs(vfs_fs_t *fs, const char *path, struct statvfs *sb)
+{
+  if (!fs || !fs->ops || !fs->ops->statvfs)
+    return -1;
+  return fs->ops->statvfs(fs, path, sb);
+}
+
+int vfs_mkdir(vfs_fs_t *fs, const char *path, mode_t mode)
+{
+  if (!fs || !fs->ops || !fs->ops->mkdir)
+    return -1;
+  return fs->ops->mkdir(fs, path, mode);
+}
+
+int vfs_rmdir(vfs_fs_t *fs, const char *path)
+{
+  if (!fs || !fs->ops || !fs->ops->rmdir)
+    return -1;
+  return fs->ops->rmdir(fs, path);
+}
+
+int vfs_stat(vfs_fs_t *fs, const char *path, struct stat *sb)
+{
+  if (!fs || !fs->ops || !fs->ops->stat)
+    return -1;
+  return fs->ops->stat(fs, path, sb);
+}
+
+int vfs_rename(vfs_fs_t *fs, const char *oldpath, const char *newpath)
+{
+  if (!fs || !fs->ops || !fs->ops->rename)
+    return -1;
+  return fs->ops->rename(fs, oldpath, newpath);
+}
+
+int vfs_access(vfs_fs_t *fs, const char *path, int mode)
+{
+  if (!fs || !fs->ops || !fs->ops->access)
+    return -1;
+  return fs->ops->access(fs, path, mode);
+}
+
+int vfs_utime(vfs_fs_t *fs, const char *fpath, time_t atime, time_t mtime)
+{
+  if (!fs || !fs->ops || !fs->ops->utime)
+    return -1;
+  return fs->ops->utime(fs, fpath, atime, mtime);
+}
+
+void *vfs_open_async(vfs_fs_t *fs, const char *path, int flags)
+{
+  if (!fs || !fs->ops || !fs->ops->open_async)
+    return NULL;
+  return fs->ops->open_async(fs, path, flags);
+}
+
+vfs_dir_t *vfs_opendir(vfs_fs_t *fs, const char *path)
+{
+  if (!fs || !fs->ops || !fs->ops->opendir)
+    return NULL;
+  return fs->ops->opendir(fs, path);
+}
+
+int vfs_close(vfs_file_t *file)
+{
+  if (!file || !file->ops || !file->ops->close)
+    return -1;
+  return file->ops->close(file);
+}
+
+ssize_t vfs_read(vfs_file_t *file, void *buf, size_t count)
+{
+  if (!file || !file->ops || !file->ops->read)
+    return -1;
+  return file->ops->read(file, buf, count);
+}
+
+ssize_t vfs_write(vfs_file_t *file, const void *buf, size_t count)
+{
+  if (!file || !file->ops || !file->ops->write)
+    return -1;
+  return file->ops->write(file, buf, count);
+}
+
+off_t vfs_lseek(vfs_file_t *file, off_t offset, int whence)
+{
+  if (!file || !file->ops || !file->ops->lseek)
+    return -1;
+  return file->ops->lseek(file, offset, whence);
+}
+
+int vfs_fstat(vfs_file_t *file, struct stat *sb)
+{
+  if (!file || !file->ops || !file->ops->fstat)
+    return -1;
+  return file->ops->fstat(file, sb);
+}
+
+int vfs_ftruncate(vfs_file_t *file, off_t length)
+{
+  if (!file || !file->ops || !file->ops->ftruncate)
+    return -1;
+  return file->ops->ftruncate(file, length);
+}
+
+int vfs_fsync(vfs_file_t *file)
+{
+  if (!file || !file->ops || !file->ops->fsync)
+    return -1;
+  return file->ops->fsync(file);
+}
+
+int vfs_get_async_fd(vfs_file_t *file, void *handle)
+{
+  if (!file || !file->ops || !file->ops->get_async_fd)
+    return -1;
+  return file->ops->get_async_fd(file, handle);
+}
+
+int vfs_closedir(vfs_dir_t *dir)
+{
+  if (!dir || !dir->ops || !dir->ops->closedir)
+    return -1;
+  return dir->ops->closedir(dir);
+}
+
+struct dirent *vfs_readdir(vfs_dir_t *dir)
+{
+  if (!dir || !dir->ops || !dir->ops->readdir)
+    return NULL;
+  return dir->ops->readdir(dir);
+}
+
+int vfs_fstatat(vfs_dir_t *dir, const char *pathname, struct stat *statbuf, int flags)
+{
+  if (!dir || !dir->ops || !dir->ops->fstatat)
+    return -1;
+  return dir->ops->fstatat(dir, pathname, statbuf, flags);
+}
+
+int vfs_dirfd(vfs_dir_t *dir)
+{
+  if (!dir || !dir->ops || !dir->ops->dirfd)
+    return -1;
+  return dir->ops->dirfd(dir);
+}

--- a/src/base/lib/vfs/vfs.h
+++ b/src/base/lib/vfs/vfs.h
@@ -1,0 +1,103 @@
+/*
+ * VFS (Virtual File System) interface
+ */
+#ifndef VFS_H
+#define VFS_H
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/statvfs.h>
+#include <dirent.h>
+#include <unistd.h>
+#include <time.h>
+
+typedef struct vfs_fs vfs_fs_t;
+typedef struct vfs_file vfs_file_t;
+typedef struct vfs_dir vfs_dir_t;
+
+struct vfs_fs_ops {
+  vfs_file_t *(*open)(vfs_fs_t *fs, const char *path, int flags);
+  vfs_file_t *(*creat)(vfs_fs_t *fs, const char *path, int flags, mode_t mode);
+  int (*unlink)(vfs_fs_t *fs, const char *path);
+  int (*getxattr)(vfs_fs_t *fs, const char *path);
+  int (*setxattr)(vfs_fs_t *fs, const char *path, int attr);
+  int (*statvfs)(vfs_fs_t *fs, const char *path, struct statvfs *sb);
+  int (*mkdir)(vfs_fs_t *fs, const char *path, mode_t mode);
+  int (*rmdir)(vfs_fs_t *fs, const char *path);
+  int (*stat)(vfs_fs_t *fs, const char *path, struct stat *sb);
+  int (*rename)(vfs_fs_t *fs, const char *oldpath, const char *newpath);
+  int (*access)(vfs_fs_t *fs, const char *path, int mode);
+  int (*utime)(vfs_fs_t *fs, const char *fpath, time_t atime, time_t mtime);
+  void *(*open_async)(vfs_fs_t *fs, const char *path, int flags);
+  vfs_dir_t *(*opendir)(vfs_fs_t *fs, const char *path);
+};
+
+struct vfs_file_ops {
+  int (*close)(vfs_file_t *file);
+  ssize_t (*read)(vfs_file_t *file, void *buf, size_t count);
+  ssize_t (*write)(vfs_file_t *file, const void *buf, size_t count);
+  off_t (*lseek)(vfs_file_t *file, off_t offset, int whence);
+  int (*fstat)(vfs_file_t *file, struct stat *sb);
+  int (*ftruncate)(vfs_file_t *file, off_t length);
+  int (*fsync)(vfs_file_t *file);
+  int (*get_async_fd)(vfs_file_t *file, void *handle);
+};
+
+struct vfs_dir_ops {
+  int (*closedir)(vfs_dir_t *dir);
+  struct dirent *(*readdir)(vfs_dir_t *dir);
+  int (*fstatat)(vfs_dir_t *dir, const char *pathname, struct stat *statbuf, int flags);
+  int (*dirfd)(vfs_dir_t *dir);
+};
+
+struct vfs_fs {
+  const struct vfs_fs_ops *ops;
+  int mfs_idx;
+};
+
+struct vfs_file {
+  const struct vfs_file_ops *ops;
+  int fd;
+};
+
+struct vfs_dir {
+  const struct vfs_dir_ops *ops;
+  DIR *d;
+  int fd;
+};
+
+vfs_fs_t *vfs_get_fs(int mfs_idx);
+
+vfs_file_t *vfs_open(vfs_fs_t *fs, const char *path, int flags);
+vfs_file_t *vfs_creat(vfs_fs_t *fs, const char *path, int flags, mode_t mode);
+int vfs_unlink(vfs_fs_t *fs, const char *path);
+int vfs_getxattr(vfs_fs_t *fs, const char *path);
+int vfs_setxattr(vfs_fs_t *fs, const char *path, int attr);
+int vfs_statvfs(vfs_fs_t *fs, const char *path, struct statvfs *sb);
+int vfs_mkdir(vfs_fs_t *fs, const char *path, mode_t mode);
+int vfs_rmdir(vfs_fs_t *fs, const char *path);
+int vfs_stat(vfs_fs_t *fs, const char *path, struct stat *sb);
+int vfs_rename(vfs_fs_t *fs, const char *oldpath, const char *newpath);
+int vfs_access(vfs_fs_t *fs, const char *path, int mode);
+int vfs_utime(vfs_fs_t *fs, const char *fpath, time_t atime, time_t mtime);
+void *vfs_open_async(vfs_fs_t *fs, const char *path, int flags);
+vfs_dir_t *vfs_opendir(vfs_fs_t *fs, const char *path);
+
+vfs_file_t *vfs_file_wrap_posix(int fd);
+vfs_dir_t *vfs_dir_wrap_posix(DIR *d, int fd);
+
+int vfs_close(vfs_file_t *file);
+ssize_t vfs_read(vfs_file_t *file, void *buf, size_t count);
+ssize_t vfs_write(vfs_file_t *file, const void *buf, size_t count);
+off_t vfs_lseek(vfs_file_t *file, off_t offset, int whence);
+int vfs_fstat(vfs_file_t *file, struct stat *sb);
+int vfs_ftruncate(vfs_file_t *file, off_t length);
+int vfs_fsync(vfs_file_t *file);
+int vfs_get_async_fd(vfs_file_t *file, void *handle);
+
+int vfs_closedir(vfs_dir_t *dir);
+struct dirent *vfs_readdir(vfs_dir_t *dir);
+int vfs_fstatat(vfs_dir_t *dir, const char *pathname, struct stat *statbuf, int flags);
+int vfs_dirfd(vfs_dir_t *dir);
+
+#endif

--- a/src/base/misc/disks.c
+++ b/src/base/misc/disks.c
@@ -322,7 +322,7 @@ read_sectors(const struct disk *dp, unsigned buffer, uint64_t sector,
       error("Sector not found in read_sector, error = %s!\n", strerror(errno));
       return -DERR_NOTFOUND;
     }
-    tmpread = dos_read(dp->fdesc, buffer, count * SECTOR_SIZE - already);
+    tmpread = dos_read_posix(dp->fdesc, buffer, count * SECTOR_SIZE - already);
   }
 
   if(tmpread != -1) {
@@ -403,7 +403,7 @@ write_sectors(struct disk *dp, unsigned buffer, uint64_t sector,
       error("Sector not found in write_sector!\n");
       return -DERR_NOTFOUND;
     }
-    tmpwrite = dos_write(dp->fdesc, buffer, count * SECTOR_SIZE - already);
+    tmpwrite = dos_write_posix(dp->fdesc, buffer, count * SECTOR_SIZE - already);
   }
 
   /* this should make floppies a little safer...I would as soon use the

--- a/src/base/misc/dos2linux.c
+++ b/src/base/misc/dos2linux.c
@@ -1104,18 +1104,18 @@ int unix_read(int fd, void *data, int cnt)
   return RPT_SYSCALL(read(fd, data, cnt));
 }
 
-int dos_read(int fd, unsigned data, int cnt)
+int dos_read(vfs_file_t *fd, unsigned data, int cnt)
 {
   int ret;
   /* GW also reads or writes directly from a file to protected video memory. */
   if (vga_write_access(data)) {
     char buf[cnt];
-    ret = unix_read(fd, buf, cnt);
+    ret = vfs_read(fd, buf, cnt);
     if (ret >= 0)
       memcpy_to_vga(data, buf, ret);
   }
   else
-    ret = unix_read(fd, LINEAR2UNIX(data), cnt);
+    ret = vfs_read(fd, LINEAR2UNIX(data), cnt);
   if (ret > 0)
 	e_invalidate(data, ret);
   return (ret);
@@ -1126,7 +1126,7 @@ int unix_write(int fd, const void *data, int cnt)
   return RPT_SYSCALL(write(fd, data, cnt));
 }
 
-int dos_write(int fd, unsigned data, int cnt)
+int dos_write(vfs_file_t *fd, unsigned data, int cnt)
 {
   int ret;
   const unsigned char *d;
@@ -1141,7 +1141,7 @@ int dos_write(int fd, unsigned data, int cnt)
   } else {
     d = LINEAR2UNIX(data);
   }
-  ret = unix_write(fd, d, cnt);
+  ret = vfs_write(fd, d, cnt);
   g_printf("Wrote %10.10s\n", d);
   return (ret);
 }
@@ -1759,4 +1759,41 @@ void set_boot_cls(void)
 void set_boot_showwin(void)
 {
     misc_e6_store_options("DOSEMU_BOOT_SHOWWIN=1");
+}
+
+
+int dos_read_posix(int fd, unsigned data, int cnt)
+{
+  int ret;
+  if (vga_write_access(data)) {
+    char buf[cnt];
+    ret = unix_read(fd, buf, cnt);
+    if (ret >= 0)
+      memcpy_to_vga(data, buf, ret);
+  }
+  else
+    ret = unix_read(fd, LINEAR2UNIX(data), cnt);
+  if (ret > 0)
+	e_invalidate(data, ret);
+  return (ret);
+}
+
+int dos_write_posix(int fd, unsigned data, int cnt)
+{
+  int ret;
+  const unsigned char *d;
+  unsigned char *buf;
+
+  if (!cnt)
+    return 0;
+  buf = alloca(cnt);
+  if (vga_read_access(data)) {
+    memcpy_from_vga(buf, data, cnt);
+    d = buf;
+  } else {
+    d = LINEAR2UNIX(data);
+  }
+  ret = unix_write(fd, d, cnt);
+  g_printf("Wrote %10.10s\n", d);
+  return (ret);
 }

--- a/src/base/misc/fatfs.c
+++ b/src/base/misc/fatfs.c
@@ -972,7 +972,7 @@ static void set_vol_and_len(fatfs_t *f, unsigned oi)
         if(!f->obj[oi].first_child) f->obj[oi].first_child = u;
         f->obj[u].dos_dir_size = 0x20;
         o->size += 0x20;
-        if (!vfs_fstat(vfs_file_wrap_posix(vfs_dirfd(f->dir_fd)), &sb)) {
+        if (!fstat(vfs_dirfd(f->dir_fd), &sb)) {
           f->obj[u].time = dos_time(&sb.st_mtime);
         }
 	fatfs_deb2("added label \"%s\"\n", f->label);

--- a/src/base/misc/fatfs.c
+++ b/src/base/misc/fatfs.c
@@ -71,8 +71,10 @@
 #include "dos2linux.h"
 #include "utilities.h"
 #include "fslib/fslib.h"
+#include "vfs/vfs.h"
 #include "fatfs.h"
 #include "fatfs_priv.h"
+
 
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -206,12 +208,13 @@ void fatfs_init(struct disk *dp)
 
   f->ffn = malloc(MAX_DIR_NAME_LEN + MAX_FILE_NAME_LEN + 1);
   assert(f->ffn);
+  f->fs = vfs_get_fs(dp->mfs_idx);
 
   f->boot_sec = malloc(0x200);
 
   f->dir = dp->dev_name;
-  f->dir_fd = open(f->dir, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
-  if (f->dir_fd == -1) {
+  f->dir_fd = vfs_opendir(f->fs, f->dir);
+  if (!f->dir_fd) {
     error("fatfs: failed to open %s: %s\n", f->dir, strerror(errno));
     leavedos_main(5);
     return;
@@ -289,7 +292,6 @@ void fatfs_init(struct disk *dp)
   f->last_cluster = (f->total_secs - f->reserved_secs - f->fats * f->fat_secs
                     - f->root_secs) / f->cluster_secs + 1;
   f->drive_num = dp->drive_num;
-  f->mfs_idx = dp->mfs_idx;
   f->group = dp->group;
 
   f->obj = NULL;
@@ -377,7 +379,7 @@ void fatfs_done(struct disk *dp)
 
   if(!(f = dp->fatfs)) return;
 
-  close(f->dir_fd);
+  vfs_closedir(f->dir_fd);
 
   for(u = 1; u < f->objs; u++) {
     if(f->obj[u].name)
@@ -799,7 +801,7 @@ static int sys_file_idx(const char *name, fatfs_t *f)
     path = full_name(f, 0, name);
     if (!path)
 	return -1;
-    err = mfs_stat_file(f->mfs_idx, path, &sb);
+    err = vfs_stat(f->fs, path, &sb);
     if (err)
 	return -1;
     if (!(S_ISREG(sb.st_mode) || (S_ISDIR(sb.st_mode) &&
@@ -970,7 +972,7 @@ static void set_vol_and_len(fatfs_t *f, unsigned oi)
         if(!f->obj[oi].first_child) f->obj[oi].first_child = u;
         f->obj[u].dos_dir_size = 0x20;
         o->size += 0x20;
-        if(!fstat(f->dir_fd, &sb)) {
+        if (!vfs_fstat(vfs_file_wrap_posix(vfs_dirfd(f->dir_fd)), &sb)) {
           f->obj[u].time = dos_time(&sb.st_mtime);
         }
 	fatfs_deb2("added label \"%s\"\n", f->label);
@@ -985,7 +987,8 @@ static void set_vol_and_len(fatfs_t *f, unsigned oi)
 static void probe_system(fatfs_t *f)
 {
     char *buf, *buf_ptr, *s;
-    int fd, size, i;
+    vfs_file_t *vfd;
+    int size, i;
     int read_bb;
     struct stat sb;
 
@@ -998,12 +1001,12 @@ static void probe_system(fatfs_t *f)
     } else {
       if (f->sys_type == MS_D) {
         s = sys_found[0].name; /* io.sys */
-        if (s && (fd = mfs_open_file(f->mfs_idx, s, O_RDONLY)) != -1) {
-            int err = fstat(fd, &sb);
+        if (s && (vfd = vfs_open(f->fs, s, O_RDONLY)) != NULL) {
+            int err = vfs_fstat(vfd, &sb);
             assert(!err);
             buf = malloc(sb.st_size + 1);
             assert(sb.st_size < PTRDIFF_MAX);  // fixes gcc warning
-            size = read(fd, buf, sb.st_size);
+            size = vfs_read(vfd, buf, sb.st_size);
             if (size > 0) {
                 if(buf[0] == 'M' && buf[1] == 'Z') {  /* MS-DOS >= 7 */
                     f->sys_type = NEWMSD_D;
@@ -1033,7 +1036,7 @@ static void probe_system(fatfs_t *f)
                 }
             }
             free(buf);
-            close(fd);
+            vfs_close(vfd);
             if ((f->sys_type == MS_D) && (sb.st_size <= 26*1024)) {
                 f->sys_type = OLDMSD_D; /* unknown but small enough to be < v4 */
             }
@@ -1045,12 +1048,12 @@ static void probe_system(fatfs_t *f)
       if (f->sys_type == PC_D) {
         /* see if it is PC-DOS or Original DR-DOS */
         s = sys_found[0].name;
-        if (s && (fd = mfs_open_file(f->mfs_idx, s, O_RDONLY)) != -1) {
-            int err = fstat(fd, &sb);
+        if (s && (vfd = vfs_open(f->fs, s, O_RDONLY)) != NULL) {
+            int err = vfs_fstat(vfd, &sb);
             assert(!err);
             buf = malloc(sb.st_size + 1);
             assert(sb.st_size < PTRDIFF_MAX);  // fixes gcc warning
-            size = read(fd, buf, sb.st_size);
+            size = vfs_read(vfd, buf, sb.st_size);
             if (size > 0) {
                 buf[size] = 0;
                 buf_ptr = buf;
@@ -1077,19 +1080,19 @@ static void probe_system(fatfs_t *f)
                 }
             }
             free(buf);
-            close(fd);
+            vfs_close(vfd);
             if ((f->sys_type == PC_D) && (sb.st_size <= 26*1024)) {
                 f->sys_type = OLDPCD_D; /* unknown but small enough to be < v4 */
             }
         }
         /* see if it is MS-DOS 4.0 */
         s = sys_found[1].name;
-        if (s && (fd = mfs_open_file(f->mfs_idx, s, O_RDONLY)) != -1) {
-            int err = fstat(fd, &sb);
+        if (s && (vfd = vfs_open(f->fs, s, O_RDONLY)) != NULL) {
+            int err = vfs_fstat(vfd, &sb);
             assert(!err);
             buf = malloc(sb.st_size + 1);
             assert(sb.st_size < PTRDIFF_MAX);  // fixes gcc warning
-            size = read(fd, buf, sb.st_size);
+            size = vfs_read(vfd, buf, sb.st_size);
             if (size > 0) {
                 buf[size] = 0;
                 buf_ptr = buf;
@@ -1101,7 +1104,7 @@ static void probe_system(fatfs_t *f)
                     f->sys_type = OLDMSD_D;  // Multitasking DOS 4.0
             }
             free(buf);
-            close(fd);
+            vfs_close(vfd);
         }
         if (f->sys_type == PC_D)
             f->sys_type = NEWPCD_D;     /* default to v4.x -> v7.x */
@@ -1110,18 +1113,18 @@ static void probe_system(fatfs_t *f)
       if (f->sys_type == MOS_D) {
         /* see if it is old MOS */
         s = sys_found[0].name;
-        if (s && ((fd = mfs_open_file(f->mfs_idx, s, O_RDONLY)) != -1)) {
+        if (s && ((vfd = vfs_open(f->fs, s, O_RDONLY)) != NULL)) {
           uint32_t buf;
-          int err = fstat(fd, &sb);
+          int err = vfs_fstat(vfd, &sb);
           int rc;
           assert(!err);
           if (sb.st_size == 128880) {
-              lseek(fd, 0x175, SEEK_SET);
-              rc = read(fd, &buf, sizeof(buf));
+              vfs_lseek(vfd, 0x175, SEEK_SET);
+              rc = vfs_read(vfd, &buf, sizeof(buf));
               if (rc == sizeof(buf) && buf == 0x20200105)    /* 5.01 */
                   f->sys_type = OLDMOS_D;
           }
-          close(fd);
+          vfs_close(vfd);
         }
       }
 
@@ -1132,15 +1135,15 @@ static void probe_system(fatfs_t *f)
     /* load boot block from "boot.blk" file or generate Dosemu's own */
     s = full_name(f, 0, "boot.blk");
     read_bb = 0;
-    if (s && (fd = mfs_open_file(f->mfs_idx, s, O_RDONLY)) != -1) {
+    if (s && (vfd = vfs_open(f->fs, s, O_RDONLY)) != NULL) {
       if (
-          fstat(fd, &sb) == 0 && S_ISREG(sb.st_mode) && sb.st_size == 0x200 &&
-          read(fd, f->boot_sec, 0x200) == 0x200) {
+          vfs_fstat(vfd, &sb) == 0 && S_ISREG(sb.st_mode) && sb.st_size == 0x200 &&
+          vfs_read(vfd, f->boot_sec, 0x200) == 0x200) {
         read_bb = 1;
         fatfs_msg("fatfs: boot block taken from boot.blk\n");
         update_geometry(f, f->boot_sec);
       }
-      close(fd);
+      vfs_close(vfd);
     }
     if (!read_bb) {
       fatfs_msg("fatfs: boot block generated\n");
@@ -1168,7 +1171,7 @@ static void scan_dir(fatfs_t *f, unsigned oi)
   int i;
   struct dirent **dlist;
   int num;
-  int dfd;
+  vfs_dir_t *vdfd;
 
   // just checking...
   if(!o->is.dir || !o->name || o->is.scanned) {
@@ -1185,13 +1188,13 @@ static void scan_dir(fatfs_t *f, unsigned oi)
     fatfs_msg("file name too complex: object %u\n", oi);
     return;
   }
-  dfd = mfs_open_file(f->mfs_idx, name, O_RDONLY | O_DIRECTORY);
-  if (dfd == -1) {
+  vdfd = vfs_opendir(f->fs, name);
+  if (!vdfd) {
     fatfs_msg("%s open failed\n", name);
     return;
   }
-  num = fdscandir(dfd, &dlist, d_filter, alphasort);
-  close(dfd);
+  num = fdscandir(vfs_dirfd(vdfd), &dlist, d_filter, alphasort);
+  vfs_closedir(vdfd);
   if (num < 0) {
     fatfs_msg("fatfs: scandir failed for %s\n", name);
     return;
@@ -1351,7 +1354,7 @@ static void _add_object(fatfs_t *f, unsigned parent, const char *s,
   struct stat sb;
 
   fatfs_deb("trying to add \"%s\":\n", s);
-  if(fstatat(f->dir_fd, relname, &sb, 0)) {
+  if (vfs_fstatat(f->dir_fd, relname, &sb, 0)) {
       fatfs_deb("file not found\n");
       return;
   }
@@ -1599,7 +1602,8 @@ int read_file(fatfs_t *f, unsigned oi, unsigned clu, unsigned pos,
   obj_t *o = f->obj + oi;
   char *s;
   off_t ofs;
-  int fd, rd;
+  vfs_file_t *vfd;
+  int rd;
 
   fatfs_deb2("read_file: obj %u, cluster %u, sec %u\n", oi, clu, pos);
 
@@ -1616,17 +1620,17 @@ int read_file(fatfs_t *f, unsigned oi, unsigned clu, unsigned pos,
   s = o->full_name;
   fatfs_deb2("going to read 0x200 bytes from file \"%s\", ofs 0x%x \n", s, pos);
 
-  if ((fd = mfs_open_file(f->mfs_idx, s, O_RDONLY | O_CLOEXEC)) == -1) {
+  if ((vfd = vfs_open(f->fs, s, O_RDONLY | O_CLOEXEC)) == NULL) {
       fatfs_deb("fatfs: open %s failed\n", s);
       return -1;
   }
 
-  if ((ofs = lseek(fd, pos, SEEK_SET)) == -1) return -1;
+  if ((ofs = vfs_lseek(vfd, pos, SEEK_SET)) == -1) { vfs_close(vfd); return -1; }
 
-  if (ofs != pos) { close(fd); return -1; }
+  if (ofs != pos) { vfs_close(vfd); return -1; }
 
-  rd = read(fd, buf, 0x200);
-  close(fd);
+  rd = vfs_read(vfd, buf, 0x200);
+  vfs_close(vfd);
   if (rd == -1) return -2;
 
   return 0;
@@ -1732,7 +1736,8 @@ unsigned next_cluster(fatfs_t *f, unsigned clu)
  */
 void mimic_boot_blk(void)
 {
-  int fd, size, idx;
+  vfs_file_t *vfd;
+  int size, idx;
   unsigned r_o, d_o, sp;
   int load_offs;
   uint16_t seg;
@@ -1746,7 +1751,7 @@ void mimic_boot_blk(void)
     return;
   }
 
-  if ((fd = mfs_open_file(f->mfs_idx, f->obj[1].full_name, O_RDONLY)) == -1) {
+  if ((vfd = vfs_open(f->fs, f->obj[1].full_name, O_RDONLY)) == NULL) {
     error("cannot open DOS system file %s\n", f->obj[1].full_name);
     leavedos(99);
   }
@@ -1933,7 +1938,7 @@ void mimic_boot_blk(void)
 	size = loadtop - (seg << 4);		/* limit loaded size to max */
       }
       if (size < 0x600) {
-	close(fd);
+	vfs_close(vfd);
 	error("too small DOS system file %s\n", f->obj[1].full_name);
 	leavedos(99);
 	return;
@@ -1978,7 +1983,7 @@ void mimic_boot_blk(void)
         /* load boot sector to stack */
         read_boot(f, LINEAR2UNIX(SEGOFF2LINEAR(_SS, _SP)));
       } else {
-        close(fd);
+        vfs_close(vfd);
         error("%s boot failed\n", system_type(f->sys_type));
         leavedos(99);
         return;
@@ -1992,8 +1997,8 @@ void mimic_boot_blk(void)
 
   // load bootfile i.e IO.SYS, IBMBIO.COM, etc
   if (!(f->sfiles[idx].flags & FLG_NOREAD))
-    dos_read(fd, SEGOFF2LINEAR(_CS, _IP) + load_offs, size);
-  close(fd);
+    dos_read(vfd, SEGOFF2LINEAR(_CS, _IP) + load_offs, size);
+  vfs_close(vfd);
 }
 
 /*

--- a/src/base/misc/fatfs_priv.h
+++ b/src/base/misc/fatfs_priv.h
@@ -1,3 +1,4 @@
+#include "vfs/vfs.h"
 /*
  * (C) Copyright 1992, ..., 2014 the "DOSEMU-Development-Team".
  *
@@ -49,9 +50,9 @@ struct fatfs_s {
   unsigned root_entries;
   unsigned cluster_secs;
   unsigned char drive_num;
-  unsigned int mfs_idx;
+  vfs_fs_t *fs;
   int group;
-  int dir_fd;
+  vfs_dir_t *dir_fd;
   uint64_t sys_type;			/* see fatfs::scan_dir() */
 
   unsigned got_all_objs;

--- a/src/dosext/drivers/cdrom.c
+++ b/src/dosext/drivers/cdrom.c
@@ -362,7 +362,7 @@ void cdrom_helper(unsigned char *req_buf, unsigned char *transfer_buf,
 	    n = *CALC_PTR(req_buf, MSCD_READ_NUMSECTORS,
 			  u_short) * CD_FRAMESIZE;
 	    if (transfer_buf == NULL) {
-		n = dos_read(cdrom_fd, dos_transfer_buf, n);
+		n = dos_read_posix(cdrom_fd, dos_transfer_buf, n);
 	    } else {
 		n = unix_read(cdrom_fd, transfer_buf, n);
 	    }
@@ -378,7 +378,7 @@ void cdrom_helper(unsigned char *req_buf, unsigned char *transfer_buf,
 		    n = *CALC_PTR(req_buf, MSCD_READ_NUMSECTORS,
 				  u_short) * CD_FRAMESIZE;
 		    if (transfer_buf == NULL)
-			n = dos_read(cdrom_fd, dos_transfer_buf, n);
+			n = dos_read_posix(cdrom_fd, dos_transfer_buf, n);
 		    else
 			n = unix_read(cdrom_fd, transfer_buf, n);
 		    if (n < 0) {

--- a/src/dosext/mfs/lfn.c
+++ b/src/dosext/mfs/lfn.c
@@ -121,7 +121,7 @@ static int vfat_search(char *dest, const char *src, const char *path, int alias,
   if (dir == NULL)
     return 0;
 
-  if (dir->dir == NULL)
+  if (dir->vdir == NULL)
     while ((de = dos_readdir(dir)) != NULL) {
       d_printf("LFN: vfat_search (short='%s', long='%s')", de->d_name, de->d_long_name);
       if ((strcasecmp(de->d_long_name, src) == 0) || (strcasecmp(de->d_name, src) == 0)) {

--- a/src/dosext/mfs/mfs.c
+++ b/src/dosext/mfs/mfs.c
@@ -1,3 +1,4 @@
+#include "vfs/vfs.h"
 /*
  * DANG_BEGIN_MODULE
  *
@@ -682,11 +683,11 @@ int get_dos_attr(const char *fname, int mode, int drive)
 
 #ifdef __linux__
   if (fname && file_on_fat(fname) && (S_ISREG(mode) || S_ISDIR(mode))) {
-    int fd = mfs_open_file(REDIR_DEVICE_IDX(drives[drive].options),
-	fname, O_RDONLY);
-    if (fd != -1) {
-      int res = ioctl(fd, FAT_IOCTL_GET_ATTRIBUTES, &attr);
-      close(fd);
+    vfs_fs_t *fs = vfs_get_fs(REDIR_DEVICE_IDX(drives[drive].options));
+    vfs_file_t *vfd = vfs_open(fs, fname, O_RDONLY);
+    if (vfd) {
+      int res = ioctl(vfd->fd, FAT_IOCTL_GET_ATTRIBUTES, &attr);
+      vfs_close(vfd);
       if (res == 0)
 	return attr;
     }
@@ -699,13 +700,13 @@ int get_dos_attr(const char *fname, int mode, int drive)
   return handle_xattr(attr, mode);
 }
 
-static int get_dos_attr_fd(int fd, int mode, const char *name, int drive)
+static int get_dos_attr_fd(vfs_file_t *fd, int mode, const char *name, int drive)
 {
   int attr;
 
 #ifdef __linux__
-  if (fd_on_fat(fd) && (S_ISREG(mode) || S_ISDIR(mode)) &&
-      ioctl(fd, FAT_IOCTL_GET_ATTRIBUTES, &attr) == 0)
+  if (fd_on_fat(fd->fd) && (S_ISREG(mode) || S_ISDIR(mode)) &&
+      ioctl(fd->fd, FAT_IOCTL_GET_ATTRIBUTES, &attr) == 0)
     return attr;
 #endif
 
@@ -730,30 +731,30 @@ static int get_unix_attr(int attr)
 }
 
 #ifdef __linux__
-int set_fat_attr(int fd, int attr)
+int set_fat_attr(vfs_file_t *fd, int attr)
 {
-  return ioctl(fd, FAT_IOCTL_SET_ATTRIBUTES, &attr);
+  return ioctl(fd->fd, FAT_IOCTL_SET_ATTRIBUTES, &attr);
 }
 #endif
 
 int set_dos_attr(char *fpath, int attr, int drive)
 {
 #ifdef __linux__
-  int fd = -1;
+  vfs_fs_t *fs = vfs_get_fs(REDIR_DEVICE_IDX(drives[drive].options));
+  vfs_file_t *vfd = NULL;
   int res;
 
   if (fpath && file_on_fat(fpath))
-    fd = mfs_open_file(REDIR_DEVICE_IDX(drives[drive].options),
-	fpath, O_RDONLY);
-  if (fd != -1) {
-    res = set_fat_attr(fd, attr);
+    vfd = vfs_open(fs, fpath, O_RDONLY);
+  if (vfd) {
+    res = set_fat_attr(vfd, attr);
     if (res && errno != ENOTTY) {
       int oldattr = 1;
-      ioctl(fd, FAT_IOCTL_GET_ATTRIBUTES, &oldattr);
+      ioctl(vfd->fd, FAT_IOCTL_GET_ATTRIBUTES, &oldattr);
       if (dos_would_allow(fpath, "FAT_IOCTL_SET_ATTRIBUTES", attr == oldattr))
 	res = 0;
     }
-    close(fd);
+    vfs_close(vfd);
     return res;
   }
 #endif
@@ -765,8 +766,7 @@ int set_dos_attr(char *fpath, int attr, int drive)
 
 int dos_utime(const char *fpath, time_t atime, time_t mtime, int drive)
 {
-  return mfs_utime(REDIR_DEVICE_IDX(drives[drive].options), fpath, atime,
-      mtime);
+  return vfs_utime(vfs_get_fs(REDIR_DEVICE_IDX(drives[drive].options)), fpath, atime, mtime);
 }
 
 static int dos_get_disk_space(const char *cwd, unsigned int *free, unsigned int *total,
@@ -931,12 +931,12 @@ void mfs_reset(void)
 
 int mfs_stat(const char *path, struct stat *sb, int drive)
 {
-  return mfs_stat_file(REDIR_DEVICE_IDX(drives[drive].options), path, sb);
+  return vfs_stat(vfs_get_fs(REDIR_DEVICE_IDX(drives[drive].options)), path, sb);
 }
 
 static int mfs_statvfs(const char *path, struct statvfs *sb, int drive)
 {
-  return do_mfs_statvfs(REDIR_DEVICE_IDX(drives[drive].options), path, sb);
+  return vfs_statvfs(vfs_get_fs(REDIR_DEVICE_IDX(drives[drive].options)), path, sb);
 }
 
 static void init_drive(int dd, char *path, uint16_t user, uint16_t options)
@@ -1589,42 +1589,34 @@ static int init_dos_offsets(int ver)
 struct mfs_dir *dos_opendir(const char *name, int drive)
 {
   struct mfs_dir *dir;
-  int fd = -1;
-  DIR *d = NULL;
+  vfs_fs_t *fs = vfs_get_fs(REDIR_DEVICE_IDX(drives[drive].options));
+  vfs_file_t *vfile = NULL;
+  vfs_dir_t *vdir = NULL;
 #ifdef __linux__
   struct __fat_dirent de[2];
 
   if (file_on_fat(name)) {
-    fd = mfs_open_file(REDIR_DEVICE_IDX(drives[drive].options),
-	name, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
-    if (fd == -1)
+    vfile = vfs_open(fs, name, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    if (!vfile)
       return NULL;
-    if (ioctl(fd, vfat_ioctl, de) != -1) {
-      lseek(fd, 0, SEEK_SET);
+    if (ioctl(vfile->fd, vfat_ioctl, de) != -1) {
+      vfs_lseek(vfile, 0, SEEK_SET);
     } else {
-      close(fd);
-      fd = -1;
+      vfs_close(vfile);
+      vfile = NULL;
     }
   }
 #endif
-  if (fd == -1) {
-    /* not a VFAT filesystem or other problems */
-    int dfd = mfs_open_file(REDIR_DEVICE_IDX(drives[drive].options), name,
-        O_RDONLY | O_DIRECTORY | O_CLOEXEC);
-    if (dfd == -1) {
+  if (!vfile) {
+    vdir = vfs_opendir(fs, name);
+    if (!vdir) {
       error("opendir failed: %s\n", strerror(errno));
-      return NULL;
-    }
-    d = fdopendir(dfd);
-    if (d == NULL) {
-      error("fdopendir failed: %s\n", strerror(errno));
-      close(dfd);
       return NULL;
     }
   }
   dir = malloc(sizeof *dir);
-  dir->fd = fd;
-  dir->dir = d;
+  dir->vfile = vfile;
+  dir->vdir = vdir;
   dir->nr = 0;
   return (dir);
 }
@@ -1634,8 +1626,8 @@ struct mfs_dirent *dos_readdir(struct mfs_dir *dir)
   if (dir->nr <= 1) {
     dir->de.d_name = dir->de.d_long_name = dir->nr ? ".." : ".";
   } else do {
-    if (dir->dir) {
-      struct direct *de = (struct direct *) readdir(dir->dir);
+    if (dir->vdir) {
+      struct dirent *de = vfs_readdir(dir->vdir);
       if (de == NULL)
 	return NULL;
       dir->de.d_name = dir->de.d_long_name = de->d_name;
@@ -1644,7 +1636,7 @@ struct mfs_dirent *dos_readdir(struct mfs_dir *dir)
       static struct __fat_dirent de[2];
       int ret;
 
-      ret = (int)RPT_SYSCALL(ioctl(dir->fd, vfat_ioctl, de));
+      ret = (int)RPT_SYSCALL(ioctl(dir->vfile->fd, vfat_ioctl, de));
       if (ret == -1 || de[0].d_reclen == 0)
         return NULL;
 
@@ -1668,20 +1660,20 @@ int dos_closedir(struct mfs_dir *dir)
 {
   int ret;
 
-  if (dir->dir)
-    ret = closedir(dir->dir);
+  if (dir->vdir)
+    ret = vfs_closedir(dir->vdir);
   else
-    ret = close(dir->fd);
+    ret = vfs_close(dir->vfile);
   free(dir);
   return (ret);
 }
 
 static inline int
-dos_flush(int fd)
+dos_flush(vfs_file_t *fd)
 {
   int ret;
 
-  ret = RPT_SYSCALL(fsync(fd));
+  ret = vfs_fsync(fd);
 
   return (ret);
 }
@@ -3102,7 +3094,7 @@ int dos_rmdir(const char *filename1, int drive, int lfn)
   build_ufs_path_(fpath, filename1, drive, !lfn);
   if (find_file(fpath, &st, NULL, drive) &&
       !is_dos_device(fpath)) {
-    if (mfs_rmdir(REDIR_DEVICE_IDX(drives[drive].options), fpath) != 0) {
+    if (vfs_rmdir(vfs_get_fs(REDIR_DEVICE_IDX(drives[drive].options)), fpath) != 0) {
       Debug0(("failed to remove directory %s\n", fpath));
       return ACCESS_DENIED;
     }
@@ -3133,7 +3125,7 @@ int dos_mkdir(const char *filename1, int drive, int lfn)
     Debug0(("parent not found '%s'\n", fpath));
     return PATH_NOT_FOUND;
   }
-  if (mfs_mkdir(REDIR_DEVICE_IDX(drives[drive].options), fpath, 0755) != 0) {
+  if (vfs_mkdir(vfs_get_fs(REDIR_DEVICE_IDX(drives[drive].options)), fpath, 0755) != 0) {
     Debug0(("make directory failed '%s'\n", fpath));
     return ACCESS_DENIED;
   }
@@ -3315,16 +3307,16 @@ static void update_seek_from_dos(uint32_t seek_from_dos, uint64_t* p_seek) {
 
 static struct file_fd *do_open_prn(const char *filename1, const char *fpath)
 {
-    int fd;
+    int prn_num;
     struct file_fd *f;
     const char *bs_pos = filename1 + strlen(LINUX_PRN_RESOURCE);
     if (bs_pos[0] != '\\' || !isdigit(bs_pos[1]))
       return NULL;
-    fd = bs_pos[1] - '0' - 1;
-    if (printer_open(fd) != 0)
+    prn_num = bs_pos[1] - '0' - 1;
+    if (printer_open(prn_num) != 0)
       return NULL;
     f = do_claim_fd(fpath);
-    f->fd = fd;
+    f->fd = vfs_file_wrap_posix(prn_num);
     f->type = TYPE_PRINTER;
     return f;
 }
@@ -3467,12 +3459,12 @@ static int dos_fs_redirect(struct vm86_regs *state, char *stk)
           return FALSE;
       f = &open_files[cnt];
       if (f->name == NULL) {
-        Debug0(("Close file %x fails\n", f->fd));
+        Debug0(("Close file %p fails\n", f->fd));
         return FALSE;
       }
       strlcpy(fpath, f->name, sizeof(fpath));
       filename1 = fpath;
-      Debug0(("Close file %x (%s)\n", f->fd, filename1));
+      Debug0(("Close file %p (%s)\n", f->fd, filename1));
 
       /* if bit 14 in device_info is set, dos requests to set the file
          date/time on closing. R.Brown states this incorrectly (inverted).
@@ -3499,8 +3491,8 @@ static int dos_fs_redirect(struct vm86_regs *state, char *stk)
         return TRUE;
       }
       if (f->type == TYPE_PRINTER) {
-        printer_close(f->fd);
-        Debug0(("printer %i closed\n", f->fd));
+        printer_close(f->fd->fd);
+        Debug0(("printer %p closed\n", f->fd));
       } else {
         mfs_close(f);
       }
@@ -3560,10 +3552,10 @@ static int dos_fs_redirect(struct vm86_regs *state, char *stk)
         if (cnt1 != -1)
           cnt = cnt1;
       }
-      Debug0(("Read file fd=%d, dta=%#x, cnt=%d\n", f->fd, dta, cnt));
+      Debug0(("Read file fd=%p, dta=%#x, cnt=%d\n", f->fd, dta, cnt));
       Debug0(("Read file pos = %"PRIu64"\n", f->seek));
       Debug0(("Handle cnt %d\n", sft_handle_cnt(sft)));
-      s_pos = lseek(f->fd, f->seek, SEEK_SET);
+      s_pos = vfs_lseek(f->fd, f->seek, SEEK_SET);
       if (s_pos < 0 && errno != ESPIPE) {
         if (locked)
           region_unlock_offs(f->fd);
@@ -3592,7 +3584,7 @@ static int dos_fs_redirect(struct vm86_regs *state, char *stk)
       if (ret + s_pos > sft_size(sft)) {
         /* someone else enlarged the file! refresh. */
         int r2;
-        r2 = fstat(f->fd, &f->st);
+        r2 = vfs_fstat(f->fd, &f->st);
         assert(r2 == 0);
         f->size = f->st.st_size;
         set_32bit_size_or_position(&_sft_size(sft), f->size);
@@ -3616,10 +3608,10 @@ static int dos_fs_redirect(struct vm86_regs *state, char *stk)
 
       update_seek_from_dos(sft_position(sft), &f->seek);
       cnt = WORD(state->ecx);
-      Debug0(("Write file fd=%d count=%x sft_mode=%x\n", f->fd, cnt, sft_open_mode(sft)));
+      Debug0(("Write file fd=%p count=%x sft_mode=%x\n", f->fd, cnt, sft_open_mode(sft)));
       if (f->type == TYPE_PRINTER) {
         for (ret = 0; ret < cnt; ret++) {
-          if (printer_write(f->fd, READ_BYTE(dta + ret)) != 1)
+          if (printer_write(f->fd->fd, READ_BYTE(dta + ret)) != 1)
             break;
         }
         SETWORD(&state->ecx, ret);
@@ -3628,7 +3620,7 @@ static int dos_fs_redirect(struct vm86_regs *state, char *stk)
 
       if (!cnt) {
         Debug0(("Applying O_TRUNC at %x\n", (int)s_pos));
-        if (ftruncate(f->fd, (off_t)f->seek)) {
+        if (vfs_ftruncate(f->fd, (off_t)f->seek)) {
           Debug0(("O_TRUNC failed\n"));
           SETWORD(&state->eax, ACCESS_DENIED);
           return FALSE;
@@ -3662,7 +3654,7 @@ static int dos_fs_redirect(struct vm86_regs *state, char *stk)
         if (cnt1 != -1)
           cnt = cnt1;
 
-        s_pos = lseek(f->fd, f->seek, SEEK_SET);
+        s_pos = vfs_lseek(f->fd, f->seek, SEEK_SET);
         if (s_pos < 0 && errno != ESPIPE) {
           if (locked)
             region_unlock_offs(f->fd);
@@ -3693,7 +3685,7 @@ static int dos_fs_redirect(struct vm86_regs *state, char *stk)
       }
       //    sft_abs_cluster(sft) = 0x174a;	/* XXX a test */
       /* update stat for atime/mtime */
-      if (fstat(f->fd, &f->st) == 0)
+      if (vfs_fstat(f->fd, &f->st) == 0)
         time_to_dos(f->st.st_mtime, &_sft_date(sft), &_sft_time(sft));
       return TRUE;
     }
@@ -4041,7 +4033,7 @@ do_open_existing:
       do_update_sft(f, fname, fext, sft, drive,
             get_dos_attr(fpath, st.st_mode, drive), FCBcall, 1);
 
-      Debug0(("open succeeds: '%s' fd = 0x%x\n", fpath, f->fd));
+      Debug0(("open succeeds: '%s' fd = %p\n", fpath, f->fd));
       Debug0(("Size : %ld\n", (long)f->st.st_size));
 
       /* If FCB open requested, we need to call int2f 0x120c */
@@ -4096,13 +4088,13 @@ do_create_truncate:
       }
       auspr(filename1, fname, fext);
       if (strncasecmp(filename1, LINUX_PRN_RESOURCE, strlen(LINUX_PRN_RESOURCE)) == 0) {
-        int fd;
+        int prn_num;
         bs_pos = filename1 + strlen(LINUX_PRN_RESOURCE);
         if (bs_pos[0] != '\\' || !isdigit(bs_pos[1]))
           return FALSE;
-        fd = bs_pos[1] - '0' - 1;
-        if (printer_open(fd) != 0) {
-          error("printer %i open failure!\n", fd);
+        prn_num = bs_pos[1] - '0' - 1;
+        if (printer_open(prn_num) != 0) {
+          error("printer %i open failure!\n", prn_num);
           return FALSE;
         }
         Debug0(("printer open succeeds: '%s'\n", filename1));
@@ -4110,7 +4102,7 @@ do_create_truncate:
         fname[0] = 0;
         fext[0] = 0;
         f = do_claim_fd(fpath);
-        f->fd = fd;
+        f->fd = vfs_file_wrap_posix(prn_num);
         f->type = TYPE_PRINTER;
       } else {
         struct stat st;
@@ -4142,8 +4134,8 @@ do_create_truncate:
           SETWORD(&state->eax, ACCESS_DENIED);
           return FALSE;
         }
-        if (fstat(f->fd, &f->st) == -1) {
-          Debug0(("can't fstat %d: %s\n", f->fd, strerror(errno)));
+        if (vfs_fstat(f->fd, &f->st) == -1) {
+          Debug0(("can't fstat %p: %s\n", f->fd, strerror(errno)));
           SETWORD(&state->eax, ACCESS_DENIED);
           return FALSE;
         }
@@ -4159,7 +4151,7 @@ do_create_truncate:
       }
 
       do_update_sft(f, fname, fext, sft, drive, attr, FCBcall, 0);
-      Debug0(("create succeeds: '%s' fd = 0x%x\n", fpath, f->fd));
+      Debug0(("create succeeds: '%s' fd = %p\n", fpath, f->fd));
       Debug0(("fsize = 0x%"PRIx64"\n", f->size));
 
       /* If FCB open requested, we need to call int2f 0x120c */
@@ -4284,13 +4276,13 @@ do_create_truncate:
         SETWORD(&state->eax, ACCESS_DENIED);
         return FALSE;
       }
-      Debug0(("Seek From EOF fd=%d ofs=%lld\n", f->fd, (long long)offset));
+      Debug0(("Seek From EOF fd=%p ofs=%lld\n", f->fd, (long long)offset));
 #if 0
       /* no need for an actual seek here. we do it before read/write */
-      new_pos = lseek(f->fd, offset, SEEK_END);
+      new_pos = vfs_lseek(f->fd, offset, SEEK_END);
 #endif
-      Debug0(("Seek returns fd=%d ofs=%lld\n", f->fd, (long long)offset));
-      if (fstat(f->fd, &f->st) == 0) {
+      Debug0(("Seek returns fd=%p ofs=%lld\n", f->fd, (long long)offset));
+      if (vfs_fstat(f->fd, &f->st) == 0) {
         off_t new_pos = offset + f->st.st_size;
         /* update file size in case other process changed it */
         f->seek = new_pos;
@@ -4350,7 +4342,7 @@ do_create_truncate:
           return FALSE;
       f = &open_files[cnt];
 
-      Debug0(("lock requested, fd=%d, is_lock=%d, start=%lx, len=%lx\n",
+      Debug0(("lock requested, fd=%p, is_lock=%d, start=%lx, len=%lx\n",
                       f->fd, is_lock, (long)pt->offset, (long)pt->size));
 
       if (f->name == NULL) {
@@ -4558,7 +4550,7 @@ do_create_truncate:
         SETWORD(&state->eax, HANDLE_INVALID);
         return FALSE;
       }
-      d_printf("found %s on fd %i\n", f->name, f->fd);
+      d_printf("found %s on fd %p\n", f->name, f->fd);
       MEMCPY_2UNIX(&seek, SEGOFF2LINEAR(SREG(ds), LWORD(edx)), sizeof seek);
       d_printf("cl=%02"PRIX8"h seek=%08"PRIX64"h "
 		"sftposition=%08"PRIX32"h\n"
@@ -4575,7 +4567,7 @@ do_create_truncate:
 	  f->seek = f->seek + seek;
 	  break;
 	case DOS_SEEK_EOF:
-	  if (fstat(f->fd, &f->st) == 0) {
+	  if (vfs_fstat(f->fd, &f->st) == 0) {
 	    /* update file size in case other process changed it */
 	    f->size = f->st.st_size;
 	    set_32bit_size_or_position(&_sft_size(sft), f->size);
@@ -4614,9 +4606,9 @@ do_create_truncate:
         SETWORD(&state->eax, HANDLE_INVALID);
         return FALSE;
       }
-      d_printf("found %s on fd %i\n", f->name, f->fd);
+      d_printf("found %s on fd %p\n", f->name, f->fd);
       /* update stat for atime/mtime */
-      if (fstat(f->fd, &f->st)) {
+      if (vfs_fstat(f->fd, &f->st)) {
         SETWORD(&state->eax, HANDLE_INVALID);
         return FALSE;
 	}

--- a/src/dosext/mfs/mfs.h
+++ b/src/dosext/mfs/mfs.h
@@ -1,3 +1,4 @@
+#include "vfs/vfs.h"
 /*
 adapted from dos.h in the mach dos emulator for the linux dosemu dos
 emulator.
@@ -263,9 +264,9 @@ struct mfs_dirent
 
 struct mfs_dir
 {
-  DIR *dir;
+  vfs_dir_t *vdir;
+  vfs_file_t *vfile;
   struct mfs_dirent de;
-  int fd;
   unsigned int nr;
 };
 
@@ -377,7 +378,7 @@ extern void build_ufs_path_(char *ufs, const char *path, int drive,
                            int lowercase);
 extern int find_file(char *fpath, struct stat *st, int *doserror, int drive);
 extern int get_dos_attr(const char *fname, int mode, int drive);
-extern int set_fat_attr(int fd,int attr);
+extern int set_fat_attr(vfs_file_t *fd, int attr);
 extern int set_dos_attr(char *fname, int attr, int drive);
 extern int dos_utime(const char *fpath, time_t atime, time_t mtime, int drive);
 extern void time_to_dos(time_t clock, u_short *date, u_short *time);
@@ -407,7 +408,7 @@ struct file_fd
 {
   char *name;
   int idx;
-  int fd;
+  vfs_file_t *fd;
   int type;
   void *shlock;
   void **shemu_locks;  // for share modes emulation

--- a/src/dosext/mfs/rlocks.c
+++ b/src/dosext/mfs/rlocks.c
@@ -1,3 +1,4 @@
+#include "vfs/vfs.h"
 /*
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -90,7 +91,7 @@ static void lock_get(int fd, struct flock *fl)
   }
 }
 
-int lock_file_region(int fd, int lck, long long start,
+int lock_file_region(vfs_file_t *fd, int lck, long long start,
     unsigned long len, int wr, int mlemu_fd)
 {
   struct flock fl;
@@ -98,25 +99,25 @@ int lock_file_region(int fd, int lck, long long start,
 
   /* make data visible before releasing the lock */
   if (!lck)
-    fsync(fd);
+    vfs_fsync(fd);
 
   fl.l_type = (lck ? (wr ? F_WRLCK : F_RDLCK) : F_UNLCK);
   fl.l_start = start;
   fl.l_len = len;
   /* needs to lock against I/O operations in another process */
-  ret = flock(fd, LOCK_EX);
+  ret = flock(fd->fd, LOCK_EX);
   if (ret)
     return -1;
-  ret = lock_set(fd, &fl);
+  ret = lock_set(fd->fd, &fl);
 #if FUNLCK_WA
   if (mlemu_fd != -1)
     lock_set(mlemu_fd, &fl);
 #endif
-  flock(fd, LOCK_UN);
+  flock(fd->fd, LOCK_UN);
   return ret;
 }
 
-int region_is_fully_owned(int fd, long long start, unsigned long len, int wr,
+int region_is_fully_owned(vfs_file_t *fd, long long start, unsigned long len, int wr,
     int mlemu_fd2)
 {
   struct flock fl;
@@ -125,7 +126,7 @@ int region_is_fully_owned(int fd, long long start, unsigned long len, int wr,
   fl.l_type = F_UNLCK;
   fl.l_start = start;
   fl.l_len = len;
-  err = do_lock_get(fd, &fl);
+  err = do_lock_get(fd->fd, &fl);
 #if FUNLCK_WA
   if (err && errno == EINVAL) {  // F_UNLCK extension unsupported
     /* check on mirror fd so rd/wr inverted */
@@ -155,7 +156,7 @@ int region_is_fully_owned(int fd, long long start, unsigned long len, int wr,
   return 1;
 }
 
-int region_lock_offs(int fd, long long start, unsigned long len, int wr)
+int region_lock_offs(vfs_file_t *fd, long long start, unsigned long len, int wr)
 {
   struct flock fl;
   int ret;
@@ -164,25 +165,25 @@ int region_lock_offs(int fd, long long start, unsigned long len, int wr)
 #ifndef __APPLE__
   /* on MacOS this kind of lock is incompatible with F_OFD_GETLK,
      which then sets l_pid to -1 */
-  ret = flock(fd, LOCK_EX);
+  ret = flock(fd->fd, LOCK_EX);
   if (ret)
     return -1;
 #endif
   fl.l_type = wr ? F_WRLCK : F_RDLCK;
   fl.l_start = start;
   fl.l_len = len;
-  lock_get(fd, &fl);
+  lock_get(fd->fd, &fl);
   if (fl.l_type == F_UNLCK)
     return len;
   if (fl.l_start > start)
     return (fl.l_start - start);  // found partially unlocked region
   /* no allowed region found, unlock and return 0 */
-  return flock(fd, LOCK_UN);
+  return flock(fd->fd, LOCK_UN);
 }
 
-void region_unlock_offs(int fd)
+void region_unlock_offs(vfs_file_t *fd)
 {
-  flock(fd, LOCK_UN);
+  flock(fd->fd, LOCK_UN);
 }
 
 #if FUNLCK_WA

--- a/src/dosext/mfs/rlocks.h
+++ b/src/dosext/mfs/rlocks.h
@@ -1,3 +1,4 @@
+#include "vfs/vfs.h"
 #ifndef RLOCKS_H
 #define RLOCKS_H
 
@@ -35,12 +36,12 @@ static inline void close_mlemu(int *fds)
 }
 #endif
 
-int lock_file_region(int fd, int lck, long long start,
+int lock_file_region(vfs_file_t *fd, int lck, long long start,
     unsigned long len, int wr, int mlemu_fd);
-int region_lock_offs(int fd, long long start, unsigned long len,
+int region_lock_offs(vfs_file_t *fd, long long start, unsigned long len,
     int wr);
-void region_unlock_offs(int fd);
-int region_is_fully_owned(int fd, long long start, unsigned long len, int wr,
+void region_unlock_offs(vfs_file_t *fd);
+int region_is_fully_owned(vfs_file_t *fd, long long start, unsigned long len, int wr,
     int mlemu_fd2);
 
 #else
@@ -53,13 +54,13 @@ static inline void close_mlemu(int *fds)
 {
 }
 
-static inline int lock_file_region(int fd, int lck, long long start,
+static inline int lock_file_region(vfs_file_t *fd, int lck, long long start,
     unsigned long len, int wr, int mlemu_fd)
 {
     return 0;
 }
 
-static inline int region_lock_offs(int fd, long long start, unsigned long len,
+static inline int region_lock_offs(vfs_file_t *fd, long long start, unsigned long len,
     int wr)
 {
     return len;
@@ -69,7 +70,7 @@ static inline void region_unlock_offs(int fd)
 {
 }
 
-static inline int region_is_fully_owned(int fd, long long start,
+static inline int region_is_fully_owned(vfs_file_t *fd, long long start,
     unsigned long len, int wr, int mlemu_fd2)
 {
     return 1;  // locks not implemented, allow everything

--- a/src/dosext/mfs/share.c
+++ b/src/dosext/mfs/share.c
@@ -1,3 +1,4 @@
+#include "vfs/vfs.h"
 /*
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -128,7 +129,7 @@ static int file_is_opened(int mfs_idx, const char *name)
     int lck = is_locked_shlock(name);
     if (lck)
         return 1;  // locked means already opened
-    return mfs_access(mfs_idx, name, F_OK);
+    return vfs_access(vfs_get_fs(mfs_idx), name, F_OK);
 }
 
 static char *prepare_shemu_name(const char *fname, int id)
@@ -222,7 +223,8 @@ static int do_mfs_open(int mfs_idx, struct file_fd *f, const char *fname,
     exlock = apply_exlock(fname);
     if (!exlock)
         return -1;
-    async = mfs_open_async(mfs_idx, fname, flags | O_CLOEXEC);
+    vfs_fs_t *fs = vfs_get_fs(mfs_idx);
+    async = vfs_open_async(fs, fname, flags | O_CLOEXEC);
     if (!async)
         goto err;
     if (!share_mode) {
@@ -268,7 +270,7 @@ static int do_mfs_open(int mfs_idx, struct file_fd *f, const char *fname,
         goto err4;
     shlock_close(exlock);
 
-    f->fd = fd;
+    f->fd = vfs_file_wrap_posix(fd);
     f->shlock = shlock;
     f->share_mode = share_mode;
     f->psp = sda_cur_psp(sda);
@@ -287,7 +289,7 @@ err2:
     if (async) {
         fd = mfs_async_getfd(async);
         if (fd != -1)
-            close(fd);
+            vfs_close(vfs_file_wrap_posix(fd));
     }
 err:
     shlock_close(exlock);
@@ -324,9 +326,9 @@ static int do_mfs_creat(int mfs_idx, struct file_fd *f, const char *fname,
     exlock = apply_exlock(fname);
     if (!exlock)
         return -1;
-    fd = mfs_create_file(mfs_idx, fname,
-                         O_RDWR | O_CLOEXEC | O_CREAT | O_TRUNC, mode);
-    if (fd == -1)
+    vfs_fs_t *fs = vfs_get_fs(mfs_idx);
+    vfs_file_t *vfd = vfs_creat(fs, fname, O_RDWR | O_CLOEXEC | O_CREAT | O_TRUNC, mode);
+    if (!vfd)
         goto err;
     /* set compat mode */
     err = open_compat(fname, O_RDWR, f->shemu_locks);
@@ -337,7 +339,7 @@ static int do_mfs_creat(int mfs_idx, struct file_fd *f, const char *fname,
         goto err3;
     shlock_close(exlock);
 
-    f->fd = fd;
+    f->fd = vfs_file_wrap_posix(fd);
     f->shlock = shlock;
     f->share_mode = 0;
     f->psp = sda_cur_psp(sda);
@@ -351,8 +353,8 @@ err3:
             shlock_close(f->shemu_locks[i]);
     }
 err2:
-    unlink(fname);
-    close(fd);
+    vfs_unlink(fs, fname);
+    vfs_close(vfd);
 err:
     shlock_close(exlock);
     return -1;
@@ -398,7 +400,7 @@ static int do_mfs_unlink(int mfs_idx, const char *fname, int force)
                 return ACCESS_DENIED;
             }
     }
-    rc = mfs_unlink_file(mfs_idx, fname);
+    rc = vfs_unlink(vfs_get_fs(mfs_idx), fname);
     shlock_close(exlock);
     if (rc)
         return FILE_NOT_FOUND;
@@ -437,7 +439,7 @@ static int do_mfs_setattr(int mfs_idx, const char *fname, int attr, int force)
                 return ACCESS_DENIED;
             }
     }
-    rc = mfs_setxattr_file(mfs_idx, fname, attr);
+    rc = vfs_setxattr(vfs_get_fs(mfs_idx), fname, attr);
     shlock_close(exlock);
     return rc;
 }
@@ -488,7 +490,7 @@ static int do_mfs_rename(int mfs_idx, const char *fname, const char *fname2,
         return ACCESS_DENIED;
     }
 
-    rc = mfs_rename_file(mfs_idx, fname, fname2);
+    rc = vfs_rename(vfs_get_fs(mfs_idx), fname, fname2);
     shlock_close(exlock2);
     shlock_close(exlock);
     if (rc) {
@@ -517,7 +519,7 @@ void mfs_close(struct file_fd *f)
 {
     int i;
 
-    close(f->fd);
+    vfs_close(f->fd);
     if (f->shlock)
         shlock_close(f->shlock);
     for (i = 0; i < lk_MAX; i++) {

--- a/src/dosext/mfs/share.c
+++ b/src/dosext/mfs/share.c
@@ -319,7 +319,7 @@ struct file_fd *mfs_open(int mfs_idx, const char *name, int flags,
 static int do_mfs_creat(int mfs_idx, struct file_fd *f, const char *fname,
                         mode_t mode)
 {
-    int fd, err, i;
+    int err, i;
     void *shlock;
     void *exlock;
 
@@ -339,7 +339,7 @@ static int do_mfs_creat(int mfs_idx, struct file_fd *f, const char *fname,
         goto err3;
     shlock_close(exlock);
 
-    f->fd = vfs_file_wrap_posix(fd);
+    f->fd = vfd;
     f->shlock = shlock;
     f->share_mode = 0;
     f->psp = sda_cur_psp(sda);

--- a/src/dosext/mfs/util.c
+++ b/src/dosext/mfs/util.c
@@ -232,14 +232,14 @@ int get_drive_from_path(char *path, int *drive)
   return 1;
 }
 
-char *probe_sfn_name(int dfd, const char *dir, const char *name,
+char *probe_sfn_name(vfs_dir_t *dfd, const char *dir, const char *name,
 	struct stat *r_st)
 {
     int rc;
     char *nbuf, *nm = NULL, *ret;
 
     assert(dir && dir[0] != '\0');
-    rc = fstatat(dfd, name, r_st, 0);
+    rc = vfs_fstatat(dfd, name, r_st, 0);
     if (rc == 0) {
         ret = assemble_path(dir, name);
         goto out;
@@ -248,7 +248,7 @@ char *probe_sfn_name(int dfd, const char *dir, const char *name,
     /* all uppercase */
     nbuf = strupperDOS(nm);
     if (strcmp(nbuf, name)) {
-        rc = fstatat(dfd, nbuf, r_st, 0);
+        rc = vfs_fstatat(dfd, nbuf, r_st, 0);
         if (rc == 0) {
             ret = assemble_path(dir, nbuf);
             goto out;
@@ -257,7 +257,7 @@ char *probe_sfn_name(int dfd, const char *dir, const char *name,
     /* all lowercase */
     nbuf = strlowerDOS(nm);
     if (strcmp(nbuf, name)) {
-        rc = fstatat(dfd, nbuf, r_st, 0);
+        rc = vfs_fstatat(dfd, nbuf, r_st, 0);
         if (rc == 0) {
             ret = assemble_path(dir, nbuf);
             goto out;
@@ -266,7 +266,7 @@ char *probe_sfn_name(int dfd, const char *dir, const char *name,
     if (nbuf[1] != '\0') {  // if just 1 letter, then already tried uppercase
         /* first uppercase */
         nbuf[0] = toupperDOS(nbuf[0]);
-        rc = fstatat(dfd, nbuf, r_st, 0);
+        rc = vfs_fstatat(dfd, nbuf, r_st, 0);
         if (rc == 0) {
             ret = assemble_path(dir, nbuf);
             goto out;

--- a/src/dosext/mfs/xattr.c
+++ b/src/dosext/mfs/xattr.c
@@ -1,3 +1,4 @@
+#include "vfs/vfs.h"
 /*
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -134,7 +135,7 @@ int get_dos_xattr_fd(int fd, const char *name)
 
 int file_is_ro(int mfs_idx, const char *fname)
 {
-    int attr = mfs_getxattr_file(mfs_idx, fname);
+    int attr = vfs_getxattr(vfs_get_fs(mfs_idx), fname);
     /* NOTE: do not use unix file perms for R/O as that may crash
      * some cdrom games:
      * https://github.com/dosemu2/dosemu2/issues/989

--- a/src/include/dos2linux.h
+++ b/src/include/dos2linux.h
@@ -10,6 +10,7 @@
 #include <sys/stat.h>
 #include "cpu.h"
 #include "dosemu_debug.h"
+#include "vfs/vfs.h"
 
 struct MCB {
 	char id;			/* 0 */
@@ -352,9 +353,11 @@ void memsetw_dos(dosaddr_t dest, unsigned short ch, size_t n);
 void memsetl_dos(dosaddr_t dest, unsigned int ch, size_t n);
 
 int unix_read(int fd, void *data, int cnt);
-int dos_read(int fd, unsigned data, int cnt);
+int dos_read(vfs_file_t *fd, unsigned data, int cnt);
+int dos_read_posix(int fd, unsigned data, int cnt);
 int unix_write(int fd, const void *data, int cnt);
-int dos_write(int fd, unsigned data, int cnt);
+int dos_write(vfs_file_t *fd, unsigned data, int cnt);
+int dos_write_posix(int fd, unsigned data, int cnt);
 int com_vsprintf(char *str, const char *format, va_list ap);
 int com_vsnprintf(char *str, size_t size, const char *format, va_list ap);
 int com_sprintf(char *str, const char *format, ...) FORMAT(printf, 2, 3);
@@ -398,7 +401,7 @@ char *strnlowerDOS(char *s, int n);
 int strequalDOS(const char *s1, const char *s2);
 char *strstrDOS(char *haystack, const char *upneedle);
 int name_ufs_to_dos(char *dest, const char *src);
-char *probe_sfn_name(int dir_fd, const char *dir, const char *name,
+char *probe_sfn_name(vfs_dir_t *dir_fd, const char *dir, const char *name,
     struct stat *r_st);
 
 void dos2tty_init(void);


### PR DESCRIPTION
This is Claudes go at finishing the vfs branch. 

I'm about to go away for a few days so might not have time to test this as much as I'd like - though if the train has Wifi + power hopefully I can give it more of a go (+ try and understand the this commit and the previous vfs one).

I imagine we wouldn't want to just commit some LLM written stuff as-is without adjusting and understanding it anyway.




vfs: add the missing vfs.c/vfs.h implementation

The VFS patch from Jules AI (ee116e7b6) introduced a vfs_fs_t/ vfs_file_t/vfs_dir_t abstraction and ~26 vfs_* functions throughout the MFS/FAT redirector code, but never added the base/lib/vfs module they depend on, so the branch never compiled. Add vfs.h/vfs.c/Makefile as thin wrappers around the existing fslib API.

Also fix three bugs found while getting this to build and boot:
- do_mfs_creat() assigned f->fd from a stale, never-initialized `fd` instead of the vfs_file_t actually returned by vfs_creat()
- set_vol_and_len() leaked a vfs_file_t wrapper manufactured just to fstat() a borrowed directory fd
- fatfs_init() called vfs_opendir(f->fs, ...) before f->fs was assigned, guaranteeing a NULL deref on the first FAT-backed drive mount

Verified with a clean build (autogen.sh/default-configure/make) and a smoke-tested boot: 4 MFS/FAT-redirected drives mounted and closed cleanly, and file creation/write/read through the redirector works.