### PR TITLE
replace most sigprocmask() with pthread_sigmask()

### DIFF
--- a/src/arch/linux/async/debug.c
+++ b/src/arch/linux/async/debug.c
@@ -198,7 +198,7 @@ static int do_fork_debug(void)
   if (getuid() != geteuid())
     return 0;
 
-  sigprocmask(SIG_BLOCK, &q_mask, &oset);
+  pthread_sigmask(SIG_BLOCK, &q_mask, &oset);
   switch ((dbg_pid = fork())) {
     case 0:
       signal_done();
@@ -219,7 +219,7 @@ static int do_fork_debug(void)
       }
       break;
   }
-  sigprocmask(SIG_SETMASK, &oset, NULL);
+  pthread_sigmask(SIG_SETMASK, &oset, NULL);
   return ret;
 }
 

--- a/src/arch/linux/async/signal.c
+++ b/src/arch/linux/async/signal.c
@@ -603,7 +603,7 @@ void signal_done(void)
 	g_printf("can't turn off timer at shutdown: %s\n", strerror(errno));
     if (setitimer(ITIMER_VIRTUAL, &itv, NULL) == -1)
 	g_printf("can't turn off vtimer at shutdown: %s\n", strerror(errno));
-    sigprocmask(SIG_BLOCK, &nonfatal_q_mask, NULL);
+    pthread_sigmask(SIG_BLOCK, &nonfatal_q_mask, NULL);
     for (i = 1; i < SIGMAX; i++) {
 	if (sigismember(&q_mask, i))
 	    signal(i, SIG_DFL);
@@ -899,7 +899,7 @@ static void async_call(void *arg)
 void signal_unblock_async_sigs(void)
 {
   /* unblock only nonfatal, fatals should already be unblocked */
-  sigprocmask(SIG_UNBLOCK, &nonfatal_q_mask, NULL);
+  pthread_sigmask(SIG_UNBLOCK, &nonfatal_q_mask, NULL);
 }
 
 void signal_restore_async_sigs(void)
@@ -907,13 +907,13 @@ void signal_restore_async_sigs(void)
   /* restore temporarily unblocked async signals in a sig context.
    * Just block them even for !sas_wa because if deinit_handler is
    * interrupted after changing %fs, we are in troubles */
-  sigprocmask(SIG_BLOCK, &nonfatal_q_mask, NULL);
+  pthread_sigmask(SIG_BLOCK, &nonfatal_q_mask, NULL);
 }
 
 void signal_unblock_fatal_sigs(void)
 {
   /* unblock only nonfatal, fatals should already be unblocked */
-  sigprocmask(SIG_UNBLOCK, &fatal_q_mask, NULL);
+  pthread_sigmask(SIG_UNBLOCK, &fatal_q_mask, NULL);
 }
 
 /* similar to above, but to call from non-signal context */

--- a/src/arch/linux/async/signal.c
+++ b/src/arch/linux/async/signal.c
@@ -802,7 +802,7 @@ static int sigasync0(int sig)
     char name[128];
     pthread_getname_np(tid, name, sizeof(name));
     dosemu_error("Async signal %i from thread %s\n", sig, name);
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) || defined(__ANDROID__)
     /* somehow SIGALRM often gets unblocked in threads on MacOS,
        forwarding to main thread */
     pthread_kill(dosemu_pthread_self, sig);

--- a/src/base/lib/libpcl/pcl_ctx.c
+++ b/src/base/lib/libpcl/pcl_ctx.c
@@ -117,7 +117,7 @@ static void pctx_pre(void *arg)
 static void pctx_post(void *arg)
 {
 	if (sig_threads_wa)
-		sigprocmask(SIG_SETMASK, arg, NULL);
+		pthread_sigmask(SIG_SETMASK, arg, NULL);
 }
 
 static int ptctx_create_context(co_ctx_t *ctx, void (*func)(void*), void *arg,

--- a/src/base/misc/dos2linux.c
+++ b/src/base/misc/dos2linux.c
@@ -502,11 +502,11 @@ int unix_run_secure(const char *path, int pos, struct popen2 *file)
     retval = pipe(outp);
     assert(!retval);
     signal_block_async_nosig(&oset);
-    sigprocmask(SIG_SETMASK, NULL, &set);
+    pthread_sigmask(SIG_SETMASK, NULL, &set);
     /* fork child */
     switch ((pid = fork())) {
     case -1: /* failed */
-	sigprocmask(SIG_SETMASK, &oset, NULL);
+	pthread_sigmask(SIG_SETMASK, &oset, NULL);
 	g_printf("run_unix_command(): fork() failed\n");
 	return -1;
     case 0: /* child */
@@ -563,7 +563,7 @@ int unix_run_secure(const char *path, int pos, struct popen2 *file)
     pshared_sem_post(crit_sem);
     pshared_sem_wait(init_sem);
     sigchld_unset_critical(&act);
-    sigprocmask(SIG_SETMASK, &oset, NULL);
+    pthread_sigmask(SIG_SETMASK, &oset, NULL);
     pshared_sem_destroy(&init_sem);
     pshared_sem_destroy(&crit_sem);
     close(outp[1]);

--- a/src/base/misc/utilities.c
+++ b/src/base/misc/utilities.c
@@ -913,7 +913,7 @@ int popen2_custom(const char *cmdline, struct popen2 *childinfo)
         perror("execl");
         _exit(99);
     }
-    sigprocmask(SIG_SETMASK, &oset, NULL);
+    pthread_sigmask(SIG_SETMASK, &oset, NULL);
     close(pipe_stdin[0]);
     close(pipe_stdout[1]);
     if (fcntl(pipe_stdin[1], F_SETFD, FD_CLOEXEC) == -1)
@@ -1146,14 +1146,14 @@ pid_t run_external_command(const char *path, int argc, const char **argv,
     retval = pshared_sem_init(&crit_sem, 0);
     assert(!retval);
     signal_block_async_nosig(&oset);
-    sigprocmask(SIG_SETMASK, NULL, &set);
+    pthread_sigmask(SIG_SETMASK, NULL, &set);
     pts_fd = pts_open();
     if (pts_fd == -1)
 	return -1;
     /* fork child */
     switch ((pid = fork())) {
     case -1: /* failed */
-	sigprocmask(SIG_SETMASK, &oset, NULL);
+	pthread_sigmask(SIG_SETMASK, &oset, NULL);
 	g_printf("run_unix_command(): fork() failed\n");
 	return -1;
     case 0: /* child */
@@ -1205,7 +1205,7 @@ pid_t run_external_command(const char *path, int argc, const char **argv,
 		}
 #endif
 	} while (wt != -1);
-	sigprocmask(SIG_SETMASK, &oset, NULL);
+	pthread_sigmask(SIG_SETMASK, &oset, NULL);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
 	retval = execve(path, argv, dosemu_envp);	/* execute command */
@@ -1219,7 +1219,7 @@ pid_t run_external_command(const char *path, int argc, const char **argv,
     pshared_sem_post(crit_sem);
     pshared_sem_wait(init_sem);
     sigchld_unset_critical(&act);
-    sigprocmask(SIG_SETMASK, &oset, NULL);
+    pthread_sigmask(SIG_SETMASK, &oset, NULL);
     pshared_sem_destroy(&init_sem);
     pshared_sem_destroy(&crit_sem);
     close(pts_fd);
@@ -1561,7 +1561,7 @@ void create_thread(pthread_t *restrict thread,
       signal_block_async_nosig(&oset);
     err = pthread_create(thread, NULL, start_routine, arg);
     if (sig_threads_wa)
-      sigprocmask(SIG_SETMASK, &oset, NULL);
+      pthread_sigmask(SIG_SETMASK, &oset, NULL);
     assert(!err);
 #if defined(HAVE_PTHREAD_SETNAME_NP) && defined(__GLIBC__)
     pthread_setname_np(*thread, name);

--- a/src/plugin/console/vc.c
+++ b/src/plugin/console/vc.c
@@ -334,7 +334,7 @@ set_process_control (void)
   sa.sa_handler = tempsigvt;
   sigaction(SIG_RELEASE, &sa, NULL);
   sigaction(SIG_ACQUIRE, &sa, NULL);
-  sigprocmask(SIG_UNBLOCK, &set, NULL);
+  pthread_sigmask(SIG_UNBLOCK, &set, NULL);
 
   if (ioctl (console_fd, VT_SETMODE, &vt_mode))
     v_printf ("initial VT_SETMODE failed!\n");

--- a/src/plugin/dnative/sigsegv.c
+++ b/src/plugin/dnative/sigsegv.c
@@ -347,7 +347,7 @@ static void dosemu_fault0(int signum, sigcontext_t *scp, const siginfo_t *si)
     */
     sigemptyset(&set);
     sigaddset(&set, signum);
-    sigprocmask(SIG_UNBLOCK, &set, NULL);
+    pthread_sigmask(SIG_UNBLOCK, &set, NULL);
   }
 #endif
 

--- a/src/plugin/sdl/sdl.c
+++ b/src/plugin/sdl/sdl.c
@@ -1027,7 +1027,7 @@ static void SDL_change_mode(int x_res, int y_res, int w_x_res, int w_y_res)
     if (!config.X_hidden)
       SDL_ShowWindow(window);
     if (sig_threads_wa)
-      sigprocmask(SIG_SETMASK, &oset, NULL);
+      pthread_sigmask(SIG_SETMASK, &oset, NULL);
     SDL_SetWindowResizable(window, !config.X_noresize);
     if (config.X_fullscreen) {
       SDL_RaiseWindow(window);
@@ -1040,7 +1040,7 @@ static void SDL_change_mode(int x_res, int y_res, int w_x_res, int w_y_res)
     signal_block_async_nosig(&oset);
   SDL_RenderPresent(renderer);
   if (sig_threads_wa)
-    sigprocmask(SIG_SETMASK, &oset, NULL);
+    pthread_sigmask(SIG_SETMASK, &oset, NULL);
 #if defined(HAVE_SDL2_TTF) && defined(HAVE_FONTCONFIG)
   if (is_text)
     setup_ttf_winsize(w_x_res, w_y_res);
@@ -1356,7 +1356,7 @@ static void SDL_handle_events(void)
     signal_block_async_nosig(&oset);
   SDL_PumpEvents();
   if (sig_threads_wa)
-    sigprocmask(SIG_SETMASK, &oset, NULL);
+    pthread_sigmask(SIG_SETMASK, &oset, NULL);
   /* XXX - Flush window resize events to avoid them being dispatched
    * from render thread! If window resize event is dispatched from
    * another thread, window will became permanently blank.

--- a/src/plugin/sdl3/sdl.c
+++ b/src/plugin/sdl3/sdl.c
@@ -1018,7 +1018,7 @@ static void SDL_change_mode(int x_res, int y_res, int w_x_res, int w_y_res)
     if (!config.X_hidden)
       SDL_ShowWindow(window);
     if (sig_threads_wa)
-      sigprocmask(SIG_SETMASK, &oset, NULL);
+      pthread_sigmask(SIG_SETMASK, &oset, NULL);
     SDL_SetWindowResizable(window, !config.X_noresize);
     if (config.X_fullscreen) {
       SDL_RaiseWindow(window);
@@ -1031,7 +1031,7 @@ static void SDL_change_mode(int x_res, int y_res, int w_x_res, int w_y_res)
     signal_block_async_nosig(&oset);
   SDL_RenderPresent(renderer);
   if (sig_threads_wa)
-    sigprocmask(SIG_SETMASK, &oset, NULL);
+    pthread_sigmask(SIG_SETMASK, &oset, NULL);
 #if defined(HAVE_SDL_TTF) && defined(HAVE_FONTCONFIG)
   if (is_text)
     setup_ttf_winsize(w_x_res, w_y_res);
@@ -1351,7 +1351,7 @@ static void SDL_handle_events(void)
     signal_block_async_nosig(&oset);
   SDL_PumpEvents();
   if (sig_threads_wa)
-    sigprocmask(SIG_SETMASK, &oset, NULL);
+    pthread_sigmask(SIG_SETMASK, &oset, NULL);
   /* XXX - Flush window resize events to avoid them being dispatched
    * from render thread! If window resize event is dispatched from
    * another thread, window will became permanently blank.


### PR DESCRIPTION
Except those immediately after fork, and at early startup.
@bartoldeman could you please check if this solves the SIGALRM mystery on MacOS?