### PR TITLE
CI: Add new main program to be run from Comcom CI

### DIFF
--- a/.github/workflows/test-suite-worker.yml
+++ b/.github/workflows/test-suite-worker.yml
@@ -22,6 +22,15 @@ jobs:
       with:
         fetch-depth: 50
 
+    - name: Check if we need to run comcom specific test
+      uses: dorny/paths-filter@v4
+      id: comcom
+      with:
+        filters: |
+          waschanged:
+            - 'test/test_comcom.py'
+            - 'test/func_comcom_internal.py'
+
     - name: Add an ACL to KVM for ourselves
       run: |
           echo 'SUBSYSTEM=="misc", KERNEL=="kvm", RUN+="/usr/bin/setfacl -m u:'${USER}':rw- /dev/kvm"' | sudo tee /etc/udev/rules.d/99-kvm4dosemu2.rules
@@ -110,6 +119,7 @@ jobs:
         RUNTYPE: ${{ inputs.runtype }}
         OS: ${{ inputs.os }}
         BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        COMCOM_CHANGED: ${{ github.event_name == 'push' || steps.comcom.outputs.waschanged }}
       run: ./ci_test.sh
 
     - name: Upload failure logs

--- a/.github/workflows/test-suite-worker.yml
+++ b/.github/workflows/test-suite-worker.yml
@@ -79,6 +79,15 @@ jobs:
         OS: ${{ inputs.os }}
       run: ./ci_build_or_install.sh
 
+    - name: Install test prerequisites
+      id: test_prereq
+      run: ./ci_test_prereq.sh
+
+    - name: Open Watcom install
+      uses: open-watcom/setup-watcom@v1
+      with:
+        version: 2.0-64
+
     - name: Cache
       id: cache
       uses: actions/cache@v5
@@ -92,17 +101,7 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
         echo "Cache missed! Populating with fresh binaries"
-        [ -h "test-binaries" ] || ln -s "${HOME}"/cache "test-binaries"
         python3 test/test_dosemu.py --get-test-binaries
-
-    - name: Install test prerequisites
-      id: test_prereq
-      run: ./ci_test_prereq.sh
-
-    - name: Open Watcom install
-      uses: open-watcom/setup-watcom@v1
-      with:
-        version: 2.0-64
 
     - name: Test
       id: test

--- a/.github/workflows/test-suite-worker.yml
+++ b/.github/workflows/test-suite-worker.yml
@@ -102,7 +102,7 @@ jobs:
       uses: actions/cache@v5
       with:
         path: ~/cache
-        key: cache-v00001
+        key: cache-v00002
         restore-keys: |
           cache-
 

--- a/ci_test.sh
+++ b/ci_test.sh
@@ -7,15 +7,6 @@ fi
 
 set -eo pipefail
 
-TBINS="test-binaries"
-if [ "${CI}" = "true" ] ; then
-  [ -d "${HOME}"/cache ] || mkdir "${HOME}"/cache
-  [ -h "${TBINS}" ] || ln -s "${HOME}"/cache "${TBINS}"
-else
-  [ -d "${TBINS}"] || mkdir "${TBINS}"
-  python3 test/test_dosemu.py --get-test-binaries
-fi
-
 export PYTHONUNBUFFERED=1
 export TEST_DOSEMU=/usr/local/bin/dosemu
 export TEST_CMDDIR=/usr/local/share/dosemu/commands

--- a/ci_test.sh
+++ b/ci_test.sh
@@ -58,6 +58,26 @@ case "${RUNTYPE}" in
     ;;
 esac
 
+# This section here only runs for proving out test_comcom changes in PRs etc, the tests are
+# run for real in the Comcom64 repository
+if [ "${COMCOM_CHANGED}" = "true" ] ; then
+    VERSION=32
+    cat >&2 << EOF3
+=====================================================
+=              Tests run on Comcom${VERSION}                =
+=====================================================
+EOF3
+    env NO_FAILFAST=1 COPY_COMMAND_COM=/usr/share/comcom${VERSION}/comcom${VERSION}.exe test/test_comcom.py TestCase${VERSION}
+
+    VERSION=64
+    cat >&2 << EOF4
+=====================================================
+=              Tests run on Comcom${VERSION}                =
+=====================================================
+EOF4
+    env NO_FAILFAST=1 COPY_COMMAND_COM=/usr/share/comcom${VERSION}/comcom${VERSION}.exe test/test_comcom.py TestCase${VERSION}
+fi
+
 for i in test_*.*.*.log ; do
   test -f $i || exit 0
 done

--- a/ci_test_prereq.sh
+++ b/ci_test_prereq.sh
@@ -12,6 +12,7 @@ sudo apt update -q
 
 sudo apt install -y \
   acl \
+  comcom32 \
   comcom64 \
   cpu-checker \
   nasm \

--- a/ci_test_prereq.sh
+++ b/ci_test_prereq.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# Ensure the test-binaries link points to ~/cache
+[ -h "test-binaries" ] || ln -s "${HOME}"/cache "test-binaries"
+
 echo "Configuring PPAs..."
 sudo add-apt-repository -y ppa:jwt27/djgpp-toolchain
 sudo add-apt-repository -y ppa:stsp-0/gcc-ia16

--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -62,6 +62,7 @@ TEST_BINARIES = (
 # Freedos 1.4 packages
 TEST_FREEDOS_HOST = "https://www.ibiblio.org/pub/micro/pc-stuff/freedos/files/repositories/1.4"
 TEST_FREEDOS_PKGS = (
+    'base/mem.zip',
     'devel/dj_make.zip',
     'devel/nasm.zip',
     'devel/watcomc.zip',
@@ -139,11 +140,12 @@ def get_test_binaries():
         ], stderr=STDOUT, cwd=tbindir)
 
     for zfile in TEST_FREEDOS_PKGS:
+        zout = zfile.rpartition('/')[-1]
         check_call([
             "wget",
             "--no-verbose",
             "--inet4-only",
-            "-O", f"{zfile.removeprefix('devel/')}",
+            "-O", f"{zout}",
             f"{TEST_FREEDOS_HOST}/{zfile}",
         ], stderr=STDOUT, cwd=tbindir)
 

--- a/test/common_framework.py
+++ b/test/common_framework.py
@@ -1016,6 +1016,11 @@ class MyTestResult(unittest.TextTestResult):
             #if hasattr(self.stream, 'startTestRun'):       # doesn't seem to be necessary, leave here in case it is.
             #    self.stream.startTestRun = False
 
+        # Remove the logfiles which will trip the overall failure logic
+        if not self.no_unlink_logs:
+            for l in getattr(test, 'logfiles', {}).values():
+                l[0].unlink(missing_ok=True)
+
         if reason.startswith("ACCEPTEDFAIL\n"):
             if self.showAll:
                 if self.with_color_terminal:
@@ -1025,11 +1030,6 @@ class MyTestResult(unittest.TextTestResult):
             elif self.dots:
                 self.stream.write('M')
                 self.stream.flush()
-
-            # Remove the logfiles which will trip the overall failure logic
-            if not self.no_unlink_logs:
-                for _, l in test.logfiles.items():
-                    l[0].unlink(missing_ok=True)
             test.logfiles = {}
         else:
             super().addSkip(test, reason)

--- a/test/common_os.py
+++ b/test/common_os.py
@@ -27,7 +27,7 @@ def drdos701(baseclass, actions):
 
         @classmethod
         def setUpClass(cls):
-            super(DRDOS701TestCase, cls).setUpClass()
+            super().setUpClass()
             cls.version = "Caldera OpenDOS 7.01"
             cls.prettyname = "DR-DOS-7.01"
             cls.files = [
@@ -76,7 +76,7 @@ def frdos120(baseclass, actions):
 
         @classmethod
         def setUpClass(cls):
-            super(FRDOS120TestCase, cls).setUpClass()
+            super().setUpClass()
             cls.version = "FreeDOS kernel 2042"
             cls.prettyname = "FR-DOS-1.20"
             cls.files = [
@@ -121,7 +121,7 @@ def frdos130(baseclass, actions):
 
         @classmethod
         def setUpClass(cls):
-            super(FRDOS130TestCase, cls).setUpClass()
+            super().setUpClass()
             cls.version = "FreeDOS kernel 2043"
             cls.prettyname = "FR-DOS-1.30"
             cls.files = [
@@ -219,7 +219,7 @@ def msdos622(baseclass, actions):
 
         @classmethod
         def setUpClass(cls):
-            super(MSDOS622TestCase, cls).setUpClass()
+            super().setUpClass()
             cls.version = "MS-DOS Version 6.22"
             cls.prettyname = "MS-DOS-6.22"
             cls.files = [
@@ -269,7 +269,7 @@ def msdos700(baseclass, actions):
 
         @classmethod
         def setUpClass(cls):
-            super(MSDOS700TestCase, cls).setUpClass()
+            super().setUpClass()
             cls.version = "Windows 95. [Version 4.00.950]"
             cls.prettyname = "MS-DOS-7.00"
             cls.files = [
@@ -328,7 +328,7 @@ def msdos710(baseclass, actions):
 
         @classmethod
         def setUpClass(cls):
-            super(MSDOS710TestCase, cls).setUpClass()
+            super().setUpClass()
             cls.version = "MS-DOS 7.1 [Version 7.10.1999]"
             cls.prettyname = "MS-DOS-7.10"
             cls.files = [
@@ -385,7 +385,7 @@ def ppdosgit(baseclass, actions):
 
         @classmethod
         def setUpClass(cls):
-            super(PPDOSGITTestCase, cls).setUpClass()
+            super().setUpClass()
             cls.version = "FDPP kernel"
             cls.prettyname = "PP-DOS-GIT"
             cls.actions = actions

--- a/test/func_comcom_internal.py
+++ b/test/func_comcom_internal.py
@@ -3,7 +3,7 @@
 # these compilers for this test, so I'm afraid that we have to just grab
 # my precompiled binaries, and trust that they are from the source below.
 
-def command_com_r200fix(self, mode):
+def comcom_r200fix(self, mode):
     self.unTarOrSkip("TEST_R200.tar", [
         ("tp40.exe", "f34a8baff122ef865d6869a04eeb5d16777073bb"),
         ("tp55.exe", "3bc0eb626bb150680cce6dcf20dd19e18df29962"),

--- a/test/func_comcom_internal.py
+++ b/test/func_comcom_internal.py
@@ -1,3 +1,104 @@
+import re
+
+from subprocess import check_output
+
+from common_framework import BINSDIR
+
+
+def comcom_mem(self):
+    content = check_output(["unzip", "-p", "-C", f"{self.topdir}/{BINSDIR}/mem.zip", "bin/mem.exe"])
+    fdmem = self.workdir / "fdmem.exe"
+    fdmem.write_bytes(content)
+
+    self.mkfile("testit.bat", """\
+c:\\fdmem
+@echo PT2
+mem
+rem end
+""", newline="\r\n")
+
+    results = self.runDosemu("testit.bat")
+    try:
+        pt2start = results.index("PT2")
+    except ValueError:
+        raise self.failureException("Parse Error:\n" + results) from None
+    pt1 = results[0:pt2start-1]
+    pt2 = results[pt2start+4:]
+    if "Bad command or file name - mem" in pt2:
+        ver = self.__class__.__name__[-2:]
+        raise self.skipTest(f"Internal command 'mem' not available in comcom{ver}")
+
+    def get_triplet(tag, text):
+        s = re.sub(r'[.,]', '', text)
+        plain_match = re.search(fr"^{tag}\s+(\d+)\s+(\d+)\s+(\d+)", s, re.MULTILINE)
+        kilob_match = re.search(fr"^{tag}\s+(\d+)K\s+(\d+)K\s+(\d+)K", s, re.MULTILINE)
+
+        if kilob_match:
+            return [int(x) * 1024 for x in kilob_match.groups()]
+        elif plain_match:
+            return [(int(x) + 1023) & ~1023 for x in plain_match.groups()]
+        else:
+            raise self.failureException(f"Couldn't parse '{tag}' in '{text}'\n")
+
+    def get_single(tag, text):
+        s = re.sub(r'[.,]', '', text)
+        match = re.search(fr"^{tag}\s+.*\((\d+)\s+bytes\)", s, re.MULTILINE)
+        if match:
+            return int(match.group(1))
+        else:
+            raise self.failureException(f"Couldn't parse '{tag}' in '{text}'\n")
+
+    # Parse 'pt1'
+    fd_conv_total, fd_conv_used, fd_conv_free = get_triplet("Conventional", pt1)
+    fd_upper_total, fd_upper_used, fd_upper_free = get_triplet("Upper", pt1)
+    fd_reserved_total, fd_reserved_used, fd_reserved_free = get_triplet("Reserved", pt1)
+    fd_extended_total, fd_extended_used, fd_extended_free = get_triplet(r"Extended \(XMS\)", pt1)
+    fd_total_total, fd_total_used, fd_total_free = get_triplet("Total memory", pt1)
+    fd_1mb_total, fd_1mb_used, fd_1mb_free, = get_triplet("Total under 1 MB", pt1)
+
+    fd_expanded_total = get_single("Total Expanded", pt1)
+    fd_expanded_free = get_single("Free Expanded", pt1)
+    fd_largest_executable = get_single("Largest executable program size", pt1)
+    fd_largest_uppermemblk = get_single("Largest free upper memory block", pt1)
+
+    # Parse 'pt2'
+    cc_conv_total, cc_conv_used, cc_conv_free = get_triplet("Conventional", pt2)
+    cc_upper_total, cc_upper_used, cc_upper_free = get_triplet("Upper", pt2)
+    cc_reserved_total, cc_reserved_used, cc_reserved_free = get_triplet("Reserved", pt2)  # Reserved missing
+    cc_extended_total, cc_extended_used, cc_extended_free = get_triplet(r"Extended \(XMS\)", pt2)
+    cc_total_total, cc_total_used, cc_total_free = get_triplet("Total memory", pt2)
+    cc_1mb_total, cc_1mb_used, cc_1mb_free, = get_triplet("Total under 1 MB", pt2)
+
+    cc_expanded_total = get_single("Total Expanded", pt2)
+    cc_expanded_free = get_single("Free Expanded", pt2)
+    cc_largest_executable = get_single("Largest executable program size", pt2)
+    cc_largest_uppermemblk = get_single("Largest available upper memory block", pt2)
+
+    # compare
+    self.assertAlmostEqual(fd_conv_total, cc_conv_total, delta=1024)
+    self.assertAlmostEqual(fd_conv_free, cc_conv_free, delta=1024)
+    self.assertAlmostEqual(fd_conv_used, cc_conv_used, delta=1024)
+    self.assertAlmostEqual(fd_upper_total, cc_upper_total, delta=1024)
+    self.assertAlmostEqual(fd_upper_free, cc_upper_free, delta=1024)
+    self.assertAlmostEqual(fd_upper_used, cc_upper_used, delta=1024)
+    self.assertAlmostEqual(fd_reserved_total, cc_reserved_total, delta=1024)
+    self.assertAlmostEqual(fd_reserved_free, cc_reserved_free, delta=1024)
+    self.assertAlmostEqual(fd_reserved_used, cc_reserved_used, delta=1024)
+    self.assertAlmostEqual(fd_extended_total, cc_extended_total, delta=1024)
+    self.assertAlmostEqual(fd_extended_free, cc_extended_free, delta=1024)
+    self.assertAlmostEqual(fd_extended_used, cc_extended_used, delta=1024)
+    self.assertAlmostEqual(fd_total_total, cc_total_total, delta=1024)
+    self.assertAlmostEqual(fd_total_free, cc_total_free, delta=1024)
+    self.assertAlmostEqual(fd_total_used, cc_total_used, delta=1024)
+    self.assertAlmostEqual(fd_1mb_total, cc_1mb_total, delta=1024)
+    self.assertAlmostEqual(fd_1mb_free, cc_1mb_free, delta=1024)
+    self.assertAlmostEqual(fd_1mb_used, cc_1mb_used, delta=1024)
+
+    self.assertAlmostEqual(fd_expanded_total, cc_expanded_total, delta=1024)
+    self.assertAlmostEqual(fd_expanded_free, cc_expanded_free, delta=1024)
+    self.assertAlmostEqual(fd_largest_executable, cc_largest_executable, delta=1024)
+    self.assertAlmostEqual(fd_largest_uppermemblk, cc_largest_uppermemblk, delta=1024)
+
 # Note: The Borland/Turbo Pascal binaries are created using the script at
 # the end of this file as I don't want to have to download and install all
 # these compilers for this test, so I'm afraid that we have to just grab

--- a/test/test_comcom.py
+++ b/test/test_comcom.py
@@ -10,7 +10,7 @@ from func_command_com_builtins import command_com_copy, command_com_keyword_exis
 from func_command_com_cmdline_length import command_com_cmdline_length
 from func_command_com_psp_checks import command_com_psp_fcbs
 
-from func_comcom_internal import comcom_r200fix
+from func_comcom_internal import comcom_mem, comcom_r200fix
 
 
 class OurTestCase(BaseTestCase):
@@ -86,6 +86,11 @@ class OurTestCase(BaseTestCase):
     def test_command_psp_fcbs(self):
         """Command.com PSP FCB Values"""
         command_com_psp_fcbs(self)
+
+    @mark('inttest')
+    def test_comcom_mem(self):
+        """Comcom mem report tool"""
+        comcom_mem(self)
 
     @mark('inttest')
     def test_comcom_r200fix_real(self):

--- a/test/test_comcom.py
+++ b/test/test_comcom.py
@@ -1,0 +1,114 @@
+#!/usr/bin/python3
+
+from common_framework import (BaseTestCase, main, main_setup, mark, acceptFailure)
+from common_os import ppdosgit
+
+from func_build_freecom import build_freecom
+from func_build_freedos import build_freedos
+from func_build_pcmos import build_pcmos
+from func_command_com_builtins import command_com_copy, command_com_keyword_exist
+from func_command_com_cmdline_length import command_com_cmdline_length
+from func_command_com_psp_checks import command_com_psp_fcbs
+
+from func_comcom_internal import comcom_r200fix
+
+
+class OurTestCase(BaseTestCase):
+    attrs = {'buildtest', 'inttest'}
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        if cls.__name__ == 'TestCase32':
+            cls.commandcom_regex = r'(?m)^comcom.*dj32'
+        elif cls.__name__ == 'TestCase64':
+            cls.commandcom_regex = r'(?m)^comcom.*dj64'
+        else:
+            raise ValueError(f"TestCase suffix specifies which comcom version expected")
+
+    def test_0_basic_boot(self):
+        """Basic boot test"""
+        # Since test names are processed alphabetically this test should
+        # get to run first, and if we fail then even if failfast is disabled
+        # we will still terminate the test run.
+        self.shouldStop = True
+
+        results = self.runDosemu("version.bat")
+
+        self.assertNotIn('NonZeroReturn', results)
+        self.assertIn(self.version, results)
+        self.assertRegex(results, self.commandcom_regex)
+
+    @mark('buildtest')
+    def test_build_freecom(self):
+        """Build FreeCOM"""
+        build_freecom(self)
+
+    @mark('buildtest')
+    def test_build_freedos(self):
+        """Build FreeDOS kernel"""
+        build_freedos(self)
+
+    @mark('buildtest')
+    def test_build_pcmos(self):
+        """Build PC-MOS"""
+        build_pcmos(self)
+
+    def test_command_cmdline_length_new_dos01(self):
+        """Command.com cmdline length(127) (env var) 01"""
+        command_com_cmdline_length(self, 'new_dos01')
+
+    def test_command_cmdline_length_new_dos02(self):
+        """Command.com cmdline length(150) (env var) 02"""
+        command_com_cmdline_length(self, 'new_dos02')
+
+    def test_command_cmdline_length_multiargs01(self):
+        """Command.com cmdline length( 30) multiple args 01"""
+        command_com_cmdline_length(self, 'multiarg01')
+
+    def test_command_cmdline_length_singlearg01(self):
+        """Command.com cmdline length( 60) single arg 01"""
+        command_com_cmdline_length(self, 'singlearg01')
+
+    def test_command_cmdline_length_singlearg02(self):
+        """Command.com cmdline length(126) single arg 02"""
+        command_com_cmdline_length(self, 'singlearg02')
+
+    def test_command_copy(self):
+        """Command.com command copy"""
+        command_com_copy(self)
+
+    def test_command_keyword_exist(self):
+        """Command.com keyword exist"""
+        command_com_keyword_exist(self)
+
+    def test_command_psp_fcbs(self):
+        """Command.com PSP FCB Values"""
+        command_com_psp_fcbs(self)
+
+    @mark('inttest')
+    def test_comcom_r200fix_real(self):
+        """Comcom r200fix Real Mode"""
+        comcom_r200fix(self, 'REAL')
+
+    @acceptFailure
+    @mark('inttest')
+    def test_comcom_r200fix_protected(self):
+        """Comcom r200fix Protected Mode"""
+        comcom_r200fix(self, 'PROTECTED')
+
+class TestCase32(ppdosgit(OurTestCase, {})):
+    pass
+
+class TestCase64(ppdosgit(OurTestCase, {})):
+    pass
+
+if __name__ == '__main__':
+
+    cases = [
+        TestCase32, TestCase64,
+    ]
+
+    xargv = main_setup(cases)
+    main(xargv)

--- a/test/test_dosemu.py
+++ b/test/test_dosemu.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python3
 
-import unittest
-
 from sys import argv
 
 from common_framework import (BaseTestCase, main, main_setup, mark, acceptFailure,
@@ -14,7 +12,6 @@ from func_bpb_set import bpb_set
 from func_command_com_builtins import command_com_copy, command_com_keyword_exist
 from func_command_com_cmdline_length import command_com_cmdline_length
 from func_command_com_psp_checks import command_com_psp_fcbs
-from func_command_com_r200fix import command_com_r200fix
 from func_disk import three_drives_vfs, int21_disk_info
 from func_ds2_dirops import (ds2_delete_common, ds2_find_common, ds2_find_first,
                              ds2_find_mixed_wild_plain, ds2_rename_common)
@@ -84,17 +81,6 @@ class OurTestCase(BaseTestCase):
     def test_command_com_psp_fcbs(self):
         """Command.com PSP FCB Values"""
         command_com_psp_fcbs(self)
-
-    @mark('cmdtest')
-    def test_command_com_r200fix_real(self):
-        """Command.com r200fix Real Mode"""
-        command_com_r200fix(self, 'REAL')
-
-    @unittest.expectedFailure
-    @mark('cmdtest')
-    def test_command_com_r200fix_protected(self):
-        """Command.com r200fix Protected Mode"""
-        command_com_r200fix(self, 'PROTECTED')
 
     def test_drv_removable(self):
         """Drive is removable (IOCTL)"""
@@ -1517,8 +1503,6 @@ class OurTestCase(BaseTestCase):
 
 DRDOS701TestCase = drdos701(OurTestCase, {
     "test_command_com_psp_fcbs": KNOWNFAIL,
-    "test_command_com_r200fix_real": UNSUPPORTED,
-    "test_command_com_r200fix_protected": UNSUPPORTED,
     "test_command_com_cmdline_length_new_dos01": UNSUPPORTED,
     "test_command_com_cmdline_length_new_dos02": UNSUPPORTED,
     "test_command_com_cmdline_length_old_dos01": UNSUPPORTED,
@@ -1557,8 +1541,6 @@ DRDOS701TestCase = drdos701(OurTestCase, {
 
 FRDOS120TestCase = frdos120(OurTestCase, {
     "test_command_com_psp_fcbs": KNOWNFAIL,
-    "test_command_com_r200fix_real": UNSUPPORTED,
-    "test_command_com_r200fix_protected": UNSUPPORTED,
     "test_command_com_cmdline_length_old_dos01": UNSUPPORTED,
     "test_command_com_cmdline_length_old_dos02": UNSUPPORTED,
     "test_drv_removable": KNOWNFAIL,
@@ -1632,8 +1614,6 @@ FRDOS120TestCase = frdos120(OurTestCase, {
 
 FRDOS130TestCase = frdos130(OurTestCase, {
     "test_command_com_psp_fcbs": KNOWNFAIL,
-    "test_command_com_r200fix_real": UNSUPPORTED,
-    "test_command_com_r200fix_protected": UNSUPPORTED,
     "test_command_com_cmdline_length_old_dos01": UNSUPPORTED,
     "test_command_com_cmdline_length_old_dos02": UNSUPPORTED,
     "test_command_com_keyword_exist": KNOWNFAIL,
@@ -1688,8 +1668,6 @@ FRDOS130TestCase = frdos130(OurTestCase, {
 })
 
 FRDOSGITTestCase = frdosgit(OurTestCase, {
-    "test_command_com_r200fix_real": UNSUPPORTED,
-    "test_command_com_r200fix_protected": UNSUPPORTED,
     "test_command_com_cmdline_length_old_dos01": UNSUPPORTED,
     "test_command_com_cmdline_length_old_dos02": UNSUPPORTED,
     "test_fat_bpb_set_fstype_dinfo": KNOWNFAIL,
@@ -1721,8 +1699,6 @@ FRDOSGITTestCase = frdosgit(OurTestCase, {
 })
 
 MSDOS622TestCase = msdos622(OurTestCase, {
-    "test_command_com_r200fix_real": UNSUPPORTED,
-    "test_command_com_r200fix_protected": UNSUPPORTED,
     "test_command_com_cmdline_length_new_dos01": UNSUPPORTED,
     "test_command_com_cmdline_length_new_dos02": UNSUPPORTED,
     "test_fat32_img_d_writable": UNSUPPORTED,
@@ -1741,8 +1717,6 @@ MSDOS622TestCase = msdos622(OurTestCase, {
 })
 
 MSDOS700TestCase = msdos700(OurTestCase, {
-    "test_command_com_r200fix_real": UNSUPPORTED,
-    "test_command_com_r200fix_protected": UNSUPPORTED,
     "test_command_com_cmdline_length_old_dos01": UNSUPPORTED,
     "test_command_com_cmdline_length_old_dos02": UNSUPPORTED,
     "test_fat32_img_d_writable": UNSUPPORTED,
@@ -1758,8 +1732,6 @@ MSDOS700TestCase = msdos700(OurTestCase, {
 })
 
 MSDOS710TestCase = msdos710(OurTestCase, {
-    "test_command_com_r200fix_real": UNSUPPORTED,
-    "test_command_com_r200fix_protected": UNSUPPORTED,
     "test_command_com_cmdline_length_old_dos01": UNSUPPORTED,
     "test_command_com_cmdline_length_old_dos02": UNSUPPORTED,
     # Real mode sharing and locking was removed on MS-DOS 7.10
@@ -1785,7 +1757,6 @@ MSDOS710TestCase = msdos710(OurTestCase, {
 })
 
 PPDOSGITTestCase = ppdosgit(OurTestCase, {
-    "test_command_com_r200fix_protected": UNSUPPORTED,
     "test_command_com_cmdline_length_old_dos01": UNSUPPORTED,
     "test_command_com_cmdline_length_old_dos02": UNSUPPORTED,
     "test_drv_removable": KNOWNFAIL,


### PR DESCRIPTION
1/ Run the new main on PRs with changes to it, and all plain pushes.
2/ Call the Comcom specific tests.
3/ Call the big builder tests (FreeDOS kernel, FreeCOM and PC-MOS).
4/ Ensure that Comcom tests run with the correct version.